### PR TITLE
fix(embervm): dial the scheduled brick for rejoin restore and prime

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.425
+version: 0.1.426

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -1719,16 +1719,15 @@ defmodule Embervm.SessionManager do
            key: workload, need_mib: Map.get(entry, :mem_mib) || 512,
            base: {:ready, :snapshot_ref}
          }),
-         # Both the restore and the prime must reach the INSTANCE that owns this
-         # lineage on disk. volume_node_id is a bare node name (an anchor), and
-         # dialing it fails :unknown_node, which is exactly how the first live
-         # rejoin died after create and park both worked.
-         dial_id <- Embervm.WakeInstance.dial_for_session_volume(state.capacity_table, volume_node_id, lineage_id),
+         # The scheduler's brick is the only instance guaranteed to fit the VM's
+         # memory. VolumeRoot is node-shared, so any instance can reach it, but
+         # both restore_session_workspace and prime must use the scheduled brick.
+         # Otherwise registration-order dial resolution can select an undersized
+         # brick and fail prime with pressure:mem forever (#4379).
+         dial_id <- Brick.dial_id(brick),
          {:ok, _restored} <- restore_session_workspace(state, dial_id, workload, lineage_id),
          snapshot_ref <- get_in(brick, [:workloads, workload, :snapshot_ref]),
          {:ok, vm_id} <- prime(state, dial_id, snapshot_ref, entry, lineage_id) do
-      # Return dial_id because this is the third distinct bare-anchor dial site.
-      # The previous fix resolved it correctly, then stopped one hop short by discarding it.
       {:ok, vm_id, dial_id}
     else
       {:error, reason} -> {:error, reason}

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -182,6 +182,7 @@ defmodule Embervm.SessionManagerTest do
           max_sessions: Keyword.get(opts, :max_sessions, 16),
           invoke_queue_cap: Keyword.get(opts, :queue_cap, 4)
         }),
+      mem_mib: Keyword.get(opts, :mem_mib),
       persistence: Keyword.get(opts, :persistence)
     })
   end
@@ -733,6 +734,47 @@ defmodule Embervm.SessionManagerTest do
     {:ok, session} = SessionStore.get(ctx.store, created.session_id)
     assert session.node_id == "node-4"
     assert session.volume_node_id == "node-4"
+  end
+
+  test "rejoin_dials_the_memory_fitting_brick_when_multiple_colocated" do
+    {:ok, dials} = Agent.start_link(fn -> [] end)
+    dial_fun = fn dial_id ->
+      Agent.update(dials, &[dial_id | &1])
+      {:ok, :fake_channel}
+    end
+
+    ctx =
+      start_stack(
+        prime_fun: fake_prime_fun("vm-rejoined-memory-fitting"),
+        channel_fun: dial_fun,
+        session_channel_fun: dial_fun
+      )
+
+    created = create_persistence_session(ctx, mem_mib: 4_096)
+    park_session(ctx, created)
+
+    put_brick(ctx, "wl-persist", "small",
+      size_class: "2gi",
+      mem_headroom: 100,
+      mem_budget: 2_048,
+      session_volumes: [%{lineage_id: created.session_id}]
+    )
+
+    put_brick(ctx, "wl-persist", "large",
+      size_class: "8gi",
+      mem_headroom: 8_000,
+      mem_budget: 8_192,
+      session_volumes: [%{lineage_id: created.session_id}]
+    )
+
+    Agent.update(dials, fn _ -> [] end)
+
+    assert {:ok, %{status_code: 200}} =
+             SessionManager.invoke(ctx.mgr, created.session_id, %{body: "wake"})
+
+    rejoin_dials = Agent.get(dials, & &1)
+    assert "node-4/large" in rejoin_dials
+    refute "node-4/small" in rejoin_dials
   end
 
   test "rejoin delivery failure destroys the primed VM and leaves session parked" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.425
+      targetRevision: 0.1.426
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Fixes #4379. Found live during the #4371 warm-restore validation.

`perform_rejoin_prime` ran the scheduler with the workload's real need_mib (correctly selecting the only brick that fits the VM), then discarded that choice and dialed `dial_for_session_volume`, which picks the FIRST instance on the node reporting the lineage under session_volumes. VolumeRoot is node-shared, so on a co-located node every instance reports every session volume and first-match is registration order. After today's brick rolls the 2gi demand brick registered ahead of the 16gi on node-4, so every relight of a parked 4096 MiB session dialed a 2 GiB brick and died `pressure:mem (need 4096 MiB, floor 512 MiB)`, forever, while the 16gi brick held ~16 GiB of headroom. The 2026-08-03 park/rejoin validation passed on iteration-order luck.

The fix dials the scheduler's chosen brick (`Brick.dial_id(brick)`, the same identity `place_create` returns for fresh creates) for both the workspace restore and the prime: any instance can reach the shared VolumeRoot, only the scheduled brick fits the VM. `dial_for_session_volume` is untouched for the lanes with genuinely per-instance warmth.

Regression test: two co-located bricks on one node, both reporting the lineage, only the second-registered one fitting the VM; asserts the rejoin dials the fitting brick and never the undersized one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG