### PR TITLE
feat(embervm): arm warm restore with volume on the 16gi brick class

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.423
+version: 0.1.424

--- a/projects/embervm/chart/templates/workload-claude-runtime.yaml
+++ b/projects/embervm/chart/templates/workload-claude-runtime.yaml
@@ -48,6 +48,16 @@ spec:
       port: {{ .Values.claudeRuntimeWorkload.port }}
       readyPath: {{ .Values.claudeRuntimeWorkload.readyPath | quote }}
       invokePath: {{ .Values.claudeRuntimeWorkload.invokePath | quote }}
+      {{- with .Values.claudeRuntimeWorkload.initEnv }}
+      # Baked guest env, and part of the workload signature (base_builder
+      # signature/1 includes sorted init_env): changing any entry re-keys and
+      # rebuilds this workload's base, and only this one. Deploy values use an
+      # epoch entry here to force a base rebuild when node-side capture
+      # behaviour changes, because noded config is deliberately excluded from
+      # the base key.
+      initEnv:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   resources:
     vcpus: {{ .Values.claudeRuntimeWorkload.vcpus }}
     memMib: {{ .Values.claudeRuntimeWorkload.memMib }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1223,6 +1223,11 @@ claudeRuntimeWorkload:
   port: 1027
   readyPath: /shim/ready
   invokePath: /shim/turn
+  # Guest env baked at base-build time (spec.source.image.initEnv). Entries are
+  # part of the workload signature, so any change re-keys and rebuilds this
+  # workload's base. Deploy values carry an epoch entry when a rebuild must be
+  # forced (issue #4371).
+  initEnv: {}
   vcpus: 2
   # 4 GiB: the CLI is a 262 MB Node ELF with a V8 heap on top, and guest-init
   # mounts tmpfs on both /tmp and /workspace. Those are caps, not reservations, so

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.423
+      targetRevision: 0.1.424
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -104,6 +104,19 @@ noded:
   # (docs/runbooks/embervm-node-scratch-setup.md).
   enabled: false
   maxLiveVMs: 16
+  # ARM warm restore with volume on the 16gi class ONLY (issue #4371 one-brick
+  # experiment). The 16gi brick is the only session-capable brick (sessions are
+  # 4096 MiB), so this is where the unproven Firecracker/ext4 fact gets
+  # answered: does a guest restored from a base snapshot, whose volume drive is
+  # then repointed at a different backing file, come up clean. Requires the
+  # claudeRuntimeWorkload.initEnv epoch below in the SAME change: base refs
+  # exclude noded config, so arming without re-keying the base would leave the
+  # brick failing every volume-bearing claim at the drive PATCH against its old
+  # placeholder-less base, with no rebuild ever coming. Expect a short window of
+  # failing session creates between the brick roll and the base rebuild.
+  # Rollback: set back to [] (and drop the epoch); no chart bump needed, the
+  # values git ref alone rolls the brick Deployment env off.
+  warmRestoreWithVolumeClasses: ["16gi"]
 
 # Node-provisioning contract (ADR embervm/012 storage-tiers amendment; warmth
 # cache-cap retention decisions 2026-07-22): DISABLED. The privileged runtime
@@ -398,6 +411,15 @@ egress:
 # session at all. Sizing and the node disk arithmetic are in chart/values.yaml.
 claudeRuntimeWorkload:
   enabled: true
+  # Epoch entry to force a base rebuild (issue #4371): init_env is in the
+  # workload signature, so this re-keys and rebuilds ONLY the claude-runtime
+  # base. Needed alongside noded.warmRestoreWithVolumeClasses above because the
+  # base key deliberately excludes noded config; without this the armed 16gi
+  # brick would keep serving its placeholder-less base and every session create
+  # would fail at the drive PATCH. The value is inert guest env; bump it any
+  # time capture behaviour changes node-side.
+  initEnv:
+    EMBER_BASE_EPOCH: "warm-restore-1"
   # ON. The ADR 027 memory:false/filesystem:true quadrant: sessions ride
   # per-lineage workspace volumes with park/rejoin instead of memory-snapshot
   # banking, and raw files in S3 replace multi-GiB snapshots.


### PR DESCRIPTION
Issue #4371 validation step 1: turn the flag on for one brick. Follows #4376 (wiring + node-stable placeholder fix).

## What

- `noded.warmRestoreWithVolumeClasses: ["16gi"]` in deploy values: the 16gi brick is the only session-capable brick (sessions are 4096 MiB; the oplog shows every session ever created placed there), so class-scoping arms exactly the brick under test.
- `claudeRuntimeWorkload.initEnv.EMBER_BASE_EPOCH: warm-restore-1` plus the chart plumbing to render `spec.source.image.initEnv`. This is load-bearing, not decoration: base refs hash (image ref, workload revision, cpu vendor) and the revision deliberately excludes noded config, so arming alone would leave the brick serving its old placeholder-less base and every volume-bearing claim failing at the drive PATCH, with no rebuild ever coming. init_env IS in the signature, so the epoch re-keys and rebuilds only the claude-runtime base, now captured with the placeholder attached. The probes' task bases (bazel/semgrep, restored volume-less on this same brick every 5 minutes) keep their old refs and are untouched.

## Expected transition

Short window of failing session creates between the 16gi brick roll and the claude-runtime base rebuild (clean PATCH abort, no corruption risk). The one parked session gets destroyed before this lands, since its rejoin pins the old base ref.

## Rollback

Empty the class list and drop the epoch in deploy values; values git ref alone rolls the env off, no chart bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG