### PR TITLE
fix(ci): fail ci test when the remote runner ran nothing

### DIFF
--- a/bazel/tools/ci/ci
+++ b/bazel/tools/ci/ci
@@ -286,7 +286,7 @@ cmd_test() {
 	# (recycle-runner=false) ran out of disk the same way.
 	local out
 	out="$(mktemp)"
-	trap 'rm -f "${out:-}"' RETURN
+	trap 'rm -f "${out:-}"' RETURN INT TERM
 	local bb_status=0
 	local esc=$'\x1b'
 	bb remote --os=linux --arch=amd64 \
@@ -297,8 +297,8 @@ cmd_test() {
 	# bb remote exits 0 when the remote ACTION fails, so require positive evidence
 	# of a test summary before accepting (#4118). Diagnose red test runs before
 	# runner failures because a genuine red run can include both outputs.
-	if grep -qE 'Executed [0-9]+ out of [0-9]+ tests' "$out"; then
-		if grep -qE 'Executed [0-9]+ out of [0-9]+ tests.* fail' "$out" ||
+	if grep -qE 'Executed [0-9]+ out of [0-9]+ tests?' "$out"; then
+		if grep -qE 'Executed [0-9]+ out of [0-9]+ tests?.* fail' "$out" ||
 			grep -qE "(^|${esc}\[[0-9;]*m)//[^ ]+ +(FAILED|TIMEOUT) in" "$out"; then
 			err "the run reported test failures, so this is a red run, not an infra failure"
 			return 1
@@ -308,7 +308,7 @@ cmd_test() {
 		err "remote runner failed before or while running tests (see output above, issue #4118)"
 		return 1
 	fi
-	if ! grep -qE 'Executed [0-9]+ out of [0-9]+ tests' "$out"; then
+	if ! grep -qE 'Executed [0-9]+ out of [0-9]+ tests?' "$out"; then
 		err "no bazel test summary was found, so nothing was verified (issue #4118)"
 		if [[ "$bb_status" -ne 0 ]]; then
 			return "$bb_status"

--- a/bazel/tools/ci/ci
+++ b/bazel/tools/ci/ci
@@ -284,10 +284,28 @@ cmd_test() {
 	# the failing target moves between runs, and it is never the target you changed.
 	# Confirmed not to be runner-recycling debris; a fresh runner
 	# (recycle-runner=false) ran out of disk the same way.
+	local out
+	out="$(mktemp)"
+	local bb_status=0
 	bb remote --os=linux --arch=amd64 \
 		--runner_exec_properties=include-secrets=true \
 		--runner_exec_properties=EstimatedFreeDiskBytes=120GB \
-		"${bazel_args[@]}"
+		"${bazel_args[@]}" 2>&1 | tee "$out" || bb_status=$?
+
+	# bb remote exits 0 when the remote ACTION fails, so require its failure
+	# markers and positive evidence of a test summary before accepting (#4118).
+	if grep -qE 'Action failed:|Command failed: exit status' "$out"; then
+		rm -f "$out"
+		err "remote runner failed before or while running tests (see output above, issue #4118)"
+		return 1
+	fi
+	if ! grep -qE 'Executed [0-9]+ out of [0-9]+ tests' "$out"; then
+		rm -f "$out"
+		err "no bazel test summary was found, so nothing was verified (issue #4118)"
+		return 1
+	fi
+	rm -f "$out"
+	return "$bb_status"
 }
 
 cmd_all() {

--- a/bazel/tools/ci/ci
+++ b/bazel/tools/ci/ci
@@ -286,25 +286,35 @@ cmd_test() {
 	# (recycle-runner=false) ran out of disk the same way.
 	local out
 	out="$(mktemp)"
+	trap 'rm -f "${out:-}"' RETURN
 	local bb_status=0
+	local esc=$'\x1b'
 	bb remote --os=linux --arch=amd64 \
 		--runner_exec_properties=include-secrets=true \
 		--runner_exec_properties=EstimatedFreeDiskBytes=120GB \
 		"${bazel_args[@]}" 2>&1 | tee "$out" || bb_status=$?
 
-	# bb remote exits 0 when the remote ACTION fails, so require its failure
-	# markers and positive evidence of a test summary before accepting (#4118).
-	if grep -qE 'Action failed:|Command failed: exit status' "$out"; then
-		rm -f "$out"
+	# bb remote exits 0 when the remote ACTION fails, so require positive evidence
+	# of a test summary before accepting (#4118). Diagnose red test runs before
+	# runner failures because a genuine red run can include both outputs.
+	if grep -qE 'Executed [0-9]+ out of [0-9]+ tests' "$out"; then
+		if grep -qE 'Executed [0-9]+ out of [0-9]+ tests.* fail' "$out" ||
+			grep -qE "(^|${esc}\[[0-9;]*m)//[^ ]+ +(FAILED|TIMEOUT) in" "$out"; then
+			err "the run reported test failures, so this is a red run, not an infra failure"
+			return 1
+		fi
+	fi
+	if grep -qE "(^|${esc}\[[0-9;]*m)(Action failed:|Command failed: exit status)" "$out"; then
 		err "remote runner failed before or while running tests (see output above, issue #4118)"
 		return 1
 	fi
 	if ! grep -qE 'Executed [0-9]+ out of [0-9]+ tests' "$out"; then
-		rm -f "$out"
 		err "no bazel test summary was found, so nothing was verified (issue #4118)"
+		if [[ "$bb_status" -ne 0 ]]; then
+			return "$bb_status"
+		fi
 		return 1
 	fi
-	rm -f "$out"
 	return "$bb_status"
 }
 

--- a/bazel/tools/ci/ci_test.sh
+++ b/bazel/tools/ci/ci_test.sh
@@ -103,6 +103,28 @@ EOF
 cat >"$TMP/bb_failure" <<'EOF'
 Executed 3 out of 361 tests: 361 tests pass.
 EOF
+cat >"$TMP/summary_reports_failures" <<'EOF'
+//projects/foo:bar    FAILED in 0.4s
+Executed 361 out of 361 tests: 358 tests pass, 3 fail locally.
+EOF
+{
+	printf '\033[31mAction failed: failed to start remote runner\033[0m\n'
+	printf '\033[31mCommand failed: exit status 1\033[0m\n'
+} >"$TMP/ansi_prefixed_markers_caught"
+cat >"$TMP/midline_marker_not_infra" <<'EOF'
+INFO: Analyzed 5 targets
+expected output: Command failed: exit status 1 (from fixture)
+Executed 5 out of 5 tests: 5 tests pass.
+EOF
+cat >"$TMP/bb_status_3_propagates" <<'EOF'
+Executed 5 out of 5 tests: 5 tests pass.
+EOF
+cat >"$TMP/red_run_with_runner_markers" <<'EOF'
+Executed 10 out of 10 tests: 8 tests pass, 2 fail locally.
+//projects/foo:bar FAILED in 2s
+Command failed: exit status 3
+Action failed: exit status 1
+EOF
 
 run_behavioral_case() {
 	local name="$1"
@@ -110,9 +132,13 @@ run_behavioral_case() {
 	local bb_status="$3"
 	local want_status="$4"
 	local output="$TMP/$name.out"
+	local home="$TMP/$name-home"
+	local xdg_cache_home="$TMP/$name-xdg-cache"
 	local got_status=0
+	mkdir -p "$home" "$xdg_cache_home"
 
-	if (cd "$FAKE_ROOT" && PATH="$STUB_BIN:$PATH" CI_FAKE_ROOT="$FAKE_ROOT" \
+	if (cd "$FAKE_ROOT" && HOME="$home" XDG_CACHE_HOME="$xdg_cache_home" \
+		PATH="$STUB_BIN:$PATH" CI_FAKE_ROOT="$FAKE_ROOT" \
 		BB_FIXTURE="$fixture" BB_STATUS="$bb_status" "$CI" test >"$output" 2>&1); then
 		got_status=0
 	else
@@ -129,6 +155,29 @@ run_behavioral_case "green_run_passes" "$TMP/green_run" 0 0
 run_behavioral_case "action_failed_caught" "$TMP/action_failed" 0 1
 run_behavioral_case "missing_summary_caught" "$TMP/missing_summary" 0 1
 run_behavioral_case "bb_failure_propagates" "$TMP/bb_failure" 1 1
+run_behavioral_case "summary_reports_failures_caught" "$TMP/summary_reports_failures" 0 1
+run_behavioral_case "ansi_prefixed_markers_caught" "$TMP/ansi_prefixed_markers_caught" 0 1
+run_behavioral_case "midline_marker_not_infra" "$TMP/midline_marker_not_infra" 0 0
+run_behavioral_case "bb_status_3_propagates" "$TMP/bb_status_3_propagates" 3 3
+
+red_run_output="$TMP/red_run_diagnosed_as_red.out"
+red_run_status=0
+if (cd "$FAKE_ROOT" && HOME="$TMP/red_run_diagnosed_as_red-home" \
+	XDG_CACHE_HOME="$TMP/red_run_diagnosed_as_red-xdg-cache" \
+	PATH="$STUB_BIN:$PATH" CI_FAKE_ROOT="$FAKE_ROOT" \
+	BB_FIXTURE="$TMP/red_run_with_runner_markers" BB_STATUS=0 "$CI" test \
+	>"$red_run_output" 2>&1); then
+	red_run_status=0
+else
+	red_run_status=$?
+fi
+if [[ "$red_run_status" -ne 0 ]] &&
+	grep -qF "the run reported test failures, so this is a red run" "$red_run_output" &&
+	! grep -qF "remote runner failed" "$red_run_output"; then
+	pass "red_run_diagnosed_as_red"
+else
+	fail "red_run_diagnosed_as_red" "expected red-run diagnosis, got exit $red_run_status: $(tr '\n' ' ' <"$red_run_output")"
+fi
 
 echo "--- $PASS passed, $FAIL failed ---"
 [[ $FAIL -eq 0 ]]

--- a/bazel/tools/ci/ci_test.sh
+++ b/bazel/tools/ci/ci_test.sh
@@ -90,6 +90,10 @@ cat >"$TMP/green_run" <<'EOF'
 INFO: Analyzed 361 targets
 Executed 3 out of 361 tests: 361 tests pass.
 EOF
+cat >"$TMP/singular_green_run" <<'EOF'
+INFO: Analyzed 1 target
+Executed 1 out of 1 test: 1 test passes.
+EOF
 cat >"$TMP/action_failed" <<'EOF'
 Command failed: exit status 1
 
@@ -125,6 +129,12 @@ Executed 10 out of 10 tests: 8 tests pass, 2 fail locally.
 Command failed: exit status 3
 Action failed: exit status 1
 EOF
+cat >"$TMP/singular_red_run_with_runner_markers" <<'EOF'
+//projects/foo:bar    FAILED in 0.4s
+Executed 1 out of 1 test: 1 fails locally.
+Command failed: exit status 3
+Action failed: exit status 1
+EOF
 
 run_behavioral_case() {
 	local name="$1"
@@ -152,6 +162,7 @@ run_behavioral_case() {
 }
 
 run_behavioral_case "green_run_passes" "$TMP/green_run" 0 0
+run_behavioral_case "singular_green_passes" "$TMP/singular_green_run" 0 0
 run_behavioral_case "action_failed_caught" "$TMP/action_failed" 0 1
 run_behavioral_case "missing_summary_caught" "$TMP/missing_summary" 0 1
 run_behavioral_case "bb_failure_propagates" "$TMP/bb_failure" 1 1
@@ -177,6 +188,26 @@ if [[ "$red_run_status" -ne 0 ]] &&
 	pass "red_run_diagnosed_as_red"
 else
 	fail "red_run_diagnosed_as_red" "expected red-run diagnosis, got exit $red_run_status: $(tr '\n' ' ' <"$red_run_output")"
+fi
+
+singular_red_stderr="$TMP/singular_red_diagnosed.err"
+singular_red_stdout="$TMP/singular_red_diagnosed.out"
+singular_red_status=0
+if (cd "$FAKE_ROOT" && HOME="$TMP/singular_red_diagnosed-home" \
+	XDG_CACHE_HOME="$TMP/singular_red_diagnosed-xdg-cache" \
+	PATH="$STUB_BIN:$PATH" CI_FAKE_ROOT="$FAKE_ROOT" \
+	BB_FIXTURE="$TMP/singular_red_run_with_runner_markers" BB_STATUS=0 "$CI" test \
+	>"$singular_red_stdout" 2>"$singular_red_stderr"); then
+	singular_red_status=0
+else
+	singular_red_status=$?
+fi
+if [[ "$singular_red_status" -ne 0 ]] &&
+	grep -qF "the run reported test failures, so this is a red run" "$singular_red_stderr" &&
+	! grep -qF "remote runner failed" "$singular_red_stderr"; then
+	pass "singular_red_diagnosed"
+else
+	fail "singular_red_diagnosed" "expected red-run diagnosis, got exit $singular_red_status: $(tr '\n' ' ' <"$singular_red_stderr")"
 fi
 
 echo "--- $PASS passed, $FAIL failed ---"

--- a/bazel/tools/ci/ci_test.sh
+++ b/bazel/tools/ci/ci_test.sh
@@ -9,7 +9,7 @@ for candidate in \
 	"${TEST_SRCDIR:-}/_main/${CI_REL}" \
 	"${BASH_SOURCE[0]%/*}/ci"; do
 	if [[ -f "$candidate" ]]; then
-		CI="$candidate"
+		CI="$(cd "${candidate%/*}" && pwd)/${candidate##*/}"
 		break
 	fi
 done
@@ -64,6 +64,71 @@ if grep -q 'need_generators' "$CI" && grep -q 'need_gazelle' "$CI"; then
 else
 	fail "regen_helpers" "missing need_* helpers"
 fi
+
+TMP="${TEST_TMPDIR:-$(mktemp -d)}"
+FAKE_ROOT="$TMP/ci-fake-root"
+STUB_BIN="$TMP/ci-stub-bin"
+mkdir -p "$FAKE_ROOT" "$STUB_BIN"
+
+cat >"$STUB_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1 ${2:-}" == "rev-parse --show-toplevel" ]]; then
+	echo "$CI_FAKE_ROOT"
+fi
+exit 0
+EOF
+chmod +x "$STUB_BIN/git"
+
+cat >"$STUB_BIN/bb" <<'EOF'
+#!/usr/bin/env bash
+cat "$BB_FIXTURE"
+exit "${BB_STATUS:-0}"
+EOF
+chmod +x "$STUB_BIN/bb"
+
+cat >"$TMP/green_run" <<'EOF'
+INFO: Analyzed 361 targets
+Executed 3 out of 361 tests: 361 tests pass.
+EOF
+cat >"$TMP/action_failed" <<'EOF'
+Command failed: exit status 1
+
+Action failed: failed to set up git repo: exit status 1
+Remote run completed at 2026-07-28 05:20:10 UTC
+EOF
+cat >"$TMP/missing_summary" <<'EOF'
+INFO: Analyzed 361 targets
+INFO: Build completed successfully, 361 total actions
+EOF
+cat >"$TMP/bb_failure" <<'EOF'
+Executed 3 out of 361 tests: 361 tests pass.
+EOF
+
+run_behavioral_case() {
+	local name="$1"
+	local fixture="$2"
+	local bb_status="$3"
+	local want_status="$4"
+	local output="$TMP/$name.out"
+	local got_status=0
+
+	if (cd "$FAKE_ROOT" && PATH="$STUB_BIN:$PATH" CI_FAKE_ROOT="$FAKE_ROOT" \
+		BB_FIXTURE="$fixture" BB_STATUS="$bb_status" "$CI" test >"$output" 2>&1); then
+		got_status=0
+	else
+		got_status=$?
+	fi
+	if [[ "$got_status" -eq "$want_status" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit $want_status, got $got_status: $(tr '\n' ' ' <"$output")"
+	fi
+}
+
+run_behavioral_case "green_run_passes" "$TMP/green_run" 0 0
+run_behavioral_case "action_failed_caught" "$TMP/action_failed" 0 1
+run_behavioral_case "missing_summary_caught" "$TMP/missing_summary" 0 1
+run_behavioral_case "bb_failure_propagates" "$TMP/bb_failure" 1 1
 
 echo "--- $PASS passed, $FAIL failed ---"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Fixes #4118.

`bb remote` exits 0 when the remote action fails, so a green `ci test` could mean the runner never checked out the repo, built nothing, and tested nothing. Both the human gate and the pre-push hook trusted that exit code.

## What
`cmd_test` now captures the streamed output (still streaming via `tee`), then:
1. Fails if the runner's own failure markers appear (`Action failed:` / `Command failed: exit status`).
2. Fails if there is no `Executed N out of M tests` bazel summary, so a run that sets up fine but tests nothing is also caught.
3. Otherwise propagates `bb`'s exit status.

Four behavioral tests pin this with stubbed `git`/`bb`, including the exact failure output observed in #4118.

## Validated on a real failure
The dogfood run of this patched wrapper caught a live occurrence of the #4391 mix-test flake that `bb` reported as exit 0: the old wrapper would have called that run green. Details in https://github.com/jomcgi/homelab/issues/4391#issuecomment-5199452994. Re-run passed clean (`Executed 0 out of 757 tests: 757 tests pass`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)