### PR TITLE
fix(embervm): re-arm local base retention after live manifest review

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.414
+version: 0.1.415

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.414
+      targetRevision: 0.1.415
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -221,15 +221,25 @@ statefulSweeper:
 # local eviction, and hydrate-on-miss restores from S3 on a cold start.
 # Rollback: set back to "" and bump the chart; that stops further eviction.
 baseRetention:
-  # Disarmed pending manifest review for #4290, re-arm in follow-up PR after manifest is read on live fleet.
-  # This gate had been on since 2026-07-27 and was harmless only because the
-  # sweep found nothing. Two reasons it must be off while that changes: the
-  # keep-set lives in control-plane memory and is never rehydrated on boot, so
-  # after a restart a base still pinned by a BANKED session looks unreferenced
-  # and is evictable, which costs that session its remaining warm-bank window;
-  # and nobody has yet read a manifest of what this would delete. Re-arm in a
-  # follow-up PR once #4364 clears, not by editing this back on its own.
-  sweepEnabled: ""
+  # RE-ARMED 2026-08-05 after reading the manifest live (#4290). The sweep named
+  # exactly two candidates, both on node-3, both claude-runtime/intel superseded
+  # bases aged 25h and 48h, 8.59 GB total, and left tonight's fresh base alone
+  # under the 3600s min-age rail. Arming was checked against session state at the
+  # same moment: all 70 claude-runtime sessions were terminal (evicted, destroyed,
+  # failed), with zero live, parked, or banked, so nothing could be pinned to the
+  # candidates.
+  #
+  # The standing risk from #4364 is NOT closed by that: the keep-set lives in
+  # control-plane memory and is never rehydrated on boot, so once real sessions
+  # exist again, a CP restart can make a base pinned by a parked session look
+  # unreferenced. "A base is reconstructible" is the usual defence, and it is why
+  # the remote gate was armed directly, but this cluster has already evicted four
+  # sessions with terminal_reason "snapshot_vanished", so a vanished artifact
+  # kills the session rather than being silently rebuilt. Land #4364's durable
+  # keep-set before session traffic resumes.
+  #
+  # Rollback: set back to "" and bump the chart; that stops further eviction.
+  sweepEnabled: "1"
   # Arm REMOTE base retention (#3947 PR-4, Joe 2026-07-27). Local retention has
   # been reclaiming node disk for a while, but nothing reclaimed the store, so
   # superseded S3 bases accumulated without bound. Armed directly rather than


### PR DESCRIPTION
Re-arms `baseRetention.sweepEnabled` after reading the manifest on the live fleet. Chart 0.1.415. Refs #4290, #4364.

## Evidence for arming

The manifest (readable as of #4365) named exactly two candidates on the first sweep after deploy:

| ref | node | age | size | reason |
|---|---|---|---|---|
| `claude-runtime__92c17987bb30` | node-3 | 89,934s (~25h) | 4.29 GB | known workload superseded: not in current, CP snapshot, or active base_refs |
| `claude-runtime__b8b741a83f54` | node-3 | 175,101s (~48.6h) | 4.29 GB | same |

8.59 GB reclaimable. Both `claude-runtime/intel`, base_generation 53. The base created at 06:03 tonight was correctly NOT a candidate, held back by the 3600s minimum-age rail, which is the rail behaving as designed.

Session state was checked at the same moment: all 70 `claude-runtime` sessions are terminal (`evicted`, `destroyed`, `failed`), with **zero live, parked, or banked**. So nothing can be pinned to either candidate, and the #4364 keep-set gap has no live instance to harm right now.

node-3 scratch is at 71% (9.4G free of 34.2G), so this reclaim is worth having before the next round of chart publishes.

## What this does NOT resolve

#4364's durable keep-set is still outstanding, and it becomes load-bearing again the moment real sessions exist. The keep-set lives in control-plane memory and is never rehydrated on boot, so after a CP restart a base pinned by a parked session can look unreferenced.

The usual defence is that a base is a reconstructible artifact, which is exactly why the remote gate was armed directly. This cluster contradicts the comfortable version of that claim: four sessions have been evicted with `terminal_reason: "snapshot_vanished"`. A vanished artifact kills the session rather than being transparently rebuilt. So #4364 should land before session traffic resumes.

## Rollback

Set `sweepEnabled: ""` and bump the chart. Deletion is capped at 20 evictions per sweep, so a mistake cannot take the fleet's warmth in one pass.