### PR TITLE
fix(embervm): stop propagating half-close onto the vsock leg for git tunnels

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.434
+version: 0.1.435

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.434
+      targetRevision: 0.1.435
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -25,6 +25,11 @@ EGRESS_PORT_ENV = "EMBER_EGRESS_PORT"
 DEFAULT_EGRESS_PORT = 1024
 VSOCK_EGRESS_CID = 2
 VSOCK_EGRESS_PORT = 1025
+# The one destination port whose tunnels must NOT propagate the client's
+# half-close onto the vsock leg (#4389): git's stateless protocol half-closes
+# after the request and FC hybrid vsock kills the in-flight response on any
+# shutdown. See VsockEgressForwarder._forward.
+GIT_DAEMON_PORT = "9418"
 EGRESS_VSOCK_CONNECT_TIMEOUT_SECONDS = 5.0
 EGRESS_VSOCK_CONNECT_ATTEMPTS = 3
 EGRESS_VSOCK_CONNECT_BACKOFF_SECONDS = 0.2
@@ -66,7 +71,8 @@ def _write_hydration_diagnostics(exc, checkout_dir):
             stderr = ""
         if isinstance(stderr, bytes):
             stderr = stderr.decode("utf-8", "replace")
-        write_value("stderr=", stderr[-800:])
+        stderr = stderr.replace("\r", "\n")
+        write_value("stderr=", stderr[-2000:])
 
         stdout = getattr(exc, "stdout", None)
         if stdout is None:
@@ -255,7 +261,8 @@ def _pump_stdin_to_socket(source, sock):
         pass
     finally:
         # Half-close: tell the server the request stream is done while the
-        # response direction keeps flowing.
+        # response direction keeps flowing. This stops at the forwarder and
+        # is deliberately not propagated onto its vsock leg.
         try:
             sock.shutdown(socket.SHUT_WR)
         except OSError:
@@ -704,9 +711,9 @@ class VsockEgressForwarder:
             threading.Thread(target=self._forward, args=(client,), daemon=True).start()
 
     @staticmethod
-    def _copy(source, destination, direction=None):
+    def _copy(source, destination, direction=None, *, propagate_half_close=True):
         total_bytes = 0
-        next_boundary = 4 * 1024 * 1024
+        next_boundary = 1024 * 1024
         error = None
 
         def write_progress(message):
@@ -731,7 +738,7 @@ class VsockEgressForwarder:
                 total_bytes += len(data)
                 while direction is not None and total_bytes >= next_boundary:
                     write_progress(str(next_boundary))
-                    next_boundary += 4 * 1024 * 1024
+                    next_boundary += 1024 * 1024
         except OSError as exc:
             error = exc
             return
@@ -741,10 +748,11 @@ class VsockEgressForwarder:
                     "closed total=%s err=%s"
                     % (total_bytes, repr(error) if error is not None else "none")
                 )
-            try:
-                destination.shutdown(socket.SHUT_WR)
-            except OSError:
-                pass
+            if propagate_half_close:
+                try:
+                    destination.shutdown(socket.SHUT_WR)
+                except OSError:
+                    pass
 
     @staticmethod
     def _read_proxy_request(client):
@@ -842,8 +850,22 @@ class VsockEgressForwarder:
                 client.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
             if pending:
                 upstream.sendall(pending)
+            # FC hybrid vsock has no half-close; propagating the client's
+            # SHUT_WR onto the vsock leg kills the in-flight response (#4389).
+            # Suppression is scoped to the git daemon port because git:// is
+            # the one protocol here that half-closes mid-exchange and then
+            # expects a large response; its server never needs the EOF (the
+            # response ends via flush-pkt) and the leaked tunnel is bounded by
+            # the VM's lifetime. Everything else (HTTPS CONNECT) only closes
+            # when the exchange is over, and keeping the propagation there is
+            # what tears those tunnels down promptly.
+            half_close_upstream = not host_port.endswith(":" + GIT_DAEMON_PORT)
             copies = [
-                threading.Thread(target=self._copy, args=(client, upstream, "up")),
+                threading.Thread(
+                    target=self._copy,
+                    args=(client, upstream, "up"),
+                    kwargs={"propagate_half_close": half_close_upstream},
+                ),
                 threading.Thread(target=self._copy, args=(upstream, client, "down")),
             ]
             for copy_thread in copies:
@@ -2677,6 +2699,7 @@ class ProcessManager:
         clone_command = [
             "git",
             "clone",
+            "--progress",
             "--branch",
             branch,
             "--config",

--- a/projects/embervm/runtimes/claude/shim_hydration_test.py
+++ b/projects/embervm/runtimes/claude/shim_hydration_test.py
@@ -216,6 +216,7 @@ def test_git_command_shape(manager, monkeypatch):
         [
             "git",
             "clone",
+            "--progress",
             "--branch",
             "main",
             "--config",
@@ -270,6 +271,7 @@ def test_hydration_works_for_non_default_branch(manager, monkeypatch):
     assert commands[0] == [
         "git",
         "clone",
+        "--progress",
         "--branch",
         "develop",
         "--config",

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -2942,12 +2942,13 @@ def test_egress_copy_counts_bytes(capsys):
     class FakeDestination:
         def __init__(self):
             self.data = bytearray()
+            self.shutdown_calls = []
 
         def sendall(self, data):
             self.data.extend(data)
 
         def shutdown(self, how):
-            pass
+            self.shutdown_calls.append(how)
 
     source = FakeSource(payload)
     destination = FakeDestination()
@@ -2955,8 +2956,102 @@ def test_egress_copy_counts_bytes(capsys):
 
     captured = capsys.readouterr().err
     assert len(destination.data) == len(payload)
-    assert "egress-copy: down 4194304" in captured
+    assert "egress-copy: down 1048576" in captured
     assert "egress-copy: down closed total=%s err=none" % len(payload) in captured
+    assert destination.shutdown_calls == [socket.SHUT_WR]
+
+
+def test_egress_copy_can_skip_half_close():
+    class FakeSource:
+        def __init__(self):
+            self.done = False
+
+        def recv(self, size):
+            if self.done:
+                return b""
+            self.done = True
+            return b"payload"
+
+    class FakeDestination:
+        def __init__(self):
+            self.data = bytearray()
+            self.shutdown_calls = []
+
+        def sendall(self, data):
+            self.data.extend(data)
+
+        def shutdown(self, how):
+            self.shutdown_calls.append(how)
+
+    destination = FakeDestination()
+    shim.VsockEgressForwarder._copy(
+        FakeSource(), destination, "up", propagate_half_close=False
+    )
+
+    assert destination.data == b"payload"
+    assert destination.shutdown_calls == []
+
+
+def test_egress_forwarder_scopes_half_close_to_git_port(monkeypatch):
+    # Port 9418 keeps the upstream write side open after the client
+    # half-closes (the #4389 shape: git sends its request, half-closes, and
+    # the bulk response must keep flowing); every other port propagates the
+    # half-close so ordinary tunnels still tear down promptly.
+    original_socket = socket.socket
+    for port, expect_propagated in (("9418", False), ("443", True)):
+        forwarder = shim.VsockEgressForwarder(port=0)
+        vsock_peer, vsock_forwarder = socket.socketpair()
+
+        class FakeVsock:
+            def __init__(self):
+                self.timeouts = []
+
+            def settimeout(self, timeout):
+                self.timeouts.append(timeout)
+
+            def connect(self, address):
+                pass
+
+            def recv(self, size):
+                return vsock_forwarder.recv(size)
+
+            def sendall(self, data):
+                return vsock_forwarder.sendall(data)
+
+            def shutdown(self, how):
+                return vsock_forwarder.shutdown(how)
+
+            def close(self):
+                return vsock_forwarder.close()
+
+        def socket_factory(family, *args, **kwargs):
+            if family == shim.VSOCK_ADDRESS_FAMILY:
+                return FakeVsock()
+            return original_socket(family, *args, **kwargs)
+
+        monkeypatch.setattr(shim.socket, "socket", socket_factory)
+        forwarder.listen()
+        client = socket.create_connection((shim.EGRESS_LOCALHOST, forwarder.port))
+        try:
+            client.sendall(("CONNECT example.com:%s HTTP/1.1\r\n\r\n" % port).encode())
+            preamble = ("example.com:%s\n" % port).encode()
+            assert vsock_peer.recv(len(preamble)) == preamble
+            established = b"HTTP/1.1 200 Connection Established\r\n\r\n"
+            assert client.recv(len(established)) == established
+            client.sendall(b"request")
+            assert vsock_peer.recv(7) == b"request"
+            client.shutdown(socket.SHUT_WR)
+            vsock_peer.settimeout(2)
+            if expect_propagated:
+                assert vsock_peer.recv(4096) == b""
+            else:
+                vsock_peer.sendall(b"late response")
+                client.settimeout(2)
+                assert client.recv(13) == b"late response"
+        finally:
+            client.close()
+            vsock_peer.close()
+            forwarder.close()
 
 
 def test_egress_forwarder_takes_absolute_uri_host_and_replays_the_request(monkeypatch):


### PR DESCRIPTION
Closes the reopened #4389 with the actual root cause, pinned by the instrumented reproduction (diag evidence on the issue):

git's stateless protocol-v2 clone sends its request and half-closes the upload leg. The forwarder propagated that SHUT_WR onto the AF_VSOCK upstream; Firecracker's hybrid vsock has no half-close, and the in-flight bulk response died just short of complete, with the guest's recv never seeing an EOF. git:// is the only lane traffic that half-closes mid-exchange and then expects a large response, which is why only hydration clones stalled while every other lane user worked, on both Firecracker versions, cold-booted or restored, on old and fresh bases.

The forwarder now skips the upstream half-close for tunnels to the git daemon port only (scoped: HTTPS CONNECT clients only close when the exchange is over, and keeping the propagation there is what tears those tunnels down promptly; a kept-open git tunnel is bounded by the VM lifetime). The unit test pins the contract in both directions: 9418 keeps the response flowing after the client's half-close, 443 still propagates.

Also: the clone runs with --progress so the hydration diag block carries git's received-byte meter, stderr tail up to 2000 bytes with CR normalization, and 1 MiB pump granularity.

ci test: Executed 758, 758 pass.

Validation after merge (the closing proof for #4389): repo-attached session hydrates end to end with TWO mirror dials, turn completes with nonzero cost. Then #4389 closes and warm restore re-arming gets its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG