### PR TITLE
fix(embervm): advertise the newest ready base per workload

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.426
+version: 0.1.427

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.426
+      targetRevision: 0.1.427
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -2230,6 +2230,7 @@ func (s *Server) PruneStaleAttach(workload, lineageID string) {
 // free_primed_slots is the count of the primed ids so the two never disagree.
 func (s *Server) workloadCapacities(primed map[string][]string) []*nodev1.WorkloadCapacity {
 	byWorkload := make(map[string]*nodev1.WorkloadCapacity)
+	winners := make(map[string]baseEntry)
 	get := func(wl string) *nodev1.WorkloadCapacity {
 		c, ok := byWorkload[wl]
 		if !ok {
@@ -2241,6 +2242,11 @@ func (s *Server) workloadCapacities(primed map[string][]string) []*nodev1.Worklo
 		}
 		return c
 	}
+	// Two READY bases for one workload is the normal state right after a re-key
+	// (old superseded base plus new, both provisioned), and last-writer-wins made
+	// the advertised ref a per-heartbeat coin flip that placed restores on the
+	// stale base (observed live 2026-08-05, PATCH 400 on the placeholder-less
+	// base); newest-READY-wins is monotonic with builds.
 	for _, b := range s.bases.snapshot() {
 		// A READY base is only reportable if its runtime image is still provisioned:
 		// the control plane places a stateful cold boot on snapshot_ref and the daemon
@@ -2253,7 +2259,25 @@ func (s *Server) workloadCapacities(primed map[string][]string) []*nodev1.Worklo
 				continue
 			}
 		}
-		c := get(b.workload)
+		current, seen := winners[b.workload]
+		currentReady := seen && current.state == nodev1.BaseBuildState_BASE_BUILD_STATE_READY
+		candidateReady := b.state == nodev1.BaseBuildState_BASE_BUILD_STATE_READY
+		replace := !seen || (!currentReady && candidateReady)
+		if seen && currentReady == candidateReady {
+			if candidateReady {
+				replace = b.createdAtUnixMs > current.createdAtUnixMs ||
+					(b.createdAtUnixMs == current.createdAtUnixMs && b.snapshotRef > current.snapshotRef)
+			} else {
+				// Preserve the existing last-writer-wins behavior for progress states.
+				replace = true
+			}
+		}
+		if replace {
+			winners[b.workload] = b
+		}
+	}
+	for workload, b := range winners {
+		c := get(workload)
 		c.SnapshotRef = b.snapshotRef
 		c.BaseState = b.state
 		// Base durability (base-durability PR-1, additive): report whether this
@@ -2264,7 +2288,7 @@ func (s *Server) workloadCapacities(primed map[string][]string) []*nodev1.Worklo
 		// artifactExported is false for a base whose prefix cannot be composed
 		// (no vendor detected), which the control plane safely reads as
 		// not-yet-exported and re-exports (the export verb is idempotent).
-		c.Exported = s.artifactExported(nodev1.ArtifactKind_ARTIFACT_KIND_BASE, b.workload, b.snapshotRef)
+		c.Exported = s.artifactExported(nodev1.ArtifactKind_ARTIFACT_KIND_BASE, workload, b.snapshotRef)
 	}
 	// Serving images (cold-boot handler artifacts) are reported in a DISTINCT field
 	// from the base memory snapshot (D-R3.11.2): serving placement cold-boots this ref,

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -1267,6 +1267,49 @@ func TestWorkloadCapacitiesSkipsStaleServingImage(t *testing.T) {
 	}
 }
 
+func TestWorkloadCapacitiesAdvertisesNewestReadyBase(t *testing.T) {
+	const (
+		workload = "claude-runtime"
+		oldRef   = "claude-runtime__old"
+		newRef   = "claude-runtime__new"
+		image    = "img@sha256:runtime"
+	)
+
+	for _, tc := range []struct {
+		name string
+		refs []string
+	}{
+		{name: "old then new", refs: []string{oldRef, newRef}},
+		{name: "new then old", refs: []string{newRef, oldRef}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, s := newTestServer(t, &fakeDriver{}, &fakeTransport{}, 8)
+			s.registry.sync([]workloadEntry{{Workload: workload, ImageRef: image, RootfsRef: "/rootfs/runtime"}})
+			for _, ref := range tc.refs {
+				s.bases.readyBuild(ref, workload, image, "", "/shim/ready", 2048)
+			}
+			s.bases.mu.Lock()
+			s.bases.bases[oldRef].createdAtUnixMs = 1000
+			s.bases.bases[newRef].createdAtUnixMs = 2000
+			s.bases.mu.Unlock()
+
+			ns, err := client.GetNodeStatus(context.Background(), &nodev1.GetNodeStatusRequest{})
+			if err != nil {
+				t.Fatalf("GetNodeStatus: %v", err)
+			}
+			for _, c := range ns.GetWorkloads() {
+				if c.GetWorkload() == workload {
+					if got := c.GetSnapshotRef(); got != newRef {
+						t.Fatalf("snapshot_ref = %q, want newer ref %q", got, newRef)
+					}
+					return
+				}
+			}
+			t.Fatalf("workload capacity for %q not reported", workload)
+		})
+	}
+}
+
 func TestParseMemHeadroomMib(t *testing.T) {
 	cases := []struct {
 		maxRaw, curRaw string


### PR DESCRIPTION
Fourth and final live finding from the #4371 warm-restore validation (after #4376, #4378, #4380).

`workloadCapacities` iterated `s.bases.snapshot()` (a Go map, nondeterministic order) with `c.SnapshotRef = b.snapshotRef` last-writer-wins. Two READY bases for one workload is the NORMAL state right after a re-key: the superseded base and the new one coexist on disk, both adopted on a brick roll, both sharing the same still-provisioned runtime image (an initEnv re-key moves the revision, not the image). Result: the advertised snapshot_ref was a per-heartbeat coin flip, and creates/rejoins placed restores on the stale placeholder-less base, dying at PATCH /drives with a 400. Observed live today as session creates alternating refs, and confirmed by retention accounting keeping both refs in the desired set (node-current fact vs CP-recorded ref disagreeing).

Fix: deterministic winner per workload: READY beats progress states, newest `createdAtUnixMs` wins among READY, lexical ref as the tie-break, and `Exported` is computed for the winner. The serving-image block below already solved this nondeterminism class for its own lane; this brings the task/session base lane in line.

Once deployed, the brick advertises the epoch-keyed base deterministically, the superseded ref drops out of the retention desired set, and the sweep reclaims it.

Regression test covers both registration orders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG