### PR TITLE
fix(embervm): send only the PATCH-legal fields when repointing a drive

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.424
+version: 0.1.425

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.424
+      targetRevision: 0.1.425
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -151,7 +151,7 @@ type fcAPI interface {
 	PutMachineConfig(ctx context.Context, m fcclient.MachineConfig) error
 	PutBootSource(ctx context.Context, b fcclient.BootSource) error
 	PutDrive(ctx context.Context, d fcclient.Drive) error
-	PatchDrive(ctx context.Context, driveID string, d fcclient.Drive) error
+	PatchDrive(ctx context.Context, driveID string, d fcclient.PatchedDrive) error
 	PutVsock(ctx context.Context, v fcclient.Vsock) error
 	PutNetworkInterface(ctx context.Context, n fcclient.NetworkInterface) error
 	Start(ctx context.Context) error
@@ -770,11 +770,9 @@ func (d *Driver) loadPatchAndResume(ctx context.Context, threadID, snapPath, mem
 		return d.abort(proc, err)
 	}
 	if volumeDiskPath != "" {
-		if err := client.PatchDrive(ctx, "volume", fcclient.Drive{
-			DriveID:      "volume",
-			PathOnHost:   volumeDiskPath,
-			IsRootDevice: false,
-			IsReadOnly:   false,
+		if err := client.PatchDrive(ctx, "volume", fcclient.PatchedDrive{
+			DriveID:    "volume",
+			PathOnHost: volumeDiskPath,
 		}); err != nil {
 			return d.abort(proc, err)
 		}

--- a/projects/embervm/noded/fcvm/fcclient/client.go
+++ b/projects/embervm/noded/fcvm/fcclient/client.go
@@ -63,6 +63,16 @@ type Drive struct {
 	IsReadOnly   bool   `json:"is_read_only"`
 }
 
+// PatchedDrive is the body of PATCH /drives/{drive_id}. Firecracker's PATCH
+// schema is a partial update accepting ONLY drive_id, path_on_host, and
+// rate_limiter, and it rejects unknown fields at JSON parse, so this cannot
+// reuse Drive: is_root_device fails the whole request with a SerdeJson error
+// before the drive is even looked up.
+type PatchedDrive struct {
+	DriveID    string `json:"drive_id"`
+	PathOnHost string `json:"path_on_host"`
+}
+
 // Vsock is the body of PUT /vsock. The controller uses a vsock device for the
 // in-VM wrapper's idle-signal channel (Phase 2).
 type Vsock struct {
@@ -126,7 +136,7 @@ func (c *Client) PutDrive(ctx context.Context, d Drive) error {
 // microVM. Used to repoint the volume drive to a session-specific backing file
 // after LoadSnapshot on the warm-restore path. The drive must already exist in
 // the snapshot's device set.
-func (c *Client) PatchDrive(ctx context.Context, driveID string, d Drive) error {
+func (c *Client) PatchDrive(ctx context.Context, driveID string, d PatchedDrive) error {
 	return c.do(ctx, http.MethodPatch, "/drives/"+driveID, d)
 }
 

--- a/projects/embervm/noded/fcvm/fcclient/client_test.go
+++ b/projects/embervm/noded/fcvm/fcclient/client_test.go
@@ -161,7 +161,7 @@ func TestClientLoadSnapshotResume(t *testing.T) {
 func TestClientPatchDrive(t *testing.T) {
 	fake, sock := startFakeFC(t)
 	c := New(sock)
-	drive := Drive{DriveID: "volume", PathOnHost: "/sessions/s1/workspace.img", IsRootDevice: false, IsReadOnly: false}
+	drive := PatchedDrive{DriveID: "volume", PathOnHost: "/sessions/s1/workspace.img"}
 	if err := c.PatchDrive(context.Background(), "volume", drive); err != nil {
 		t.Fatalf("PatchDrive: %v", err)
 	}
@@ -175,8 +175,14 @@ func TestClientPatchDrive(t *testing.T) {
 	if r.Method != http.MethodPatch || r.Path != "/drives/volume" {
 		t.Fatalf("request = %s %s, want PATCH /drives/volume", r.Method, r.Path)
 	}
-	if r.Body["drive_id"] != "volume" || r.Body["path_on_host"] != drive.PathOnHost || r.Body["is_read_only"] != false {
+	if r.Body["drive_id"] != "volume" || r.Body["path_on_host"] != drive.PathOnHost {
 		t.Fatalf("drive body = %v", r.Body)
+	}
+	// Firecracker rejects unknown fields on PATCH /drives at JSON parse (its
+	// schema is drive_id, path_on_host, rate_limiter only), so the PUT-only
+	// fields must be absent from the wire body, not merely false.
+	if len(r.Body) != 2 {
+		t.Fatalf("drive body has extra fields = %v, want exactly drive_id and path_on_host", r.Body)
 	}
 }
 


### PR DESCRIPTION
Live finding from the #4371 one-brick experiment (armed in #4377). The mechanism chain worked exactly as designed up to the drive repoint: brick rolled with the flag, the epoch re-keyed the base, the rebuild captured the placeholder at the node-stable path, and volume-bearing claims took PUT /snapshot/load with resume_vm:false. Then every claim died at the PATCH:

```
SerdeJson(Error("unknown field is_root_device, expected one of drive_id, path_on_host, rate_limiter"))
```

Firecracker's PATCH /drives/{id} is a partial update with its own schema and it rejects unknown fields at parse. `fcclient.PatchDrive` sent the full PUT `Drive` struct. Both the client test's fake and the driver fakes modeled PATCH as accepting the full struct, so no test could see it: the same each-fake-models-its-own-side seam failure recorded on #4371 for the guest/driver split, this time between fcclient and the real FC API.

Fix: dedicated `PatchedDrive` body (drive_id + path_on_host), and the client test now pins the wire body to exactly those two fields so a PUT-only field reappearing is a structural failure.

Failure mode observed was clean: claims aborted pre-resume, CP retried with fresh session ids, no corruption, probes unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG