### PR TITLE
feat(embervm): push mid-turn progress from the guest shim

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.405
+version: 0.1.406

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.405
+      targetRevision: 0.1.406
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -303,9 +303,10 @@ egress:
     # upload-pack plus receive-pack restricted to refs/agents/** by the mirror's
     # pre-receive hook; no credential exists on this path.
     # monolith.monolith.svc.cluster.local:8091
-    # Progress-ingest listener: write-only single-route for mid-turn visibility (ADR 051).
-    # Port 8091 only; the main API on 8000 stays deny. Token-bearer authorization boundaries
-    # what a prompt-injected guest can write to (its own session's partial_text), not network access.
+    # Monolith progress-ingest (8091): mid-turn visibility, write-only single route
+    # (ADR 051). Port 8091 only; the main API on 8000 stays deny. Token-bearer auth
+    # bounds what a prompt-injected guest can write to (its own session's
+    # partial_text), not network access.
     allowlist:
       - inference.inference.svc.cluster.local:8080
       - git-mirror.monolith.svc.cluster.local:9418

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -289,7 +289,7 @@ warmthS3Gc:
 egress:
   enabled: true
   internal:
-    # TWO deliberate holes in the split-horizon guardrail. Matching is an exact
+    # THREE deliberate holes in the split-horizon guardrail. Matching is an exact
     # case-insensitive host compare against BOTH the requested host:port and the
     # resolved ip:port, so a name and its address are both accepted and pinning
     # the resolved IP is what defeats SSRF-by-name and DNS rebinding. No
@@ -302,9 +302,14 @@ egress:
     # git-mirror: workspace hydration (ADR agents/050). Anonymous read-only
     # upload-pack plus receive-pack restricted to refs/agents/** by the mirror's
     # pre-receive hook; no credential exists on this path.
+    # monolith.monolith.svc.cluster.local:8091
+    # Progress-ingest listener: write-only single-route for mid-turn visibility (ADR 051).
+    # Port 8091 only; the main API on 8000 stays deny. Token-bearer authorization boundaries
+    # what a prompt-injected guest can write to (its own session's partial_text), not network access.
     allowlist:
       - inference.inference.svc.cluster.local:8080
       - git-mirror.monolith.svc.cluster.local:9418
+      - monolith.monolith.svc.cluster.local:8091
   # The claude runtime's subscription OAuth token. The sidecar SETS the
   # Authorization header on requests to api.anthropic.com and originates the
   # verified TLS to :443 itself, so the credential never exists inside a guest

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import threading
 import time
+import urllib.request
 
 
 GUEST_HTTP_PORT = 1027
@@ -607,6 +608,57 @@ class VsockEgressForwarder:
                     pass
 
 
+class _ProgressPusher:
+    """Fire-and-forget progress pusher: latest-text slot, throttled, exceptions swallowed."""
+
+    def __init__(self, progress_token):
+        self.progress_token = progress_token
+        self.latest_text = ""
+        self.last_push_time = 0
+        self.thread = None
+        self.stop_event = threading.Event()
+
+    def push(self, text):
+        """Update the latest text and trigger a push if throttle allows."""
+        self.latest_text = text
+        now = time.time()
+        if now - self.last_push_time >= 1.0:
+            self.last_push_time = now
+            if self.thread is None or not self.thread.is_alive():
+                self.thread = threading.Thread(target=self._do_push, daemon=True)
+                self.thread.start()
+
+    def _do_push(self):
+        """Push in a background thread; all exceptions swallowed."""
+        try:
+            egress_port = int(os.environ.get(EGRESS_PORT_ENV, str(DEFAULT_EGRESS_PORT)))
+            proxy_handler = urllib.request.ProxyHandler(
+                {"http": "http://%s:%s" % (EGRESS_LOCALHOST, egress_port)}
+            )
+            opener = urllib.request.build_opener(proxy_handler)
+            url = "http://monolith.monolith.svc.cluster.local:8091/ingest/progress"
+            data = json.dumps({"partial_text": self.latest_text}).encode("utf-8")
+            request = urllib.request.Request(
+                url,
+                data=data,
+                headers={
+                    "Authorization": "Bearer %s" % self.progress_token,
+                    "Content-Type": "application/json",
+                },
+                method="POST",
+            )
+            response = opener.open(request, timeout=2)
+            response.close()
+        except Exception:
+            # Fire-and-forget: all exceptions swallowed (decision 6, ADR 051).
+            pass
+
+    def stop(self):
+        """Drain and stop. Called at turn end."""
+        if self.thread and self.thread.is_alive():
+            self.thread.join(timeout=1)
+
+
 class ClaudeProcess:
     """Own the CLI and serialize turns sent through its JSONL stream."""
 
@@ -873,7 +925,13 @@ class ClaudeProcess:
         _managed_child_pids.discard(process.pid)
         _reap_orphans()
 
-    def turn(self, message, session_id=None, model=None):
+    def turn(
+        self,
+        message,
+        session_id=None,
+        model=None,
+        progress_token=None,
+    ):
         with self.turn_lock:
             with self.process_lock:
                 process = self.process
@@ -917,31 +975,47 @@ class ClaudeProcess:
                 process.stdin.write(_user_message_line(message))
                 process.stdin.flush()
             events = []
-            while True:
-                try:
-                    turn_read_timeout = TURN_READ_TIMEOUT
-                    raw = self._read_output(process, turn_read_timeout)
-                except TimeoutError:
-                    self._timeout_interrupt(process, turn_read_timeout, "turn output")
-                    raise RuntimeError(
-                        "timed out waiting for Claude output after %s seconds"
-                        % turn_read_timeout
-                    )
-                if raw is None:
-                    code = process.poll()
-                    self._close_process(kill=False)
-                    error_msg = "claude crashed during turn, exit code %s" % code
-                    raise RuntimeError(self._assemble_error_with_rings(error_msg))
-                event = self._parse_line(raw)
-                if event is None:
-                    continue
-                events.append(event)
-                if event.get("type") == "result":
-                    self.current_result = event
-                    record = dict(event)
-                    record["voice"] = voice_summary(event.get("result", ""))
-                    record["activity"] = activity_from_events(events)
-                    return record
+            accumulated_text = ""
+            pusher = _ProgressPusher(progress_token) if progress_token else None
+            try:
+                while True:
+                    try:
+                        turn_read_timeout = TURN_READ_TIMEOUT
+                        raw = self._read_output(process, turn_read_timeout)
+                    except TimeoutError:
+                        self._timeout_interrupt(
+                            process, turn_read_timeout, "turn output"
+                        )
+                        raise RuntimeError(
+                            "timed out waiting for Claude output after %s seconds"
+                            % turn_read_timeout
+                        )
+                    if raw is None:
+                        code = process.poll()
+                        self._close_process(kill=False)
+                        error_msg = "claude crashed during turn, exit code %s" % code
+                        raise RuntimeError(self._assemble_error_with_rings(error_msg))
+                    event = self._parse_line(raw)
+                    if event is None:
+                        continue
+                    events.append(event)
+                    if event.get("type") == "assistant":
+                        message_event = event.get("message", {})
+                        if message_event.get("role") == "assistant":
+                            for content_block in message_event.get("content", []):
+                                if content_block.get("type") == "text":
+                                    accumulated_text += content_block.get("text", "")
+                            if pusher:
+                                pusher.push(accumulated_text)
+                    if event.get("type") == "result":
+                        self.current_result = event
+                        record = dict(event)
+                        record["voice"] = voice_summary(event.get("result", ""))
+                        record["activity"] = activity_from_events(events)
+                        return record
+            finally:
+                if pusher:
+                    pusher.stop()
 
     def _timeout_interrupt(self, process, timeout, phase):
         sys.stderr.write(
@@ -1625,7 +1699,15 @@ class ProcessManager:
     def ready(self):
         return self.claude.ready() and self.codex.ready() and self.pi.ready()
 
-    def turn(self, message, session_id=None, model=None, repo=None, branch=None):
+    def turn(
+        self,
+        message,
+        session_id=None,
+        model=None,
+        repo=None,
+        branch=None,
+        progress_token=None,
+    ):
         if repo is not None and branch is not None:
             self._hydrate_workspace(repo, branch)
         adapter = self._adapter(model)
@@ -1635,7 +1717,12 @@ class ProcessManager:
             elif adapter is self.codex:
                 record = adapter.turn(message, session_id, model or DEFAULT_CODEX_MODEL)
             else:
-                record = adapter.turn(message, session_id, model)
+                # Only the claude adapter pushes progress (codex and pi parse
+                # tool-use JSON, not stream-json with assistant messages), and
+                # the kwarg is forwarded only when set so plain turns keep the
+                # pre-progress arity.
+                extra = {"progress_token": progress_token} if progress_token else {}
+                record = adapter.turn(message, session_id, model, **extra)
             if repo is not None and isinstance(record, dict):
                 if self._hydration_error:
                     record["workspace_hydration"] = {"failed": self._hydration_error}
@@ -1739,10 +1826,20 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
         ):
             self._send(400, {"error": "repo and branch must be non-empty strings"})
             return
+        progress_token = payload.get("progress_token")
+        if progress_token is not None and (
+            not isinstance(progress_token, str) or not progress_token.strip()
+        ):
+            self._send(400, {"error": "progress_token must be a non-empty string"})
+            return
         try:
             hydration = {"repo": repo, "branch": branch} if repo is not None else {}
+            progress = {"progress_token": progress_token} if progress_token else {}
             record = self.manager.turn(
-                message, payload.get("session_id"), payload.get("model"), **hydration
+                message,
+                payload.get("session_id"),
+                payload.get("model"),
+                **(hydration | progress),
             )
             if repo is not None and isinstance(record, dict):
                 if getattr(self.manager, "_hydration_error", None):

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -614,19 +614,26 @@ class _ProgressPusher:
     def __init__(self, progress_token):
         self.progress_token = progress_token
         self.latest_text = ""
-        self.last_push_time = 0
+        self.last_push_time = -1.0
         self.thread = None
-        self.stop_event = threading.Event()
 
     def push(self, text):
         """Update the latest text and trigger a push if throttle allows."""
-        self.latest_text = text
-        now = time.time()
-        if now - self.last_push_time >= 1.0:
-            self.last_push_time = now
-            if self.thread is None or not self.thread.is_alive():
-                self.thread = threading.Thread(target=self._do_push, daemon=True)
-                self.thread.start()
+        try:
+            self.latest_text = text
+            now = time.monotonic()
+            if now - self.last_push_time >= 1.0:  # At most 1 push/sec
+                self.last_push_time = now
+                if self.thread is None or not self.thread.is_alive():
+                    self.thread = threading.Thread(
+                        target=self._do_push,
+                        daemon=True,
+                    )
+                    self.thread.start()
+        except Exception:
+            # Fire-and-forget: even thread startup failures never fail the turn
+            # (ADR 051 decision 6).
+            pass
 
     def _do_push(self):
         """Push in a background thread; all exceptions swallowed."""
@@ -637,7 +644,12 @@ class _ProgressPusher:
             )
             opener = urllib.request.build_opener(proxy_handler)
             url = "http://monolith.monolith.svc.cluster.local:8091/ingest/progress"
-            data = json.dumps({"partial_text": self.latest_text}).encode("utf-8")
+            text = (
+                self.latest_text[-65536:]
+                if len(self.latest_text) > 65536
+                else self.latest_text
+            )
+            data = json.dumps({"partial_text": text}).encode("utf-8")
             request = urllib.request.Request(
                 url,
                 data=data,
@@ -654,9 +666,9 @@ class _ProgressPusher:
             pass
 
     def stop(self):
-        """Drain and stop. Called at turn end."""
+        """Drain and stop. Waits up to 3 seconds for in-flight push to complete."""
         if self.thread and self.thread.is_alive():
-            self.thread.join(timeout=1)
+            self.thread.join(timeout=3.0)
 
 
 class ClaudeProcess:
@@ -1000,11 +1012,21 @@ class ClaudeProcess:
                         continue
                     events.append(event)
                     if event.get("type") == "assistant":
-                        message_event = event.get("message", {})
-                        if message_event.get("role") == "assistant":
-                            for content_block in message_event.get("content", []):
-                                if content_block.get("type") == "text":
-                                    accumulated_text += content_block.get("text", "")
+                        message_event = event.get("message")
+                        if (
+                            isinstance(message_event, dict)
+                            and message_event.get("role") == "assistant"
+                        ):
+                            content = message_event.get("content")
+                            if isinstance(content, list):
+                                for block in content:
+                                    if (
+                                        isinstance(block, dict)
+                                        and block.get("type") == "text"
+                                    ):
+                                        text = block.get("text")
+                                        if isinstance(text, str):
+                                            accumulated_text += text
                             if pusher:
                                 pusher.push(accumulated_text)
                     if event.get("type") == "result":
@@ -1834,7 +1856,9 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
             return
         try:
             hydration = {"repo": repo, "branch": branch} if repo is not None else {}
-            progress = {"progress_token": progress_token} if progress_token else {}
+            progress = (
+                {"progress_token": progress_token.strip()} if progress_token else {}
+            )
             record = self.manager.turn(
                 message,
                 payload.get("session_id"),

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -3,6 +3,7 @@
 import json
 import ast
 import datetime
+import io
 import os
 import signal
 import socket
@@ -62,7 +63,8 @@ for line in sys.stdin:
             "reason": "requires_approval"
         }]
         terminal_reason = "completed"
-    print(json.dumps({"type": "assistant", "message": {"content": [
+    print(json.dumps({"type": "assistant", "message": {"role": "assistant", "content": [
+        {"type": "text", "text": "Assistant progress."},
         {"type": "tool_use", "name": "Read", "input": {"file_path": "a.txt"}},
         {"type": "tool_use", "name": "Edit", "input": {"file_path": "b.txt"}},
         {"type": "tool_use", "name": "Write", "input": {"file_path": "c.txt"}},
@@ -647,6 +649,135 @@ def test_turn_extracts_voice_activity_and_tolerates_malformed_json(
     ]
     assert manager.ready()
     manager._close_process(kill=True)
+
+
+def test_assistant_message_triggers_progress_push(tmp_path, monkeypatch):
+    requests = []
+
+    class _Response:
+        def close(self):
+            pass
+
+    class _Opener:
+        def open(self, request, timeout):
+            requests.append((request, timeout))
+            return _Response()
+
+    monkeypatch.setattr(shim.urllib.request, "build_opener", lambda _handler: _Opener())
+    manager = _manager(tmp_path, monkeypatch)
+    manager.turn("make changes", progress_token="abc123")
+    manager._close_process(kill=True)
+
+    assert len(requests) == 1
+    request, timeout = requests[0]
+    assert request.full_url == (
+        "http://monolith.monolith.svc.cluster.local:8091/ingest/progress"
+    )
+    assert request.method == "POST"
+    assert request.get_header("Authorization") == "Bearer abc123"
+    assert json.loads(request.data) == {"partial_text": "Assistant progress."}
+    assert timeout == 2
+
+
+def test_no_progress_push_without_token(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        shim.urllib.request,
+        "build_opener",
+        lambda _handler: pytest.fail("progress push should be disabled"),
+    )
+    manager = _manager(tmp_path, monkeypatch)
+    manager.turn("make changes")
+    manager._close_process(kill=True)
+
+
+def test_progress_pusher_uses_egress_proxy_and_swallows_errors(monkeypatch):
+    handlers = []
+
+    def proxy_handler(proxies):
+        handlers.append(proxies)
+        return object()
+
+    class _Opener:
+        def open(self, _request, timeout):
+            assert timeout == 2
+            raise ConnectionRefusedError("egress unavailable")
+
+    monkeypatch.setattr(shim.urllib.request, "ProxyHandler", proxy_handler)
+    monkeypatch.setattr(shim.urllib.request, "build_opener", lambda _handler: _Opener())
+    pusher = shim._ProgressPusher("abc123")
+    pusher.push("text")
+    pusher.stop()
+    assert handlers == [
+        {"http": "http://%s:%s" % (shim.EGRESS_LOCALHOST, shim.DEFAULT_EGRESS_PORT)}
+    ]
+
+
+def test_progress_pusher_collapses_rapid_events_to_latest():
+    started = threading.Event()
+    release = threading.Event()
+    pushed = []
+    pusher = shim._ProgressPusher("abc123")
+
+    def delayed_push():
+        started.set()
+        release.wait(timeout=1)
+        pushed.append(pusher.latest_text)
+
+    pusher._do_push = delayed_push
+    pusher.push("first")
+    assert started.wait(timeout=1)
+    pusher.push("second")
+    release.set()
+    pusher.stop()
+
+    assert pushed == ["second"]
+
+
+def test_progress_token_validation_and_threading():
+    class _Headers:
+        def __init__(self, length):
+            self.length = length
+
+        def get(self, name, default=None):
+            return str(self.length) if name == "Content-Length" else default
+
+    class _Manager:
+        def __init__(self):
+            self.calls = []
+
+        def turn(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return {"result": "ok"}
+
+    def post(payload, manager):
+        handler = object.__new__(shim.RequestHandler)
+        raw = json.dumps(payload).encode("utf-8")
+        handler.path = shim.TURN_PATH
+        handler.headers = _Headers(len(raw))
+        handler.rfile = io.BytesIO(raw)
+        responses = []
+        handler._send = lambda status, value: responses.append((status, value))
+        handler.manager = manager
+        shim.RequestHandler.do_POST(handler)
+        return responses
+
+    manager = _Manager()
+    assert post({"message": "hello", "progress_token": "abc123"}, manager) == [
+        (200, {"result": "ok"})
+    ]
+    assert manager.calls[0][1] == {"progress_token": "abc123"}
+
+    manager = _Manager()
+    assert post({"message": "hello"}, manager) == [(200, {"result": "ok"})]
+    assert manager.calls[0][1] == {}
+
+    for token in ("", 123):
+        manager = _Manager()
+        responses = post({"message": "hello", "progress_token": token}, manager)
+        assert responses == [
+            (400, {"error": "progress_token must be a non-empty string"})
+        ]
+        assert manager.calls == []
 
 
 def test_claude_model_argv_and_mid_session_switch_resumes(tmp_path, monkeypatch):

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -54,6 +54,28 @@ for line in sys.stdin:
         result = "First sentence. Second sentence."
     else:
         result = "Done <voice>Changed the files and need review.</voice>"
+    if os.environ.get("FAKE_MALFORMED"):
+        malformed = [
+            {"type": "assistant", "message": None},
+            {"type": "assistant", "message": "not an object"},
+            {
+                "type": "assistant",
+                "message": {"role": "assistant", "content": None},
+            },
+            {
+                "type": "assistant",
+                "message": {"role": "assistant", "content": "text"},
+            },
+            {
+                "type": "assistant",
+                "message": {"role": "assistant", "content": [None]},
+            },
+            {"type": "assistant", "message": {"role": "assistant", "content": [
+                {"type": "text", "text": None}
+            ]}},
+        ]
+        for event in malformed:
+            print(json.dumps(event), flush=True)
     permission_denials = []
     terminal_reason = "end_turn"
     if text == "permission denied":
@@ -679,6 +701,15 @@ def test_assistant_message_triggers_progress_push(tmp_path, monkeypatch):
     assert timeout == 2
 
 
+def test_malformed_assistant_events_are_skipped(tmp_path, monkeypatch):
+    """Malformed assistant shapes do not abort the turn or poison the stream."""
+    monkeypatch.setenv("FAKE_MALFORMED", "1")
+    manager = _manager(tmp_path, monkeypatch)
+    record = manager.turn("make changes", progress_token="abc123")
+    assert record["terminal_reason"] == "end_turn"
+    manager._close_process(kill=True)
+
+
 def test_no_progress_push_without_token(tmp_path, monkeypatch):
     monkeypatch.setattr(
         shim.urllib.request,
@@ -733,7 +764,7 @@ def test_progress_pusher_collapses_rapid_events_to_latest():
     assert pushed == ["second"]
 
 
-def test_progress_token_validation_and_threading():
+def test_progress_token_validation():
     class _Headers:
         def __init__(self, length):
             self.length = length
@@ -762,7 +793,7 @@ def test_progress_token_validation_and_threading():
         return responses
 
     manager = _Manager()
-    assert post({"message": "hello", "progress_token": "abc123"}, manager) == [
+    assert post({"message": "hello", "progress_token": "  abc123  "}, manager) == [
         (200, {"result": "ok"})
     ]
     assert manager.calls[0][1] == {"progress_token": "abc123"}
@@ -778,6 +809,177 @@ def test_progress_token_validation_and_threading():
             (400, {"error": "progress_token must be a non-empty string"})
         ]
         assert manager.calls == []
+
+
+def test_progress_token_forwarded_to_claude_adapter(monkeypatch):
+    """ProcessManager.turn forwards progress_token only when supplied."""
+    manager = object.__new__(shim.ProcessManager)
+    manager._hydration_error = None
+    manager._hydration_status = None
+    monkeypatch.setattr(shim, "_sync_session_volume", lambda: None)
+    calls = []
+
+    class FakeAdapter:
+        def turn(self, *args, **kwargs):
+            calls.append((args, kwargs))
+            return {"result": "ok"}
+
+    manager.claude = FakeAdapter()
+    manager.codex = FakeAdapter()
+    manager.pi = FakeAdapter()
+
+    manager.turn("msg", session_id="s1", model=None, progress_token="token123")
+    assert len(calls) == 1
+    assert calls[0][1].get("progress_token") == "token123"
+
+    calls.clear()
+    manager.turn("msg", session_id="s1", model=None)
+    assert len(calls) == 1
+    assert "progress_token" not in calls[0][1]
+
+
+def test_throttle_allows_push_after_1_second(monkeypatch):
+    """After 1+ second, the next push fires."""
+    current_time = [0.0]
+    monkeypatch.setattr(shim.time, "monotonic", lambda: current_time[0])
+    requests = []
+
+    def fake_opener_open(request, timeout):
+        requests.append(request)
+
+        class FakeResp:
+            def close(self):
+                pass
+
+        return FakeResp()
+
+    class FakeOpener:
+        open = staticmethod(fake_opener_open)
+
+    monkeypatch.setattr(
+        shim.urllib.request, "build_opener", lambda _handler: FakeOpener()
+    )
+    pusher = shim._ProgressPusher("token")
+    pusher.push("text1")
+    pusher.stop()
+    assert len(requests) == 1
+
+    current_time[0] = 1.1
+    pusher.push("text2")
+    pusher.stop()
+    assert len(requests) == 2
+
+
+def test_throttle_blocks_push_within_1_second(monkeypatch):
+    """Within 1 second of the last push, the next push does not fire."""
+    current_time = [0.0]
+    monkeypatch.setattr(shim.time, "monotonic", lambda: current_time[0])
+    requests = []
+
+    def fake_opener_open(request, timeout):
+        requests.append(request)
+
+        class FakeResp:
+            def close(self):
+                pass
+
+        return FakeResp()
+
+    class FakeOpener:
+        open = staticmethod(fake_opener_open)
+
+    monkeypatch.setattr(
+        shim.urllib.request, "build_opener", lambda _handler: FakeOpener()
+    )
+    pusher = shim._ProgressPusher("token")
+    pusher.push("text1")
+    pusher.stop()
+    assert len(requests) == 1
+
+    current_time[0] = 0.2
+    pusher.push("text2")
+    pusher.stop()
+    assert len(requests) == 1
+
+
+def test_push_thread_creation_failure_swallowed(monkeypatch):
+    """Thread startup failure is swallowed; the turn can continue."""
+
+    def fake_thread_init(*args, **kwargs):
+        raise RuntimeError("thread creation failed")
+
+    monkeypatch.setattr(shim.threading, "Thread", fake_thread_init)
+    shim._ProgressPusher("token").push("text")
+
+
+def test_large_accumulation_capped_to_tail(monkeypatch):
+    """Text larger than 65536 bytes is capped to its tail in the payload."""
+    captured_payloads = []
+
+    def fake_opener_open(request, timeout):
+        captured_payloads.append(request.data)
+
+        class FakeResp:
+            def close(self):
+                pass
+
+        return FakeResp()
+
+    class FakeOpener:
+        open = staticmethod(fake_opener_open)
+
+    monkeypatch.setattr(
+        shim.urllib.request, "build_opener", lambda _handler: FakeOpener()
+    )
+    pusher = shim._ProgressPusher("token")
+    large_text = "x" * 100000
+    pusher.push(large_text)
+    pusher.stop()
+
+    assert len(captured_payloads) == 1
+    payload = json.loads(captured_payloads[0].decode())
+    assert payload["partial_text"] == large_text[-65536:]
+    assert len(payload["partial_text"]) == 65536
+
+
+def test_accumulation_order_preserves_assistant_text(monkeypatch):
+    """Sequential pushes preserve the accumulated assistant text order."""
+    current_time = [0.0]
+    monkeypatch.setattr(shim.time, "monotonic", lambda: current_time[0])
+    payloads = []
+
+    def fake_opener_open(request, timeout):
+        payloads.append(json.loads(request.data.decode())["partial_text"])
+
+        class FakeResp:
+            def close(self):
+                pass
+
+        return FakeResp()
+
+    class FakeOpener:
+        open = staticmethod(fake_opener_open)
+
+    class ImmediateThread:
+        def __init__(self, target, daemon):
+            self.target = target
+
+        def is_alive(self):
+            return False
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(
+        shim.urllib.request, "build_opener", lambda _handler: FakeOpener()
+    )
+    monkeypatch.setattr(shim.threading, "Thread", ImmediateThread)
+    pusher = shim._ProgressPusher("token")
+    for text in ("block1", "block1block2", "block1block2block3"):
+        pusher.push(text)
+        current_time[0] += 1.0
+
+    assert payloads == ["block1", "block1block2", "block1block2block3"]
 
 
 def test_claude_model_argv_and_mid_session_switch_resumes(tmp_path, monkeypatch):


### PR DESCRIPTION
EmberVM half of ADR agents/051 (#4346), under #4330. Pairs with #4348 (the ingest listener; safe in either merge order since pushes to a missing listener are swallowed by design).

- The shim parses an optional progress_token from the turn payload and, during claude turns, pushes accumulated assistant text after each assistant event: latest-text slot, single background thread, one push per second, 2s timeout, every exception swallowed. A down listener degrades to turn-end-only output and can never stall a turn (ADR 051 decision 6).
- The POST rides the local egress forwarder as an absolute-URI HTTP proxy request, the same lane the git clone uses.
- The egress allowlist gains its third entry, monolith.monolith.svc.cluster.local:8091: port 8091 only, the main API on 8000 stays deny, the per-session token is the write boundary.
- Codex and pi adapters are out of scope; the progress kwarg forwards to the claude adapter only when set, preserving plain-turn arity (a review-class regression caught and fixed pre-push; local suites 78 passed with only the known macOS codex timing flake).

Chart: embervm bumped (guest image change; bricks rebuild bases on the roll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)