### PR TITLE
fix(embervm): unstall the guest git proxy and retry workspace hydration

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.416
+version: 0.1.417

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.416
+      targetRevision: 0.1.417
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -140,7 +140,13 @@ DEFAULT_EGRESS_PORT = 1024
 def _pump_stdin_to_socket(source, sock):
     try:
         while True:
-            data = source.read(65536)
+            # read1, NOT read: BufferedReader.read(n) blocks until it has all n
+            # bytes or EOF, and git's protocol is request/response in messages of
+            # a few hundred bytes. read(65536) therefore holds each request until
+            # 64 KiB accumulates or the stream closes, stalling every negotiation
+            # round trip and turning a 4s clone into a timeout. read1 returns what
+            # is available after one syscall.
+            data = source.read1(65536)
             if not data:
                 break
             sock.sendall(data)

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -92,6 +92,10 @@ INIT_READ_TIMEOUT = _read_init_timeout()
 TURN_READ_TIMEOUT = 600.0
 INTERRUPT_TIMEOUT = 30.0
 CLI_PROBE_TIMEOUT = 10.0
+HYDRATION_ATTEMPT_CAP = 3
+# The guest path is proxied over vsock, so it is materially slower than a direct
+# clone. A partial clone of this repo is approximately 67 MB.
+GIT_CLONE_TIMEOUT_SECONDS = 300
 PERMISSION_MODE_ENV = "EMBER_PERMISSION_MODE"
 DEFAULT_PERMISSION_MODE = "bypassPermissions"
 CLI_UID_ENV = "EMBER_CLI_UID"
@@ -2080,7 +2084,7 @@ class ProcessManager:
         self.workspace = os.path.abspath(
             workspace or os.environ.get("EMBER_CLAUDE_WORKSPACE", DEFAULT_WORKSPACE)
         )
-        self._hydration_attempted = False
+        self._hydration_attempts = 0
         self._hydration_error = None
         self._checkout_dir = None
         self._hydration_status = None
@@ -2090,11 +2094,27 @@ class ProcessManager:
         self.pi = PiProcess(self.workspace, pi_executable)
 
     def _hydrate_workspace(self, repo, branch):
-        if self._hydration_attempted:
+        if self._hydration_status == "ok":
             if self._checkout_dir and os.path.isdir(self._checkout_dir):
                 self._hydration_status = "skipped_existing"
             return
-        self._hydration_attempted = True
+        if self._hydration_status == "skipped_existing":
+            return
+        if self._hydration_attempts >= HYDRATION_ATTEMPT_CAP:
+            return
+        if self._hydration_attempts:
+            sys.stderr.write(
+                "ember-claude-shim: retrying workspace hydration for %s@%s "
+                "(attempt %s/%s)\n"
+                % (
+                    repo,
+                    branch,
+                    self._hydration_attempts + 1,
+                    HYDRATION_ATTEMPT_CAP,
+                )
+            )
+            sys.stderr.flush()
+        self._hydration_attempts += 1
         checkout_dir = os.path.join(self.workspace, "src")
         # Idempotency gate: restored/rejoined volumes reuse existing checkout.
         # This deliberately ignores repo/branch changes on restored volumes; per-session
@@ -2132,54 +2152,49 @@ class ProcessManager:
             "git://git-mirror.monolith.svc.cluster.local:9418/%s" % repo,
             checkout_dir,
         ]
-        for attempt in range(2):
-            try:
-                result = subprocess.run(
-                    clone_command,
-                    capture_output=True,
-                    timeout=120,
-                    **_cli_privilege_kwargs(),
+        try:
+            result = subprocess.run(
+                clone_command,
+                capture_output=True,
+                timeout=GIT_CLONE_TIMEOUT_SECONDS,
+                **_cli_privilege_kwargs(),
+            )
+            if result.returncode != 0:
+                stderr = result.stderr
+                if isinstance(stderr, bytes):
+                    stderr = stderr.decode("utf-8", "replace")
+                stderr = (stderr or "").strip()
+                raise RuntimeError(
+                    "git command failed with exit code %s%s"
+                    % (result.returncode, ": " + stderr if stderr else "")
                 )
-                if result.returncode != 0:
-                    stderr = result.stderr
-                    if isinstance(stderr, bytes):
-                        stderr = stderr.decode("utf-8", "replace")
-                    stderr = (stderr or "").strip()
-                    raise RuntimeError(
-                        "git command failed with exit code %s%s"
-                        % (result.returncode, ": " + stderr if stderr else "")
-                    )
-                validation = subprocess.run(
-                    ["git", "-C", checkout_dir, "rev-parse", "--verify", "HEAD"],
-                    capture_output=True,
-                    timeout=5,
-                    **_cli_privilege_kwargs(),
-                )
-                if validation.returncode == 0:
-                    break
-                shutil.rmtree(checkout_dir, ignore_errors=True)
-                if attempt == 1:
-                    raise RuntimeError(
-                        "cloned directory validation failed: HEAD not found"
-                    )
-            except subprocess.TimeoutExpired as exc:
-                shutil.rmtree(checkout_dir, ignore_errors=True)
-                self._hydration_error = str(exc)
-                sys.stderr.write(
-                    "ember-claude-shim: workspace hydration failed for %s@%s: %s\n"
-                    % (repo, branch, exc)
-                )
-                sys.stderr.flush()
-                return
-            except Exception as exc:
-                shutil.rmtree(checkout_dir, ignore_errors=True)
-                self._hydration_error = str(exc)
-                sys.stderr.write(
-                    "ember-claude-shim: workspace hydration failed for %s@%s: %s\n"
-                    % (repo, branch, exc)
-                )
-                sys.stderr.flush()
-                return
+            validation = subprocess.run(
+                ["git", "-C", checkout_dir, "rev-parse", "--verify", "HEAD"],
+                capture_output=True,
+                timeout=5,
+                **_cli_privilege_kwargs(),
+            )
+            if validation.returncode != 0:
+                raise RuntimeError("cloned directory validation failed: HEAD not found")
+        except subprocess.TimeoutExpired as exc:
+            shutil.rmtree(checkout_dir, ignore_errors=True)
+            self._hydration_error = str(exc)
+            sys.stderr.write(
+                "ember-claude-shim: workspace hydration failed for %s@%s: %s\n"
+                % (repo, branch, exc)
+            )
+            sys.stderr.flush()
+            return
+        except Exception as exc:
+            shutil.rmtree(checkout_dir, ignore_errors=True)
+            self._hydration_error = str(exc)
+            sys.stderr.write(
+                "ember-claude-shim: workspace hydration failed for %s@%s: %s\n"
+                % (repo, branch, exc)
+            )
+            sys.stderr.flush()
+            return
+        self._hydration_error = None
         exclude_file = os.path.join(checkout_dir, ".git/info/exclude")
         os.makedirs(os.path.dirname(exclude_file), exist_ok=True)
         with open(exclude_file, "a") as stream:

--- a/projects/embervm/runtimes/claude/shim_hydration_test.py
+++ b/projects/embervm/runtimes/claude/shim_hydration_test.py
@@ -26,7 +26,7 @@ def manager(tmp_path):
     instance.claude = _Adapter(instance.workspace)
     instance.codex = _Adapter(instance.workspace)
     instance.pi = _Adapter(instance.workspace)
-    instance._hydration_attempted = False
+    instance._hydration_attempts = 0
     instance._hydration_error = None
     instance._checkout_dir = None
     instance._hydration_status = None
@@ -141,8 +141,8 @@ def test_hydration_failure_logs_and_continues(manager, monkeypatch, capsys):
 
 def test_hydration_timeout(manager, monkeypatch, capsys):
     def fake_run(*_a, **kwargs):
-        if kwargs.get("timeout") == 120:
-            raise subprocess.TimeoutExpired("git", 120)
+        if kwargs.get("timeout") == shim.GIT_CLONE_TIMEOUT_SECONDS:
+            raise subprocess.TimeoutExpired("git", shim.GIT_CLONE_TIMEOUT_SECONDS)
         return _GitProcess()
 
     monkeypatch.setattr(shim.subprocess, "run", fake_run)
@@ -150,6 +150,51 @@ def test_hydration_timeout(manager, monkeypatch, capsys):
     manager.turn("first", repo="owner/repo", branch="main")
 
     assert "workspace hydration failed" in capsys.readouterr().err
+
+
+def test_failed_hydration_retries_on_next_turn_and_succeeds(
+    manager, monkeypatch, capsys
+):
+    clone_calls = []
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "clone":
+            clone_calls.append(command)
+            if len(clone_calls) == 1:
+                raise subprocess.TimeoutExpired("git", shim.GIT_CLONE_TIMEOUT_SECONDS)
+        return _GitProcess()
+
+    monkeypatch.setattr(shim.subprocess, "run", fake_run)
+
+    first = manager.turn("first", repo="owner/repo", branch="main")
+    second = manager.turn("second", repo="owner/repo", branch="main")
+
+    assert first["workspace_hydration"]["failed"]
+    assert second["workspace_hydration"] == "ok"
+    assert len(clone_calls) == 2
+    assert manager.claude.workspace == os.path.join(manager.workspace, "src")
+    assert "retrying workspace hydration" in capsys.readouterr().err
+
+
+def test_hydration_failure_is_capped_and_keeps_reporting(manager, monkeypatch):
+    clone_calls = []
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "clone":
+            clone_calls.append(command)
+            raise subprocess.TimeoutExpired("git", shim.GIT_CLONE_TIMEOUT_SECONDS)
+        return _GitProcess()
+
+    monkeypatch.setattr(shim.subprocess, "run", fake_run)
+
+    records = [
+        manager.turn("turn", repo="owner/repo", branch="main")
+        for _ in range(shim.HYDRATION_ATTEMPT_CAP + 1)
+    ]
+
+    assert len(clone_calls) == shim.HYDRATION_ATTEMPT_CAP
+    assert manager._hydration_attempts == shim.HYDRATION_ATTEMPT_CAP
+    assert all(record["workspace_hydration"]["failed"] for record in records)
 
 
 def test_git_command_shape(manager, monkeypatch):
@@ -199,7 +244,7 @@ def test_no_hydration_when_repo_absent(manager, monkeypatch):
 
     manager.turn("first", session_id="session")
 
-    assert manager._hydration_attempted is False
+    assert manager._hydration_attempts == 0
     assert manager.claude.calls
 
 


### PR DESCRIPTION
Two fixes for the same live failure: a session whose workspace never arrived, then never recovered. Refs #4329.

## The live failure

```
ember-claude-shim: workspace hydration failed for jomcgi/homelab@main:
git clone --branch main --config core.gitProxy=/tmp/ember-git-proxy --single-branch --filter=blob:none
git://git-mirror.monolith.svc.cluster.local:9418/jomcgi/homelab /workspace/src
timed out after 120 seconds
```

The user's next turn answered "there is no Git repository in /workspace", because there wasn't one.

## Fix 1: the git proxy stalled on every request (the root cause)

`_pump_stdin_to_socket` used `source.read(65536)` on `sys.stdin.buffer`. `BufferedReader.read(n)` blocks until it has **all n bytes or EOF**, and git's protocol is request/response in messages of a few hundred bytes. So each request sat in the proxy until 64 KiB accumulated or the stream closed, stalling every negotiation round trip.

Measured:

| path | result |
|---|---|
| direct to the mirror (port-forward) | **4.54s**, 67 MB |
| from a guest, through the proxy | **timed out at 120s** |

The mirror itself is healthy: `ls-remote` answers in 0.19s.

Reproduced the pattern in isolation, 30 bytes available immediately:

- `read(65536)` returned them **after 1.98s**, only on EOF
- `read1(65536)` returned them **at 0.00s**

`read1` returns what is available after one syscall, which is the correct idiom for a relay. `_pump_socket_to_stdout` was already fine, since `sock.recv` returns what is available.

## Fix 2: a failed hydration latched forever

`_hydrate_workspace` set `_hydration_attempted = True` **before** attempting and never cleared it on the failure paths, so every later turn hit the short-circuit and the workspace could never appear again for the life of the session. One slow clone permanently disabled the workspace.

Now a failure is retryable on a later turn, bounded by `HYDRATION_ATTEMPT_CAP = 3`, while a success is still attempted only once and the `skipped_existing` path for restored durable volumes is unchanged. Retries log explicitly so "failed once then recovered" is distinguishable from "never attempted". The clone timeout also moves from 120s to `GIT_CLONE_TIMEOUT_SECONDS = 300`, sized for the proxied path.

## Note on clone shape

Considered and rejected as the cause: the clone is `--single-branch --filter=blob:none` with no `--depth`, so it carries full commit and tree history. Measured against the mirror, that costs about 2x versus shallow (24 MB of `.git` and 4.54s, versus 13 MB and 2.43s at `--depth 1`). Real, but nowhere near the 26x gap, so depth was not the problem. Worth revisiting separately if we want faster hydration, along with the fact that `--filter=blob:none` defers historical blob fetches onto the same lane.

## Verification

`ci test`: 757 tests pass. Chart 0.1.417.