### PR TITLE
feat(embervm): enable web search for codex sessions

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.431
+version: 0.1.432

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.431
+      targetRevision: 0.1.432
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -1471,6 +1471,11 @@ chatgpt_base_url = %s
 sandbox_mode = "danger-full-access"
 approval_policy = "never"
 
+# Codex 0.146.0 binary inspection exposes [tools].web_search, while
+# web_search_request is deprecated because web search is enabled by default.
+[tools]
+web_search = true
+
 [model_providers.ember-openai]
 name = "ember-openai"
 base_url = %s

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -745,6 +745,7 @@ def test_codex_config_uses_subscription_endpoint_override(tmp_path, monkeypatch)
     assert config["model_provider"] == "ember-openai"
     assert config["sandbox_mode"] == "danger-full-access"
     assert config["approval_policy"] == "never"
+    assert config["tools"]["web_search"] is True
     assert config["model_providers"]["ember-openai"]["wire_api"] == "responses"
 
 
@@ -764,6 +765,7 @@ def test_codex_config_appends_codex_to_no_slash_endpoint(tmp_path, monkeypatch):
     assert config["chatgpt_base_url"] == endpoint
     assert config["sandbox_mode"] == "danger-full-access"
     assert config["approval_policy"] == "never"
+    assert config["tools"]["web_search"] is True
 
 
 def test_codex_child_env_drops_openai_api_key(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #4390. The generated codex config.toml never enabled web search, so codex sessions (the largest recent slice) could not search. Adds [tools] web_search = true, verified against the vendored codex 0.146.0 key syntax; search executes server-side in the subscription backend so no egress change is needed. Suites 142 passed locally, remote ci test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG