### PR TITLE
fix(embervm): take over the base's captured tmpfs when the session volume arrives

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.428
+version: 0.1.429

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.428
+      targetRevision: 0.1.429
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/guest-init/cmd/main_test.go
+++ b/projects/embervm/runtimes/claude/guest-init/cmd/main_test.go
@@ -144,13 +144,13 @@ func TestMountWorkspaceVolumePathsAreIsolated(t *testing.T) {
 	originalRead := readFileFn
 	originalWrite := writeFileFn
 	originalDeviceAvailable := deviceAvailableFn
-	originalMounted := isMountedFn
+	originalMounted := mountedFstypeFn
 	t.Cleanup(func() {
 		statFn = originalStat
 		readFileFn = originalRead
 		writeFileFn = originalWrite
 		deviceAvailableFn = originalDeviceAvailable
-		isMountedFn = originalMounted
+		mountedFstypeFn = originalMounted
 	})
 	mountFn = func(string, string, string, uintptr, string) error { return nil }
 	mkdirAllFn = func(string, os.FileMode) error { return nil }
@@ -160,7 +160,7 @@ func TestMountWorkspaceVolumePathsAreIsolated(t *testing.T) {
 	statFn = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
 	readFileFn = func(string) ([]byte, error) { return []byte("{}"), nil }
 	writeFileFn = func(string, []byte, os.FileMode) error { return nil }
-	isMountedFn = func(string) bool { return false }
+	mountedFstypeFn = func(string) (string, bool) { return "", false }
 	for _, tc := range []struct {
 		name, cmdline string
 		wantErr       bool
@@ -197,12 +197,12 @@ func TestEnsureWorkspaceVolumeIsIdempotentAndSeedsIdentically(t *testing.T) {
 	originalMount, originalVolume := mountFn, mountVolumeDeviceFn
 	originalMkdir, originalChown, originalChmod := mkdirAllFn, chownFn, chmodFn
 	originalStat, originalRead, originalWrite := statFn, readFileFn, writeFileFn
-	originalDeviceAvailable, originalMounted := deviceAvailableFn, isMountedFn
+	originalDeviceAvailable, originalMounted := deviceAvailableFn, mountedFstypeFn
 	t.Cleanup(func() {
 		mountFn, mountVolumeDeviceFn = originalMount, originalVolume
 		mkdirAllFn, chownFn, chmodFn = originalMkdir, originalChown, originalChmod
 		statFn, readFileFn, writeFileFn = originalStat, originalRead, originalWrite
-		deviceAvailableFn, isMountedFn = originalDeviceAvailable, originalMounted
+		deviceAvailableFn, mountedFstypeFn = originalDeviceAvailable, originalMounted
 	})
 
 	mounts := 0
@@ -233,7 +233,7 @@ func TestEnsureWorkspaceVolumeIsIdempotentAndSeedsIdentically(t *testing.T) {
 		return nil
 	}
 	deviceAvailableFn = func(string) bool { return true }
-	isMountedFn = func(string) bool { return mounted }
+	mountedFstypeFn = func(string) (string, bool) { return "ext4", mounted }
 
 	if err := ensureWorkspaceVolume(logger); err != nil {
 		t.Fatal(err)
@@ -263,12 +263,12 @@ func TestEnsureWorkspaceVolumeUsesTmpfsWithoutDevice(t *testing.T) {
 	originalMount, originalVolume := mountFn, mountVolumeDeviceFn
 	originalMkdir, originalChown, originalChmod := mkdirAllFn, chownFn, chmodFn
 	originalStat, originalRead, originalWrite := statFn, readFileFn, writeFileFn
-	originalDeviceAvailable, originalMounted := deviceAvailableFn, isMountedFn
+	originalDeviceAvailable, originalMounted := deviceAvailableFn, mountedFstypeFn
 	t.Cleanup(func() {
 		mountFn, mountVolumeDeviceFn = originalMount, originalVolume
 		mkdirAllFn, chownFn, chmodFn = originalMkdir, originalChown, originalChmod
 		statFn, readFileFn, writeFileFn = originalStat, originalRead, originalWrite
-		deviceAvailableFn, isMountedFn = originalDeviceAvailable, originalMounted
+		deviceAvailableFn, mountedFstypeFn = originalDeviceAvailable, originalMounted
 	})
 
 	deviceMounts := 0
@@ -290,7 +290,7 @@ func TestEnsureWorkspaceVolumeUsesTmpfsWithoutDevice(t *testing.T) {
 	readFileFn = func(string) ([]byte, error) { return []byte("{}"), nil }
 	writeFileFn = func(string, []byte, os.FileMode) error { return nil }
 	deviceAvailableFn = func(string) bool { return false }
-	isMountedFn = func(string) bool { return false }
+	mountedFstypeFn = func(string) (string, bool) { return "", false }
 
 	if err := ensureWorkspaceVolume(logger); err != nil {
 		t.Fatal(err)
@@ -312,12 +312,12 @@ func TestEnsureWorkspaceVolumePlaceholderDeviceIgnoredWithoutCmdlineArg(t *testi
 	originalMount, originalVolume := mountFn, mountVolumeDeviceFn
 	originalMkdir, originalChown, originalChmod := mkdirAllFn, chownFn, chmodFn
 	originalStat, originalRead, originalWrite := statFn, readFileFn, writeFileFn
-	originalDeviceAvailable, originalMounted := deviceAvailableFn, isMountedFn
+	originalDeviceAvailable, originalMounted := deviceAvailableFn, mountedFstypeFn
 	t.Cleanup(func() {
 		mountFn, mountVolumeDeviceFn = originalMount, originalVolume
 		mkdirAllFn, chownFn, chmodFn = originalMkdir, originalChown, originalChmod
 		statFn, readFileFn, writeFileFn = originalStat, originalRead, originalWrite
-		deviceAvailableFn, isMountedFn = originalDeviceAvailable, originalMounted
+		deviceAvailableFn, mountedFstypeFn = originalDeviceAvailable, originalMounted
 	})
 
 	deviceMounts := 0
@@ -340,7 +340,7 @@ func TestEnsureWorkspaceVolumePlaceholderDeviceIgnoredWithoutCmdlineArg(t *testi
 	writeFileFn = func(string, []byte, os.FileMode) error { return nil }
 	// Device node EXISTS but is NOT requested on cmdline
 	deviceAvailableFn = func(path string) bool { return path == "/dev/vdb" }
-	isMountedFn = func(string) bool { return false }
+	mountedFstypeFn = func(string) (string, bool) { return "", false }
 
 	// No explicit device, so should use tmpfs
 	if err := ensureWorkspaceVolume(logger); err != nil {
@@ -363,12 +363,12 @@ func TestEnsureWorkspaceVolumeWithExplicitDeviceMountsWithoutCmdlineArg(t *testi
 	originalMount, originalVolume := mountFn, mountVolumeDeviceFn
 	originalMkdir, originalChown, originalChmod := mkdirAllFn, chownFn, chmodFn
 	originalStat, originalRead, originalWrite := statFn, readFileFn, writeFileFn
-	originalDeviceAvailable, originalMounted := deviceAvailableFn, isMountedFn
+	originalDeviceAvailable, originalMounted := deviceAvailableFn, mountedFstypeFn
 	t.Cleanup(func() {
 		mountFn, mountVolumeDeviceFn = originalMount, originalVolume
 		mkdirAllFn, chownFn, chmodFn = originalMkdir, originalChown, originalChmod
 		statFn, readFileFn, writeFileFn = originalStat, originalRead, originalWrite
-		deviceAvailableFn, isMountedFn = originalDeviceAvailable, originalMounted
+		deviceAvailableFn, mountedFstypeFn = originalDeviceAvailable, originalMounted
 	})
 
 	deviceMounts := 0
@@ -392,7 +392,7 @@ func TestEnsureWorkspaceVolumeWithExplicitDeviceMountsWithoutCmdlineArg(t *testi
 	readFileFn = func(string) ([]byte, error) { return []byte("{}"), nil }
 	writeFileFn = func(string, []byte, os.FileMode) error { return nil }
 	deviceAvailableFn = func(path string) bool { return path == "/dev/vdb" }
-	isMountedFn = func(string) bool { return false }
+	mountedFstypeFn = func(string) (string, bool) { return "", false }
 
 	// Explicit device, so should mount it despite cmdline having nothing
 	if err := ensureWorkspaceVolumeWithDevice(logger, "/dev/vdb"); err != nil {
@@ -400,6 +400,114 @@ func TestEnsureWorkspaceVolumeWithExplicitDeviceMountsWithoutCmdlineArg(t *testi
 	}
 	if tmpfsMounts != 0 || deviceMounts != 1 || mountedDev != "/dev/vdb" {
 		t.Fatalf("mounts = tmpfs:%d device:%d (dev=%q), want tmpfs:0 device:1 (dev=/dev/vdb) (restored guest must mount explicit device)", tmpfsMounts, deviceMounts, mountedDev)
+	}
+}
+
+func TestEnsureWorkspaceVolumeMountDecisions(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	path := t.TempDir() + "/cmdline"
+	if err := os.WriteFile(path, []byte("init=/init\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withCmdlinePath(t, path)
+
+	originalMount, originalUnmount := mountFn, unmountFn
+	originalVolume, originalMkdir := mountVolumeDeviceFn, mkdirAllFn
+	originalChown, originalChmod := chownFn, chmodFn
+	originalStat, originalRead, originalWrite := statFn, readFileFn, writeFileFn
+	originalAvailable, originalFstype := deviceAvailableFn, mountedFstypeFn
+	t.Cleanup(func() {
+		mountFn, unmountFn = originalMount, originalUnmount
+		mountVolumeDeviceFn, mkdirAllFn = originalVolume, originalMkdir
+		chownFn, chmodFn = originalChown, originalChmod
+		statFn, readFileFn, writeFileFn = originalStat, originalRead, originalWrite
+		deviceAvailableFn, mountedFstypeFn = originalAvailable, originalFstype
+	})
+	mkdirAllFn = func(string, os.FileMode) error { return nil }
+	chownFn = func(string, int, int) error { return nil }
+	chmodFn = func(string, os.FileMode) error { return nil }
+	statFn = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	readFileFn = func(string) ([]byte, error) { return []byte("{}"), nil }
+	writeFileFn = func(string, []byte, os.FileMode) error { return nil }
+	deviceAvailableFn = func(string) bool { return true }
+
+	for _, tc := range []struct {
+		name, fstype, explicit string
+		wantUnmounts           []string
+		wantDeviceMounts       int
+		wantTrustWrites        int
+	}{
+		{name: "takeover", fstype: "tmpfs", explicit: "/dev/vdb", wantUnmounts: []string{workspaceMountPath, runtimeHomePath, defaultSessionRoot}, wantDeviceMounts: 1, wantTrustWrites: 1},
+		{name: "already on device", fstype: "ext4", explicit: "/dev/vdb", wantDeviceMounts: 0},
+		{name: "base build unchanged", fstype: "tmpfs", wantDeviceMounts: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var unmounts []string
+			deviceMounts := 0
+			var binds []string
+			trustWrites := 0
+			mountedFstypeFn = func(string) (string, bool) { return tc.fstype, true }
+			unmountFn = func(path string, flags int) error {
+				if flags != unix.MNT_DETACH {
+					t.Fatalf("unmount flags = %d, want MNT_DETACH", flags)
+				}
+				unmounts = append(unmounts, path)
+				return nil
+			}
+			mountFn = func(source, target, _ string, flags uintptr, _ string) error {
+				if flags&unix.MS_BIND != 0 {
+					binds = append(binds, source+" -> "+target)
+				}
+				return nil
+			}
+			mountVolumeDeviceFn = func(*slog.Logger, string, string) error {
+				deviceMounts++
+				return nil
+			}
+			writeFileFn = func(string, []byte, os.FileMode) error {
+				trustWrites++
+				return nil
+			}
+			if err := ensureWorkspaceVolumeWithDevice(logger, tc.explicit); err != nil {
+				t.Fatal(err)
+			}
+			if len(unmounts) != len(tc.wantUnmounts) {
+				t.Fatalf("unmounts = %v, want %v", unmounts, tc.wantUnmounts)
+			}
+			for i := range tc.wantUnmounts {
+				if unmounts[i] != tc.wantUnmounts[i] {
+					t.Fatalf("unmounts = %v, want %v", unmounts, tc.wantUnmounts)
+				}
+			}
+			if deviceMounts != tc.wantDeviceMounts {
+				t.Fatalf("device mounts = %d, want %d", deviceMounts, tc.wantDeviceMounts)
+			}
+			if trustWrites != tc.wantTrustWrites {
+				t.Fatalf("trust writes = %d, want %d", trustWrites, tc.wantTrustWrites)
+			}
+			wantBinds := 0
+			if tc.wantDeviceMounts != 0 {
+				wantBinds = 2
+			}
+			if len(binds) != wantBinds {
+				t.Fatalf("binds = %v, want %d", binds, wantBinds)
+			}
+		})
+	}
+}
+
+func TestMountedFstypeParsesMountinfo(t *testing.T) {
+	original := mountInfoFn
+	t.Cleanup(func() { mountInfoFn = original })
+	mountInfoFn = func(string) ([]byte, error) {
+		return []byte("36 25 0:32 / /session\\040data rw,relatime - tmpfs tmpfs rw,size=2g\n" +
+			"37 25 8:17 / /session rw,relatime shared:1 - ext4 /dev/vdb rw\n"), nil
+	}
+	if got, ok := mountedFstype("/session"); !ok || got != "ext4" {
+		t.Fatalf("mountedFstype(/session) = %q, %v, want ext4, true", got, ok)
+	}
+	if got, ok := mountedFstype("/session data"); !ok || got != "tmpfs" {
+		t.Fatalf("mountedFstype(/session data) = %q, %v, want tmpfs, true", got, ok)
 	}
 }
 

--- a/projects/embervm/runtimes/claude/guest-init/cmd/volume_linux.go
+++ b/projects/embervm/runtimes/claude/guest-init/cmd/volume_linux.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -38,6 +39,7 @@ var (
 	workspaceMountPath  = "/workspace"
 	runtimeHomePath     = "/home/runtime"
 	mountFn             = unix.Mount
+	unmountFn           = unix.Unmount
 	mountVolumeDeviceFn = mountVolumeDevice
 	mkdirAllFn          = os.MkdirAll
 	chownFn             = os.Chown
@@ -46,7 +48,7 @@ var (
 	writeFileFn         = os.WriteFile
 	statFn              = os.Stat
 	deviceAvailableFn   = deviceAvailable
-	isMountedFn         = isMounted
+	mountedFstypeFn     = mountedFstype
 	mountInfoFn         = os.ReadFile
 )
 
@@ -74,8 +76,10 @@ func mountWorkspaceVolume(logger *slog.Logger) error {
 // A restored VM resumes after guest-init, so init-only mounts cannot repair a
 // volume device that was attached or repointed after the snapshot. The shim
 // calls this through the first real turn. The mountinfo guard is the important
-// idempotency boundary: a cold guest is already mounted, while a resumed guest
-// mounts the device that is present after the driver swaps the backing file.
+// idempotency boundary: a root mounted by the requested device is already
+// usable, while a resumed guest can still have the base's captured tmpfs and
+// binds. The latter must be replaced before the device is mounted, or session
+// writes die when the guest is parked.
 //
 // explicitDevice allows the caller to override the device on the cmdline. When
 // set, it takes precedence over cmdline arguments. This is necessary for resumed
@@ -98,9 +102,24 @@ func ensureWorkspaceVolumeWithDevice(logger *slog.Logger, explicitDevice string)
 		dev = explicitDevice
 	}
 
-	if isMountedFn(root) {
-		logger.Info("session volume: already mounted", "mount", root)
-		return nil
+	if fstype, mounted := mountedFstypeFn(root); mounted {
+		if fstype != "tmpfs" {
+			logger.Info("session volume: already mounted", "mount", root, "fstype", fstype)
+			return nil
+		}
+		if dev == "" || !deviceAvailableFn(dev) {
+			// Base builds intentionally retain their tmpfs fallback. A later shim
+			// call with an explicit device performs the takeover.
+			logger.Info("session volume: captured tmpfs retained", "mount", root)
+			return nil
+		}
+		// The shim ensures this before spawning the adapter, so detaching the
+		// captured binds is safe: no CLI process can be using them yet.
+		for _, path := range []string{workspaceMountPath, runtimeHomePath, root} {
+			if err := unmountFn(path, unix.MNT_DETACH); err != nil && !errors.Is(err, unix.EINVAL) {
+				return fmt.Errorf("detach captured mount %s: %w", path, err)
+			}
+		}
 	}
 
 	// The device node is the explicit availability marker. Cold-booted sessions
@@ -150,18 +169,23 @@ func deviceAvailable(path string) bool {
 	return err == nil
 }
 
-func isMounted(path string) bool {
+func mountedFstype(path string) (string, bool) {
 	data, err := mountInfoFn("/proc/self/mountinfo")
 	if err != nil {
-		return false
+		return "", false
 	}
 	for _, line := range strings.Split(string(data), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) >= 5 && unescapeMountInfoPath(fields[4]) == path {
-			return true
+			for i, field := range fields[5:] {
+				if field == "-" && i+6 < len(fields) {
+					return fields[i+6], true
+				}
+			}
+			return "", false
 		}
 	}
-	return false
+	return "", false
 }
 
 func unescapeMountInfoPath(path string) string {


### PR DESCRIPTION
Fixes #4385, the last gap from the #4371 validation: conversations now survive park on the warm path.

A warm base is captured with the tmpfs fallback mounted at /session and the workspace/HOME binds pointing into it, so a restored guest arrives with that mount table alive. `ensureWorkspaceVolumeWithDevice`'s boolean already-mounted guard early-returned on it and the per-session device never took over: writes landed on the captured tmpfs (turns completed and billed normally, which is what made this invisible), died with the VM at park, and the relight's `claude --resume` found the base's pristine HOME: exit 1, "No conversation found".

The guard now reads HOW root is mounted from mountinfo:
- mounted by the requested device: no-op (cold boots, repeat turns)
- tmpfs + requested device present (only the resumed shim's explicit-device call): detach the captured binds then the tmpfs (MNT_DETACH; the shim ensures before spawning any adapter, so nothing holds them), mount the device, rerun the binds and trust seed
- tmpfs + no device: base builds keep their fallback untouched

Tests cover all three branches with ordered detach assertions, plus a mountinfo fstype parser test with escaped-path and optional-fields fixtures. The guest image digest moves with this change, so the workload signature re-keys and bases rebuild on deploy without an epoch bump.

Validation after deploy: create -> turn planting a token -> park -> relight -> recall the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG