### PR TITLE
feat(embervm): instrument hydration failures and egress copies for #4389

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.433
+version: 0.1.434

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.433
+      targetRevision: 0.1.434
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -37,6 +37,90 @@ CLOCK_PATH = "/shim/clock"
 DEFAULT_WORKSPACE = "/workspace"
 VOLUME_DEVICE_ENV = "EMBER_VOLUME_DEV"
 DEFAULT_VOLUME_DEVICE = "/dev/vdb"
+
+
+def _write_hydration_diagnostics(exc, checkout_dir):
+    """Write hydration diagnostics to stderr when subprocess.TimeoutExpired occurs.
+
+    Args:
+        exc: subprocess.TimeoutExpired or any Exception.
+        checkout_dir: path to the directory being checked out.
+
+    The diagnostic path is deliberately best-effort because it runs while
+    handling another failure and stderr is the guest's only telemetry channel.
+    """
+    prefix = "ember-claude-shim: hydration-diag: "
+
+    def write_line(line):
+        sys.stderr.write(prefix + line + "\n")
+        sys.stderr.flush()
+
+    def write_value(label, value):
+        for line in value.splitlines() or [""]:
+            write_line("%s%s" % (label, line))
+
+    try:
+        write_line("exception=%s" % type(exc).__name__)
+        stderr = getattr(exc, "stderr", None)
+        if stderr is None:
+            stderr = ""
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", "replace")
+        write_value("stderr=", stderr[-800:])
+
+        stdout = getattr(exc, "stdout", None)
+        if stdout is None:
+            stdout = ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", "replace")
+        write_value("stdout=", stdout[-200:])
+
+        checkout_bytes = 0
+        for root, dirs, files in os.walk(checkout_dir):
+            for name in dirs + files:
+                try:
+                    checkout_bytes += (
+                        os.stat(
+                            os.path.join(root, name), follow_symlinks=False
+                        ).st_blocks
+                        * 512
+                    )
+                except OSError:
+                    pass
+        try:
+            checkout_bytes += (
+                os.stat(checkout_dir, follow_symlinks=False).st_blocks * 512
+            )
+        except OSError:
+            pass
+        write_line("checkout_kb=%s" % (checkout_bytes // 1024))
+
+        def read_diskstats(label):
+            try:
+                with open("/proc/diskstats") as stream:
+                    lines = [
+                        line.rstrip("\n")
+                        for line in stream
+                        if len(line.split()) >= 3 and line.split()[2] in ("vda", "vdb")
+                    ]
+            except (OSError, IOError):
+                lines = []
+            if lines:
+                for line in lines:
+                    write_line("%s%s" % (label, line))
+            else:
+                write_line("%sunavailable" % label)
+
+        read_diskstats("diskstats=")
+        time.sleep(2)
+        read_diskstats("diskstats2=")
+    except Exception as diag_exc:
+        try:
+            write_line("hydration-diag failed: %s" % diag_exc)
+        except Exception:
+            pass
+
+
 PREWARM_CLIS_ENV = "EMBER_PREWARM_CLIS"
 SUPPORTED_PREWARM_CLIS = ("claude",)
 CODEX_MODELS = {
@@ -620,16 +704,43 @@ class VsockEgressForwarder:
             threading.Thread(target=self._forward, args=(client,), daemon=True).start()
 
     @staticmethod
-    def _copy(source, destination):
+    def _copy(source, destination, direction=None):
+        total_bytes = 0
+        next_boundary = 4 * 1024 * 1024
+        error = None
+
+        def write_progress(message):
+            if direction is None:
+                return
+            # Copy threads are daemon threads that can outlive their test's (or
+            # the process's) stderr; diagnostic chatter must never raise.
+            try:
+                sys.stderr.write(
+                    "ember-claude-shim: egress-copy: %s %s\n" % (direction, message)
+                )
+                sys.stderr.flush()
+            except Exception:
+                pass
+
         try:
             while True:
                 data = source.recv(64 * 1024)
                 if not data:
                     return
                 destination.sendall(data)
-        except OSError:
+                total_bytes += len(data)
+                while direction is not None and total_bytes >= next_boundary:
+                    write_progress(str(next_boundary))
+                    next_boundary += 4 * 1024 * 1024
+        except OSError as exc:
+            error = exc
             return
         finally:
+            if direction is not None:
+                write_progress(
+                    "closed total=%s err=%s"
+                    % (total_bytes, repr(error) if error is not None else "none")
+                )
             try:
                 destination.shutdown(socket.SHUT_WR)
             except OSError:
@@ -732,8 +843,8 @@ class VsockEgressForwarder:
             if pending:
                 upstream.sendall(pending)
             copies = [
-                threading.Thread(target=self._copy, args=(client, upstream)),
-                threading.Thread(target=self._copy, args=(upstream, client)),
+                threading.Thread(target=self._copy, args=(client, upstream, "up")),
+                threading.Thread(target=self._copy, args=(upstream, client, "down")),
             ]
             for copy_thread in copies:
                 copy_thread.start()
@@ -2600,6 +2711,7 @@ class ProcessManager:
             if validation.returncode != 0:
                 raise RuntimeError("cloned directory validation failed: HEAD not found")
         except subprocess.TimeoutExpired as exc:
+            _write_hydration_diagnostics(exc, checkout_dir)
             shutil.rmtree(checkout_dir, ignore_errors=True)
             self._hydration_error = str(exc)
             sys.stderr.write(
@@ -2609,6 +2721,7 @@ class ProcessManager:
             sys.stderr.flush()
             return
         except Exception as exc:
+            _write_hydration_diagnostics(exc, checkout_dir)
             shutil.rmtree(checkout_dir, ignore_errors=True)
             self._hydration_error = str(exc)
             sys.stderr.write(

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -2889,6 +2889,76 @@ def _forwarder_exchange(monkeypatch, request_bytes):
         forwarder.close()
 
 
+def test_hydration_diagnostics_timeout(capsys, monkeypatch, tmp_path):
+    checkout_dir = tmp_path / "checkout"
+    checkout_dir.mkdir()
+    (checkout_dir / "small").write_bytes(b"content")
+    monkeypatch.setattr(shim.time, "sleep", lambda seconds: None)
+    exc = subprocess.TimeoutExpired(
+        cmd=["git", "clone"],
+        timeout=300,
+        output=b"out",
+        stderr=b"Receiving objects: 87%",
+    )
+
+    shim._write_hydration_diagnostics(exc, str(checkout_dir))
+
+    captured = capsys.readouterr().err
+    assert "Receiving objects: 87%" in captured
+    assert "checkout_kb=" in captured
+    assert "diskstats=" in captured
+    assert (
+        "diskstats=unavailable" in captured
+        or " vda " in captured
+        or " vdb " in captured
+    )
+
+
+def test_hydration_diagnostics_generic_exception(capsys, monkeypatch, tmp_path):
+    monkeypatch.setattr(shim.time, "sleep", lambda seconds: None)
+
+    shim._write_hydration_diagnostics(
+        ValueError("not a subprocess error"), str(tmp_path)
+    )
+
+    captured = capsys.readouterr().err
+    assert "ValueError" in captured
+
+
+def test_egress_copy_counts_bytes(capsys):
+    payload = b"x" * (4 * 1024 * 1024 + 123)
+
+    class FakeSource:
+        def __init__(self, data):
+            self.data = data
+            self.done = False
+
+        def recv(self, size):
+            if self.done:
+                return b""
+            self.done = True
+            return self.data
+
+    class FakeDestination:
+        def __init__(self):
+            self.data = bytearray()
+
+        def sendall(self, data):
+            self.data.extend(data)
+
+        def shutdown(self, how):
+            pass
+
+    source = FakeSource(payload)
+    destination = FakeDestination()
+    shim.VsockEgressForwarder._copy(source, destination, "down")
+
+    captured = capsys.readouterr().err
+    assert len(destination.data) == len(payload)
+    assert "egress-copy: down 4194304" in captured
+    assert "egress-copy: down closed total=%s err=none" % len(payload) in captured
+
+
 def test_egress_forwarder_takes_absolute_uri_host_and_replays_the_request(monkeypatch):
     # HTTP_PROXY is set alongside HTTPS_PROXY, so a plain-HTTP request arrives as
     # an absolute-URI line rather than a CONNECT. The destination comes from Host,


### PR DESCRIPTION
Diagnostic instrumentation for the reopened #4389: every environmental factor is now falsified (stall reproduces byte-identically under FC v1.12.1 and v1.16.1, on warm-restored and cold-booted VMs, on old and freshly rebuilt bases), so the next reproduction has to name its wedged layer itself.

On hydration timeout or failure the shim writes to the guest console: git's captured stderr tail (the progress meter states exactly how many bytes git received), the checkout's on-disk size, and /proc/diskstats for vda/vdb sampled twice 2s apart (a stuck in-flight IO count proves the virtio-blk volume wedge, the current leading suspect since repo sessions are the only bulk volume writers). The forwarder copy pumps log cumulative bytes per direction every 4 MiB plus a closed total, splitting relay delivery from git consumption.

All additive and best-effort, failure-path only. ci test: Executed 758, 758 pass (one earlier flake from copy threads outliving pytest's stderr capture was fixed by making the progress writes swallow exceptions).

Validation after merge: one deliberate repo-attached session; read the diag block from the noded console log. Part of #4389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG