### PR TITLE
fix(embervm): re-arm warm restore with volume fleet-wide

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -121,14 +121,21 @@ noded:
   # Rollback: set back to [] (uniformly, never partially); no chart bump
   # needed, the values git ref alone rolls the brick Deployment envs off.
   #
-  # DISARMED 2026-08-06 (#4389, reopened): the hydration-clone stall follows
-  # RESTORED session VMs and survives the Firecracker v1.16.1 upgrade, while
-  # cold-booted sessions cloned cleanly for weeks before the fleet-wide arming.
-  # Cold boot is both the A/B discriminator and the mitigation that unblocks
-  # repo-attached turns while the restore-path vsock fault (guest kernel
-  # 6.18.35 driver state across snapshot restore is the leading suspect) is
-  # run down. Re-arm with the full class list once #4389 closes for real.
-  warmRestoreWithVolumeClasses: []
+  # RE-ARMED 2026-08-06 (#4418) after a diagnostic disarm. The disarm was an A/B
+  # discriminator for #4389, and it EXONERATED restore: cold-booted sessions
+  # stalled byte-identically, so "the stall follows restored VMs" was a
+  # coincidence of timing, not a cause. The real chain was four stacked defects
+  # on the egress lane, all fixed and validated live: SHUT_WR propagated onto a
+  # vsock leg that has no half-close (#4412), the resulting suppression severing
+  # the git proxy helper's exit chain (#4415), blob:none forcing a second lane
+  # connection at checkout (#4414, the wedge itself now tracked as #4417), and a
+  # clone budget too short for the full-clone shape (#4413). A repo-attached
+  # session then hydrated and ran billed turns end to end.
+  #
+  # Restoring the full list is the whole point of the feature: sessions start
+  # from a disk snapshot at 2.5ms load-to-resume instead of paying a cold boot
+  # every time. Uniform, per the rollback contract above, never partial.
+  warmRestoreWithVolumeClasses: ["2gi", "4gi", "8gi", "16gi"]
 
 # Node-provisioning contract (ADR embervm/012 storage-tiers amendment; warmth
 # cache-cap retention decisions 2026-07-22): DISABLED. The privileged runtime


### PR DESCRIPTION
Restores `warmRestoreWithVolumeClasses` to the full class list after the diagnostic disarm in `c40ba556c`. Closes #4418.

## Why

The disarm was an A/B discriminator for #4389, and it **exonerated restore**: cold-booted sessions stalled byte-identically, so "the stall follows restored VMs" was a coincidence of timing rather than a cause. The real chain was four stacked defects on the egress lane, each fixed and validated live:

| PR | Defect |
|----|--------|
| #4412 | `SHUT_WR` propagated onto a vsock leg that has no half-close |
| #4415 | That suppression severed the git proxy helper's exit chain |
| #4414 | `blob:none` forced a second lane connection at checkout (the wedge itself is now #4417) |
| #4413 | Clone budget too short for the full-clone shape |

A repo-attached session then hydrated and ran billed turns end to end.

## What this restores

Sessions start from a disk snapshot at 2.5ms load-to-resume instead of paying a cold boot every time. That is the point of the feature.

Uniform per the documented rollback contract, never partial: base refs exclude noded config, so a mixed fleet would export placeholder-less twins under the same ref and break session creates on any brick that later hydrates one.

## Verification

Values-only, so no chart bump: the values git ref alone rolls the brick Deployment envs.

`helm template` diff against the pre-change values is exactly eight additions of `EMBERVM_NODED_WARM_RESTORE_WITH_VOLUME: "true"` and nothing else, one per brick Deployment:

```
embervm-embervm-noded-brick-2gi           class=2gi    warm=True
embervm-embervm-noded-brick-4gi           class=4gi    warm=True
embervm-embervm-noded-brick-8gi           class=8gi    warm=True
embervm-embervm-noded-brick-16gi          class=16gi   warm=True
embervm-embervm-noded-brick-2gi-node-1    class=2gi    warm=True
embervm-embervm-noded-brick-2gi-node-2    class=2gi    warm=True
embervm-embervm-noded-brick-2gi-node-3    class=2gi    warm=True
embervm-embervm-noded-brick-16gi-node-4   class=16gi   warm=True
```

All four size classes, uniformly armed. `ci test`: `Executed 1 out of 758 tests: 758 tests pass`.

Post-merge validation is tracked separately: confirm the bricks rolled with the env, then a repo-attached session that RESTORES (not cold-boots), hydrates, runs a billed turn, and survives one park/relight cycle.