### PR TITLE
fix(embervm): bump the base epoch to converge off the stale recorded ref

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -418,8 +418,16 @@ claudeRuntimeWorkload:
   # brick would keep serving its placeholder-less base and every session create
   # would fail at the drive PATCH. The value is inert guest env; bump it any
   # time capture behaviour changes node-side.
+  #
+  # warm-restore-2: the CP restarted during the pre-#4381 window when the brick
+  # coin-flipped its advertised ref, adopted the STALE placeholder-less ref as
+  # recorded, and reconcile's signature-match no-op froze it there, so creates
+  # and rejoins kept restoring the old base after every fact-side fix. Moving
+  # the epoch re-keys the base, which forces a re-record and a fresh build that
+  # every consumer (recorded ref, node facts, retention desired set) converges
+  # on.
   initEnv:
-    EMBER_BASE_EPOCH: "warm-restore-1"
+    EMBER_BASE_EPOCH: "warm-restore-2"
   # ON. The ADR 027 memory:false/filesystem:true quadrant: sessions ride
   # per-lineage workspace volumes with park/rejoin instead of memory-snapshot
   # banking, and raw files in S3 replace multi-GiB snapshots.


### PR DESCRIPTION
Part of #4371. The CP restarted during the pre-#4381 coin-flip window, adopted the stale placeholder-less claude-runtime ref as its recorded snapshot_ref, and reconcile's signature-match idempotency froze it there: creates and rejoins kept restoring the old base even after #4381 made the brick's advertisement deterministic. Observed live: turns 7 and 8 both loaded `claude-runtime__d9ad98875826` after the fixed brick rolled.

Moving the epoch to `warm-restore-2` re-keys the base, which voids the recorded ref (signature moved), triggers a fresh placeholder-bearing build, and converges the recorded ref, the node facts, and the retention desired set on the new key. Both stale bases then leave the desired set and get swept.

Values-only change; syncs on the git ref without a chart bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG