### PR TITLE
fix(embervm): hydrate with a full clone so the lane needs one connection

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.435
+version: 0.1.436

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.435
+      targetRevision: 0.1.436
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -191,7 +191,8 @@ INTERRUPT_TIMEOUT = 30.0
 CLI_PROBE_TIMEOUT = 10.0
 HYDRATION_ATTEMPT_CAP = 3
 # The guest path is proxied over vsock, so it is materially slower than a direct
-# clone. A partial clone of this repo is approximately 67 MB.
+# clone. A full clone of this repo moves roughly 25 MB through the lane, well
+# inside this cap at observed lane throughput.
 GIT_CLONE_TIMEOUT_SECONDS = 300
 PERMISSION_MODE_ENV = "EMBER_PERMISSION_MODE"
 DEFAULT_PERMISSION_MODE = "bypassPermissions"
@@ -2705,7 +2706,10 @@ class ProcessManager:
             "--config",
             "core.gitProxy=%s" % GIT_PROXY_PATH,
             "--single-branch",
-            "--filter=blob:none",
+            # Deliberately a FULL clone, not --filter=blob:none: a blob filter
+            # makes checkout open a SECOND lane connection for the lazy blob
+            # fetch, and connection #2 through the vsock lane wedges (#4389).
+            # One fetch on one connection moves ~12 MB more and works.
             "git://git-mirror.monolith.svc.cluster.local:9418/%s" % repo,
             checkout_dir,
         ]

--- a/projects/embervm/runtimes/claude/shim_hydration_test.py
+++ b/projects/embervm/runtimes/claude/shim_hydration_test.py
@@ -222,7 +222,6 @@ def test_git_command_shape(manager, monkeypatch):
             "--config",
             "core.gitProxy=/tmp/ember-git-proxy",
             "--single-branch",
-            "--filter=blob:none",
             "git://git-mirror.monolith.svc.cluster.local:9418/owner/repo",
             checkout_dir,
         ],
@@ -277,7 +276,6 @@ def test_hydration_works_for_non_default_branch(manager, monkeypatch):
         "--config",
         "core.gitProxy=/tmp/ember-git-proxy",
         "--single-branch",
-        "--filter=blob:none",
         "git://git-mirror.monolith.svc.cluster.local:9418/owner/repo",
         checkout_dir,
     ]


### PR DESCRIPTION
The half-close fix moved #4389 forward: fetch 1 now completes end to end (Resolving deltas 100% done, captured by the instrumented shim). The clone then wedges opening its SECOND lane connection, the lazy blob fetch --filter=blob:none forces at checkout: one sidecar dial, connect completes guest-side, first bytes never arrive host-side.

A full clone needs exactly one fetch on one connection, which now demonstrably works. ~12MB more through the lane, seconds at observed throughput, no promisor machinery. The multi-connection lane wedge stays open on #4389 (it matters for in-session git fetches).

ci test: Executed 758, 758 pass.

Post-merge: the closing validation for repo-attached sessions: hydration completes, turn answers with nonzero cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG