### PR TITLE
feat(embervm): wire WarmRestoreWithVolume and make the base volume placeholder node-stable

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.422
+version: 0.1.423

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -173,6 +173,12 @@ containers:
       # request), which is what keeps the DS pod identical to its pre-brick form.
       - name: EMBERVM_NODED_SIZE_CLASS
         value: {{ .sizeClass | quote }}
+      # Class-scoped because the flag is driver-wide per brick and sessions
+      # place only on the listed class. An empty list renders nothing.
+      {{- if and .sizeClass (has .sizeClass ($ctx.Values.noded.warmRestoreWithVolumeClasses | default (list))) }}
+      - name: EMBERVM_NODED_WARM_RESTORE_WITH_VOLUME
+        value: "true"
+      {{- end }}
       {{- end }}
       # Dial-home registration target: the control plane's HTTP base URL the
       # daemon POSTs {node, pod_uid, address, boot_id} to on start and on a

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -789,6 +789,9 @@ rootfsBuilder:
 # is Task 11), so its steady footprint is just the daemon.
 noded:
   enabled: true
+  # Brick size-classes whose noded gets warm restore with volume enabled;
+  # default empty disables it fleet-wide, armed via deploy values for issue #4371.
+  warmRestoreWithVolumeClasses: []
   image:
     # Pinned at build time by helm_chart(images={"noded.image": ".../noded/image:image.info"}).
     repository: ghcr.io/jomcgi/homelab/projects/embervm/noded/image

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.422
+      targetRevision: 0.1.423
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -71,6 +71,10 @@ func run(logger *slog.Logger) error {
 	}); len(removed) > 0 {
 		logger.Info("startup GC: reaped stale instance warmth", "count", len(removed), "segments", removed)
 	}
+	// Unconditional so every brick can restore a placeholder-bearing base hydrated from S3.
+	if _, err := driver.EnsurePlaceholderVolume(cfg.SnapshotRoot); err != nil {
+		return err
+	}
 
 	self, err := os.Executable()
 	if err != nil {
@@ -396,20 +400,21 @@ type driverExtras struct {
 // restore driver leaves them zero because restore ignores them.
 func newDriver(cfg config.Config, self string, x driverExtras) *driver.Driver {
 	return driver.New(driver.Config{
-		KernelImagePath:   cfg.KernelImagePath,
-		KernelBootArgs:    cfg.KernelBootArgs,
-		RootfsPath:        x.rootfsPath,
-		RootfsReadOnly:    true,
-		CanonicalVsockDir: cfg.CanonicalVsockDir,
-		HarnessInit:       x.harnessInit,
-		VCPUs:             x.vcpus,
-		MemMib:            x.memMib,
-		SnapshotRoot:      cfg.SnapshotRoot,
-		WarmthRoot:        cfg.WarmthRoot,
-		Node:              cfg.Node,
-		Arch:              cfg.Arch,
-		Vendor:            cfg.CpuVendor,
-		Template:          cfg.CpuTemplate,
+		KernelImagePath:       cfg.KernelImagePath,
+		KernelBootArgs:        cfg.KernelBootArgs,
+		RootfsPath:            x.rootfsPath,
+		RootfsReadOnly:        true,
+		CanonicalVsockDir:     cfg.CanonicalVsockDir,
+		HarnessInit:           x.harnessInit,
+		VCPUs:                 x.vcpus,
+		MemMib:                x.memMib,
+		SnapshotRoot:          cfg.SnapshotRoot,
+		WarmthRoot:            cfg.WarmthRoot,
+		Node:                  cfg.Node,
+		Arch:                  cfg.Arch,
+		Vendor:                cfg.CpuVendor,
+		Template:              cfg.CpuTemplate,
+		WarmRestoreWithVolume: cfg.WarmRestoreWithVolume,
 	}, &driver.ExecLauncher{
 		Bin:             cfg.BinPath,
 		OOMScoreAdj:     cfg.GuestOomScoreAdj,

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -270,6 +270,12 @@ type Config struct {
 	// what actually bound it, and the cgroup budget reader (NodeStatus fields
 	// 26/27) reports the real ceiling.
 	SizeClass string
+	// WarmRestoreWithVolume gates the driver's warm-base restore for volume-bearing
+	// claims and the placeholder attach at base build; default false; armed per
+	// brick size-class through the chart value noded.warmRestoreWithVolumeClasses
+	// (see _noded-pod.tpl). The live experiment is issue #4371. Env var:
+	// EMBERVM_NODED_WARM_RESTORE_WITH_VOLUME.
+	WarmRestoreWithVolume bool
 	// ControlPlaneURL is the control plane's HTTP base URL the daemon dials home to
 	// (EMBERVM_NODED_CONTROL_PLANE_URL, e.g. "http://embervm.embervm.svc:8080").
 	// On start and on a jittered interval the daemon POSTs its identity
@@ -414,6 +420,7 @@ func Load() (Config, error) {
 		// the control plane instead of being discovered via EndpointSlices.
 		PodUID:                os.Getenv("EMBERVM_POD_UID"),
 		SizeClass:             os.Getenv("EMBERVM_NODED_SIZE_CLASS"),
+		WarmRestoreWithVolume: boolDefault("EMBERVM_NODED_WARM_RESTORE_WITH_VOLUME", false),
 		ControlPlaneURL:       os.Getenv("EMBERVM_NODED_CONTROL_PLANE_URL"),
 		ControlPlaneTokenPath: getenvDefault("EMBERVM_NODED_CONTROL_PLANE_TOKEN_PATH", "/var/run/secrets/kubernetes.io/serviceaccount/token"),
 		RegisterInterval:      30 * time.Second,

--- a/projects/embervm/noded/config/config_test.go
+++ b/projects/embervm/noded/config/config_test.go
@@ -87,6 +87,41 @@ func TestLoadCpuVendorEnvOverride(t *testing.T) {
 	}
 }
 
+func TestLoadWarmRestoreWithVolumeEnv(t *testing.T) {
+	const key = "EMBERVM_NODED_WARM_RESTORE_WITH_VOLUME"
+	for _, tc := range []struct {
+		name  string
+		value *string
+		want  bool
+	}{
+		{name: "unset", want: false},
+		{name: "true", value: stringPtr("true"), want: true},
+		{name: "false", value: stringPtr("false"), want: false},
+		{name: "garbage", value: stringPtr("garbage"), want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.value == nil {
+				if err := os.Unsetenv(key); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				t.Setenv(key, *tc.value)
+			}
+			c, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if c.WarmRestoreWithVolume != tc.want {
+				t.Errorf("WarmRestoreWithVolume = %v, want %v", c.WarmRestoreWithVolume, tc.want)
+			}
+		})
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
 func TestLoadAdmissionConfig(t *testing.T) {
 	t.Setenv("EMBERVM_NODED_ADMISSION_MODEL", "reserved")
 	t.Setenv("EMBERVM_NODED_VM_OVERHEAD_MIB", "64")

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"path/filepath"
@@ -961,7 +962,7 @@ func (d *Driver) coldBoot(ctx context.Context, threadID string, cb coldBootSpec)
 			}
 		}
 		if d.cfg.WarmRestoreWithVolume && cb.volumeDiskPath == "" {
-			placeholder, err := d.ensurePlaceholderVolume(dir)
+			placeholder, err := d.ensurePlaceholderVolume()
 			if err != nil {
 				return err
 			}
@@ -1004,11 +1005,24 @@ func (d *Driver) coldBoot(ctx context.Context, threadID string, cb coldBootSpec)
 	return h, nil
 }
 
-// ensurePlaceholderVolume creates the sparse backing file captured in a warm
-// base's device set. The guest owns filesystem initialization and mounting;
-// this raw image only needs to provide a stable block-device path in the base.
-func (d *Driver) ensurePlaceholderVolume(threadDir string) (string, error) {
-	path := filepath.Join(threadDir, "placeholder-volume.img")
+// EnsurePlaceholderVolume creates the sparse backing file captured in a warm
+// base's device set. The snapshot bakes this absolute backing path into the
+// base's device table and Firecracker reopens it at snapshot load, so the file
+// must outlive the build VM's bundle directory, which RemoveBundle deletes
+// immediately after capture, and must exist at the same path on any brick that
+// may later restore the base because bases hydrate from S3 across bricks.
+// SnapshotRoot is the node-SHARED snapshots root, using the same chart-derived
+// path on every node, unlike the per-instance WarmthRoot, which is why the file
+// lives there. Guests never mount or write the device unless explicitly told to
+// through the ember.volume_dev / shim --device contract, so one shared backing
+// file is safe across concurrent VMs.
+func EnsurePlaceholderVolume(snapshotRoot string) (string, error) {
+	// Startup calls this before anything else has touched SnapshotRoot on a
+	// fresh node, so the parent cannot be assumed to exist yet.
+	if err := os.MkdirAll(snapshotRoot, 0o750); err != nil {
+		return "", fmt.Errorf("driver: mkdir snapshot root: %w", err)
+	}
+	path := filepath.Join(snapshotRoot, "placeholder-volume.img")
 	if _, err := os.Stat(path); err == nil {
 		return path, nil
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -1016,6 +1030,9 @@ func (d *Driver) ensurePlaceholderVolume(threadDir string) (string, error) {
 	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
 	if err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return path, nil
+		}
 		return "", fmt.Errorf("driver: create placeholder volume: %w", err)
 	}
 	defer f.Close()
@@ -1024,6 +1041,10 @@ func (d *Driver) ensurePlaceholderVolume(threadDir string) (string, error) {
 		return "", fmt.Errorf("driver: size placeholder volume: %w", err)
 	}
 	return path, nil
+}
+
+func (d *Driver) ensurePlaceholderVolume() (string, error) {
+	return EnsurePlaceholderVolume(d.cfg.SnapshotRoot)
 }
 
 // ClaimServing cold-boots a serving-class microVM from a per-workload rootfs WITH a

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -241,7 +241,7 @@ func TestDriverWarmRestoreFlagAttachesBasePlaceholderVolume(t *testing.T) {
 		t.Fatalf("Claim: %v", err)
 	}
 	t.Cleanup(func() { _ = d.Release(context.Background(), h) })
-	placeholder := filepath.Join(d.threadDir(h.ThreadID), "placeholder-volume.img")
+	placeholder := filepath.Join(root, "placeholder-volume.img")
 	info, err := os.Stat(placeholder)
 	if err != nil {
 		t.Fatalf("placeholder volume: %v", err)


### PR DESCRIPTION
Part of #4371 (validation step 1 groundwork). Inert on merge: the chart default arms nothing and no brick pod template changes.

## What

- Wires `WarmRestoreWithVolume` (merged inert in #4373) to reality: `EMBERVM_NODED_WARM_RESTORE_WITH_VOLUME` env into noded config, passed to the driver from the single `newDriver` site, rendered by the chart only for brick size-classes listed in `noded.warmRestoreWithVolumeClasses` (default `[]`).
- Fixes a latent bug in the placeholder-volume design: the base build created the placeholder inside the build VM's bundle directory, which `RemoveBundle` deletes immediately after capture. Firecracker reopens every baked drive backing path at `PUT /snapshot/load`, so any volume-less warm restore of a placeholder-bearing base (the synthetic probes do exactly this every 5 minutes on the 16gi brick for the task bases) would have hard-failed. The placeholder now lives at the node-shared `SnapshotRoot/placeholder-volume.img`, and every brick ensures it at startup regardless of its own flag, so bases hydrated from S3 across bricks stay restorable.

## Why class-scoped, not node-scoped

The oplog shows every session ever created placed on the 16gi brick (node-4): sessions are 4096 MiB and no other class fits them. The floor bricks build the claude-runtime base but never host session VMs, so a node-scoped canary on node-1/2/3 would test nothing. Scoping by size-class arms exactly the session-capable brick; with the list empty every Deployment renders byte-identical (verified via helm template: 0 occurrences unarmed, 1 Deployment armed).

## Arming (separate PR, next)

Deploy values get `warmRestoreWithVolumeClasses: ["16gi"]` plus an `initEnv` epoch entry on the claude-runtime Workload: base refs key on the workload signature and deliberately exclude noded config, so without the epoch the armed brick would sit on its old placeholder-less base and every volume-bearing claim would fail at the drive PATCH with no rebuild ever coming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG