### PR TITLE
feat(embervm): restore warm base with per-session volume

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.420
+version: 0.1.421

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.420
+      targetRevision: 0.1.421
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -108,6 +108,11 @@ type Config struct {
 	// until that verify step runs on the Alder Lake-S masters, this field only
 	// drives the sku stamp/mismatch/grandfather gate, never the FC API call.
 	Template string
+	// WarmRestoreWithVolume, when true, allows restore from a warm base even when
+	// spec.VolumeDiskPath is set. The base must have been captured with a volume
+	// device attached. Keep this disabled until guest-init defers its volume
+	// mount, so the guest can handle the volume contents changing before resume.
+	WarmRestoreWithVolume bool
 }
 
 func (c Config) withDefaults() Config {
@@ -145,6 +150,7 @@ type fcAPI interface {
 	PutMachineConfig(ctx context.Context, m fcclient.MachineConfig) error
 	PutBootSource(ctx context.Context, b fcclient.BootSource) error
 	PutDrive(ctx context.Context, d fcclient.Drive) error
+	PatchDrive(ctx context.Context, driveID string, d fcclient.Drive) error
 	PutVsock(ctx context.Context, v fcclient.Vsock) error
 	PutNetworkInterface(ctx context.Context, n fcclient.NetworkInterface) error
 	Start(ctx context.Context) error
@@ -728,9 +734,16 @@ func (d *Driver) servingMetafile(ref string) string {
 }
 
 // loadInto launches a fresh Firecracker process for threadID and restores it
-// from the given snapfile + memfile (File backend, resume). Used by both
-// thread-snapshot restore and warm-base restore.
+// from the given snapfile + memfile (File backend, resume). Used by all restore
+// paths that do not need to rebind a snapshot drive.
 func (d *Driver) loadInto(ctx context.Context, threadID, snapPath, memPath, sockName string) (substrate.Handle, error) {
+	return d.loadPatchAndResume(ctx, threadID, snapPath, memPath, sockName, "")
+}
+
+// loadPatchAndResume restores a snapshot, optionally repoints its volume drive,
+// and resumes it. Firecracker requires the drive patch while the loaded VM is
+// still paused.
+func (d *Driver) loadPatchAndResume(ctx context.Context, threadID, snapPath, memPath, sockName, volumeDiskPath string) (substrate.Handle, error) {
 	dir := d.threadDir(threadID)
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return substrate.Handle{}, fmt.Errorf("driver: mkdir bundle: %w", err)
@@ -747,12 +760,26 @@ func (d *Driver) loadInto(ctx context.Context, threadID, snapPath, memPath, sock
 		return substrate.Handle{}, fmt.Errorf("driver: launch firecracker for restore: %w", err)
 	}
 	client := d.newClient(sock)
+	resumeVM := volumeDiskPath == ""
 	if err := client.LoadSnapshot(ctx, fcclient.SnapshotLoad{
 		SnapshotPath: snapPath,
 		MemBackend:   &fcclient.MemBackend{BackendType: "File", BackendPath: memPath},
-		ResumeVM:     true,
+		ResumeVM:     resumeVM,
 	}); err != nil {
 		return d.abort(proc, err)
+	}
+	if volumeDiskPath != "" {
+		if err := client.PatchDrive(ctx, "volume", fcclient.Drive{
+			DriveID:      "volume",
+			PathOnHost:   volumeDiskPath,
+			IsRootDevice: false,
+			IsReadOnly:   false,
+		}); err != nil {
+			return d.abort(proc, err)
+		}
+		if err := client.Resume(ctx); err != nil {
+			return d.abort(proc, err)
+		}
 	}
 	h := substrate.Handle{ThreadID: threadID, ID: vmID, Node: d.cfg.Node}
 	d.track(&instance{handle: h, proc: proc, client: client, dir: dir, sock: sock, memMib: d.cfg.MemMib})
@@ -772,7 +799,7 @@ func (d *Driver) Claim(ctx context.Context, spec substrate.ClaimSpec) (substrate
 
 	// Warm-base start: restore the new thread from a base bundle for an instant
 	// ready start, skipping boot + harness init.
-	if spec.BaseSnapshotRef.ID != "" && spec.VolumeDiskPath == "" {
+	if spec.BaseSnapshotRef.ID != "" && (spec.VolumeDiskPath == "" || d.cfg.WarmRestoreWithVolume) {
 		ref := spec.BaseSnapshotRef
 		if ref.Arch != "" && d.cfg.Arch != "" && ref.Arch != d.cfg.Arch {
 			return substrate.Handle{}, fmt.Errorf("driver: base arch mismatch: ref %q != node %q", ref.Arch, d.cfg.Arch)
@@ -786,6 +813,9 @@ func (d *Driver) Claim(ctx context.Context, spec substrate.ClaimSpec) (substrate
 		snap := d.baseSnapfile(ref.ID)
 		if _, err := os.Stat(snap); err != nil {
 			return substrate.Handle{}, fmt.Errorf("driver: base bundle missing for %q: %w", ref.ID, err)
+		}
+		if spec.VolumeDiskPath != "" {
+			return d.loadPatchAndResume(ctx, threadID, snap, d.baseMemfile(ref.ID), "api.sock", spec.VolumeDiskPath)
 		}
 		return d.loadInto(ctx, threadID, snap, d.baseMemfile(ref.ID), "api.sock")
 	}
@@ -930,6 +960,15 @@ func (d *Driver) coldBoot(ctx context.Context, threadID string, cb coldBootSpec)
 				return err
 			}
 		}
+		if d.cfg.WarmRestoreWithVolume && cb.volumeDiskPath == "" {
+			placeholder, err := d.ensurePlaceholderVolume(dir)
+			if err != nil {
+				return err
+			}
+			if err := client.PutDrive(ctx, fcclient.Drive{DriveID: "volume", PathOnHost: placeholder, IsRootDevice: false, IsReadOnly: false}); err != nil {
+				return err
+			}
+		}
 		// Serving class (R3): attach the tap NIC pre-Start. Task/session claims leave
 		// nic nil and never reach this, so their boot path is byte-unchanged
 		// (vsock-only, no NIC). Firecracker cannot hot-attach a NIC to a resumed
@@ -963,6 +1002,28 @@ func (d *Driver) coldBoot(ctx context.Context, threadID string, cb coldBootSpec)
 	h := substrate.Handle{ThreadID: threadID, ID: vmID, Node: d.cfg.Node}
 	d.track(&instance{handle: h, proc: proc, client: client, dir: dir, sock: sock, memMib: cb.memMib})
 	return h, nil
+}
+
+// ensurePlaceholderVolume creates the sparse backing file captured in a warm
+// base's device set. The guest owns filesystem initialization and mounting;
+// this raw image only needs to provide a stable block-device path in the base.
+func (d *Driver) ensurePlaceholderVolume(threadDir string) (string, error) {
+	path := filepath.Join(threadDir, "placeholder-volume.img")
+	if _, err := os.Stat(path); err == nil {
+		return path, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("driver: stat placeholder volume: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("driver: create placeholder volume: %w", err)
+	}
+	defer f.Close()
+	if err := f.Truncate(16 * 1024 * 1024); err != nil {
+		_ = os.Remove(path)
+		return "", fmt.Errorf("driver: size placeholder volume: %w", err)
+	}
+	return path, nil
 }
 
 // ClaimServing cold-boots a serving-class microVM from a per-workload rootfs WITH a

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -23,6 +23,7 @@ import (
 type fakeLauncher struct {
 	mu       sync.Mutex
 	launched int
+	requests []string
 }
 
 type fakeProcess struct {
@@ -45,7 +46,13 @@ func (l *fakeLauncher) Launch(_ context.Context, _ string, socketPath string) (P
 		return nil, err
 	}
 	mux := http.NewServeMux()
+	record := func(r *http.Request) {
+		l.mu.Lock()
+		l.requests = append(l.requests, r.Method+" "+r.URL.Path)
+		l.mu.Unlock()
+	}
 	mux.HandleFunc("/snapshot/create", func(w http.ResponseWriter, r *http.Request) {
+		record(r)
 		var body map[string]any
 		b, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(b, &body)
@@ -58,12 +65,19 @@ func (l *fakeLauncher) Launch(_ context.Context, _ string, socketPath string) (P
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
-	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		record(r)
 		w.WriteHeader(http.StatusNoContent)
 	})
 	srv := &http.Server{Handler: mux}
 	go func() { _ = srv.Serve(ln) }()
 	return &fakeProcess{srv: srv}, nil
+}
+
+func (l *fakeLauncher) requestPaths() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.requests...)
 }
 
 // shortTempDir returns a temp dir under /tmp with a short path. The fake
@@ -132,6 +146,118 @@ func TestDriverClaimBootsMicroVM(t *testing.T) {
 	}
 	if d.LiveCount() != 1 {
 		t.Fatalf("LiveCount = %d, want 1", d.LiveCount())
+	}
+}
+
+func TestDriverClaimWithVolumeColdBootsWhenWarmRestoreDisabled(t *testing.T) {
+	launcher := &fakeLauncher{}
+	d := New(Config{
+		KernelImagePath: "/opt/kata/vmlinux",
+		RootfsPath:      "/dev/mapper/thread",
+		SnapshotRoot:    shortTempDir(t),
+		Node:            "node-4",
+		Arch:            "amd64",
+	}, launcher, nil)
+	h, err := d.Claim(context.Background(), substrate.ClaimSpec{
+		ThreadID:        "cold-volume",
+		BaseSnapshotRef: substrate.SnapshotRef{ID: "base"},
+		VolumeDiskPath:  "/sessions/s1/workspace.img",
+	})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Release(context.Background(), h) })
+	paths := launcher.requestPaths()
+	for _, path := range paths {
+		if path == "PUT /snapshot/load" {
+			t.Fatalf("disabled warm restore unexpectedly loaded a snapshot: %v", paths)
+		}
+	}
+	foundVolume := false
+	for _, path := range paths {
+		if path == "PUT /drives/volume" {
+			foundVolume = true
+		}
+	}
+	if !foundVolume {
+		t.Fatalf("cold boot did not attach volume: %v", paths)
+	}
+}
+
+func TestDriverClaimWithVolumeLoadPatchResume(t *testing.T) {
+	launcher := &fakeLauncher{}
+	root := shortTempDir(t)
+	d := New(Config{
+		KernelImagePath:       "/opt/kata/vmlinux",
+		RootfsPath:            "/dev/mapper/thread",
+		SnapshotRoot:          root,
+		Node:                  "node-4",
+		Arch:                  "amd64",
+		WarmRestoreWithVolume: true,
+	}, launcher, nil)
+	if err := os.MkdirAll(d.baseDir("base"), 0o750); err != nil {
+		t.Fatalf("mkdir base: %v", err)
+	}
+	if err := os.WriteFile(d.baseSnapfile("base"), []byte("snap"), 0o600); err != nil {
+		t.Fatalf("write snapfile: %v", err)
+	}
+	h, err := d.Claim(context.Background(), substrate.ClaimSpec{
+		ThreadID:        "warm-volume",
+		BaseSnapshotRef: substrate.SnapshotRef{ID: "base", Arch: "amd64"},
+		VolumeDiskPath:  "/sessions/s1/workspace.img",
+	})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Release(context.Background(), h) })
+	if h.ID == "" {
+		t.Fatal("Claim returned empty handle")
+	}
+	paths := launcher.requestPaths()
+	want := []string{"PUT /snapshot/load", "PATCH /drives/volume", "PATCH /vm"}
+	if len(paths) != len(want) {
+		t.Fatalf("request paths = %v, want %v", paths, want)
+	}
+	for i := range want {
+		if paths[i] != want[i] {
+			t.Fatalf("request path[%d] = %q, want %q", i, paths[i], want[i])
+		}
+	}
+}
+
+func TestDriverWarmRestoreFlagAttachesBasePlaceholderVolume(t *testing.T) {
+	launcher := &fakeLauncher{}
+	root := shortTempDir(t)
+	d := New(Config{
+		KernelImagePath:       "/opt/kata/vmlinux",
+		RootfsPath:            "/dev/mapper/thread",
+		SnapshotRoot:          root,
+		Node:                  "node-4",
+		Arch:                  "amd64",
+		WarmRestoreWithVolume: true,
+	}, launcher, nil)
+	h, err := d.Claim(context.Background(), substrate.ClaimSpec{ThreadID: "base-build"})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Release(context.Background(), h) })
+	placeholder := filepath.Join(d.threadDir(h.ThreadID), "placeholder-volume.img")
+	info, err := os.Stat(placeholder)
+	if err != nil {
+		t.Fatalf("placeholder volume: %v", err)
+	}
+	if info.Size() != 16*1024*1024 {
+		t.Fatalf("placeholder size = %d, want %d", info.Size(), 16*1024*1024)
+	}
+	paths := launcher.requestPaths()
+	foundVolume := false
+	for _, path := range paths {
+		if path == "PUT /drives/volume" {
+			foundVolume = true
+		}
+	}
+	if !foundVolume {
+		t.Fatalf("warm base cold boot did not attach placeholder volume: %v", paths)
 	}
 }
 

--- a/projects/embervm/noded/fcvm/fcclient/client.go
+++ b/projects/embervm/noded/fcvm/fcclient/client.go
@@ -122,6 +122,14 @@ func (c *Client) PutDrive(ctx context.Context, d Drive) error {
 	return c.do(ctx, http.MethodPut, "/drives/"+d.DriveID, d)
 }
 
+// PatchDrive updates a drive's path_on_host on a loaded (not-yet-resumed)
+// microVM. Used to repoint the volume drive to a session-specific backing file
+// after LoadSnapshot on the warm-restore path. The drive must already exist in
+// the snapshot's device set.
+func (c *Client) PatchDrive(ctx context.Context, driveID string, d Drive) error {
+	return c.do(ctx, http.MethodPatch, "/drives/"+driveID, d)
+}
+
 // PutVsock attaches a vsock device for the wrapper channel.
 func (c *Client) PutVsock(ctx context.Context, v Vsock) error {
 	return c.do(ctx, http.MethodPut, "/vsock", v)

--- a/projects/embervm/noded/fcvm/fcclient/client_test.go
+++ b/projects/embervm/noded/fcvm/fcclient/client_test.go
@@ -158,6 +158,28 @@ func TestClientLoadSnapshotResume(t *testing.T) {
 	}
 }
 
+func TestClientPatchDrive(t *testing.T) {
+	fake, sock := startFakeFC(t)
+	c := New(sock)
+	drive := Drive{DriveID: "volume", PathOnHost: "/sessions/s1/workspace.img", IsRootDevice: false, IsReadOnly: false}
+	if err := c.PatchDrive(context.Background(), "volume", drive); err != nil {
+		t.Fatalf("PatchDrive: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(fake.requests))
+	}
+	r := fake.requests[0]
+	if r.Method != http.MethodPatch || r.Path != "/drives/volume" {
+		t.Fatalf("request = %s %s, want PATCH /drives/volume", r.Method, r.Path)
+	}
+	if r.Body["drive_id"] != "volume" || r.Body["path_on_host"] != drive.PathOnHost || r.Body["is_read_only"] != false {
+		t.Fatalf("drive body = %v", r.Body)
+	}
+}
+
 func TestClientPropagatesAPIError(t *testing.T) {
 	fake, sock := startFakeFC(t)
 	fake.failPath = "/actions"


### PR DESCRIPTION
## Summary

Implement the driver-side mechanism for warm-base restore with a per-session volume device. Currently, persistent sessions are excluded from warm-base restore (Claim rejects BaseSnapshotRef + VolumeDiskPath), so every session start is a cold boot despite having real memory snapshots.

This PR adds:
1. **fcclient.PatchDrive**: PATCH /drives/{id} to repoint a drive's backing path on a loaded VM
2. **loadPatchAndResume**: Load snapshot without resume, patch volume drive, then resume (the warm-restore-with-volume sequence)
3. **Placeholder volume device**: Captured in base snapshots when WarmRestoreWithVolume flag is on, so later restores can patch it to session-specific backing files
4. **WarmRestoreWithVolume flag**: Config option (default false) that gates the entire mechanism behind a safe default

All existing guards (arch, vendor, template mismatch, missing bundle) still apply to warm-restore-with-volume paths.

## Mechanism

When WarmRestoreWithVolume is enabled:
- Base captures attach a 16 MiB placeholder volume device (backed by threadDir/placeholder-volume.img)
- Claim with BaseSnapshotRef + VolumeDiskPath now takes the warm path
- LoadSnapshot is called with ResumeVM: false
- PatchDrive repoints the volume to the session's workspace.img
- Resume completes the restore

When disabled (default), claims with volume still cold-boot (existing behavior).

## Test Coverage

- PatchDrive issues correct HTTP PATCH method and body
- Load-patch-resume sequence happens in order
- Flag-off still cold-boots with volume (backward compat)
- Flag-on warm-restores with volume + patches
- Mismatch guards still reject across all warm paths

## Safety

The flag defaults **off** because the guest-init must defer its volume mount. Today, guest-init mounts /dev/vdb during the early boot before the guest is paused for the snapshot, so the placeholder's contents would be captured in the snapshot. When restored with a patched backing file, the guest would see stale data. The guest-side mount deferral change must land separately before this flag can be enabled in production.

## Refs #4371

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>