### PR TITLE
feat(embervm): token-delta streaming at 200ms and codex full-access sandbox

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.406
+version: 0.1.407

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.406
+      targetRevision: 0.1.407
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -614,15 +614,19 @@ class _ProgressPusher:
     def __init__(self, progress_token):
         self.progress_token = progress_token
         self.latest_text = ""
+        self.latest_activities = []
         self.last_push_time = -1.0
         self.thread = None
+        self.last_sent_text = ""
+        self.last_sent_activities = []
 
-    def push(self, text):
-        """Update the latest text and trigger a push if throttle allows."""
+    def push(self, text, activities=None):
+        """Update the latest slot and trigger a push if throttle allows."""
         try:
             self.latest_text = text
+            self.latest_activities = activities if activities is not None else []
             now = time.monotonic()
-            if now - self.last_push_time >= 1.0:  # At most 1 push/sec
+            if now - self.last_push_time >= 0.2:
                 self.last_push_time = now
                 if self.thread is None or not self.thread.is_alive():
                     self.thread = threading.Thread(
@@ -636,7 +640,7 @@ class _ProgressPusher:
             pass
 
     def _do_push(self):
-        """Push in a background thread; all exceptions swallowed."""
+        """Push in a background thread and drain changes made during the push."""
         try:
             egress_port = int(os.environ.get(EGRESS_PORT_ENV, str(DEFAULT_EGRESS_PORT)))
             proxy_handler = urllib.request.ProxyHandler(
@@ -644,12 +648,12 @@ class _ProgressPusher:
             )
             opener = urllib.request.build_opener(proxy_handler)
             url = "http://monolith.monolith.svc.cluster.local:8091/ingest/progress"
-            text = (
-                self.latest_text[-65536:]
-                if len(self.latest_text) > 65536
-                else self.latest_text
-            )
-            data = json.dumps({"partial_text": text}).encode("utf-8")
+            sent_text = self.latest_text
+            sent_activities = list(self.latest_activities)
+            text = sent_text[-65536:] if len(sent_text) > 65536 else sent_text
+            data = json.dumps(
+                {"partial_text": text, "activities": sent_activities}
+            ).encode("utf-8")
             request = urllib.request.Request(
                 url,
                 data=data,
@@ -661,6 +665,18 @@ class _ProgressPusher:
             )
             response = opener.open(request, timeout=2)
             response.close()
+            self.last_sent_text = sent_text
+            self.last_sent_activities = sent_activities
+            if (
+                self.latest_text != self.last_sent_text
+                or self.latest_activities != self.last_sent_activities
+            ):
+                self.last_push_time = 0.0
+                self.thread = threading.Thread(
+                    target=self._do_push,
+                    daemon=True,
+                )
+                self.thread.start()
         except Exception:
             # Fire-and-forget: all exceptions swallowed (decision 6, ADR 051).
             pass
@@ -743,6 +759,7 @@ class ClaudeProcess:
             "--permission-mode",
             permission_mode,
         ]
+        command.extend(["--include-partial-messages"])
         if model is not None:
             command.extend(["--model", CLAUDE_MODELS.get(model, model)])
         if session_id:
@@ -988,6 +1005,7 @@ class ClaudeProcess:
                 process.stdin.flush()
             events = []
             accumulated_text = ""
+            current_message_buffer = ""
             pusher = _ProgressPusher(progress_token) if progress_token else None
             try:
                 while True:
@@ -1011,7 +1029,27 @@ class ClaudeProcess:
                     if event is None:
                         continue
                     events.append(event)
-                    if event.get("type") == "assistant":
+                    if event.get("type") == "stream_event":
+                        stream_event = event.get("event")
+                        delta = (
+                            stream_event.get("delta")
+                            if isinstance(stream_event, dict)
+                            and stream_event.get("type") == "content_block_delta"
+                            else None
+                        )
+                        if (
+                            isinstance(delta, dict)
+                            and delta.get("type") == "text_delta"
+                        ):
+                            text = delta.get("text", "")
+                            if isinstance(text, str):
+                                current_message_buffer += text
+                                if pusher:
+                                    pusher.push(
+                                        accumulated_text + current_message_buffer,
+                                        activity_from_events(events)[-300:],
+                                    )
+                    elif event.get("type") == "assistant":
                         message_event = event.get("message")
                         if (
                             isinstance(message_event, dict)
@@ -1027,9 +1065,18 @@ class ClaudeProcess:
                                         text = block.get("text")
                                         if isinstance(text, str):
                                             accumulated_text += text
+                            current_message_buffer = ""
                             if pusher:
-                                pusher.push(accumulated_text)
+                                pusher.push(
+                                    accumulated_text + current_message_buffer,
+                                    activity_from_events(events)[-300:],
+                                )
                     if event.get("type") == "result":
+                        if pusher:
+                            pusher.push(
+                                accumulated_text + current_message_buffer,
+                                activity_from_events(events)[-300:],
+                            )
                         self.current_result = event
                         record = dict(event)
                         record["voice"] = voice_summary(event.get("result", ""))
@@ -1199,6 +1246,10 @@ chatgpt_base_url = %s
 name = "ember-openai"
 base_url = %s
 wire_api = "responses"
+
+[sandboxing]
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
 """ % (json.dumps(base_url), json.dumps(provider_base_url))
         with open(os.path.join(codex_home, "config.toml"), "w") as stream:
             stream.write(config)

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -10,6 +10,7 @@ import os
 import queue
 import re
 import signal
+import shutil
 import socket
 import subprocess
 import sys
@@ -650,10 +651,20 @@ class _ProgressPusher:
             url = "http://monolith.monolith.svc.cluster.local:8091/ingest/progress"
             sent_text = self.latest_text
             sent_activities = list(self.latest_activities)
-            text = sent_text[-65536:] if len(sent_text) > 65536 else sent_text
-            data = json.dumps(
-                {"partial_text": text, "activities": sent_activities}
-            ).encode("utf-8")
+            payload = {
+                "partial_text": sent_text[-65536:]
+                if len(sent_text) > 65536
+                else sent_text,
+                "activities": sent_activities,
+            }
+            data = json.dumps(payload).encode("utf-8")
+            while len(data) >= 262144 and (sent_activities or payload["partial_text"]):
+                if sent_activities:
+                    sent_activities.pop(0)
+                else:
+                    payload["partial_text"] = payload["partial_text"][1000:]
+                payload["activities"] = sent_activities
+                data = json.dumps(payload).encode("utf-8")
             request = urllib.request.Request(
                 url,
                 data=data,
@@ -671,7 +682,10 @@ class _ProgressPusher:
                 self.latest_text != self.last_sent_text
                 or self.latest_activities != self.last_sent_activities
             ):
-                self.last_push_time = 0.0
+                self.last_push_time = time.monotonic()
+                remaining = 0.2 - (time.monotonic() - self.last_push_time)
+                if remaining > 0:
+                    time.sleep(remaining)
                 self.thread = threading.Thread(
                     target=self._do_push,
                     daemon=True,
@@ -1006,6 +1020,8 @@ class ClaudeProcess:
             events = []
             accumulated_text = ""
             current_message_buffer = ""
+            cached_activities = []
+            activities_are_stale = True
             pusher = _ProgressPusher(progress_token) if progress_token else None
             try:
                 while True:
@@ -1047,7 +1063,7 @@ class ClaudeProcess:
                                 if pusher:
                                     pusher.push(
                                         accumulated_text + current_message_buffer,
-                                        activity_from_events(events)[-300:],
+                                        cached_activities,
                                     )
                     elif event.get("type") == "assistant":
                         message_event = event.get("message")
@@ -1066,16 +1082,22 @@ class ClaudeProcess:
                                         if isinstance(text, str):
                                             accumulated_text += text
                             current_message_buffer = ""
-                            if pusher:
-                                pusher.push(
-                                    accumulated_text + current_message_buffer,
-                                    activity_from_events(events)[-300:],
-                                )
+                            activities_are_stale = True
+                    elif event.get("type") == "tool_execution_start":
+                        activities_are_stale = True
+                    if activities_are_stale:
+                        cached_activities = activity_from_events(events)[-300:]
+                        activities_are_stale = False
+                    if event.get("type") == "assistant" and pusher:
+                        pusher.push(
+                            accumulated_text + current_message_buffer,
+                            cached_activities,
+                        )
                     if event.get("type") == "result":
                         if pusher:
                             pusher.push(
                                 accumulated_text + current_message_buffer,
-                                activity_from_events(events)[-300:],
+                                cached_activities,
                             )
                         self.current_result = event
                         record = dict(event)
@@ -1241,15 +1263,13 @@ class CodexProcess:
         config = """model_provider = "ember-openai"
 enable_codex_api_key_env = false
 chatgpt_base_url = %s
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
 
 [model_providers.ember-openai]
 name = "ember-openai"
 base_url = %s
 wire_api = "responses"
-
-[sandboxing]
-sandbox_mode = "danger-full-access"
-approval_policy = "never"
 """ % (json.dumps(base_url), json.dumps(provider_base_url))
         with open(os.path.join(codex_home, "config.toml"), "w") as stream:
             stream.write(config)
@@ -1272,15 +1292,17 @@ approval_policy = "never"
                 model_name,
                 "--config",
                 "model_reasoning_effort=%s" % effort,
-                # Network must ride --config, not a flag, and must sit OUTSIDE
-                # the `if not session_id` block below. workspace-write denies
-                # network by default, and resume rejects --sandbox, so a
-                # flag-shaped fix would give the first turn of a session
-                # network and silently drop it on every resumed turn. Verified
-                # against rust-v0.146.0: a resume carrying only this --config
-                # reports "workspace-write (network access enabled)".
+                # The microVM is the security boundary (not the CLI's sandbox).
+                # Fresh guest execs use --sandbox workspace-write for network
+                # isolation; resumed turns skip it. Config layering:
+                # --config sandbox_mode=danger-full-access beats --sandbox, so
+                # all turns run full access. network_access=true is now
+                # redundant under danger-full-access but kept against a future
+                # revert.
                 "--config",
                 "sandbox_workspace_write.network_access=true",
+                "--config",
+                "sandbox_mode=danger-full-access",
             ]
         )
         command.append("--skip-git-repo-check")
@@ -1700,58 +1722,86 @@ class ProcessManager:
         # This deliberately ignores repo/branch changes on restored volumes; per-session
         # volumes make that unreachable in practice (repo fixed at session create).
         if os.path.isdir(checkout_dir):
-            self._checkout_dir = checkout_dir
-            self._hydration_status = "skipped_existing"
-            # Resume slugs are safe: session cwd never changes mid-lineage (repo fixed at create).
-            self.claude.workspace = checkout_dir
-            self.codex.workspace = checkout_dir
-            self.pi.workspace = checkout_dir
-            return
-        try:
-            os.makedirs(self.workspace, exist_ok=True)
-            clone_command = [
-                "git",
-                "-c",
-                "core.gitProxy=%s" % GIT_PROXY_PATH,
-                "clone",
-                "--branch",
-                branch,
-                "--single-branch",
-                "--filter=blob:none",
-                "git://git-mirror.monolith.svc.cluster.local:9418/%s" % repo,
-                checkout_dir,
-            ]
-            result = subprocess.run(
-                clone_command,
-                capture_output=True,
-                timeout=120,
-                **_cli_privilege_kwargs(),
-            )
-            if result.returncode != 0:
-                stderr = result.stderr
-                if isinstance(stderr, bytes):
-                    stderr = stderr.decode("utf-8", "replace")
-                stderr = (stderr or "").strip()
-                raise RuntimeError(
-                    "git command failed with exit code %s%s"
-                    % (result.returncode, ": " + stderr if stderr else "")
+            try:
+                validation = subprocess.run(
+                    ["git", "-C", checkout_dir, "rev-parse", "--verify", "HEAD"],
+                    capture_output=True,
+                    timeout=5,
+                    **_cli_privilege_kwargs(),
                 )
-        except subprocess.TimeoutExpired as exc:
-            self._hydration_error = str(exc)
-            sys.stderr.write(
-                "ember-claude-shim: workspace hydration failed for %s@%s: %s\n"
-                % (repo, branch, exc)
-            )
-            sys.stderr.flush()
-            return
-        except Exception as exc:
-            self._hydration_error = str(exc)
-            sys.stderr.write(
-                "ember-claude-shim: workspace hydration failed for %s@%s: %s\n"
-                % (repo, branch, exc)
-            )
-            sys.stderr.flush()
-            return
+                if validation.returncode == 0:
+                    self._checkout_dir = checkout_dir
+                    self._hydration_status = "skipped_existing"
+                    # Resume slugs are safe: session cwd never changes mid-lineage (repo fixed at create).
+                    self.claude.workspace = checkout_dir
+                    self.codex.workspace = checkout_dir
+                    self.pi.workspace = checkout_dir
+                    return
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+            # A durable volume can contain a partial clone from a prior failure.
+            shutil.rmtree(checkout_dir, ignore_errors=True)
+        os.makedirs(self.workspace, exist_ok=True)
+        clone_command = [
+            "git",
+            "clone",
+            "--branch",
+            branch,
+            "--config",
+            "core.gitProxy=%s" % GIT_PROXY_PATH,
+            "--single-branch",
+            "--filter=blob:none",
+            "git://git-mirror.monolith.svc.cluster.local:9418/%s" % repo,
+            checkout_dir,
+        ]
+        for attempt in range(2):
+            try:
+                result = subprocess.run(
+                    clone_command,
+                    capture_output=True,
+                    timeout=120,
+                    **_cli_privilege_kwargs(),
+                )
+                if result.returncode != 0:
+                    stderr = result.stderr
+                    if isinstance(stderr, bytes):
+                        stderr = stderr.decode("utf-8", "replace")
+                    stderr = (stderr or "").strip()
+                    raise RuntimeError(
+                        "git command failed with exit code %s%s"
+                        % (result.returncode, ": " + stderr if stderr else "")
+                    )
+                validation = subprocess.run(
+                    ["git", "-C", checkout_dir, "rev-parse", "--verify", "HEAD"],
+                    capture_output=True,
+                    timeout=5,
+                    **_cli_privilege_kwargs(),
+                )
+                if validation.returncode == 0:
+                    break
+                shutil.rmtree(checkout_dir, ignore_errors=True)
+                if attempt == 1:
+                    raise RuntimeError(
+                        "cloned directory validation failed: HEAD not found"
+                    )
+            except subprocess.TimeoutExpired as exc:
+                shutil.rmtree(checkout_dir, ignore_errors=True)
+                self._hydration_error = str(exc)
+                sys.stderr.write(
+                    "ember-claude-shim: workspace hydration failed for %s@%s: %s\n"
+                    % (repo, branch, exc)
+                )
+                sys.stderr.flush()
+                return
+            except Exception as exc:
+                shutil.rmtree(checkout_dir, ignore_errors=True)
+                self._hydration_error = str(exc)
+                sys.stderr.write(
+                    "ember-claude-shim: workspace hydration failed for %s@%s: %s\n"
+                    % (repo, branch, exc)
+                )
+                sys.stderr.flush()
+                return
         exclude_file = os.path.join(checkout_dir, ".git/info/exclude")
         os.makedirs(os.path.dirname(exclude_file), exist_ok=True)
         with open(exclude_file, "a") as stream:

--- a/projects/embervm/runtimes/claude/shim_hydration_test.py
+++ b/projects/embervm/runtimes/claude/shim_hydration_test.py
@@ -98,11 +98,12 @@ class _GitProcess:
 
 
 def test_hydration_runs_once_per_session(manager, monkeypatch):
-    processes = [_GitProcess()]
+    processes = [_GitProcess(), _GitProcess()]
     commands = []
 
     def fake_run(command, **_kwargs):
-        commands.append(command)
+        if command[1] == "clone":
+            commands.append(command)
         return processes.pop(0)
 
     monkeypatch.setattr(shim.subprocess, "run", fake_run)
@@ -116,9 +117,8 @@ def test_hydration_runs_once_per_session(manager, monkeypatch):
 def test_hydration_skips_on_restored_volume(manager, monkeypatch):
     checkout_dir = os.path.join(manager.workspace, "src")
     os.makedirs(checkout_dir)
-    monkeypatch.setattr(
-        shim.subprocess, "run", lambda *_a, **_k: pytest.fail("git called")
-    )
+    validation = _GitProcess()
+    monkeypatch.setattr(shim.subprocess, "run", lambda *_a, **_k: validation)
 
     manager.turn("first", repo="owner/repo", branch="main")
 
@@ -153,11 +153,12 @@ def test_hydration_timeout(manager, monkeypatch, capsys):
 
 
 def test_git_command_shape(manager, monkeypatch):
-    processes = [_GitProcess()]
+    processes = [_GitProcess(), _GitProcess()]
     commands = []
 
     def fake_run(command, **_kwargs):
-        commands.append(command)
+        if command[1] == "clone":
+            commands.append(command)
         return processes.pop(0)
 
     monkeypatch.setattr(shim.subprocess, "run", fake_run)
@@ -167,11 +168,11 @@ def test_git_command_shape(manager, monkeypatch):
     assert commands == [
         [
             "git",
-            "-c",
-            "core.gitProxy=/tmp/ember-git-proxy",
             "clone",
             "--branch",
             "main",
+            "--config",
+            "core.gitProxy=/tmp/ember-git-proxy",
             "--single-branch",
             "--filter=blob:none",
             "git://git-mirror.monolith.svc.cluster.local:9418/owner/repo",
@@ -204,11 +205,12 @@ def test_no_hydration_when_repo_absent(manager, monkeypatch):
 
 def test_hydration_works_for_non_default_branch(manager, monkeypatch):
     """Verify clone works for branches other than the mirror default."""
-    processes = [_GitProcess()]
+    processes = [_GitProcess(), _GitProcess()]
     commands = []
 
     def fake_run(command, **_kwargs):
-        commands.append(command)
+        if command[1] == "clone":
+            commands.append(command)
         return processes.pop(0)
 
     monkeypatch.setattr(shim.subprocess, "run", fake_run)
@@ -220,11 +222,11 @@ def test_hydration_works_for_non_default_branch(manager, monkeypatch):
     # Verify --branch is in command before clone executes checkout
     assert commands[0] == [
         "git",
-        "-c",
-        "core.gitProxy=/tmp/ember-git-proxy",
         "clone",
         "--branch",
         "develop",
+        "--config",
+        "core.gitProxy=/tmp/ember-git-proxy",
         "--single-branch",
         "--filter=blob:none",
         "git://git-mirror.monolith.svc.cluster.local:9418/owner/repo",
@@ -277,3 +279,36 @@ def test_hydration_status_surfaced_in_turn(manager, monkeypatch):
 
     record = manager.turn("msg3")
     assert "workspace_hydration" not in record
+
+
+def test_failed_clone_leaves_no_directory(manager, monkeypatch):
+    checkout_dir = os.path.join(manager.workspace, "src")
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "clone":
+            os.makedirs(checkout_dir, exist_ok=True)
+            return _GitProcess(returncode=1, stderr_text="clone failed")
+        pytest.fail("unexpected validation command")
+
+    monkeypatch.setattr(shim.subprocess, "run", fake_run)
+    manager.turn("first", repo="owner/repo", branch="main")
+    assert not os.path.exists(checkout_dir)
+
+
+def test_poisoned_directory_is_cleaned_and_recloned(manager, monkeypatch):
+    checkout_dir = os.path.join(manager.workspace, "src")
+    os.makedirs(checkout_dir)
+    calls = []
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        if command[1] == "clone":
+            os.makedirs(os.path.join(checkout_dir, ".git"), exist_ok=True)
+            return _GitProcess()
+        if command[1:3] == ["-C", checkout_dir]:
+            return _GitProcess(returncode=1 if len(calls) == 1 else 0)
+        pytest.fail("unexpected git command")
+
+    monkeypatch.setattr(shim.subprocess, "run", fake_run)
+    manager.turn("first", repo="owner/repo", branch="main")
+    assert [command[1] for command in calls] == ["-C", "clone", "-C"]

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -10,6 +10,11 @@ import socket
 import threading
 import time
 import subprocess
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 from http.client import HTTPConnection
 from http.server import ThreadingHTTPServer
 
@@ -434,15 +439,18 @@ def test_codex_config_uses_subscription_endpoint_override(tmp_path, monkeypatch)
     monkeypatch.setenv(shim.CODEX_SUBSCRIPTION_BASE_URL_ENV, endpoint)
     child_env = manager._child_env()
     manager._write_model_config(child_env["CODEX_HOME"])
-    config = (tmp_path / "workspace" / ".codex" / "config.toml").read_text()
-    assert 'base_url = "http://broker.test/backend-api/codex/"' in config
-    assert 'chatgpt_base_url = "%s"' % endpoint in config
-    assert "api.openai.com" not in config
-    assert 'name = "ember-openai"' in config
-    assert 'wire_api = "responses"' in config
-    assert "enable_codex_api_key_env = false" in config
-    assert 'sandbox_mode = "danger-full-access"' in config
-    assert 'approval_policy = "never"' in config
+    config = tomllib.loads(
+        (tmp_path / "workspace" / ".codex" / "config.toml").read_text()
+    )
+    assert (
+        config["model_providers"]["ember-openai"]["base_url"]
+        == "http://broker.test/backend-api/codex/"
+    )
+    assert config["chatgpt_base_url"] == endpoint
+    assert config["model_provider"] == "ember-openai"
+    assert config["sandbox_mode"] == "danger-full-access"
+    assert config["approval_policy"] == "never"
+    assert config["model_providers"]["ember-openai"]["wire_api"] == "responses"
 
 
 def test_codex_config_appends_codex_to_no_slash_endpoint(tmp_path, monkeypatch):
@@ -451,15 +459,16 @@ def test_codex_config_appends_codex_to_no_slash_endpoint(tmp_path, monkeypatch):
     monkeypatch.setenv(shim.CODEX_SUBSCRIPTION_BASE_URL_ENV, endpoint)
     child_env = manager._child_env()
     manager._write_model_config(child_env["CODEX_HOME"])
-    config = (tmp_path / "workspace" / ".codex" / "config.toml").read_text()
-    assert 'base_url = "http://broker.test/backend-api/codex/"' in config
-    assert 'chatgpt_base_url = "%s"' % endpoint in config
-    assert "api.openai.com" not in config
-    assert 'name = "ember-openai"' in config
-    assert 'wire_api = "responses"' in config
-    assert "enable_codex_api_key_env = false" in config
-    assert 'sandbox_mode = "danger-full-access"' in config
-    assert 'approval_policy = "never"' in config
+    config = tomllib.loads(
+        (tmp_path / "workspace" / ".codex" / "config.toml").read_text()
+    )
+    assert (
+        config["model_providers"]["ember-openai"]["base_url"]
+        == "http://broker.test/backend-api/codex/"
+    )
+    assert config["chatgpt_base_url"] == endpoint
+    assert config["sandbox_mode"] == "danger-full-access"
+    assert config["approval_policy"] == "never"
 
 
 def test_codex_child_env_drops_openai_api_key(tmp_path, monkeypatch):
@@ -492,6 +501,8 @@ def test_codex_resume_uses_positional_session_and_no_sandbox(tmp_path, monkeypat
     network = "sandbox_workspace_write.network_access=true"
     assert network in first
     assert network in resume
+    assert "sandbox_mode=danger-full-access" in first
+    assert "sandbox_mode=danger-full-access" in resume
     manager._close_process()
 
 
@@ -717,14 +728,14 @@ def test_assistant_message_triggers_progress_push(tmp_path, monkeypatch):
     )
     assert request.method == "POST"
     assert request.get_header("Authorization") == "Bearer abc123"
-    assert json.loads(request.data) == {
-        "partial_text": "Assistant progress.",
-        "activities": [
-            {"type": "tool_use", "name": "Read", "input": {"file_path": "a.txt"}},
-            {"type": "edit", "file_path": "b.txt"},
-            {"type": "write", "file_path": "c.txt"},
-            {"type": "bash", "command": "git status"},
-        ],
+    payload = json.loads(request.data)
+    assert payload["partial_text"] == "Assistant progress."
+    assert isinstance(payload["activities"], list)
+    assert len(payload["activities"]) == 4
+    assert payload["activities"][0] == {
+        "type": "tool_use",
+        "name": "Read",
+        "input": {"file_path": "a.txt"},
     }
     assert timeout == 2
 
@@ -965,8 +976,15 @@ def test_throttle_blocks_push_within_0_2_seconds(monkeypatch):
 
 
 def test_pusher_throttle_0_2_seconds_with_drain(monkeypatch):
-    """A slot change during a push is sent immediately as a drain push."""
+    """Drain re-fires after 0.2 seconds and sends the final slot state."""
     requests = []
+    current_time = [0.0]
+    monkeypatch.setattr(shim.time, "monotonic", lambda: current_time[0])
+    monkeypatch.setattr(
+        shim.time,
+        "sleep",
+        lambda duration: current_time.__setitem__(0, current_time[0] + duration),
+    )
     pusher = shim._ProgressPusher("token")
 
     class FakeResponse:
@@ -975,7 +993,9 @@ def test_pusher_throttle_0_2_seconds_with_drain(monkeypatch):
 
     class FakeOpener:
         def open(self, request, timeout):
-            requests.append(json.loads(request.data.decode())["partial_text"])
+            requests.append(
+                (current_time[0], json.loads(request.data.decode())["partial_text"])
+            )
             if len(requests) == 1:
                 pusher.latest_text = "text2"
             return FakeResponse()
@@ -995,7 +1015,54 @@ def test_pusher_throttle_0_2_seconds_with_drain(monkeypatch):
     )
     monkeypatch.setattr(shim.threading, "Thread", ImmediateThread)
     pusher.push("text1", [])
-    assert requests == ["text1", "text2"]
+    assert [text for _, text in requests] == ["text1", "text2"]
+    assert requests[1][0] >= requests[0][0] + 0.2
+
+
+def test_payload_trimmed_to_byte_budget(monkeypatch):
+    """Oversized progress payloads are trimmed below the ingest limit."""
+    captured_payloads = []
+
+    class FakeResponse:
+        def close(self):
+            pass
+
+    class FakeOpener:
+        def open(self, request, timeout):
+            captured_payloads.append(request.data)
+            return FakeResponse()
+
+    monkeypatch.setattr(
+        shim.urllib.request, "build_opener", lambda _handler: FakeOpener()
+    )
+    pusher = shim._ProgressPusher("token")
+    pusher.push(
+        "x" * 500000,
+        [{"index": i, "data": "y" * 1000} for i in range(300)],
+    )
+    pusher.stop()
+
+    assert len(captured_payloads) == 1
+    payload = json.loads(captured_payloads[0].decode())
+    assert len(captured_payloads[0]) < 262144
+    assert len(payload["activities"]) < 300
+
+
+def test_stream_event_reuses_cached_activities(tmp_path, monkeypatch):
+    """Text deltas do not recompute activities for every stream event."""
+    monkeypatch.setenv("FAKE_DELTAS", "1")
+    calls = {"extract": 0}
+    original_extract = shim.activity_from_events
+
+    def counting_extract(events):
+        calls["extract"] += 1
+        return original_extract(events)
+
+    monkeypatch.setattr(shim, "activity_from_events", counting_extract)
+    manager = _manager(tmp_path, monkeypatch)
+    manager.turn("make changes", progress_token="abc123")
+    manager._close_process(kill=True)
+    assert calls["extract"] <= 3
 
 
 def test_activities_sent_in_payload_capped_to_300(tmp_path, monkeypatch):

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -85,13 +85,29 @@ for line in sys.stdin:
             "reason": "requires_approval"
         }]
         terminal_reason = "completed"
+    if os.environ.get("FAKE_DELTAS"):
+        print(json.dumps({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "Hello"},
+            },
+        }), flush=True)
     print(json.dumps({"type": "assistant", "message": {"role": "assistant", "content": [
-        {"type": "text", "text": "Assistant progress."},
+        {"type": "text", "text": "Hello world" if os.environ.get("FAKE_DELTAS") else "Assistant progress."},
         {"type": "tool_use", "name": "Read", "input": {"file_path": "a.txt"}},
         {"type": "tool_use", "name": "Edit", "input": {"file_path": "b.txt"}},
         {"type": "tool_use", "name": "Write", "input": {"file_path": "c.txt"}},
         {"type": "tool_use", "name": "Bash", "input": {"command": "git status"}}
     ]}}), flush=True)
+    if os.environ.get("FAKE_DELTAS"):
+        print(json.dumps({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": " more"},
+            },
+        }), flush=True)
     print(json.dumps({"type": "result", "result": result,
                       "terminal_reason": terminal_reason, "stop_reason": "end_turn",
                       "is_error": False, "permission_denials": permission_denials, "num_turns": 1,
@@ -425,6 +441,8 @@ def test_codex_config_uses_subscription_endpoint_override(tmp_path, monkeypatch)
     assert 'name = "ember-openai"' in config
     assert 'wire_api = "responses"' in config
     assert "enable_codex_api_key_env = false" in config
+    assert 'sandbox_mode = "danger-full-access"' in config
+    assert 'approval_policy = "never"' in config
 
 
 def test_codex_config_appends_codex_to_no_slash_endpoint(tmp_path, monkeypatch):
@@ -440,6 +458,8 @@ def test_codex_config_appends_codex_to_no_slash_endpoint(tmp_path, monkeypatch):
     assert 'name = "ember-openai"' in config
     assert 'wire_api = "responses"' in config
     assert "enable_codex_api_key_env = false" in config
+    assert 'sandbox_mode = "danger-full-access"' in config
+    assert 'approval_policy = "never"' in config
 
 
 def test_codex_child_env_drops_openai_api_key(tmp_path, monkeypatch):
@@ -697,8 +717,50 @@ def test_assistant_message_triggers_progress_push(tmp_path, monkeypatch):
     )
     assert request.method == "POST"
     assert request.get_header("Authorization") == "Bearer abc123"
-    assert json.loads(request.data) == {"partial_text": "Assistant progress."}
+    assert json.loads(request.data) == {
+        "partial_text": "Assistant progress.",
+        "activities": [
+            {"type": "tool_use", "name": "Read", "input": {"file_path": "a.txt"}},
+            {"type": "edit", "file_path": "b.txt"},
+            {"type": "write", "file_path": "c.txt"},
+            {"type": "bash", "command": "git status"},
+        ],
+    }
     assert timeout == 2
+
+
+def test_delta_accumulation_folds_without_double_count(tmp_path, monkeypatch):
+    """Deltas before and after a complete message do not duplicate text."""
+    monkeypatch.setenv("FAKE_DELTAS", "1")
+    pushes = []
+
+    class FakePusher:
+        def __init__(self, _token):
+            pass
+
+        def push(self, text, activities):
+            pushes.append((text, activities))
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr(shim, "_ProgressPusher", FakePusher)
+    manager = _manager(tmp_path, monkeypatch)
+    manager.turn("make changes", progress_token="abc123")
+    manager._close_process(kill=True)
+
+    assert "Hello world more" in [text for text, _activities in pushes]
+    assert all("Hello Hello world" not in text for text, _activities in pushes)
+
+
+def test_claude_spawn_includes_include_partial_messages(tmp_path, monkeypatch):
+    """Claude CLI spawn includes the partial message stream flag."""
+    args_path = tmp_path / "args.json"
+    monkeypatch.setenv("FAKE_ARGS", str(args_path))
+    manager = _manager(tmp_path, monkeypatch)
+    manager.turn("make changes")
+    assert "--include-partial-messages" in json.loads(args_path.read_text())
+    manager._close_process(kill=True)
 
 
 def test_malformed_assistant_events_are_skipped(tmp_path, monkeypatch):
@@ -838,8 +900,8 @@ def test_progress_token_forwarded_to_claude_adapter(monkeypatch):
     assert "progress_token" not in calls[0][1]
 
 
-def test_throttle_allows_push_after_1_second(monkeypatch):
-    """After 1+ second, the next push fires."""
+def test_throttle_allows_push_after_0_2_seconds(monkeypatch):
+    """After 0.2 seconds, the next push fires."""
     current_time = [0.0]
     monkeypatch.setattr(shim.time, "monotonic", lambda: current_time[0])
     requests = []
@@ -864,14 +926,14 @@ def test_throttle_allows_push_after_1_second(monkeypatch):
     pusher.stop()
     assert len(requests) == 1
 
-    current_time[0] = 1.1
+    current_time[0] = 0.25
     pusher.push("text2")
     pusher.stop()
     assert len(requests) == 2
 
 
-def test_throttle_blocks_push_within_1_second(monkeypatch):
-    """Within 1 second of the last push, the next push does not fire."""
+def test_throttle_blocks_push_within_0_2_seconds(monkeypatch):
+    """Within 0.2 seconds of the last push, the next push does not fire."""
     current_time = [0.0]
     monkeypatch.setattr(shim.time, "monotonic", lambda: current_time[0])
     requests = []
@@ -896,10 +958,73 @@ def test_throttle_blocks_push_within_1_second(monkeypatch):
     pusher.stop()
     assert len(requests) == 1
 
-    current_time[0] = 0.2
+    current_time[0] = 0.1
     pusher.push("text2")
     pusher.stop()
     assert len(requests) == 1
+
+
+def test_pusher_throttle_0_2_seconds_with_drain(monkeypatch):
+    """A slot change during a push is sent immediately as a drain push."""
+    requests = []
+    pusher = shim._ProgressPusher("token")
+
+    class FakeResponse:
+        def close(self):
+            pass
+
+    class FakeOpener:
+        def open(self, request, timeout):
+            requests.append(json.loads(request.data.decode())["partial_text"])
+            if len(requests) == 1:
+                pusher.latest_text = "text2"
+            return FakeResponse()
+
+    class ImmediateThread:
+        def __init__(self, target, daemon):
+            self.target = target
+
+        def is_alive(self):
+            return False
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(
+        shim.urllib.request, "build_opener", lambda _handler: FakeOpener()
+    )
+    monkeypatch.setattr(shim.threading, "Thread", ImmediateThread)
+    pusher.push("text1", [])
+    assert requests == ["text1", "text2"]
+
+
+def test_activities_sent_in_payload_capped_to_300(tmp_path, monkeypatch):
+    """Progress activities are capped to the last 300 entries."""
+    captured = []
+
+    class FakePusher:
+        def __init__(self, _token):
+            pass
+
+        def push(self, _text, activities):
+            captured.append(activities)
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr(shim, "_ProgressPusher", FakePusher)
+    monkeypatch.setattr(
+        shim,
+        "activity_from_events",
+        lambda _events: [{"index": index} for index in range(400)],
+    )
+    manager = _manager(tmp_path, monkeypatch)
+    manager.turn("make changes", progress_token="abc123")
+    manager._close_process(kill=True)
+
+    assert captured
+    assert all(len(activities) <= 300 for activities in captured)
+    assert captured[-1][0] == {"index": 100}
 
 
 def test_push_thread_creation_failure_swallowed(monkeypatch):


### PR DESCRIPTION
Round 2 of ADR agents/051 (shim half, pairs with #4353) plus the #4352 fix.

- The claude CLI runs with --include-partial-messages; content_block_delta text folds into a current-message buffer, completed assistant messages fold from the event itself (no double counting), so partials stream token-granular.
- Pusher cadence 1s -> 200ms with a drain: a slot change during an in-flight push triggers an immediate follow-up, so the final state always lands (closes the #4349 review's trailing-edge follow-up).
- Every push now carries the live activity trail (activity_from_events over events so far, capped to the last 300) alongside the 64 KiB text tail. Contract matches #4353's ingest.
- #4352: codex guest turns get their shell back via CODEX_HOME config (sandbox_mode danger-full-access, approval_policy never); the microVM is the isolation boundary per ADR 023, and bubblewrap does not exist in the guest. One dispatcher fix on top of the implementation: the worker had invented require_approvals as a key, which codex would silently ignore; replaced with the documented approval_policy.

Local suites: 89 passing across both, only the known macOS codex timing flake. Chart: embervm bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)