### PR TITLE
fix(embervm): let the git proxy helper exit once the response goes idle

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.437
+version: 0.1.438

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.437
+      targetRevision: 0.1.438
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -243,6 +243,7 @@ import os
 import socket
 import sys
 import threading
+import time
 
 EGRESS_LOCALHOST = "127.0.0.1"
 EGRESS_PORT_ENV = "EMBER_EGRESS_PORT"
@@ -274,12 +275,16 @@ def _pump_stdin_to_socket(source, sock):
             pass
 
 
+LAST_RX = [time.monotonic()]
+
+
 def _pump_socket_to_stdout(sock, destination):
     try:
         while True:
             data = sock.recv(65536)
             if not data:
                 break
+            LAST_RX[0] = time.monotonic()
             destination.write(data)
             destination.flush()
     except OSError:
@@ -319,18 +324,49 @@ def main():
             sys.stderr.write("ERROR: proxy handshake returned a non-200 response\n")
             return 1
         sock.settimeout(None)
-        threads = [
-            threading.Thread(
-                target=_pump_stdin_to_socket, args=(sys.stdin.buffer, sock)
-            ),
-            threading.Thread(
-                target=_pump_socket_to_stdout, args=(sock, sys.stdout.buffer)
-            ),
-        ]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
+        try:
+            idle_exit = float(
+                os.environ.get("EMBER_GIT_PROXY_IDLE_EXIT_SECONDS", "10")
+            )
+            if idle_exit <= 0:
+                idle_exit = 10
+        except ValueError:
+            idle_exit = 10
+        # Daemon threads: interpreter exit must never wait on a pump still
+        # blocked in recv (the idle-exit path below leaves exactly that).
+        stdin_pump = threading.Thread(
+            target=_pump_stdin_to_socket, args=(sys.stdin.buffer, sock), daemon=True
+        )
+        stdout_pump = threading.Thread(
+            target=_pump_socket_to_stdout, args=(sock, sys.stdout.buffer), daemon=True
+        )
+        stdin_pump.start()
+        stdout_pump.start()
+        stdin_pump.join()
+        # git half-closes stdin right after its request and then reads the
+        # response, so stdin EOF says nothing about completion. The response
+        # side has no EOF either: the lane deliberately never propagates the
+        # half-close onto vsock (#4389), so the server-held connection stays
+        # open forever and git waits for THIS process to exit. Once the
+        # response has been idle past the deadline, close up and leave; a
+        # mid-response server pause shorter than the deadline is unaffected.
+        LAST_RX[0] = time.monotonic()
+        while stdout_pump.is_alive():
+            stdout_pump.join(timeout=0.5)
+            if not stdout_pump.is_alive():
+                break
+            if time.monotonic() - LAST_RX[0] > idle_exit:
+                # shutdown, not just close: close() does not wake a thread
+                # blocked in recv, SHUT_RDWR does.
+                try:
+                    sock.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+                break
         return 0
     except (OSError, ValueError) as exc:
         sys.stderr.write("ERROR: %s\n" % exc)

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -3054,6 +3054,54 @@ def test_egress_forwarder_scopes_half_close_to_git_port(monkeypatch):
             forwarder.close()
 
 
+def test_git_proxy_helper_exits_when_response_goes_idle(tmp_path, monkeypatch):
+    # The lane never propagates the client half-close onto vsock (#4389), so
+    # the server-held connection stays open forever after the response ends.
+    # git waits for the helper process to exit, so the helper must leave on
+    # its own once the response has been idle past the deadline.
+    helper_path = tmp_path / "ember-git-proxy"
+    monkeypatch.setattr(shim, "GIT_PROXY_PATH", str(helper_path))
+    shim._write_git_proxy_helper()
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind((shim.EGRESS_LOCALHOST, 0))
+    listener.listen()
+    accepted = []
+
+    def serve_connection():
+        connection, _ = listener.accept()
+        accepted.append(connection)
+        connection.recv(4096)
+        connection.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        connection.recv(4096)
+        connection.sendall(b"response payload")
+        # Deliberately neither close nor shutdown: the connection idles open,
+        # exactly like the suppressed-half-close lane.
+        time.sleep(8)
+
+    accept_thread = threading.Thread(target=serve_connection, daemon=True)
+    accept_thread.start()
+    environment = os.environ.copy()
+    environment[shim.EGRESS_PORT_ENV] = str(listener.getsockname()[1])
+    environment["EMBER_GIT_PROXY_IDLE_EXIT_SECONDS"] = "1"
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            [sys.executable, str(helper_path), "example.com", "9418"],
+            input=b"request",
+            env=environment,
+            capture_output=True,
+            timeout=6,
+        )
+    finally:
+        listener.close()
+        for connection in accepted:
+            connection.close()
+    assert result.returncode == 0
+    assert result.stdout == b"response payload"
+    assert time.monotonic() - started < 6
+
+
 def test_egress_forwarder_takes_absolute_uri_host_and_replays_the_request(monkeypatch):
     # HTTP_PROXY is set alongside HTTPS_PROXY, so a plain-HTTP request arrives as
     # an absolute-URI line rather than a CONNECT. The destination comes from Host,


### PR DESCRIPTION
Fourth and final link in the #4389 chain: the suppressed vsock half-close severed the helper's exit path, so git finished all data work (full pack, 86k deltas, checkout) and then waited forever on the proxy child whose response pump had no EOF coming. Both instrumented runs froze at the identical 151MB with the disk idle.

The helper now idle-exits: after stdin EOF, once the response side has been silent past a deadline (10s default, env-tunable), it shuts the socket down (SHUT_RDWR, since close alone does not wake a blocked recv), and its pump threads are daemons so interpreter exit never waits. Sideband progress bytes keep the clock fresh during active transfers.

ci test: Executed 758, 758 pass (including the new idle-exit subprocess test).

Post-merge: the closing validation for #4389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG