### PR TITLE
fix(embervm): arm the disk-driven base eviction gate

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.415
+version: 0.1.416

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.415
+      targetRevision: 0.1.416
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -240,6 +240,18 @@ baseRetention:
   #
   # Rollback: set back to "" and bump the chart; that stops further eviction.
   sweepEnabled: "1"
+  # Arm the DISK-DRIVEN eviction path. This is a second gate, added alongside the
+  # disk-driven candidate logic so that fixing the enumeration could not silently
+  # inherit the legacy gate above, which had been armed since 2026-07-27. Setting
+  # sweepEnabled alone leaves the sweep logging "DRY RUN, deletion disabled",
+  # because candidates now come from the disk-driven plan and are gated here.
+  #
+  # Armed after two consecutive live sweeps named the same two candidates and
+  # nothing else: node-3 claude-runtime/intel superseded bases aged 25h and 48h,
+  # 8.59 GB, with tonight's fresh base correctly spared by the 3600s min-age rail.
+  # Rollback is setting this back to "" and bumping the chart; eviction is also
+  # capped at 20 per sweep, so a logic error cannot clear the fleet in one pass.
+  diskDrivenEnabled: "1"
   # Arm REMOTE base retention (#3947 PR-4, Joe 2026-07-27). Local retention has
   # been reclaiming node disk for a while, but nothing reclaimed the store, so
   # superseded S3 bases accumulated without bound. Armed directly rather than


### PR DESCRIPTION
Follow-on to #4366, which armed `sweepEnabled` but left the sweep logging `DRY RUN, deletion disabled`. Chart 0.1.416. Refs #4290, #4364.

## Why #4366 was not enough

Disk-driven candidates are gated by a **second** flag, `diskDrivenEnabled`, added alongside the enumeration fix precisely so that making the sweep see the disk could not silently inherit the legacy gate (which had been armed since 2026-07-27 and was harmless only because the sweep found nothing). The selection reads:

```elixir
deletion_enabled? =
  if disk_driven_plan?, do: state.retention_disk_driven_enabled, else: state.retention_sweep_enabled
```

So with only `sweepEnabled: "1"` the pod had `EMBERVM_BASE_RETENTION_SWEEP=1` and still deleted nothing. Verified live: the 07:01:25 sweep logged `DRY RUN, deletion disabled, 2 candidates, 8589993530 bytes reclaimable`.

The two-gate design is right; it just needs both flipped to actually arm.

## Evidence

Two consecutive sweeps (06:48:39 and 07:01:25) named the same two candidates and nothing else:

- `claude-runtime__92c17987bb30`, node-3, ~25h, 4.29 GB
- `claude-runtime__b8b741a83f54`, node-3, ~48.6h, 4.29 GB

Both `known workload superseded: not in current, CP snapshot, or active base_refs`. Tonight's base, created 06:03, is correctly excluded by the 3600s minimum-age rail.

## Rollback

Set `diskDrivenEnabled: ""` and bump the chart. Eviction is capped at 20 per sweep.

## Still outstanding

#4364's durable keep-set. The keep-set is control-plane memory and is never rehydrated on boot, so once sessions are live again a CP restart can make a base pinned by a parked session look unreferenced. This cluster has evicted sessions with `terminal_reason: "snapshot_vanished"`, so a vanished base kills a session rather than being transparently rebuilt.