### PR TITLE
feat(embervm): pi adapter on long-lived rpc mode with late-bound session switch

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.410
+version: 0.1.412

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.410
+      targetRevision: 0.1.412
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -1654,7 +1654,7 @@ wire_api = "responses"
 
 
 class PiProcess:
-    """Run one Pi JSON event-stream process per turn."""
+    """Own one long-lived Pi RPC process and bind sessions lazily."""
 
     INFERENCE_BASE_URL = "http://inference.inference.svc.cluster.local:8080/v1"
 
@@ -1669,6 +1669,13 @@ class PiProcess:
         self.process_lock = threading.Lock()
         self.stderr_lines = collections.deque(maxlen=5)
         self._stderr_thread = None
+        self._stdout_queue = None
+        self._write_lock = threading.Lock()
+        self._turn_done = threading.Event()
+        self._turn_done.set()
+        self._in_flight = False
+        self._model = None
+        self._session_file = None
 
     def ready(self):
         with self.process_lock:
@@ -1715,7 +1722,7 @@ class PiProcess:
         with open(os.path.join(agent_dir, "models.json"), "w") as stream:
             json.dump(config, stream)
 
-    def _spawn(self, message, session_id, model):
+    def _spawn(self, model):
         if not os.path.isdir(self.workspace):
             raise StartupError("workspace does not exist: %s" % self.workspace)
         model_name = PI_MODELS.get(model, PI_MODELS[DEFAULT_PI_MODEL])
@@ -1724,9 +1731,8 @@ class PiProcess:
         self._write_model_config(pi_home)
         command = [
             self.executable,
-            "-p",
             "--mode",
-            "json",
+            "rpc",
             "--provider",
             "openai-completions",
             "--model",
@@ -1742,15 +1748,10 @@ class PiProcess:
             "--session-dir",
             os.path.join(pi_home, "sessions"),
         ]
-        if session_id:
-            command.extend(["--session", session_id])
-        command.append(message)
-        # The turn message rides argv (command above); pi never reads it from
-        # stdin, so close it rather than inherit the shim's never-EOF stdin.
         process = subprocess.Popen(
             command,
             cwd=self.workspace,
-            stdin=subprocess.DEVNULL,
+            stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=child_env,
@@ -1759,9 +1760,11 @@ class PiProcess:
         output_queue = queue.Queue()
         with self.process_lock:
             self.process = process
+            self._stdout_queue = output_queue
+            self._model = model
             _managed_child_pids.add(process.pid)
         threading.Thread(
-            target=CodexProcess._pump_codex_stdout,
+            target=self._pump_pi_stdout,
             args=(process, output_queue),
             daemon=True,
         ).start()
@@ -1772,12 +1775,85 @@ class PiProcess:
             daemon=True,
         )
         self._stderr_thread.start()
-        return process, output_queue
+        try:
+            self._state()
+        except Exception:
+            self._close_process(kill=True)
+            raise
+        return process
+
+    @staticmethod
+    def _pump_pi_stdout(process, output_queue):
+        try:
+            for raw in process.stdout:
+                output_queue.put(raw)
+        finally:
+            output_queue.put(None)
+
+    def _read_event(self, timeout):
+        with self.process_lock:
+            output_queue = self._stdout_queue
+        if output_queue is None:
+            return None
+        try:
+            raw = output_queue.get(timeout=timeout)
+        except queue.Empty as exc:
+            raise TimeoutError from exc
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("pi emitted invalid JSON: %s" % exc) from exc
+
+    def _send(self, command):
+        with self._write_lock:
+            with self.process_lock:
+                process = self.process
+            if process is None or process.poll() is not None:
+                raise self._empty_stream_error(process)
+            process.stdin.write(_json_line(command))
+            process.stdin.flush()
+
+    def _command(self, command, timeout=INIT_READ_TIMEOUT):
+        self._send(command)
+        while True:
+            event = self._read_event(timeout)
+            if event is None:
+                raise self._empty_stream_error(self.process)
+            if event.get("type") == "response" and event.get("command") == command.get(
+                "type"
+            ):
+                if not event.get("success", False):
+                    raise RuntimeError(
+                        "%s failed: %s" % (command["type"], json.dumps(event)[:1500])
+                    )
+                return event.get("data") or {}
+
+    def _session_path(self, session_id):
+        sessions_dir = os.path.join(self._child_env()["PI_HOME"], "sessions")
+        return os.path.join(sessions_dir, "%s.jsonl" % session_id)
+
+    def _state(self):
+        data = self._command({"type": "get_state"})
+        session_file = data.get("sessionFile")
+        session_id = data.get("sessionId")
+        if isinstance(session_id, str) and session_id:
+            self.session_id = session_id
+        if isinstance(session_file, str) and session_file:
+            self._session_file = session_file
+        model = data.get("model")
+        if isinstance(model, dict):
+            model_id = model.get("id")
+            if isinstance(model_id, str):
+                self._model = model_id
+        return data
 
     def _empty_stream_error(self, process):
-        code = process.poll()
+        code = None if process is None else process.poll()
         if code is None:
-            code = process.wait()
+            if process is not None:
+                code = process.wait()
         if self._stderr_thread is not None:
             self._stderr_thread.join(timeout=1)
         error_msg = "pi exited before agent_end, exit code %s" % code
@@ -1793,106 +1869,183 @@ class PiProcess:
                     "session_id %r does not match active session %r"
                     % (session_id, self.session_id)
                 )
-            process, output_queue = self._spawn(
-                message, session_id or self.session_id, model
-            )
+            with self.process_lock:
+                process = self.process
+            model_name = PI_MODELS.get(model, PI_MODELS[DEFAULT_PI_MODEL])
+            if process is None or process.poll() is not None:
+                self._close_process(kill=False)
+                process = self._spawn(model)
+            elif self._model != model_name:
+                self._command(
+                    {
+                        "type": "set_model",
+                        "provider": "openai-completions",
+                        "modelId": model_name,
+                    }
+                )
+                self._model = model_name
+            requested_session = session_id or self.session_id
+            if requested_session and requested_session != self.session_id:
+                try:
+                    data = self._command(
+                        {
+                            "type": "switch_session",
+                            "sessionPath": self._session_path(requested_session),
+                        }
+                    )
+                except RuntimeError as exc:
+                    raise SessionConflictError(
+                        "switch_session failed for session %s: %s"
+                        % (requested_session, exc)
+                    ) from exc
+                if data.get("cancelled"):
+                    raise SessionConflictError(
+                        "switch_session cancelled for session %s" % requested_session
+                    )
+                self._state()
             result_text = ""
             usage = {}
             events = []
             terminal_reason = "completed"
-            while True:
-                try:
-                    raw = output_queue.get(timeout=TURN_READ_TIMEOUT)
-                except queue.Empty as exc:
-                    raise RuntimeError(
-                        "timed out waiting for Pi output after %s seconds"
-                        % TURN_READ_TIMEOUT
-                    ) from exc
-                if raw is None:
-                    raise self._empty_stream_error(process)
-                try:
-                    event = json.loads(raw.decode("utf-8"))
-                except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-                    raise RuntimeError("pi emitted invalid JSON: %s" % exc) from exc
-                events.append(event)
-                if event.get("type") == "session":
-                    candidate = event.get("id")
-                    if isinstance(candidate, str) and candidate:
-                        self.session_id = candidate
-                elif event.get("type") == "message_end":
-                    message_event = event.get("message", {})
-                    if message_event.get("role") == "assistant":
-                        result_text = "".join(
-                            item.get("text", "")
-                            for item in message_event.get("content", [])
-                            if item.get("type") == "text"
-                        )
-                        raw_usage = message_event.get("usage", {})
-                        usage = {
-                            "input_tokens": raw_usage.get("input", 0),
-                            "output_tokens": raw_usage.get("output", 0),
-                            "cache_read_tokens": raw_usage.get("cacheRead", 0),
-                            "cache_write_tokens": raw_usage.get("cacheWrite", 0),
-                        }
-                        terminal_reason = message_event.get("stopReason", "completed")
-                elif event.get("type") == "agent_end":
-                    if not result_text:
-                        for message_event in reversed(event.get("messages", [])):
-                            if message_event.get("role") == "assistant":
-                                result_text = "".join(
-                                    item.get("text", "")
-                                    for item in message_event.get("content", [])
-                                    if item.get("type") == "text"
-                                )
-                                break
-                    if not result_text:
-                        # A textless terminal event is an ERROR, never an empty
-                        # success: pi normalizes provider failures into the
-                        # assistant message's errorMessage (docs/custom-provider.md),
-                        # and live turns persisted blank records with no error
-                        # anywhere. Surface the errorMessage when present, else
-                        # the raw terminal event, so the cause reaches the turn
-                        # record instead of vanishing.
-                        error_detail = ""
-                        for message_event in reversed(event.get("messages", [])):
-                            if message_event.get("errorMessage"):
-                                error_detail = str(message_event["errorMessage"])
-                                break
-                        if not error_detail:
-                            error_detail = (
-                                "terminal event carried no text: %s"
-                                % (json.dumps(event)[:1500])
-                            )
-                        stderr = _truncate_ring_for_error(self.stderr_lines)
-                        if stderr:
-                            error_detail += "\nCLI stderr:\n%s" % stderr
-                        # Reap before raising: the success path hands the child
-                        # to a reaper thread, and skipping that here leaks a
-                        # zombie the PID-1 orphan reaper must not touch.
-                        CodexProcess._reap_process(process)
+            self._turn_done.clear()
+            self._in_flight = True
+            try:
+                self._send({"type": "prompt", "message": message})
+                while True:
+                    try:
+                        event = self._read_event(TURN_READ_TIMEOUT)
+                    except TimeoutError as exc:
+                        self._close_process(kill=True)
                         raise RuntimeError(
-                            "pi turn produced no output: %s" % error_detail
-                        )
-                    record = {
-                        "result": result_text,
-                        "terminal_reason": terminal_reason,
-                        "session_id": self.session_id,
-                        "usage": usage,
-                        "voice": voice_summary(result_text),
-                        "activity": activity_from_events(events),
-                    }
-                    threading.Thread(
-                        target=CodexProcess._reap_process,
-                        args=(process,),
-                        daemon=True,
-                    ).start()
-                    return record
+                            "timed out waiting for Pi output after %s seconds"
+                            % TURN_READ_TIMEOUT
+                        ) from exc
+                    if event is None:
+                        raise self._empty_stream_error(process)
+                    if event.get("type") == "response":
+                        if event.get("command") == "prompt" and not event.get(
+                            "success"
+                        ):
+                            raise RuntimeError(
+                                "prompt failed: %s" % json.dumps(event)[:1500]
+                            )
+                        continue
+                    events.append(event)
+                    if event.get("type") == "session":
+                        candidate = event.get("id")
+                        if isinstance(candidate, str) and candidate:
+                            self.session_id = candidate
+                    elif event.get("type") == "message_end":
+                        message_event = event.get("message", {})
+                        if message_event.get("role") == "assistant":
+                            result_text = "".join(
+                                item.get("text", "")
+                                for item in message_event.get("content", [])
+                                if item.get("type") == "text"
+                            )
+                            raw_usage = message_event.get("usage", {})
+                            usage = {
+                                "input_tokens": raw_usage.get("input", 0),
+                                "output_tokens": raw_usage.get("output", 0),
+                                "cache_read_tokens": raw_usage.get("cacheRead", 0),
+                                "cache_write_tokens": raw_usage.get("cacheWrite", 0),
+                            }
+                            terminal_reason = message_event.get(
+                                "stopReason", "completed"
+                            )
+                    elif event.get("type") == "agent_end":
+                        if not result_text:
+                            for message_event in reversed(event.get("messages", [])):
+                                if message_event.get("role") == "assistant":
+                                    result_text = "".join(
+                                        item.get("text", "")
+                                        for item in message_event.get("content", [])
+                                        if item.get("type") == "text"
+                                    )
+                                    break
+                        if not result_text:
+                            error_detail = ""
+                            for message_event in reversed(event.get("messages", [])):
+                                if message_event.get("errorMessage"):
+                                    error_detail = str(message_event["errorMessage"])
+                                    break
+                            if not error_detail:
+                                error_detail = (
+                                    "terminal event carried no text: %s"
+                                    % (json.dumps(event)[:1500])
+                                )
+                            stderr = _truncate_ring_for_error(self.stderr_lines)
+                            if stderr:
+                                error_detail += "\nCLI stderr:\n%s" % stderr
+                            raise RuntimeError(
+                                "pi turn produced no output: %s" % error_detail
+                            )
+                        self._state()
+                        record = {
+                            "result": result_text,
+                            "terminal_reason": terminal_reason,
+                            "session_id": self.session_id,
+                            "usage": usage,
+                            "voice": voice_summary(result_text),
+                            "activity": activity_from_events(events),
+                        }
+                        return record
+            finally:
+                self._in_flight = False
+                self._turn_done.set()
 
     def interrupt(self, timeout=INTERRUPT_TIMEOUT):
-        return {"terminal_reason": "user_interrupt", "killed": False, "timeout": False}
+        with self.process_lock:
+            process = self.process
+        if process is None or process.poll() is not None or not self._in_flight:
+            return {
+                "terminal_reason": "user_interrupt",
+                "killed": False,
+                "timeout": False,
+            }
+        self._in_flight = False
+        try:
+            self._send({"type": "abort"})
+        except Exception:
+            self._close_process(kill=True)
+            return {
+                "terminal_reason": "user_interrupt",
+                "killed": False,
+                "timeout": False,
+            }
+        timed_out = not self._turn_done.wait(timeout=timeout)
+        if timed_out:
+            self._close_process(kill=True)
+        return {
+            "terminal_reason": "user_interrupt",
+            "killed": timed_out,
+            "timeout": timed_out,
+        }
 
     def _close_process(self, kill=False):
-        return None
+        with self.process_lock:
+            process = self.process
+            self.process = None
+            self._stdout_queue = None
+            self._model = None
+            self._in_flight = False
+        self._turn_done.set()
+        if process is None:
+            return
+        if kill and process.poll() is None:
+            process.kill()
+        try:
+            if process.stdin:
+                process.stdin.close()
+        except OSError:
+            pass
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+        _managed_child_pids.discard(process.pid)
+        _reap_orphans()
 
 
 def _sync_session_volume():

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -285,6 +285,7 @@ FAKE_PI_CLI = r"""#!/usr/bin/env python3
 import json
 import os
 import sys
+import time
 
 args_path = os.environ.get("FAKE_PI_ARGS")
 if args_path:
@@ -298,22 +299,62 @@ for flag in ("--no-context-files", "--no-extensions", "--no-skills", "--no-promp
     assert flag in sys.argv
 assert sys.argv[sys.argv.index("--tools") + 1] == "read,bash,edit,write"
 assert "End every response with a single line" in sys.argv[sys.argv.index("--system-prompt") + 1]
-if os.environ.get("FAKE_PI_MODE") == "provider-error":
-    print(json.dumps({"type": "session", "id": "pi-session", "version": 3}), flush=True)
-    print(json.dumps({"type": "agent_end", "messages": [{
-        "role": "assistant",
-        "content": [],
-        "errorMessage": "connect ECONNREFUSED inference.inference.svc.cluster.local:8080"
-    }]}), flush=True)
-    sys.exit(0)
-print(json.dumps({"type": "session", "id": "pi-session", "version": 3}), flush=True)
-print(json.dumps({"type": "message_end", "message": {
-    "role": "assistant",
-    "content": [{"type": "text", "text": "Done <voice>Pi completed the work.</voice>"}],
-    "stopReason": "stop",
-    "usage": {"input": 5, "output": 7}
-}}), flush=True)
-print(json.dumps({"type": "agent_end", "messages": []}), flush=True)
+rpc_path = os.environ.get("FAKE_PI_RPC")
+state = {"sessionId": "pi-session", "model": {"id": "qwen3.6-27b"}}
+def record(value):
+    if rpc_path:
+        with open(rpc_path, "a") as stream:
+            json.dump(value, stream)
+            stream.write("\n")
+def emit(value):
+    print(json.dumps(value), flush=True)
+def response(command, success=True, data=None):
+    value = {"type": "response", "command": command, "success": success}
+    if data is not None:
+        value["data"] = data
+    emit(value)
+for line in sys.stdin:
+    request = json.loads(line)
+    record(request)
+    command = request["type"]
+    if command == "get_state":
+        response(command, data=state)
+    elif command == "set_model":
+        state["model"] = {"id": request["modelId"]}
+        response(command, data=state["model"])
+    elif command == "switch_session":
+        if os.environ.get("FAKE_PI_SWITCH") == "failed":
+            response(command, success=False)
+        else:
+            state["sessionId"] = os.path.basename(request["sessionPath"]).split(".")[0]
+            response(command, data={"cancelled": os.environ.get("FAKE_PI_SWITCH") == "cancelled"})
+    elif command == "prompt":
+        response(command)
+        if os.environ.get("FAKE_PI_MODE") == "death":
+            print("fake pi died mid-turn", file=sys.stderr, flush=True)
+            sys.exit(17)
+        if os.environ.get("FAKE_PI_MODE") == "interruptible":
+            emit({"type": "agent_start"})
+            abort_request = json.loads(sys.stdin.readline())
+            record(abort_request)
+            response("abort")
+            emit({"type": "agent_end", "messages": []})
+            continue
+        if os.environ.get("FAKE_PI_SLEEP"):
+            time.sleep(float(os.environ["FAKE_PI_SLEEP"]))
+        if os.environ.get("FAKE_PI_MODE") == "provider-error":
+            emit({"type": "agent_end", "messages": [{"role": "assistant", "content": [],
+                  "errorMessage": "provider failed: ECONNREFUSED"}]})
+        elif os.environ.get("FAKE_PI_MODE") == "textless":
+            emit({"type": "agent_end", "messages": []})
+        else:
+            emit({"type": "message_end", "message": {"role": "assistant",
+                  "content": [{"type": "text", "text": "Done <voice>Pi completed the work.</voice>"}],
+                  "stopReason": "stop", "usage": {"input": 5, "output": 7}}})
+            emit({"type": "agent_end", "messages": []})
+    elif command == "abort":
+        response(command)
+        emit({"type": "agent_end", "messages": []})
 """
 
 
@@ -369,6 +410,7 @@ def _pi_manager(tmp_path, monkeypatch):
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("FAKE_PI_ARGS", str(tmp_path / "pi-args.jsonl"))
+    monkeypatch.setenv("FAKE_PI_RPC", str(tmp_path / "pi-rpc.jsonl"))
     monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
     return shim.PiProcess(str(workspace), str(executable))
 
@@ -410,6 +452,22 @@ def test_pi_first_turn_returns_text_session_and_usage(tmp_path, monkeypatch):
     manager._close_process()
 
 
+def test_pi_rpc_reuses_process_and_records_commands(tmp_path, monkeypatch):
+    manager = _pi_manager(tmp_path, monkeypatch)
+    manager.turn("first", model="qwen")
+    first_process = manager.process
+    manager.turn("second", model="qwen")
+    assert manager.process is first_process
+    requests = [
+        json.loads(line)
+        for line in (tmp_path / "pi-rpc.jsonl").read_text().splitlines()
+    ]
+    assert [request["type"] for request in requests].count("get_state") == 3
+    assert [request["type"] for request in requests].count("prompt") == 2
+    assert [request["type"] for request in requests].count("switch_session") == 0
+    manager._close_process()
+
+
 def test_pi_textless_terminal_event_surfaces_error_message(tmp_path, monkeypatch):
     # A provider failure arrives as errorMessage on a textless assistant
     # message (pi docs/custom-provider.md); it must become a turn ERROR, not
@@ -421,15 +479,95 @@ def test_pi_textless_terminal_event_surfaces_error_message(tmp_path, monkeypatch
     assert "ECONNREFUSED" in str(excinfo.value)
 
 
+def test_pi_cancelled_switch_raises_session_conflict(tmp_path, monkeypatch):
+    monkeypatch.setenv("FAKE_PI_SWITCH", "cancelled")
+    manager = _pi_manager(tmp_path, monkeypatch)
+    manager.turn("first", model="qwen")
+    manager.session_id = None
+    with pytest.raises(shim.SessionConflictError, match="pi-session"):
+        manager.turn("resume", session_id="pi-session", model="qwen")
+    manager._close_process()
+
+
+def test_pi_failed_switch_raises_session_conflict(tmp_path, monkeypatch):
+    monkeypatch.setenv("FAKE_PI_SWITCH", "failed")
+    manager = _pi_manager(tmp_path, monkeypatch)
+    manager.turn("first", model="qwen")
+    manager.session_id = None
+    with pytest.raises(
+        shim.SessionConflictError, match="switch_session failed.*pi-session"
+    ):
+        manager.turn("resume", session_id="pi-session", model="qwen")
+    manager._close_process()
+
+
+def test_pi_interrupt_sends_abort(tmp_path, monkeypatch):
+    monkeypatch.setenv("FAKE_PI_MODE", "interruptible")
+    manager = _pi_manager(tmp_path, monkeypatch)
+    result = [None]
+    exception = [None]
+
+    def run_turn():
+        try:
+            result[0] = manager.turn("block", model="qwen")
+        except Exception as exc:
+            exception[0] = exc
+
+    thread = threading.Thread(target=run_turn)
+    thread.start()
+    time.sleep(0.2)
+    interrupt_result = manager.interrupt()
+    thread.join(timeout=2)
+    requests = [
+        json.loads(line)
+        for line in (tmp_path / "pi-rpc.jsonl").read_text().splitlines()
+    ]
+    assert any(request["type"] == "abort" for request in requests)
+    assert interrupt_result == {
+        "terminal_reason": "user_interrupt",
+        "killed": False,
+        "timeout": False,
+    }
+    assert thread.is_alive() is False
+    assert "pi turn produced no output" in str(exception[0])
+    manager._close_process()
+
+
+def test_pi_read_timeout_respawns(tmp_path, monkeypatch):
+    monkeypatch.setattr(shim, "TURN_READ_TIMEOUT", 0.1)
+    monkeypatch.setenv("FAKE_PI_SLEEP", "1")
+    manager = _pi_manager(tmp_path, monkeypatch)
+    with pytest.raises(RuntimeError, match="timed out waiting for Pi output"):
+        manager.turn("slow", model="qwen")
+    assert manager.process is None
+    monkeypatch.delenv("FAKE_PI_SLEEP")
+    manager.turn("again", model="qwen")
+    manager._close_process()
+
+
+def test_pi_death_mid_turn_includes_stderr(tmp_path, monkeypatch):
+    monkeypatch.setenv("FAKE_PI_MODE", "death")
+    manager = _pi_manager(tmp_path, monkeypatch)
+    with pytest.raises(RuntimeError) as excinfo:
+        manager.turn("die", model="qwen")
+    assert "fake pi died mid-turn" in str(excinfo.value)
+    assert "exit code 17" in str(excinfo.value)
+    manager._close_process()
+
+
 def test_pi_resume_uses_session_flag(tmp_path, monkeypatch):
     manager = _pi_manager(tmp_path, monkeypatch)
     manager.turn("first", model="qwen")
+    manager.session_id = None
     manager.turn("second", session_id="pi-session", model="qwen")
-    args = [
+    requests = [
         json.loads(line)
-        for line in (tmp_path / "pi-args.jsonl").read_text().splitlines()
+        for line in (tmp_path / "pi-rpc.jsonl").read_text().splitlines()
     ]
-    assert "--session" in args[1] and "pi-session" in args[1]
+    switch = next(
+        request for request in requests if request["type"] == "switch_session"
+    )
+    assert switch["sessionPath"].endswith("/sessions/pi-session.jsonl")
     manager._close_process()
 
 
@@ -840,8 +978,7 @@ def test_spawn_keeps_codex_stdin_as_a_pipe(tmp_path, monkeypatch):
     codex._close_process(kill=True)
 
 
-def test_spawn_closes_pi_stdin(tmp_path, monkeypatch):
-    # pi's message is argv too; same rationale as codex (#4303).
+def test_spawn_keeps_pi_stdin_as_a_pipe(tmp_path, monkeypatch):
     pi = _pi_manager(tmp_path, monkeypatch)
     captured = {}
 
@@ -851,8 +988,8 @@ def test_spawn_closes_pi_stdin(tmp_path, monkeypatch):
 
     monkeypatch.setattr(shim.subprocess, "Popen", fake_popen)
     with pytest.raises(RuntimeError, match="stop after capturing"):
-        pi._spawn("hello", None, "qwen")
-    assert captured["stdin"] is subprocess.DEVNULL
+        pi._spawn("qwen")
+    assert captured["stdin"] is subprocess.PIPE
 
 
 def _manager(tmp_path, monkeypatch, api_key="none"):


### PR DESCRIPTION
Rework PiProcess from spawn-per-turn to ONE long-lived pi --mode rpc process with late-bound session identity via switch_session.

Removes per-turn spawn cost, enables real interrupt via abort command, session identity binds late. Record contract unchanged.

Relates to #4358 toward #4356.