### PR TITLE
fix(embervm): mount-only workspace remediation until the respawn init wait is fixed

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.430
+version: 0.1.431

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.430
+      targetRevision: 0.1.431
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -2645,16 +2645,16 @@ class ProcessManager:
                         self.claude, "_process_workspace_identity", None
                     )
                     if identity_changed or process_dead:
+                        # Mount-only remediation: close the stranded process
+                        # and leave the respawn to the turn path's proven lazy
+                        # spawn. The eager respawn here waited its full 30s
+                        # init budget without ever observing the init event
+                        # (#4393), turning every warm-restore rejoin into a
+                        # 30s stall; until that wait is fixed, closing early
+                        # and spawning lazily restores the ~3s pre-deploy
+                        # rejoin while prewarm keeps its create and cold-boot
+                        # wins.
                         self.claude._close_process(kill=False)
-                        if not self.claude.session_id:
-                            _ensure_cli_dir(self.claude.workspace)
-                            self.claude._spawn(
-                                session_id=None,
-                                first_message=None,
-                                model=None,
-                                init_timeout=30,
-                            )
-                            self.claude.session_id = None
                     with self._remediation_lock:
                         self._remediation_attempts += 1
                 except Exception as exc:

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -1395,7 +1395,9 @@ def test_adoption_latch_rolls_back_before_result(tmp_path, monkeypatch):
     assert manager.session_id is None
 
 
-def test_takeover_remediation_closes_stranded_process_without_respawn(tmp_path, monkeypatch):
+def test_takeover_remediation_closes_stranded_process_without_respawn(
+    tmp_path, monkeypatch
+):
     manager = _new_process_manager()
     manager.workspace = str(tmp_path)
     manager._prewarm_clis = ("claude",)

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -1395,7 +1395,7 @@ def test_adoption_latch_rolls_back_before_result(tmp_path, monkeypatch):
     assert manager.session_id is None
 
 
-def test_takeover_remediation_replaces_parked_process(tmp_path, monkeypatch):
+def test_takeover_remediation_closes_stranded_process_without_respawn(tmp_path, monkeypatch):
     manager = _new_process_manager()
     manager.workspace = str(tmp_path)
     manager._prewarm_clis = ("claude",)
@@ -1439,10 +1439,9 @@ def test_takeover_remediation_replaces_parked_process(tmp_path, monkeypatch):
 
     assert manager.ready()
     manager._remediation_thread.join(timeout=1)
-    # Remediation replaced the parked process with a fresh one.
-    assert manager.claude.process is not old_process
-    assert manager.claude.process is not None
-    assert manager.claude.process.poll() is None
+    # Mount-only remediation (#4393): the stranded process is closed and the
+    # respawn is left to the turn path's lazy spawn.
+    assert manager.claude.process is None
     assert manager.ready()
 
 


### PR DESCRIPTION
Live mitigation for #4393. After #4392 deployed, every warm-restore rejoin paid a 30s stall: the remediation thread's eager respawn waited its full init budget without ever observing the CLI's init event, failed, and the turn's lazy spawn then succeeded in seconds with the same recipe (guest console evidence in the issue). Until the init-event wait works in the remediation context, remediation keeps its mount duty and closes stranded or dead parked processes, but leaves respawning to the turn path's proven lazy spawn. Rejoins return to the ~3s class; prewarm keeps its create and cold-boot adoption wins.

Suites green locally (141 passed plus the known darwin-only egress-forwarder flake) and remote ci test fully green.

Refs #4393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG