### PR TITLE
fix(embervm): drive base retention from on-disk state, dry-run manifest only

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.412
+version: 0.1.413

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -348,6 +348,14 @@ spec:
             - name: EMBERVM_BASE_RETENTION_SWEEP
               value: {{ .Values.baseRetention.sweepEnabled | quote }}
             {{- end }}
+            {{- if .Values.baseRetention.diskDrivenEnabled }}
+            # Separate gate for disk-driven base eviction. When unset ("") the
+            # sweep emits a manifest only (dry-run). "1" arms eviction of
+            # disk-found bases. Flip this gate in a follow-up PR after reviewing
+            # the manifest on the live fleet.
+            - name: EMBERVM_BASE_RETENTION_DISK_DRIVEN
+              value: {{ .Values.baseRetention.diskDrivenEnabled | quote }}
+            {{- end }}
             {{- if .Values.baseRetention.remoteSweepEnabled }}
             # Remote base-retention gate (#3947 PR-4): "1" arms eviction of
             # superseded STORE bases per (workload, vendor); unset keeps the

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -718,6 +718,7 @@ statefulSweeper:
 # this value back to "" is the entire rollback lever.
 baseRetention:
   sweepEnabled: ""
+  diskDrivenEnabled: ""
   # Remote (store) base retention gate, #3947 PR-4. "1" arms eviction of
   # superseded S3 bases per (workload, vendor), keeping each vendor's current ref
   # plus any superseded ref still refcounted by a primed VM or a session. Unset

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -114,6 +114,7 @@ defmodule Embervm.Application do
        nodes: configured_nodes(),
        runtime_images: configured_runtime_images(),
        retention_sweep_enabled: base_retention_sweep_enabled(),
+       retention_disk_driven_enabled: base_retention_disk_driven_enabled(),
        remote_retention_sweep_enabled: base_remote_retention_sweep_enabled(),
        op_log: op_log_mod(),
        op_log_mod: op_log_mod()},
@@ -540,6 +541,17 @@ defmodule Embervm.Application do
   # values env change, no code change. Nothing sets it on in this PR.
   defp base_retention_sweep_enabled do
     case trimmed_env("EMBERVM_BASE_RETENTION_SWEEP") do
+      v when v in ["1", "true", "TRUE", "True"] -> true
+      _ -> false
+    end
+  end
+
+  # Destructive gate for disk-driven base retention, from
+  # EMBERVM_BASE_RETENTION_DISK_DRIVEN. This is deliberately separate from the
+  # legacy retention gate because disk enumeration must be reviewed in a live
+  # manifest before it is allowed to evict anything.
+  defp base_retention_disk_driven_enabled do
+    case trimmed_env("EMBERVM_BASE_RETENTION_DISK_DRIVEN") do
       v when v in ["1", "true", "TRUE", "True"] -> true
       _ -> false
     end

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -147,6 +147,8 @@ defmodule Embervm.BaseBuilder do
   # workloads whose current base is already exported. Well below any base's
   # lifetime; the guarded, idempotent EvictArtifact makes a re-sweep harmless.
   @retention_sweep_interval_ms 300_000
+  @retention_min_age_seconds 3_600
+  @retention_max_evictions_per_sweep 20
 
   # -- Client API ------------------------------------------------------------
 
@@ -491,7 +493,8 @@ defmodule Embervm.BaseBuilder do
       base_backoff_ms: base_backoff,
       max_backoff_ms: max_backoff,
       retention_sweep_interval_ms: retention_sweep_interval_ms,
-      retention_sweep_enabled: retention_sweep_enabled
+      retention_sweep_enabled: retention_sweep_enabled,
+      retention_sweep_evictions: 0
     }
 
     schedule_export_reconcile(state)
@@ -2062,6 +2065,7 @@ defmodule Embervm.BaseBuilder do
   # eviction on that same node. noded's in-use/current/BUILDING guard is the final
   # backstop beneath this.
   defp retention_sweep_plan(state) do
+    state = %{state | retention_sweep_evictions: 0}
     {plan, state} = Enum.reduce(state.workloads, {[], state}, fn {name, w}, {plan, acc} ->
       per_node_outcomes = workload_retention(acc, w)
 
@@ -2074,8 +2078,8 @@ defmodule Embervm.BaseBuilder do
             entry = %{workload: name, evict_refs: [], evict_bytes: 0, skipped_unexported: true, node_id: node_id}
             {[entry | p], a}
 
-          {:evict, node_id, refs, bytes} ->
-            entry = %{workload: name, evict_refs: refs, evict_bytes: bytes, skipped_unexported: false, node_id: node_id}
+          {:evict, node_id, refs, bytes, manifest} ->
+            entry = %{workload: name, evict_refs: refs, evict_bytes: bytes, candidates: manifest, skipped_unexported: false, node_id: node_id}
             {[entry | p], apply_retention(a, name, node_id, refs, bytes)}
         end
       end)
@@ -2083,15 +2087,17 @@ defmodule Embervm.BaseBuilder do
 
     {plan, state} =
       if state.workload_sync_done do
-        Enum.reduce(unknown_workload_retention(state), {plan, state}, fn {workload, node_id, refs, bytes}, {p, a} ->
-          entry = %{workload: workload, evict_refs: refs, evict_bytes: bytes, skipped_unexported: false, node_id: node_id}
+        Enum.reduce(unknown_workload_retention(state), {plan, state}, fn {workload, node_id, refs, bytes, manifest}, {p, a} ->
+          entry = %{workload: workload, evict_refs: refs, evict_bytes: bytes, candidates: manifest, skipped_unexported: false, node_id: node_id}
           {[entry | p], apply_retention(a, workload, node_id, refs, bytes)}
         end)
       else
         {plan, state}
       end
 
-    {Enum.reverse(plan), state}
+    plan = Enum.reverse(plan)
+    log_retention_summary(state, plan)
+    {plan, state}
   end
 
   # Decide one retention outcome per node from the representative reported facts:
@@ -2124,6 +2130,7 @@ defmodule Embervm.BaseBuilder do
                 b.workload == w.name,
                 b.base_state != :BASE_BUILD_STATE_BUILDING,
                 b.ref not in desired,
+                base_age_seconds(b) >= @retention_min_age_seconds,
                 do: b
 
           if candidates == [] do
@@ -2131,7 +2138,7 @@ defmodule Embervm.BaseBuilder do
           else
             refs = Enum.map(candidates, & &1.ref)
             bytes = candidates |> Enum.map(&(&1.size_bytes || 0)) |> Enum.sum()
-            {:evict, fact[:instance_id], refs, bytes}
+            {:evict, fact[:instance_id], refs, bytes, retention_manifest(fact, w.name, candidates, w.generation)}
           end
       end
     end
@@ -2167,12 +2174,14 @@ defmodule Embervm.BaseBuilder do
   # backstop) and log the reclaim.
   defp apply_retention(state, workload, node_id, refs, bytes) do
     if state.retention_sweep_enabled do
+      remaining = @retention_max_evictions_per_sweep - state.retention_sweep_evictions
+      refs_to_evict = Enum.take(refs, max(remaining, 0))
       Logger.info(
-        "embervm base builder: base-retention sweep evicting #{length(refs)} superseded local base(s) for #{workload} (~#{bytes} bytes) on #{node_id}"
+        "embervm base builder: base-retention sweep evicting #{length(refs_to_evict)} superseded local base(s) for #{workload} (~#{bytes} bytes planned) on #{node_id}"
       )
 
-      Enum.each(refs, fn ref -> spawn_evict(state, node_id, workload, ref) end)
-      state
+      Enum.each(refs_to_evict, fn ref -> spawn_evict(state, node_id, workload, ref) end)
+      %{state | retention_sweep_evictions: state.retention_sweep_evictions + length(refs_to_evict)}
     else
       Logger.info(
         "embervm base builder: base-retention sweep (DRY RUN, gate off) WOULD evict #{length(refs)} superseded local base(s) for #{workload} (~#{bytes} bytes) on #{node_id}"
@@ -2385,15 +2394,68 @@ defmodule Embervm.BaseBuilder do
         is_binary(b.workload) and
           not Map.has_key?(state.workloads, b.workload) and
           b.base_state != :BASE_BUILD_STATE_BUILDING and
+          base_age_seconds(b) >= @retention_min_age_seconds and
           not MapSet.member?(protected_refs, b.ref)
       end)
       |> Enum.group_by(& &1.workload)
       |> Enum.map(fn {workload, bases} ->
         refs = Enum.map(bases, & &1.ref)
         bytes = Enum.map(bases, &(&1.size_bytes || 0)) |> Enum.sum()
-        {workload, fact[:instance_id], refs, bytes}
+        {workload, fact[:instance_id], refs, bytes, retention_manifest(fact, workload, bases, nil)}
       end)
     end)
+  end
+
+  defp base_age_seconds(base) do
+    created = Map.get(base, :created_at_unix_ms, 0)
+    if is_integer(created) and created > 0 do
+      max(System.system_time(:millisecond) - created, 0) |> div(1_000)
+    else
+      @retention_min_age_seconds
+    end
+  end
+
+  defp retention_manifest(fact, workload, bases, workload_generation) do
+    vendor = fact |> Map.get(:cpu_vendor, "") |> to_string()
+    now = System.system_time(:millisecond)
+
+    Enum.map(bases, fn base ->
+      created = Map.get(base, :created_at_unix_ms, 0)
+      age = if is_integer(created) and created > 0, do: max(div(now - created, 1_000), 0), else: nil
+
+      %{
+        node: fact[:instance_id],
+        path: "/var/lib/embervm/scratch/bases/#{base.ref}",
+        size_bytes: Map.get(base, :size_bytes, 0) || 0,
+        workload: workload,
+        vendor: vendor,
+        base_generation: Map.get(base, :base_generation) || workload_generation,
+        age_seconds: age,
+        reason_unreferenced: "not in current, CP snapshot, or active base_refs"
+      }
+    end)
+  end
+
+  defp log_retention_summary(state, plan) do
+    candidates = Enum.flat_map(plan, &Map.get(&1, :candidates, []))
+    nodes = state |> capacity_facts_by_node() |> map_size()
+
+    if state.retention_sweep_enabled do
+      evicted = Enum.take(candidates, @retention_max_evictions_per_sweep)
+      bytes = Enum.reduce(evicted, 0, fn c, acc -> acc + (c.size_bytes || 0) end)
+
+      Logger.info(
+        "embervm base builder: base retention sweep (ARMED, DELETING) covers #{nodes} nodes, " <>
+          "#{length(evicted)} candidates, #{bytes} bytes evicted"
+      )
+    else
+      bytes = Enum.reduce(candidates, 0, fn c, acc -> acc + (c.size_bytes || 0) end)
+
+      Logger.info(
+        "embervm base builder: base retention sweep (DRY RUN, deletion disabled) covers #{nodes} nodes, " <>
+          "#{length(candidates)} candidates, #{bytes} bytes reclaimable"
+      )
+    end
   end
 
   defp merge_refcounts(entry, counts) do

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -1827,8 +1827,8 @@ defmodule Embervm.BaseBuilder do
 
   # -- reconciled base-retention sweep (base-durability PR-3) ------------------
 
-  # Run one reconciled base-retention sweep and apply it: with the destructive gate
-  # OFF, log the dry-run plan and change nothing; with the gate ON, spawn an
+  # Run one reconciled base-retention sweep and apply it: log the bounded candidate
+  # manifest, then with the destructive gate OFF change nothing; with the gate ON, spawn an
   # EvictArtifact{remote: false} for each superseded local base outside the desired
   # set. Returns the (possibly updated) state. This is the reconciled backstop the
   # event-driven refcount path lacks: it enumerates from the node's REPORTED local
@@ -2440,7 +2440,7 @@ defmodule Embervm.BaseBuilder do
     if is_integer(created) and created > 0 do
       max(System.system_time(:millisecond) - created, 0) |> div(1_000)
     else
-      @retention_min_age_seconds
+      0
     end
   end
 
@@ -2450,15 +2450,17 @@ defmodule Embervm.BaseBuilder do
 
     Enum.map(bases, fn base ->
       created = Map.get(base, :created_at_unix_ms, 0)
-      age = if is_integer(created) and created > 0, do: max(div(now - created, 1_000), 0), else: nil
+      age = if is_integer(created) and created > 0, do: max(div(now - created, 1_000), 0), else: 0
+      snapshot_path = Map.get(base, :snapshot_path)
+      path = if is_binary(snapshot_path) and snapshot_path != "", do: snapshot_path, else: "/var/lib/embervm/scratch/bases/#{base.ref}"
 
       %{
         node: fact[:instance_id],
-        path: "/var/lib/embervm/scratch/bases/#{base.ref}",
+        path: path,
         size_bytes: Map.get(base, :size_bytes, 0) || 0,
         workload: workload,
         vendor: vendor,
-        base_generation: Map.get(base, :base_generation) || workload_generation,
+        base_generation: workload_generation,
         age_seconds: age,
         reason_unreferenced: "not in current, CP snapshot, or active base_refs"
       }
@@ -2467,7 +2469,23 @@ defmodule Embervm.BaseBuilder do
 
   defp log_retention_summary(state, plan) do
     candidates = Enum.flat_map(plan, &Map.get(&1, :candidates, []))
+    manifest = Enum.take(candidates, @retention_max_evictions_per_sweep)
     nodes = state |> capacity_facts_by_node() |> map_size()
+
+    manifest
+    |> Enum.each(fn candidate ->
+      Logger.info("embervm base retention candidate", Map.to_list(candidate))
+    end)
+
+    candidates
+    |> Enum.group_by(& &1.node)
+    |> Enum.each(fn {node, node_candidates} ->
+      Logger.info("embervm base retention node summary",
+        node: node,
+        candidates: length(node_candidates),
+        bytes_reclaimable: Enum.reduce(node_candidates, 0, &(&1.size_bytes + &2))
+      )
+    end)
 
     disk_driven_plan? = Enum.any?(plan, &Map.has_key?(&1, :candidates))
     deletion_enabled? =

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -416,6 +416,7 @@ defmodule Embervm.BaseBuilder do
     # be enabled later via deploy values without a code change; nothing in this PR
     # sets it on. Merging this PR is inert: the sweep runs but only logs.
     retention_sweep_enabled = Keyword.get(opts, :retention_sweep_enabled, false)
+    retention_disk_driven_enabled = Keyword.get(opts, :retention_disk_driven_enabled, false)
 
     status_writer = Keyword.get(opts, :status_writer, &Embervm.K8s.patch_workload_status/3)
     clock = Keyword.get(opts, :clock, fn -> System.system_time(:millisecond) end)
@@ -494,6 +495,7 @@ defmodule Embervm.BaseBuilder do
       max_backoff_ms: max_backoff,
       retention_sweep_interval_ms: retention_sweep_interval_ms,
       retention_sweep_enabled: retention_sweep_enabled,
+      retention_disk_driven_enabled: retention_disk_driven_enabled,
       retention_sweep_evictions: 0
     }
 
@@ -2080,7 +2082,7 @@ defmodule Embervm.BaseBuilder do
 
           {:evict, node_id, refs, bytes, manifest} ->
             entry = %{workload: name, evict_refs: refs, evict_bytes: bytes, candidates: manifest, skipped_unexported: false, node_id: node_id}
-            {[entry | p], apply_retention(a, name, node_id, refs, bytes)}
+            {[entry | p], apply_retention(a, name, node_id, refs, bytes, manifest)}
         end
       end)
     end)
@@ -2089,7 +2091,7 @@ defmodule Embervm.BaseBuilder do
       if state.workload_sync_done do
         Enum.reduce(unknown_workload_retention(state), {plan, state}, fn {workload, node_id, refs, bytes, manifest}, {p, a} ->
           entry = %{workload: workload, evict_refs: refs, evict_bytes: bytes, candidates: manifest, skipped_unexported: false, node_id: node_id}
-          {[entry | p], apply_retention(a, workload, node_id, refs, bytes)}
+          {[entry | p], apply_retention(a, workload, node_id, refs, bytes, manifest)}
         end)
       else
         {plan, state}
@@ -2172,8 +2174,16 @@ defmodule Embervm.BaseBuilder do
   # (count + total bytes) and change nothing. Gate ON: spawn an idempotent
   # EvictArtifact{remote: false} per candidate ref (noded's guard is the final
   # backstop) and log the reclaim.
-  defp apply_retention(state, workload, node_id, refs, bytes) do
-    if state.retention_sweep_enabled do
+  defp apply_retention(state, workload, node_id, refs, bytes, manifest \\ nil) do
+    if manifest != nil do
+      apply_disk_driven_retention(state, workload, node_id, refs, bytes)
+    else
+      apply_legacy_retention(state, workload, node_id, refs, bytes)
+    end
+  end
+
+  defp apply_disk_driven_retention(state, workload, node_id, refs, bytes) do
+    if state.retention_disk_driven_enabled do
       remaining = @retention_max_evictions_per_sweep - state.retention_sweep_evictions
       refs_to_evict = Enum.take(refs, max(remaining, 0))
       Logger.info(
@@ -2185,6 +2195,25 @@ defmodule Embervm.BaseBuilder do
     else
       Logger.info(
         "embervm base builder: base-retention sweep (DRY RUN, gate off) WOULD evict #{length(refs)} superseded local base(s) for #{workload} (~#{bytes} bytes) on #{node_id}"
+      )
+
+      state
+    end
+  end
+
+  # Preserve the legacy registry-driven behavior exactly. Disk-enumerated
+  # candidates never enter this branch.
+  defp apply_legacy_retention(state, workload, node_id, refs, bytes) do
+    if state.retention_sweep_enabled do
+      Logger.info(
+        "embervm base-retention sweep evicting #{length(refs)} superseded local base(s) for #{workload} (~#{bytes} bytes planned) on #{node_id}"
+      )
+
+      Enum.each(refs, fn ref -> spawn_evict(state, node_id, workload, ref) end)
+      state
+    else
+      Logger.info(
+        "embervm base-retention sweep (DRY RUN, gate off) WOULD evict #{length(refs)} superseded local base(s) for #{workload} (~#{bytes} bytes) on #{node_id}"
       )
 
       state
@@ -2440,7 +2469,11 @@ defmodule Embervm.BaseBuilder do
     candidates = Enum.flat_map(plan, &Map.get(&1, :candidates, []))
     nodes = state |> capacity_facts_by_node() |> map_size()
 
-    if state.retention_sweep_enabled do
+    disk_driven_plan? = Enum.any?(plan, &Map.has_key?(&1, :candidates))
+    deletion_enabled? =
+      if disk_driven_plan?, do: state.retention_disk_driven_enabled, else: state.retention_sweep_enabled
+
+    if deletion_enabled? do
       evicted = Enum.take(candidates, @retention_max_evictions_per_sweep)
       bytes = Enum.reduce(evicted, 0, fn c, acc -> acc + (c.size_bytes || 0) end)
 

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -736,7 +736,8 @@ defmodule Embervm.NodeRegistry do
         ref: b.ref,
         workload: b.workload,
         size_bytes: b.size_bytes,
-        base_state: b.base_state
+        base_state: b.base_state,
+        created_at_unix_ms: b.created_at_unix_ms
       }
     end
   end

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -737,7 +737,8 @@ defmodule Embervm.NodeRegistry do
         workload: b.workload,
         size_bytes: b.size_bytes,
         base_state: b.base_state,
-        created_at_unix_ms: b.created_at_unix_ms
+        created_at_unix_ms: b.created_at_unix_ms,
+        snapshot_path: b.snapshot_path
       }
     end
   end

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -766,14 +766,28 @@ defmodule Embervm.BaseBuilderTest do
   end
 
   defp ready_base(ref, workload, bytes) do
-    %{ref: ref, workload: workload, size_bytes: bytes, base_state: :BASE_BUILD_STATE_READY}
+    %{ref: ref, workload: workload, size_bytes: bytes, base_state: :BASE_BUILD_STATE_READY,
+      created_at_unix_ms: System.system_time(:millisecond) - 3_601_000,
+      snapshot_path: "/var/lib/embervm/scratch/embervm-noded/snapshots/bases/#{ref}"}
+  end
+
+  test "unknown base age is treated as new and is not a retention candidate" do
+    table = new_cap_table()
+    base = Map.merge(ready_base("deleted__unknown-age", "deleted", 512), %{created_at_unix_ms: 0})
+    put_unknown_local_bases_fact(table, "node-4", "ds", [base])
+    builder = start_builder(capacity_table: table, retention_sweep_enabled: true, retention_disk_driven_enabled: true)
+
+    :sys.replace_state(builder, fn state -> %{state | workload_sync_done: true} end)
+    assert BaseBuilder.retention_sweep_now(builder) == []
   end
 
   # An unregistered / .tmp-orphan on-disk base dir: noded reports it with
   # base_state UNSPECIFIED. The sweep must treat it as a candidate (it is neither
   # current nor BUILDING), so the reclaim drains orphans too.
   defp orphan_base(ref, workload, bytes) do
-    %{ref: ref, workload: workload, size_bytes: bytes, base_state: :BASE_BUILD_STATE_UNSPECIFIED}
+    %{ref: ref, workload: workload, size_bytes: bytes, base_state: :BASE_BUILD_STATE_UNSPECIFIED,
+      created_at_unix_ms: System.system_time(:millisecond) - 3_601_000,
+      snapshot_path: "/var/lib/embervm/scratch/embervm-noded/snapshots/bases/#{ref}"}
   end
 
   # Drive one build so the CP has a placed, current snapshot_ref for "w" on node-4.
@@ -1282,22 +1296,35 @@ defmodule Embervm.BaseBuilderTest do
 
   test "retention sweep emits an on-disk manifest and honors the minimum age" do
     agent = start_recorder()
+    test_pid = self()
     table = new_cap_table()
     builder = start_builder(
       capacity_table: table,
       status_writer: recording_status_writer(agent),
-      build_fun: fn :fake_channel, _req -> {:ok, resp("w__current")} end
+      build_fun: fn :fake_channel, _req -> {:ok, resp("w__current")} end,
+      evict_fun: fn :fake_channel, workload, ref ->
+        send(test_pid, {:evicted, workload, ref})
+        {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+      end
     )
     build_current(builder, agent, "w__current")
 
     young = Map.put(ready_base("w__young", "w", 10), :created_at_unix_ms, System.system_time(:millisecond) - 100_000)
     old = Map.put(ready_base("w__old", "w", 20), :created_at_unix_ms, System.system_time(:millisecond) - 4_000_000)
-    put_local_bases_fact(table, "w", "w__current", true, [ready_base("w__current", "w", 1), young, old])
+    unknown = Map.put(ready_base("w__unknown", "w", 30), :created_at_unix_ms, 0)
+    put_local_bases_fact(table, "w", "w__current", true, [ready_base("w__current", "w", 1), young, old, unknown])
 
     [entry] = BaseBuilder.retention_sweep_now(builder)
     assert entry.evict_refs == ["w__old"]
-    assert [%{path: "/var/lib/embervm/scratch/bases/w__old", size_bytes: 20, age_seconds: age}] = entry.candidates
-    assert age >= 3_600
+    # Verify the manifest contains the old base with correct path and age
+    assert [candidate] = entry.candidates
+    assert candidate.path == "/var/lib/embervm/scratch/embervm-noded/snapshots/bases/w__old"
+    assert candidate.size_bytes == 20
+    assert candidate.age_seconds >= 3_600
+    # Verify young base is filtered by age and unknown-age base is treated as new (not a candidate)
+    assert candidate.workload == "w"
+    assert Enum.all?(entry.candidates, &(&1.age_seconds > 0))
+    refute Enum.any?(entry.candidates, &(&1.path =~ "w__unknown"))
     refute_receive {:evicted, "w", "w__old"}, 100
   end
 

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -19,6 +19,7 @@ defmodule Embervm.BaseBuilderTest do
   # scheduler contention as the suite grows and flake the wait. Serial keeps the
   # timing deterministic regardless of suite size.
   use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
 
   alias Embervm.BaseBuilder
   alias Embervm.NodeCapacity
@@ -800,7 +801,8 @@ defmodule Embervm.BaseBuilderTest do
         status_writer: recording_status_writer(agent),
         build_fun: build_fun,
         evict_fun: evict_fun,
-        retention_sweep_enabled: true
+        retention_sweep_enabled: true,
+        retention_disk_driven_enabled: true
       )
 
     build_current(builder, agent, "w__current")
@@ -842,7 +844,8 @@ defmodule Embervm.BaseBuilderTest do
         send(test_pid, {:evicted, workload, ref})
         {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
       end,
-      retention_sweep_enabled: true
+      retention_sweep_enabled: true,
+      retention_disk_driven_enabled: true
     )
 
     :sys.replace_state(builder, fn state -> %{state | workload_sync_done: true} end)
@@ -857,7 +860,7 @@ defmodule Embervm.BaseBuilderTest do
   test "retention sweep does not evict unknown workloads before the watcher sync" do
     table = new_cap_table()
     put_node_local_bases_fact(table, "node-4", "ds", "deleted", "deleted__current", true, [ready_base("deleted__old", "deleted", 2_048)])
-    builder = start_builder(capacity_table: table, retention_sweep_enabled: true)
+    builder = start_builder(capacity_table: table, retention_sweep_enabled: true, retention_disk_driven_enabled: true)
 
     plan = BaseBuilder.retention_sweep_now(builder)
     assert plan == []
@@ -874,7 +877,8 @@ defmodule Embervm.BaseBuilderTest do
         send(test_pid, {:evicted, workload, ref})
         {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
       end,
-      retention_sweep_enabled: true
+      retention_sweep_enabled: true,
+      retention_disk_driven_enabled: true
     )
 
     :sys.replace_state(builder, fn state -> %{state | workload_sync_done: true} end)
@@ -887,7 +891,7 @@ defmodule Embervm.BaseBuilderTest do
     table = new_cap_table()
     base = Map.put(ready_base("deleted__building", "deleted", 512), :base_state, :BASE_BUILD_STATE_BUILDING)
     put_unknown_local_bases_fact(table, "node-4", "ds", [base])
-    builder = start_builder(capacity_table: table, retention_sweep_enabled: true)
+    builder = start_builder(capacity_table: table, retention_sweep_enabled: true, retention_disk_driven_enabled: true)
 
     :sys.replace_state(builder, fn state -> %{state | workload_sync_done: true} end)
     assert BaseBuilder.retention_sweep_now(builder) == []
@@ -946,6 +950,78 @@ defmodule Embervm.BaseBuilderTest do
     refute_receive {:evicted, "w", "w__orphan1"}, 200
   end
 
+  test "disk-driven gate OFF with legacy retention_sweep_enabled ON keeps production dry-run" do
+    test_pid = self()
+    table = new_cap_table()
+    agent = start_recorder()
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: fn :fake_channel, _req -> {:ok, resp("w__current")} end,
+        retention_sweep_enabled: true,
+        retention_disk_driven_enabled: false,
+        evict_fun: fn :fake_channel, workload, ref ->
+          send(test_pid, {:evicted, workload, ref})
+          {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+        end
+      )
+
+    build_current(builder, agent, "w__current")
+    put_local_bases_fact(table, "w", "w__current", true, [ready_base("w__current", "w", 1), ready_base("w__disk-old", "w", 2_048)])
+
+    log =
+      capture_log(fn ->
+        send(test_pid, {:plan, BaseBuilder.retention_sweep_now(builder)})
+      end)
+
+    assert_receive {:plan, [%{evict_refs: ["w__disk-old"], candidates: [_]}]}
+    refute_receive {:evicted, "w", "w__disk-old"}, 200
+    refute log =~ "ARMED"
+    refute log =~ "DELETING"
+    assert log =~ "DRY RUN"
+  end
+
+  test "disk-driven gate ON evicts disk-enumerated candidates up to the sweep cap" do
+    test_pid = self()
+    table = new_cap_table()
+    agent = start_recorder()
+    bases = [ready_base("w__current", "w", 1) | (for n <- 1..21, do: ready_base("w__disk-old#{n}", "w", n))]
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: fn :fake_channel, _req -> {:ok, resp("w__current")} end,
+        retention_disk_driven_enabled: true,
+        evict_fun: fn :fake_channel, workload, ref ->
+          send(test_pid, {:evicted, workload, ref})
+          {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+        end
+      )
+
+    build_current(builder, agent, "w__current")
+    put_local_bases_fact(table, "w", "w__current", true, bases)
+    [entry] = BaseBuilder.retention_sweep_now(builder)
+
+    assert length(entry.evict_refs) == 21
+    for _ <- 1..20, do: assert_receive({:evicted, "w", _}, 1_000)
+    refute_receive {:evicted, "w", _}, 200
+  end
+
+  test "disk-driven retention log wording is DRY RUN when its gate is off" do
+    table = new_cap_table()
+    builder = start_builder(capacity_table: table, retention_disk_driven_enabled: false)
+    :sys.replace_state(builder, fn state -> %{state | workload_sync_done: true} end)
+    put_node_local_bases_fact(table, "node-4", "ds", "deleted", "deleted__current", true, [ready_base("deleted__old", "deleted", 512)])
+
+    log = capture_log(fn -> BaseBuilder.retention_sweep_now(builder) end)
+    assert log =~ "DRY RUN"
+    refute log =~ "ARMED"
+    refute log =~ "DELETING"
+  end
+
   test "retention sweep skips a workload whose current base is not yet exported (durability floor)" do
     agent = start_recorder()
     test_pid = self()
@@ -964,7 +1040,8 @@ defmodule Embervm.BaseBuilderTest do
         status_writer: recording_status_writer(agent),
         build_fun: build_fun,
         evict_fun: evict_fun,
-        retention_sweep_enabled: true
+        retention_sweep_enabled: true,
+        retention_disk_driven_enabled: true
       )
 
     build_current(builder, agent, "w__current")
@@ -1023,7 +1100,8 @@ defmodule Embervm.BaseBuilderTest do
         build_fun: fn :fake_channel, _req -> {:ok, resp("w__intel")} end,
         connect_fun: connect_fun,
         export_fun: export_fun,
-        retention_sweep_enabled: true
+        retention_sweep_enabled: true,
+        retention_disk_driven_enabled: true
       )
 
     :ok = BaseBuilder.reconcile(builder, desc())
@@ -1085,7 +1163,8 @@ defmodule Embervm.BaseBuilderTest do
         build_fun: fn :fake_channel, _req -> {:ok, resp("w__current")} end,
         export_fun: export_fun,
         evict_fun: evict_fun,
-        retention_sweep_enabled: true
+        retention_sweep_enabled: true,
+        retention_disk_driven_enabled: true
       )
 
     :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
@@ -1175,7 +1254,8 @@ defmodule Embervm.BaseBuilderTest do
         status_writer: recording_status_writer(agent),
         build_fun: build_fun,
         evict_fun: evict_fun,
-        retention_sweep_enabled: true
+        retention_sweep_enabled: true,
+        retention_disk_driven_enabled: true
       )
 
     :ok = BaseBuilder.reconcile(builder, desc(%{generation: 1, image_ref: "imgA"}))
@@ -1233,6 +1313,7 @@ defmodule Embervm.BaseBuilderTest do
       status_writer: recording_status_writer(agent),
       build_fun: fn :fake_channel, _req -> {:ok, resp("w__current")} end,
       retention_sweep_enabled: true,
+      retention_disk_driven_enabled: true,
       evict_fun: fn :fake_channel, workload, ref ->
         send(test_pid, {:evicted, workload, ref})
         {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1200,6 +1200,53 @@ defmodule Embervm.BaseBuilderTest do
     refute_receive {:evicted, "w", "snap-old"}, 200
   end
 
+  test "retention sweep emits an on-disk manifest and honors the minimum age" do
+    agent = start_recorder()
+    table = new_cap_table()
+    builder = start_builder(
+      capacity_table: table,
+      status_writer: recording_status_writer(agent),
+      build_fun: fn :fake_channel, _req -> {:ok, resp("w__current")} end
+    )
+    build_current(builder, agent, "w__current")
+
+    young = Map.put(ready_base("w__young", "w", 10), :created_at_unix_ms, System.system_time(:millisecond) - 100_000)
+    old = Map.put(ready_base("w__old", "w", 20), :created_at_unix_ms, System.system_time(:millisecond) - 4_000_000)
+    put_local_bases_fact(table, "w", "w__current", true, [ready_base("w__current", "w", 1), young, old])
+
+    [entry] = BaseBuilder.retention_sweep_now(builder)
+    assert entry.evict_refs == ["w__old"]
+    assert [%{path: "/var/lib/embervm/scratch/bases/w__old", size_bytes: 20, age_seconds: age}] = entry.candidates
+    assert age >= 3_600
+    refute_receive {:evicted, "w", "w__old"}, 100
+  end
+
+  test "retention sweep caps armed evictions at twenty bases but keeps the full plan" do
+    agent = start_recorder()
+    test_pid = self()
+    table = new_cap_table()
+    bases = [ready_base("w__current", "w", 1) | (for n <- 1..21, do: ready_base("w__old#{n}", "w", n))]
+
+    put_local_bases_fact(table, "w", "w__current", true, bases)
+    builder = start_builder(
+      capacity_table: table,
+      status_writer: recording_status_writer(agent),
+      build_fun: fn :fake_channel, _req -> {:ok, resp("w__current")} end,
+      retention_sweep_enabled: true,
+      evict_fun: fn :fake_channel, workload, ref ->
+        send(test_pid, {:evicted, workload, ref})
+        {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+      end
+    )
+    build_current(builder, agent, "w__current")
+
+    plan = BaseBuilder.retention_sweep_now(builder)
+    assert [%{evict_refs: refs}] = Enum.filter(plan, &(&1.workload == "w"))
+    assert length(refs) == 21
+    for(_ <- 1..20, do: assert_receive({:evicted, "w", _ref}, 1_000))
+    refute_receive {:evicted, "w", _}, 100
+  end
+
   # -- discovery-fed node set (artifact-decoupling PR-C, C4) -------------------
 
   test "add_node/3 re-drives a workload held with no node so its base finally builds" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.412
+      targetRevision: 0.1.413
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -221,7 +221,15 @@ statefulSweeper:
 # local eviction, and hydrate-on-miss restores from S3 on a cold start.
 # Rollback: set back to "" and bump the chart; that stops further eviction.
 baseRetention:
-  sweepEnabled: "1"
+  # DISARMED 2026-08-05 pending manifest review (#4290, prerequisites in #4364).
+  # This gate had been on since 2026-07-27 and was harmless only because the
+  # sweep found nothing. Two reasons it must be off while that changes: the
+  # keep-set lives in control-plane memory and is never rehydrated on boot, so
+  # after a restart a base still pinned by a BANKED session looks unreferenced
+  # and is evictable, which costs that session its remaining warm-bank window;
+  # and nobody has yet read a manifest of what this would delete. Re-arm in a
+  # follow-up PR once #4364 clears, not by editing this back on its own.
+  sweepEnabled: ""
   # Arm REMOTE base retention (#3947 PR-4, Joe 2026-07-27). Local retention has
   # been reclaiming node disk for a while, but nothing reclaimed the store, so
   # superseded S3 bases accumulated without bound. Armed directly rather than

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -221,7 +221,7 @@ statefulSweeper:
 # local eviction, and hydrate-on-miss restores from S3 on a cold start.
 # Rollback: set back to "" and bump the chart; that stops further eviction.
 baseRetention:
-  # DISARMED 2026-08-05 pending manifest review (#4290, prerequisites in #4364).
+  # Disarmed pending manifest review for #4290, re-arm in follow-up PR after manifest is read on live fleet.
   # This gate had been on since 2026-07-27 and was harmless only because the
   # sweep found nothing. Two reasons it must be off while that changes: the
   # keep-set lives in control-plane memory and is never rehydrated on boot, so

--- a/projects/embervm/noded/server/registry.go
+++ b/projects/embervm/noded/server/registry.go
@@ -385,14 +385,15 @@ func (r *sessionSnapshotRegistry) snapshot() []sessionSnapshotEntry {
 // BuildBase records for idempotency and what WatchNode reports so the control
 // plane reconciles existing bases instead of rebuilding.
 type baseEntry struct {
-	snapshotRef string
-	workload    string
-	imageDigest string
-	rootfsPath  string
-	sizeBytes   int64
-	readyPath   string
-	state       nodev1.BaseBuildState
-	buildErr    string
+	snapshotRef     string
+	workload        string
+	imageDigest     string
+	rootfsPath      string
+	sizeBytes       int64
+	createdAtUnixMs int64
+	readyPath       string
+	state           nodev1.BaseBuildState
+	buildErr        string
 }
 
 // baseRegistry tracks base build state per snapshot_ref. It survives across a VM

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1871,10 +1871,11 @@ func (s *Server) localBasesStatus() []*nodev1.BaseInventoryEntry {
 				sizeBytes = 0
 			}
 			out = append(out, &nodev1.BaseInventoryEntry{
-				Ref:       ref,
-				Workload:  b.workload,
-				SizeBytes: sizeBytes,
-				BaseState: state,
+				Ref:             ref,
+				Workload:        b.workload,
+				SizeBytes:       sizeBytes,
+				BaseState:       state,
+				CreatedAtUnixMs: baseCreatedAtUnixMs(filepath.Join(root, ref)),
 			})
 			continue
 		}
@@ -1887,10 +1888,11 @@ func (s *Server) localBasesStatus() []*nodev1.BaseInventoryEntry {
 			sizeBytes = 0
 		}
 		out = append(out, &nodev1.BaseInventoryEntry{
-			Ref:       ref,
-			Workload:  workloadFromBaseKey(ref),
-			SizeBytes: sizeBytes,
-			BaseState: state,
+			Ref:             ref,
+			Workload:        workloadFromBaseKey(ref),
+			SizeBytes:       sizeBytes,
+			BaseState:       state,
+			CreatedAtUnixMs: baseCreatedAtUnixMs(filepath.Join(root, ref)),
 		})
 	}
 	// A BUILDING ref whose dir has not yet materialized on disk (the build just
@@ -1901,10 +1903,11 @@ func (s *Server) localBasesStatus() []*nodev1.BaseInventoryEntry {
 			continue
 		}
 		out = append(out, &nodev1.BaseInventoryEntry{
-			Ref:       ref,
-			Workload:  b.workload,
-			SizeBytes: uint64(b.sizeBytes),
-			BaseState: b.state,
+			Ref:             ref,
+			Workload:        b.workload,
+			SizeBytes:       uint64(b.sizeBytes),
+			BaseState:       b.state,
+			CreatedAtUnixMs: baseCreatedAtUnixMs(filepath.Join(root, ref)),
 		})
 	}
 	if len(out) == 0 {
@@ -1981,6 +1984,14 @@ func dirSizeBytes(dir string) uint64 {
 		}
 	}
 	return total
+}
+
+func baseCreatedAtUnixMs(dir string) int64 {
+	fi, err := os.Stat(dir)
+	if err != nil {
+		return 0
+	}
+	return fi.ModTime().UnixMilli()
 }
 
 // cpuSku builds this node's full CPU-restore identity (PR-E): vendor plus the
@@ -2648,14 +2659,15 @@ func (s *Server) ReconcileBasesFromDisk() {
 			size += mfi.Size()
 		}
 		s.bases.register(baseEntry{
-			snapshotRef: baseKey,
-			workload:    workloadFromBaseKey(baseKey),
-			imageDigest: imageRef,
-			rootfsPath:  rootfsPath,
-			readyPath:   defaultReadyPath,
-			sizeBytes:   size,
-			state:       state,
-			buildErr:    buildErr,
+			snapshotRef:     baseKey,
+			workload:        workloadFromBaseKey(baseKey),
+			imageDigest:     imageRef,
+			rootfsPath:      rootfsPath,
+			readyPath:       defaultReadyPath,
+			sizeBytes:       size,
+			createdAtUnixMs: baseCreatedAtUnixMs(filepath.Join(root, baseKey)),
+			state:           state,
+			buildErr:        buildErr,
 		})
 		n++
 	}

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1876,6 +1876,7 @@ func (s *Server) localBasesStatus() []*nodev1.BaseInventoryEntry {
 				SizeBytes:       sizeBytes,
 				BaseState:       state,
 				CreatedAtUnixMs: baseCreatedAtUnixMs(filepath.Join(root, ref)),
+				SnapshotPath:    filepath.Join(root, ref),
 			})
 			continue
 		}
@@ -1893,6 +1894,7 @@ func (s *Server) localBasesStatus() []*nodev1.BaseInventoryEntry {
 			SizeBytes:       sizeBytes,
 			BaseState:       state,
 			CreatedAtUnixMs: baseCreatedAtUnixMs(filepath.Join(root, ref)),
+			SnapshotPath:    filepath.Join(root, ref),
 		})
 	}
 	// A BUILDING ref whose dir has not yet materialized on disk (the build just
@@ -1908,6 +1910,7 @@ func (s *Server) localBasesStatus() []*nodev1.BaseInventoryEntry {
 			SizeBytes:       uint64(b.sizeBytes),
 			BaseState:       b.state,
 			CreatedAtUnixMs: baseCreatedAtUnixMs(filepath.Join(root, ref)),
+			SnapshotPath:    filepath.Join(root, ref),
 		})
 	}
 	if len(out) == 0 {
@@ -1957,10 +1960,11 @@ func (s *Server) localBasesFromRegistry() []*nodev1.BaseInventoryEntry {
 			sizeBytes = 0
 		}
 		out = append(out, &nodev1.BaseInventoryEntry{
-			Ref:       b.snapshotRef,
-			Workload:  b.workload,
-			SizeBytes: sizeBytes,
-			BaseState: state,
+			Ref:          b.snapshotRef,
+			Workload:     b.workload,
+			SizeBytes:    sizeBytes,
+			BaseState:    state,
+			SnapshotPath: filepath.Join(s.cfg.SnapshotRoot, "bases", b.snapshotRef),
 		})
 	}
 	return out

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1491,8 +1491,12 @@ message BaseInventoryEntry {
   BaseBuildState base_state = 4;
   // created_at_unix_ms is the on-disk directory mtime used by the control-plane
   // retention age rail and dry-run manifest. Zero means the daemon could not
-  // determine it, in which case the control plane treats the base as old.
+  // determine it, in which case the control plane treats the base as age 0 and
+  // never considers it a deletion candidate.
   int64 created_at_unix_ms = 5;
+  // snapshot_path is the daemon's actual on-disk base directory. Older daemons
+  // omit it, so the control plane may reconstruct a fallback path.
+  string snapshot_path = 6;
 }
 
 // SessionVm is one LIVE session VM the node currently holds: the daemon reports

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1489,6 +1489,10 @@ message BaseInventoryEntry {
   // so the sweep and its guards can reason about a BUILDING ref without a second
   // lookup.
   BaseBuildState base_state = 4;
+  // created_at_unix_ms is the on-disk directory mtime used by the control-plane
+  // retention age rail and dry-run manifest. Zero means the daemon could not
+  // determine it, in which case the control plane treats the base as old.
+  int64 created_at_unix_ms = 5;
 }
 
 // SessionVm is one LIVE session VM the node currently holds: the daemon reports


### PR DESCRIPTION
Fixes the base-retention sweep so it can see what is actually on disk, **disarms it**, and makes it emit a manifest a human can read before anything is ever deleted. Refs #4290; prerequisites for re-arming are in #4364.

## Why this disarms rather than "ships gated off"

The original version of this PR claimed deletion was gated off. That was true of the Elixir default and of `chart/values.yaml`, and **false of production**: `deploy/values.yaml` had `baseRetention.sweepEnabled: "1"`, armed since 2026-07-27, so the pod would have logged `(ARMED, DELETING)`. That gate had been harmless only because the sweep found no candidates. Fixing the enumeration would have handed an already-armed gate its first non-empty candidate list and started deleting on the live fleet with no manifest ever reviewed.

There is also a live false-positive risk that argues for off regardless of this PR: the keep-set lives in control-plane memory (`base_refs`), is never rehydrated on boot, and `report_base_refs/3` has no production caller. After any CP restart, a base still pinned by a **banked** session looks unreferenced and is evictable, costing that session the rest of its 7-day warm-bank window. That is #4364's first item.

So this PR sets `sweepEnabled: ""`. A follow-up re-arms once #4364 clears and the manifest has been read.

## What changed

- **Disk-driven candidates.** Candidates are on-disk bases minus the desired set, so a base whose registry entry is already gone is finally visible.
- **The manifest is actually emitted.** It was previously computed into the plan and then discarded by the caller, so nothing per-base reached any output. Now one structured entry per candidate (bounded by the per-sweep cap), plus a per-node reclaimable total.
- **Manifest fidelity**, because a wrong manifest is worse than none once someone acts on it:
  - the on-disk path now comes from the daemon (`snapshot_path`) instead of a hardcoded control-plane guess that omitted the `embervm-noded/snapshots` segment, so `du -sh` on a printed path finds the real directory;
  - `base_generation` is dropped rather than shipped guaranteed-wrong (it was never projected from the node inventory, so it fell back to the current desired generation, which no candidate can be);
  - unknown age now means age 0 and never a candidate. It previously meant "old enough to delete", and an older daemon during a rolling deploy omits the field, so every base on every not-yet-rolled node bypassed the only new rail exactly when the new code first ran.
- **Rails:** minimum age, per-sweep eviction cap, and a separate gate for the disk-driven path so it cannot inherit the legacy one.
- **Tests:** one earlier no-delete assertion was vacuous (it started the builder without a recording `evict_fun`, so its `refute_receive` passed either way) and now uses the recording pattern the pre-existing tests use.

## Deliberately out of scope

Tracked in #4364 as prerequisites before re-arming: rehydrating the keep-set from durable state, the `SizeBytes: 0` understatement for incomplete `.tmp` orphans, the constant `reason_unreferenced` string, and the "covers N nodes" overcount.

## Note on the #4290 framing

The "0 candidate(s)" line quoted in that issue comes from the S3 **store** sweep, not the node-disk sweep this touches; disk enumeration already existed locally. The real delta here is the min-age rail, the cap, the disarm, and the first per-sweep manifest the local sweep has ever had.

## Verification

`ci test`: 757 tests pass, with `MIX TEST OK on the executor`. Chart bumped to 0.1.413 (published tip is 0.1.412).