### PR TITLE
feat(monolith): add repo and branch selectors to /agents UI plus Cmd+Enter send

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.358
+version: 0.89.359
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.358
+      targetRevision: 0.89.359
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.433
+version: 0.285.434
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.433
+      targetRevision: 0.285.434
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -25,10 +25,14 @@
   let sending = $state(false);
   let creating = $state(false);
   let showNewPanel = $state(false);
+  let repos = $state([]);
+  let branches = $state([]);
+  let repoLoading = $state(false);
+  let branchLoading = $state(false);
   let newSession = $state({
     prompt: "",
     model: "",
-    workspace: "",
+    repo: "",
     branch: "",
   });
   let errorMessage = $state(
@@ -98,6 +102,11 @@
       session?.local_session_id ||
       `${session?.workspace || "workspace"}/${session?.branch || "branch"}`
     );
+  }
+
+  function formatRepoContext(session) {
+    if (session?.repo) return `${session.repo}@${session.branch || "main"}`;
+    return `${session?.workspace || "workspace"} / ${session?.branch || "branch"}`;
   }
 
   function cost(value) {
@@ -171,6 +180,43 @@
       }
     } catch (error) {
       errorMessage = error.message;
+    }
+  }
+
+  async function loadRepos() {
+    repoLoading = true;
+    try {
+      const response = await fetch("/agents/repos");
+      if (!response.ok) throw new Error("Unable to load repos");
+      const body = await response.json();
+      repos = body.repos ?? [];
+    } catch (error) {
+      errorMessage = error.message;
+    } finally {
+      repoLoading = false;
+    }
+  }
+
+  async function loadBranches(repoId) {
+    if (!repoId) {
+      branches = [];
+      return;
+    }
+    branchLoading = true;
+    const [owner, repo] = repoId.split("/");
+    try {
+      const response = await fetch(
+        `/agents/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/branches`,
+      );
+      if (!response.ok) throw new Error("Unable to load branches");
+      const body = await response.json();
+      branches = body.branches ?? [];
+      newSession.branch = body.default_branch ?? "main";
+    } catch (error) {
+      branches = [];
+      newSession.branch = "main";
+    } finally {
+      branchLoading = false;
     }
   }
 
@@ -279,10 +325,15 @@
     try {
       const requestBody = {
         prompt: newSession.prompt.trim(),
-        workspace: newSession.workspace.trim(),
-        branch: newSession.branch.trim(),
       };
       if (newSession.model) requestBody.model = newSession.model;
+      if (newSession.repo) {
+        requestBody.repo = newSession.repo;
+        requestBody.branch = newSession.branch;
+      } else {
+        requestBody.workspace = newSession.workspace?.trim() || "";
+        requestBody.branch = newSession.branch?.trim() || "";
+      }
       const response = await fetch("/agents/sessions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -293,7 +344,8 @@
         throw new Error(body.error || "Session was not created");
       creating = false;
       showNewPanel = false;
-      newSession = { prompt: "", model: "", workspace: "", branch: "" };
+      newSession = { prompt: "", model: "", repo: "", branch: "" };
+      branches = [];
       await loadSessions();
       selectSession(body.session_id);
     } catch (error) {
@@ -341,6 +393,12 @@
       hasActiveSessions ? 2000 : 15000,
     );
     return () => clearInterval(interval);
+  });
+
+  $effect(() => {
+    if (showNewPanel && repos.length === 0) {
+      loadRepos();
+    }
   });
 
   $effect(() => () => {
@@ -428,7 +486,7 @@
         <div>
           <div class="eyebrow mono">{displayName(selectedSession)}</div>
           <div class="session-context mono">
-            {selectedSession.workspace} / {selectedSession.branch}
+            {formatRepoContext(selectedSession)}
           </div>
         </div>
         <div class="head-actions">
@@ -495,7 +553,18 @@
         <textarea
           bind:value={prompt}
           placeholder="send a prompt to this session"
-          rows="3"></textarea>
+          rows="3"
+          onkeydown={(e) => {
+            if (
+              (e.metaKey || e.ctrlKey) &&
+              e.key === "Enter" &&
+              !sending &&
+              prompt.trim()
+            ) {
+              e.preventDefault();
+              sendPrompt();
+            }
+          }}></textarea>
         <div class="composer-actions">
           <select class="mono" bind:value={composerModel} aria-label="Model">
             <option value="">session default</option>
@@ -527,7 +596,18 @@
           >prompt<textarea
             bind:value={newSession.prompt}
             rows="7"
-            placeholder="what should the agent do?"></textarea></label
+            placeholder="what should the agent do?"
+            onkeydown={(e) => {
+              if (
+                (e.metaKey || e.ctrlKey) &&
+                e.key === "Enter" &&
+                !creating &&
+                newSession.prompt.trim()
+              ) {
+                e.preventDefault();
+                createSession();
+              }
+            }}></textarea></label
         >
         <label
           >model<select class="mono" bind:value={newSession.model}
@@ -537,19 +617,39 @@
           ></label
         >
         <label
-          >workspace<input
+          >repo<select
             class="mono"
-            bind:value={newSession.workspace}
-            placeholder="workspace"
-          /></label
+            bind:value={newSession.repo}
+            onchange={() => {
+              newSession.branch = "";
+              loadBranches(newSession.repo);
+            }}
+          >
+            <option value="">none (bare workspace)</option>
+            {#each repos as repo}
+              <option value={repo.id} title={repo.description || ""}>
+                {repo.id}
+              </option>
+            {/each}
+          </select></label
         >
-        <label
-          >branch<input
+        <label>
+          branch<select
             class="mono"
             bind:value={newSession.branch}
-            placeholder="branch"
-          /></label
-        >
+            disabled={!newSession.repo || branchLoading}
+          >
+            {#if branchLoading}
+              <option value="">loading branches</option>
+            {:else if branches.length === 0}
+              <option value="">main</option>
+            {:else}
+              {#each branches as branch}
+                <option value={branch.name}>{branch.name}</option>
+              {/each}
+            {/if}
+          </select>
+        </label>
         <div class="new-actions">
           <button
             type="button"
@@ -586,10 +686,12 @@
     <span class="row-main"
       ><span class="session-name">{displayName(session)}</span><span
         class="row-sub mono"
-        >{session.model || "luna"} · {relativeTime(
-          session.last_turn_at || session.created_at,
-        )}</span
-      ></span
+      >
+        {#if session.repo}{session.repo}@{session.branch ||
+            "main"}{:else}{session.model || "luna"} · {relativeTime(
+            session.last_turn_at || session.created_at,
+          )}{/if}
+      </span></span
     >
     <span class="row-cost mono">{cost(session.total_cost_usd)}</span>
   </button>
@@ -868,6 +970,9 @@
   .session-context {
     margin-top: 4px;
     font-family: var(--font-mono);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .session-state {
     color: #625e56;

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -29,6 +29,8 @@
   let branches = $state([]);
   let repoLoading = $state(false);
   let branchLoading = $state(false);
+  let reposLoaded = $state(false);
+  let branchLoadSequence = 0;
   let newSession = $state({
     prompt: "",
     model: "",
@@ -194,6 +196,7 @@
       errorMessage = error.message;
     } finally {
       repoLoading = false;
+      reposLoaded = true;
     }
   }
 
@@ -203,6 +206,7 @@
       return;
     }
     branchLoading = true;
+    const generation = ++branchLoadSequence;
     const [owner, repo] = repoId.split("/");
     try {
       const response = await fetch(
@@ -210,13 +214,25 @@
       );
       if (!response.ok) throw new Error("Unable to load branches");
       const body = await response.json();
-      branches = body.branches ?? [];
-      newSession.branch = body.default_branch ?? "main";
+      if (generation === branchLoadSequence) {
+        branches = body.branches ?? [];
+        newSession.branch = body.default_branch ?? "main";
+        if (
+          branches.length > 0 &&
+          !branches.some((b) => b.name === newSession.branch)
+        ) {
+          newSession.branch = branches[0].name;
+        }
+      }
     } catch (error) {
-      branches = [];
-      newSession.branch = "main";
+      if (generation === branchLoadSequence) {
+        branches = [];
+        newSession.branch = "main";
+      }
     } finally {
-      branchLoading = false;
+      if (generation === branchLoadSequence) {
+        branchLoading = false;
+      }
     }
   }
 
@@ -330,9 +346,6 @@
       if (newSession.repo) {
         requestBody.repo = newSession.repo;
         requestBody.branch = newSession.branch;
-      } else {
-        requestBody.workspace = newSession.workspace?.trim() || "";
-        requestBody.branch = newSession.branch?.trim() || "";
       }
       const response = await fetch("/agents/sessions", {
         method: "POST",
@@ -396,7 +409,7 @@
   });
 
   $effect(() => {
-    if (showNewPanel && repos.length === 0) {
+    if (showNewPanel && !reposLoaded && !repoLoading) {
       loadRepos();
     }
   });
@@ -558,6 +571,7 @@
             if (
               (e.metaKey || e.ctrlKey) &&
               e.key === "Enter" &&
+              !e.isComposing &&
               !sending &&
               prompt.trim()
             ) {
@@ -601,6 +615,7 @@
               if (
                 (e.metaKey || e.ctrlKey) &&
                 e.key === "Enter" &&
+                !e.isComposing &&
                 !creating &&
                 newSession.prompt.trim()
               ) {
@@ -620,17 +635,22 @@
           >repo<select
             class="mono"
             bind:value={newSession.repo}
+            disabled={repoLoading}
             onchange={() => {
               newSession.branch = "";
               loadBranches(newSession.repo);
             }}
           >
-            <option value="">none (bare workspace)</option>
-            {#each repos as repo}
-              <option value={repo.id} title={repo.description || ""}>
-                {repo.id}
-              </option>
-            {/each}
+            {#if repoLoading}
+              <option value="">loading repos</option>
+            {:else}
+              <option value="">none (bare workspace)</option>
+              {#each repos as repo}
+                <option value={repo.id} title={repo.description || ""}>
+                  {repo.id}
+                </option>
+              {/each}
+            {/if}
           </select></label
         >
         <label>
@@ -642,7 +662,7 @@
             {#if branchLoading}
               <option value="">loading branches</option>
             {:else if branches.length === 0}
-              <option value="">main</option>
+              <option value="main">main</option>
             {:else}
               {#each branches as branch}
                 <option value={branch.name}>{branch.name}</option>
@@ -687,8 +707,9 @@
       ><span class="session-name">{displayName(session)}</span><span
         class="row-sub mono"
       >
-        {#if session.repo}{session.repo}@{session.branch ||
-            "main"}{:else}{session.model || "luna"} · {relativeTime(
+        {#if session.repo}{session.repo}@{session.branch || "main"} · {relativeTime(
+            session.last_turn_at || session.created_at,
+          )}{:else}{session.model || "luna"} · {relativeTime(
             session.last_turn_at || session.created_at,
           )}{/if}
       </span></span

--- a/projects/monolith/frontend/src/routes/private/agents/repos/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/repos/+server.js
@@ -1,0 +1,18 @@
+const API_BASE = process.env.API_BASE;
+
+export async function GET() {
+  try {
+    const res = await fetch(`${API_BASE}/api/agents/repos`, {
+      signal: AbortSignal.timeout(10000),
+    });
+    return new Response(res.body, {
+      status: res.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return new Response(JSON.stringify({ error: "repos unavailable" }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/projects/monolith/frontend/src/routes/private/agents/repos/+server.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/repos/+server.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, test, vi } from "vitest";
+import { GET as getRepos } from "./+server.js";
+
+describe("repos proxy", () => {
+  test("forwards repo field from API", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ repos: [{ id: "owner/repo" }] }), {
+          ok: true,
+          status: 200,
+        }),
+    );
+
+    const response = await getRepos();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.repos).toEqual([{ id: "owner/repo" }]);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/agents/repos"),
+      expect.any(Object),
+    );
+  });
+
+  test("handles API timeout", async () => {
+    global.fetch = vi.fn(() => {
+      throw new Error("timeout");
+    });
+
+    const response = await getRepos();
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.error).toBe("repos unavailable");
+  });
+});

--- a/projects/monolith/frontend/src/routes/private/agents/repos/+server.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/repos/+server.test.js
@@ -22,6 +22,22 @@ describe("repos proxy", () => {
     );
   });
 
+  test("forwards upstream status and error body on failure", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "service unavailable" }), {
+          ok: false,
+          status: 503,
+        }),
+    );
+
+    const response = await getRepos();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.error).toBe("service unavailable");
+  });
+
   test("handles API timeout", async () => {
     global.fetch = vi.fn(() => {
       throw new Error("timeout");

--- a/projects/monolith/frontend/src/routes/private/agents/repos/[owner]/[repo]/branches/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/repos/[owner]/[repo]/branches/+server.js
@@ -1,0 +1,21 @@
+const API_BASE = process.env.API_BASE;
+
+export async function GET({ params }) {
+  try {
+    const res = await fetch(
+      `${API_BASE}/api/agents/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/branches`,
+      {
+        signal: AbortSignal.timeout(10000),
+      },
+    );
+    return new Response(res.body, {
+      status: res.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return new Response(JSON.stringify({ error: "branches unavailable" }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/projects/monolith/frontend/src/routes/private/agents/repos/[owner]/[repo]/branches/+server.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/repos/[owner]/[repo]/branches/+server.test.js
@@ -40,6 +40,24 @@ describe("branches proxy", () => {
     expect(callUrl).toContain("my-repo");
   });
 
+  test("forwards upstream status and error body on failure", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "not found" }), {
+          ok: false,
+          status: 503,
+        }),
+    );
+
+    const response = await getBranches({
+      params: { owner: "owner", repo: "repo" },
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.error).toBe("not found");
+  });
+
   test("handles API timeout", async () => {
     global.fetch = vi.fn(() => {
       throw new Error("timeout");

--- a/projects/monolith/frontend/src/routes/private/agents/repos/[owner]/[repo]/branches/+server.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/repos/[owner]/[repo]/branches/+server.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, test, vi } from "vitest";
+import { GET as getBranches } from "./+server.js";
+
+describe("branches proxy", () => {
+  test("forwards branch list from API", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            branches: [{ name: "main" }, { name: "develop" }],
+            default_branch: "main",
+          }),
+          { ok: true, status: 200 },
+        ),
+    );
+
+    const response = await getBranches({
+      params: { owner: "owner", repo: "repo" },
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.branches).toEqual([{ name: "main" }, { name: "develop" }]);
+    expect(body.default_branch).toBe("main");
+  });
+
+  test("encodes path parameters correctly", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ branches: [] }), {
+          ok: true,
+          status: 200,
+        }),
+    );
+
+    await getBranches({ params: { owner: "org/name", repo: "my-repo" } });
+
+    const callUrl = global.fetch.mock.calls[0][0];
+    expect(callUrl).toContain("org%2Fname");
+    expect(callUrl).toContain("my-repo");
+  });
+
+  test("handles API timeout", async () => {
+    global.fetch = vi.fn(() => {
+      throw new Error("timeout");
+    });
+
+    const response = await getBranches({
+      params: { owner: "owner", repo: "repo" },
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.error).toBe("branches unavailable");
+  });
+
+  test("handles null default_branch", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            branches: [{ name: "main" }],
+            default_branch: null,
+          }),
+          { ok: true, status: 200 },
+        ),
+    );
+
+    const response = await getBranches({
+      params: { owner: "owner", repo: "repo" },
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.default_branch).toBeNull();
+  });
+});

--- a/projects/monolith/frontend/src/routes/private/agents/sessions/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/sessions/+server.js
@@ -9,6 +9,7 @@ export async function POST({ request }) {
       body: JSON.stringify({
         prompt: body.prompt,
         ...(body.model ? { model: body.model } : {}),
+        ...(body.repo ? { repo: body.repo } : {}),
         ...(body.workspace ? { workspace: body.workspace } : {}),
         ...(body.branch ? { branch: body.branch } : {}),
       }),

--- a/projects/monolith/frontend/src/routes/private/agents/sessions/+server.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/sessions/+server.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, test, vi } from "vitest";
+import { POST } from "./+server.js";
+
+describe("sessions proxy", () => {
+  test("forwards repo and branch fields in POST body", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ session_id: "123" }), {
+          ok: true,
+          status: 200,
+        }),
+    );
+
+    const request = new Request("http://localhost/agents/sessions", {
+      method: "POST",
+      body: JSON.stringify({
+        prompt: "test",
+        repo: "owner/repo",
+        branch: "main",
+      }),
+    });
+
+    await POST({ request });
+
+    const callBody = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(callBody.repo).toBe("owner/repo");
+    expect(callBody.branch).toBe("main");
+    expect(callBody.prompt).toBe("test");
+  });
+
+  test("omits repo field when not provided", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ session_id: "123" }), {
+          ok: true,
+          status: 200,
+        }),
+    );
+
+    const request = new Request("http://localhost/agents/sessions", {
+      method: "POST",
+      body: JSON.stringify({
+        prompt: "test",
+        workspace: "ws",
+      }),
+    });
+
+    await POST({ request });
+
+    const callBody = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(callBody.repo).toBeUndefined();
+    expect(callBody.workspace).toBe("ws");
+  });
+
+  test("includes model field when provided", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ session_id: "123" }), {
+          ok: true,
+          status: 200,
+        }),
+    );
+
+    const request = new Request("http://localhost/agents/sessions", {
+      method: "POST",
+      body: JSON.stringify({
+        prompt: "test",
+        model: "opus",
+      }),
+    });
+
+    await POST({ request });
+
+    const callBody = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(callBody.model).toBe("opus");
+  });
+});


### PR DESCRIPTION
Work item 4 of #4330 plus two UX asks.

- The NEW SESSION form replaces the free-text workspace and branch inputs with a repo dropdown (fed by /api/agents/repos via a new SvelteKit proxy, lazy-loaded when the panel opens) and a branch dropdown (per-repo, default branch preselected, disabled states while loading and for bare-workspace mode). A none option preserves today's bare-workspace behavior exactly.
- Cmd+Enter and Ctrl+Enter send in both the composer and the new-session prompt textareas; plain Enter still inserts a newline. The console previously had zero keyboard handling.
- The transcript header and sidebar rows show repo@branch when a session has a repo.
- The sessions POST proxy forwards the new repo field (the proxies re-serialize field by field, so this is the layer that silently drops fields when missed).
- Three new proxy test files (vitest); depends on the #4342 endpoints and carries the expected chart-version collision with it: whichever merges second re-bumps at update-branch time.

Refs #4330, ADR agents/050 (#4339).

🤖 Generated with [Claude Code](https://claude.com/claude-code)