### PR TITLE
fix(embervm): re-key bases again now that every brick runs v1.16.1

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.438
+version: 0.1.439

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -36,7 +36,14 @@ scratchSizeGi: 35
 # any Firecracker version change. Banked session and stateful memory snapshots
 # are separate artifacts this knob does not rebuild; they must be drained or
 # left to fail over cold at rollout.
-hypervisorEpoch: "fc-v1.16.1"
+# r2: the first fc-v1.16.1 re-key raced the brick roll. The CR update landed
+# while the outgoing v1.12.1 bricks still served builds, five workload bases
+# were written by the OLD binary under the NEW epoch, and the v1.16.1 bricks
+# re-registered them as Ready with no format check (#4407), failing every
+# restore with a bitcode error. Bricks are all v1.16.1 now, so this re-key
+# rebuilds on the right binary. Sequencing lesson: an epoch move only takes
+# effect safely once the fleet it names is actually serving.
+hypervisorEpoch: "fc-v1.16.1-r2"
 
 # Node-provisioning contract actuator (ADR embervm/012 storage-tiers amendment):
 # the scratch-prep DaemonSet that provisions the uniform capped loop scratch (see

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.438
+      targetRevision: 0.1.439
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
The first epoch re-key raced the brick roll: five workload bases were built by the outgoing v1.12.1 bricks under the new epoch, re-registered as Ready by the v1.16.1 bricks without format validation (#4407's gap), and every restore since 05:30Z bitcode-errors while the pool retry-loops. describe-snapshot: the 05:27 snapfiles are unreadable; the post-roll claude base reads v10.

Values-only epoch move to fc-v1.16.1-r2; the fleet is uniformly v1.16.1 so this rebuild lands on the right binary. Part of #4389, hard evidence for #4407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFioNqs3EQ74PRzuSXeWrG