### PR TITLE
fix(embervm): give the first-turn hydration clone a 600 second budget

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.436
+version: 0.1.437

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.436
+      targetRevision: 0.1.437
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -191,9 +191,13 @@ INTERRUPT_TIMEOUT = 30.0
 CLI_PROBE_TIMEOUT = 10.0
 HYDRATION_ATTEMPT_CAP = 3
 # The guest path is proxied over vsock, so it is materially slower than a direct
-# clone. A full clone of this repo moves roughly 25 MB through the lane, well
-# inside this cap at observed lane throughput.
-GIT_CLONE_TIMEOUT_SECONDS = 300
+# clone, and a FULL clone additionally pays 86k delta resolutions plus a 151 MB
+# checkout on 2 vCPUs: the instrumented #4389 run finished deltas and most of
+# the checkout just past the old 300 second cap. Only the first turn per
+# session volume ever pays this (the rev-parse gate skips hydration after one
+# success), and the outer budgets (monolith 1800s wall clock, invocation 900s)
+# leave headroom.
+GIT_CLONE_TIMEOUT_SECONDS = 600
 PERMISSION_MODE_ENV = "EMBER_PERMISSION_MODE"
 DEFAULT_PERMISSION_MODE = "bypassPermissions"
 CLI_UID_ENV = "EMBER_CLI_UID"


### PR DESCRIPTION
The single-connection full clone works end to end (86176/86176 deltas, 151MB checked out in the instrumented run) and was killed by the 300s cap in the final stretch. Only the first turn per session volume pays hydration (rev-parse gate skips after one success); outer budgets (1800s transport, 900s invocation) leave headroom. Double the cap.

ci test: Executed 758, 758 pass. Part of #4389; the closing validation runs post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG