### PR TITLE
fix(agents): give Luna sandbox network access and stop UI turns pinging Discord

### DIFF
--- a/.claude/skills/codex-implement/SKILL.md
+++ b/.claude/skills/codex-implement/SKILL.md
@@ -50,7 +50,10 @@ SPEC
 Rules:
 
 1. **Prefer Luna.** Do not default to Terra or Sol to "be safe."
-2. **One worktree per worker.** No commit/push/network in the sandbox.
+2. **One worktree per worker.** The sandbox blocks writes outside the worktree.
+   It does NOT block network (workers need to fetch deps and read upstream
+   docs), so "no commit, no push" is enforced by the spec guardrails the
+   wrapper appends, not by the sandbox.
 3. **Full spec up front** (files, acceptance, patterns to imitate).
 4. **Fan out in parallel** for independent tasks.
 5. **Opus reviews** the diff, runs **`ci`** (or `ci lint` + `ci test`), then

--- a/bazel/tools/codex/dispatch.sh
+++ b/bazel/tools/codex/dispatch.sh
@@ -18,8 +18,15 @@
 #   *   codex exec's own failure code, passed through
 #
 # Guardrails baked in:
-#   - workspace-write sandbox scoped to <workdir>: no network, no writes
-#     outside the worktree, so the worker cannot push or commit upstream
+#   - workspace-write sandbox scoped to <workdir>: no writes outside the
+#     worktree
+#   - network IS enabled in the sandbox. workspace-write denies it by default,
+#     which silently broke any worker that needed to fetch a dependency or read
+#     an upstream doc: the turn still connects and bills (the sandbox governs
+#     model-run shell commands, not codex's own API calls), so the only symptom
+#     is DNS failures buried in the transcript. With network on, "cannot push
+#     upstream" is enforced by the spec guardrails below rather than by the
+#     sandbox, so keep that line in GUARDRAILS.
 #   - repo guardrails appended to every spec (no local tests, no commits,
 #     apko not Dockerfiles, non-root, conventional repo patterns)
 set -euo pipefail
@@ -61,7 +68,9 @@ GUARDRAILS='
 - Do NOT run pytest/go test/npm test/bazel test on the Mac. The orchestrator
   runs `ci` (bb remote Linux Test) after reviewing your diff.
 - Do NOT run git commit, git push, or any git state-changing command. The
-  orchestrator reviews and commits your diff.
+  orchestrator reviews and commits your diff. The sandbox has network access,
+  so this is on you to respect: nothing stops a push at the sandbox layer.
+- You DO have network access for reads (fetching deps, reading upstream docs).
 - Never use em-dashes in anything you write.
 - Containers: apko only (no Dockerfiles), non-root uid 65532.
 - Never hardcode .svc.cluster.local URLs or @sha256: image digests.
@@ -74,6 +83,7 @@ set +e
 codex exec \
 	--model "$MODEL" \
 	--config model_reasoning_effort="$EFFORT" \
+	--config sandbox_workspace_write.network_access=true \
 	--sandbox workspace-write \
 	--skip-git-repo-check \
 	-C "$WORKDIR" \

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.404
+version: 0.1.405

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.404
+      targetRevision: 0.1.405
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -1125,6 +1125,15 @@ wire_api = "responses"
                 model_name,
                 "--config",
                 "model_reasoning_effort=%s" % effort,
+                # Network must ride --config, not a flag, and must sit OUTSIDE
+                # the `if not session_id` block below. workspace-write denies
+                # network by default, and resume rejects --sandbox, so a
+                # flag-shaped fix would give the first turn of a session
+                # network and silently drop it on every resumed turn. Verified
+                # against rust-v0.146.0: a resume carrying only this --config
+                # reports "workspace-write (network access enabled)".
+                "--config",
+                "sandbox_workspace_write.network_access=true",
             ]
         )
         command.append("--skip-git-repo-check")

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -442,6 +442,12 @@ def test_codex_resume_uses_positional_session_and_no_sandbox(tmp_path, monkeypat
     assert "-C" not in resume
     assert resume[resume.index("--model") + 1] == "gpt-5.6-terra"
     assert resume[resume.index("--config") + 1] == "model_reasoning_effort=high"
+    # Sandbox network rides --config on BOTH turns. workspace-write denies
+    # network by default and resume rejects --sandbox, so a flag-shaped fix
+    # would give turn one network and silently drop it on every turn after.
+    network = "sandbox_workspace_write.network_access=true"
+    assert network in first
+    assert network in resume
     manager._close_process()
 
 

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.360
+version: 0.89.361
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.360
+      targetRevision: 0.89.361
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import collections
 import json
 import logging
 import os
@@ -32,6 +33,40 @@ _transport = EmberVmShimTransport()
 _sweep_task: asyncio.Task | None = None
 _REPLICA_ID = platform.node()
 logger = logging.getLogger(__name__)
+
+# Messages queued by the /agents UI, so their terminal Discord post can be
+# suppressed: someone watching the UI is already looking at the result and does
+# not need it echoed to a channel. Only MCP-originated turns notify.
+#
+# Deliberately process-local rather than a column on pending_messages. That
+# makes it BEST EFFORT: a message the sweep hands to another replica, or one
+# outliving a restart, loses its mark and notifies anyway. That direction is
+# fail-open, which for a notification is the benign one (a stray post, never a
+# missed one). Move the flag onto the row if the strays become annoying.
+#
+# Bounded because an entry is only consumed when THIS replica claims the
+# message; eviction of the oldest is the same benign fail-open.
+_UI_ORIGINATED_CAP = 1024
+_ui_originated: collections.OrderedDict[tuple[int, int], bool] = (
+    collections.OrderedDict()
+)
+
+
+def _mark_ui_originated(session_id: int, seq: int) -> None:
+    """Flag a queued message as UI-originated so its turn skips the notify."""
+    _ui_originated[(session_id, seq)] = True
+    while len(_ui_originated) > _UI_ORIGINATED_CAP:
+        _ui_originated.popitem(last=False)
+
+
+def _consume_ui_originated(session_id: int, seq: int) -> bool:
+    """Read and clear the UI mark for a message.
+
+    Called once, at claim time rather than at notify time, because the turn has
+    several early-return paths and this way the entry clears on all of them
+    instead of leaking on the ones that never reach the notify.
+    """
+    return _ui_originated.pop((session_id, seq), False)
 
 
 def _load_session(session_id: int) -> tuple[AgentSession | None, list[AgentTurn]]:
@@ -254,6 +289,8 @@ async def _execute_pending_message(session_id: int) -> None:
     if claimed_seq is None:
         return
 
+    ui_originated = _consume_ui_originated(session_id, claimed_seq)
+
     # Set once the claim is lost to another replica; checked before starting and
     # again after deliver, so a stolen claim never persists a duplicate turn.
     claim_stolen = False
@@ -405,7 +442,8 @@ async def _execute_pending_message(session_id: int) -> None:
             )
             return
         await asyncio.to_thread(_delete_pending_message_sync, session_id, claimed_seq)
-        await _notify_terminal(turn, summary, status)
+        if not ui_originated:
+            await _notify_terminal(turn, summary, status)
         # This session's next message could not be claimed while this one was
         # outstanding, so nudge the queue now that it is not. Without this the
         # follow-up waits for the sweep, which is correct but adds its interval

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -1253,3 +1253,74 @@ def test_broker_login_rejects_bad_grant_and_unset_url(monkeypatch):
     monkeypatch.delenv("EMBER_TOKENBROKER_URL")
     with pytest.raises(ValueError):
         asyncio.run(mcp.monolith_codex_broker_login_status())
+
+
+def _run_turn_capturing_notifies(monkeypatch, session, *, mark_ui: bool) -> list:
+    """Drive one turn through the executor and return its Discord notify calls."""
+    row = store.create_session(session, "sid-ui-notify", "/workspace", "main")
+    pending = store.create_pending_message(session, row.id, "hello")
+    notify_calls = []
+
+    async def mock_deliver(*args, **_kwargs):
+        return _completed_delivery(args[2])
+
+    async def mock_notify(*args, **_kwargs):
+        notify_calls.append(args)
+
+    monkeypatch.setattr(mcp._transport, "deliver", mock_deliver)
+    monkeypatch.setattr(mcp.agent_api, "notify", mock_notify)
+    monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
+    if mark_ui:
+        mcp._mark_ui_originated(row.id, pending.seq)
+    asyncio.run(mcp._execute_pending_message(row.id))
+    return notify_calls
+
+
+def test_ui_originated_turn_does_not_notify_discord(monkeypatch, session):
+    """A turn queued from the /agents UI must not echo its result to Discord.
+
+    Someone driving the UI is already looking at the result, so the channel
+    post is noise. Only MCP-originated turns notify.
+    """
+    mcp._ui_originated.clear()
+    calls = _run_turn_capturing_notifies(monkeypatch, session, mark_ui=True)
+    assert calls == []
+
+
+def test_mcp_originated_turn_still_notifies_discord(monkeypatch, session):
+    """The unmarked path is the MCP path, and it must keep notifying."""
+    mcp._ui_originated.clear()
+    calls = _run_turn_capturing_notifies(monkeypatch, session, mark_ui=False)
+    assert len(calls) == 1
+
+
+def test_ui_mark_is_consumed_so_it_cannot_suppress_a_later_turn():
+    """The mark is one-shot, cleared at claim time.
+
+    If it survived the turn, a re-used (session, seq) pair would go on
+    suppressing notifies forever.
+    """
+    mcp._ui_originated.clear()
+    mcp._mark_ui_originated(7, 1)
+    assert mcp._consume_ui_originated(7, 1) is True
+    assert mcp._consume_ui_originated(7, 1) is False
+
+
+def test_unmarked_message_reads_as_not_ui_originated():
+    mcp._ui_originated.clear()
+    assert mcp._consume_ui_originated(99, 1) is False
+
+
+def test_ui_mark_store_is_bounded():
+    """Entries only clear when THIS replica claims the message, so a mark whose
+    message ran elsewhere leaks. The cap keeps that leak from growing without
+    bound; evicting the oldest fails open, which is the benign direction.
+    """
+    mcp._ui_originated.clear()
+    for seq in range(mcp._UI_ORIGINATED_CAP + 50):
+        mcp._mark_ui_originated(1, seq)
+    assert len(mcp._ui_originated) == mcp._UI_ORIGINATED_CAP
+    # The oldest went first, the newest survived.
+    assert mcp._consume_ui_originated(1, 0) is False
+    assert mcp._consume_ui_originated(1, mcp._UI_ORIGINATED_CAP + 49) is True
+    mcp._ui_originated.clear()

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -18,6 +18,7 @@ from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.mcp import (
     _clear_ember_bindings_for,
     _load_session_row,
+    _mark_ui_originated,
     _persist_pending_message,
     _persist_session,
     _schedule_next_message,
@@ -222,6 +223,8 @@ async def start_session(request: StartRequest) -> dict:
     turn = await asyncio.to_thread(
         _persist_pending_message, row.id, request.prompt, request.model
     )
+    # Queued from the UI, so its result does not get echoed to Discord.
+    _mark_ui_originated(row.id, turn)
     _schedule_next_message(row.id)
     return {"accepted": True, "session_id": row.id, "turn": turn}
 
@@ -344,6 +347,8 @@ async def send_message(session_id: int, request: MessageRequest) -> dict:
     turn = await asyncio.to_thread(
         _persist_pending_message, session_id, request.prompt, effective_model
     )
+    # Queued from the UI, so its result does not get echoed to Discord.
+    _mark_ui_originated(session_id, turn)
     await asyncio.to_thread(_set_session_status, session_id, "running")
     _schedule_next_message(session_id)
     return {"accepted": True, "session_id": session_id, "turn": turn}

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -415,3 +415,51 @@ def test_mcp_tools_still_work(session, monkeypatch):
     body = asyncio.run(mcp.monolith_agent_session_start("hello"))
     assert body["accepted"] is True
     assert body["turn"] == 1
+
+
+def test_start_session_marks_message_ui_originated(client, session, monkeypatch):
+    """A session started from the UI must not echo its turn to Discord."""
+    mcp._ui_originated.clear()
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_session",
+        lambda local, workspace, branch, model, repo: store.create_session(
+            session, local, workspace, branch, model, repo
+        ),
+    )
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_pending_message",
+        lambda session_id, prompt, model: (
+            store.create_pending_message(session, session_id, prompt, model).seq
+        ),
+    )
+    monkeypatch.setattr("agent_sessions.router._schedule_next_message", lambda _: None)
+
+    body = client.post("/api/agents/sessions", json={"prompt": "Hello"}).json()
+    assert mcp._consume_ui_originated(body["session_id"], body["turn"]) is True
+    mcp._ui_originated.clear()
+
+
+def test_send_message_marks_message_ui_originated(client, session, monkeypatch):
+    """A follow-up sent from the UI must not echo its turn to Discord."""
+    mcp._ui_originated.clear()
+    row = _session(session, "send-ui", status="completed")
+    monkeypatch.setattr("agent_sessions.router._load_session_row", lambda _: row)
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_pending_message",
+        lambda session_id, prompt, model: (
+            store.create_pending_message(session, session_id, prompt, model).seq
+        ),
+    )
+    monkeypatch.setattr(
+        "agent_sessions.router._set_session_status",
+        lambda session_id, status: store.update_session_status(
+            session, session_id, status
+        ),
+    )
+    monkeypatch.setattr("agent_sessions.router._schedule_next_message", lambda _: None)
+
+    body = client.post(
+        f"/api/agents/sessions/{row.id}/messages", json={"prompt": "follow up"}
+    ).json()
+    assert mcp._consume_ui_originated(row.id, body["turn"]) is True
+    mcp._ui_originated.clear()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.435
+version: 0.285.436
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.435
+      targetRevision: 0.285.436
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Two independent fixes to the agent plumbing, each carrying its chart bump.

## 1. Luna had no internet, and the recent egress work never reached it

`codex exec --sandbox workspace-write` denies network to model-generated shell
commands by default. Both dispatch paths passed that flag and never set the
network override:

- `bazel/tools/codex/dispatch.sh:77`
- `projects/embervm/runtimes/claude/shim.py:1136`

Confirmed from artifacts rather than from reading config. Every recorded Luna
rollout in `~/.codex/sessions/` carries
`"sandbox_policy":{"type":"workspace-write","network_access":false}` and
`"network":"restricted"`.

The recent EmberVM egress work (git proxy, egress forwarder, credential
injection) gave the *guest VM* a route out. That is a different gate from the
per-process sandbox running inside it, so it never reached the worker. The
failure is quiet because the sandbox governs model-run shell commands, not
codex's own API calls: turns connect, stream, and bill normally while every
`curl` or `pip install` dies at DNS resolution.

### This is the whole fix, on both paths

Open internet from the guest is already the intended posture, not something
this PR has to open up. `chart/values.yaml:1106` sets `external: allow` ("lets
the agent read the open internet") with `internal.default: deny` as the
separate split-horizon guardrail, and `shim.py:1022` already injects
`HTTPS_PROXY` into the codex process env. The sandbox was the only gate in the
way. Verified each link against the real CLI (rust-v0.146.0):

- sandbox permits the socket once `network_access=true`: `CODE=200` to an
  external host, where the default `workspace-write` could not resolve DNS
- arbitrary env passes through to sandboxed shell commands verbatim, so the
  guest's `HTTPS_PROXY` reaches `curl`/`git`/`pip` and not just the CLI
- egress-proxy classifies public destinations as external, which is `allow`

The credential boundary is untouched: `egressTo` still bounds injection to
`api.anthropic.com` and `chatgpt.com`, and `internal.default: deny` still
blocks cluster pivoting. Reaching the open internet and being handed a
credential remain separate things.

### The resume trap

The fix rides `--config`, not a flag, and sits outside the `if not session_id`
branch in the shim. `exec resume` rejects `--sandbox` on the pinned
rust-v0.146.0, so a flag-shaped fix would give turn one network and silently
drop it on every resumed turn. Verified:

```
codex exec        -c sandbox_workspace_write.network_access=true ... -> network access enabled, CODE=200
codex exec resume -c sandbox_workspace_write.network_access=true ... -> network access enabled, CODE=200
```

`shim_test.py` now asserts the config rides both the fresh and resume argv.

### Tradeoff

This gives up the sandbox-enforced "cannot push upstream" property on the local
dispatch path. That now rests on the spec guardrails the wrapper appends. The
header comment and the `codex-implement` skill both say so plainly rather than
claiming a network block that is no longer there.

## 2. UI-driven turns no longer echo to Discord

The `/agents` router and the MCP session tools feed one executor, which ends
every turn with `_notify_terminal`. Origin was not recorded, so clicking send
in the UI fired a Discord post at someone already watching the result.

UI-queued messages are now marked at the two router enqueue sites and skip the
notify. The mark is process-local rather than a column on `pending_messages`,
which keeps this migration free at the cost of being **best effort**: a message
the sweep hands to another replica, or one outliving a restart, loses its mark
and notifies anyway. That fails open, so the worst case is a stray post rather
than a missed one. Moving the flag onto the row is the upgrade path if strays
get annoying.

The store is capped and consumed at claim time rather than notify time, so it
clears on every early-return path instead of leaking on the ones that never
reach the notify. The two broker-login notifies are MCP tools already and are
unchanged.

## Verification

`ci test` green: `Executed 56 out of 752 tests: 752 tests pass`, so the new
tests genuinely ran rather than cache-hitting.

Charts bumped: monolith 0.285.436, monolith-public 0.89.361 (rides monolith's
image), embervm 0.1.405 for the guest shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDjrfDPyRJKZYAYyutgd7Y