### PR TITLE
fix(embervm): carry createdAtUnixMs through base registration

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.427
+version: 0.1.428

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.427
+      targetRevision: 0.1.428
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/registry.go
+++ b/projects/embervm/noded/server/registry.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"sync"
+	"time"
 
 	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
 
@@ -473,7 +474,11 @@ func (b *baseRegistry) readyBuild(ref, workload, imageDigest, rootfsPath, readyP
 		rootfsPath:  rootfsPath,
 		sizeBytes:   sizeBytes,
 		readyPath:   readyPath,
-		state:       nodev1.BaseBuildState_BASE_BUILD_STATE_READY,
+		// Stamped here, not left zero: workloadCapacities picks the workload's
+		// advertised base by newest createdAtUnixMs, and a zero here demotes a
+		// fresh build to the lexical tie-break against adopted bases.
+		createdAtUnixMs: time.Now().UnixMilli(),
+		state:           nodev1.BaseBuildState_BASE_BUILD_STATE_READY,
 	}
 }
 
@@ -506,6 +511,11 @@ func (b *baseRegistry) register(e baseEntry) {
 		sizeBytes:   e.sizeBytes,
 		readyPath:   e.readyPath,
 		state:       e.state,
+		// Carried, not dropped: workloadCapacities picks the advertised base by
+		// newest createdAtUnixMs, and this copy silently zeroing it made every
+		// adopted base tie at 0, so the lexical tie-break advertised whichever
+		// ref sorted greatest, the STALE placeholder-less base live 2026-08-05.
+		createdAtUnixMs: e.createdAtUnixMs,
 		// Carried, not dropped: a base reconciled from disk as NONE explains WHY in
 		// buildErr (a missing backing rootfs), and that reason is the only thing
 		// distinguishing it from a base that was simply never built.

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -1268,30 +1268,37 @@ func TestWorkloadCapacitiesSkipsStaleServingImage(t *testing.T) {
 }
 
 func TestWorkloadCapacitiesAdvertisesNewestReadyBase(t *testing.T) {
+	// oldRef sorts lexically GREATER than newRef on purpose: if either
+	// registration path drops createdAtUnixMs again, the comparison falls to
+	// the lexical tie-break and advertises the stale base, and this test must
+	// catch exactly that (the live 2026-08-05 failure). The old base goes in
+	// through register (the disk-adoption path, which once zeroed the stamp in
+	// its field-by-field copy) and the new one through readyBuild (which once
+	// never stamped at all), so both real paths are exercised, no hand-patching.
 	const (
 		workload = "claude-runtime"
-		oldRef   = "claude-runtime__old"
-		newRef   = "claude-runtime__new"
+		oldRef   = "claude-runtime__zzzstale"
+		newRef   = "claude-runtime__aaafresh"
 		image    = "img@sha256:runtime"
 	)
 
 	for _, tc := range []struct {
 		name string
-		refs []string
+		run  func(s *Server)
 	}{
-		{name: "old then new", refs: []string{oldRef, newRef}},
-		{name: "new then old", refs: []string{newRef, oldRef}},
+		{name: "adopted then built", run: func(s *Server) {
+			s.bases.register(baseEntry{snapshotRef: oldRef, workload: workload, imageDigest: image, readyPath: "/shim/ready", createdAtUnixMs: 1000, state: nodev1.BaseBuildState_BASE_BUILD_STATE_READY})
+			s.bases.readyBuild(newRef, workload, image, "", "/shim/ready", 2048)
+		}},
+		{name: "built then adopted", run: func(s *Server) {
+			s.bases.readyBuild(newRef, workload, image, "", "/shim/ready", 2048)
+			s.bases.register(baseEntry{snapshotRef: oldRef, workload: workload, imageDigest: image, readyPath: "/shim/ready", createdAtUnixMs: 1000, state: nodev1.BaseBuildState_BASE_BUILD_STATE_READY})
+		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			client, s := newTestServer(t, &fakeDriver{}, &fakeTransport{}, 8)
 			s.registry.sync([]workloadEntry{{Workload: workload, ImageRef: image, RootfsRef: "/rootfs/runtime"}})
-			for _, ref := range tc.refs {
-				s.bases.readyBuild(ref, workload, image, "", "/shim/ready", 2048)
-			}
-			s.bases.mu.Lock()
-			s.bases.bases[oldRef].createdAtUnixMs = 1000
-			s.bases.bases[newRef].createdAtUnixMs = 2000
-			s.bases.mu.Unlock()
+			tc.run(s)
 
 			ns, err := client.GetNodeStatus(context.Background(), &nodev1.GetNodeStatusRequest{})
 			if err != nil {


### PR DESCRIPTION
Fifth live finding from the #4371 validation, and the reason #4381 didn't take effect.

#4381's newest-ready-base selection compared `createdAtUnixMs`, but that field never survived registration: `register()` rebuilds the entry field-by-field and silently drops it, and `readyBuild()` never stamped it. Every base tied at zero, the lexical tie-break decided, and `d9ad...` (the stale placeholder-less base) sorts above both newer refs, so the brick advertised it deterministically on every heartbeat: confirmed live by polling /v1/nodes six times (rock-stable stale ref) while three claude-runtime bases sat on disk with correct mtimes. The #4381 regression test masked this by hand-setting the field after registration.

Fix: `register()` carries the stamp, `readyBuild()` stamps `time.Now`, and the regression test now goes through both real registration paths with the stale ref deliberately chosen to sort lexically greatest, so dropping the stamp anywhere reproduces the live failure in the test.

After deploy the brick re-adopts with real mtimes and advertises the epoch-2 base; creates and relights stop landing on the stale base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG