### PR TITLE
fix(embervm): move the base epoch with the warm restore re-arm

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -459,8 +459,20 @@ claudeRuntimeWorkload:
   # the epoch re-keys the base, which forces a re-record and a fresh build that
   # every consumer (recorded ref, node facts, retention desired set) converges
   # on.
+  #
+  # warm-restore-3: the #4418 re-arm restored warmRestoreWithVolumeClasses
+  # without moving this epoch, and the two MUST move together. Every base on
+  # disk was rebuilt at 09:43Z under hypervisorEpoch fc-v1.16.1-r2 by bricks
+  # that were still DISARMED, so it carries no placeholder volume drive
+  # (verified: the claude-runtime snapfile holds the rootfs drive id and no
+  # volume one). An armed brick restoring a session PATCHes a "volume" drive
+  # that the base does not have, and every session create fails there. The base
+  # signature deliberately excludes noded config, so arming alone can never
+  # trigger the rebuild that arming requires. Scoped to claude-runtime because
+  # only a restore that carries a volume needs the placeholder: task bases
+  # restore volume-less and are unaffected either way.
   initEnv:
-    EMBER_BASE_EPOCH: "warm-restore-2"
+    EMBER_BASE_EPOCH: "warm-restore-3"
     # initEnv participates in the base signature, so this re-keys and rebuilds
     # only the claude-runtime base at the next chart bump. Prewarm failure fails
     # the base build by design.


### PR DESCRIPTION
Follow-up to #4420, which re-armed `warmRestoreWithVolumeClasses` without moving `EMBER_BASE_EPOCH`. The two must move together. Part of #4418.

## The coupling

An armed brick attaches a placeholder `volume` drive when it **builds** a base (`driver.go:962`). A session restore then **patches** that drive to point at the session's real volume (`driver.go:772`).

Every base on disk was rebuilt at 09:43Z under `hypervisorEpoch: fc-v1.16.1-r2` by bricks that were still **disarmed**, so none carries the placeholder. Verified directly against the live artifact:

```
$ strings .../bases/claude-runtime__57372a218f3a/snapfile | grep -E '^(volume|rootfs)$' | sort | uniq -c
      2 rootfs
```

No `volume` drive id. With the fleet armed and the base placeholder-less, the PATCH targets a drive that does not exist and every session create fails there.

## Why it cannot self-correct

The base signature deliberately **excludes** noded config. That is what makes this a trap rather than a transient: arming can never trigger the rebuild that arming requires. The original arming PR moved both knobs for this reason, and the values comment documents it. The re-arm moved only one.

## Scope

Scoped to `claude-runtime` because only a restore that carries a volume needs the placeholder:

| base | restore | result |
|------|---------|--------|
| placeholder-less | volume-less | fine |
| placeholder-bearing | volume-less | fine (reopens the node-stable placeholder) |
| placeholder-less | **with volume** | **fails at the PATCH** |
| placeholder-bearing | with volume | the goal |

Task bases restore volume-less, so re-keying them fleet-wide would rebuild five bases to no purpose.

## Verification

Values-only, no chart bump. `helm template` diff against the current tip is exactly one line:

```
-        EMBER_BASE_EPOCH: warm-restore-2
+        EMBER_BASE_EPOCH: warm-restore-3
```

Post-merge: confirm the rebuilt claude-runtime base contains the `volume` drive id, then a repo-attached session that restores, hydrates, and runs a billed turn.