### PR TITLE
fix(embervm): move gRPC channel ownership from streamer to NodeRegistry

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.439
+version: 0.1.440

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -363,6 +363,29 @@ defmodule Embervm.NodeRegistry do
     end
   end
 
+  # A channel from the CURRENT streamer. Events from a superseded streamer are
+  # handled carefully: if the pid is dead (killed before it sent this message or
+  # already reaped), its after clause will never run, so we must disconnect here.
+  # If the pid is alive, it still owns the channel and will release it itself.
+  def handle_info({:streamer_channel, pid, channel}, state) do
+    case Map.get(state.streamers, pid) do
+      nil ->
+        # The pid is not the current streamer. If it is also DEAD, its after clause
+        # either already ran or never will (untrappable kill), and no one else holds
+        # this channel, so release it here rather than orphan it. A live superseded
+        # streamer still owns its channel and releases it itself. is_pid/1 guards
+        # first: Process.alive?/1 RAISES on a non-pid, and a raise here would take
+        # the registry down over a message it should simply ignore.
+        if is_pid(pid) and not Process.alive?(pid) do
+          safe_channel_disconnect(state.disconnect_fun, channel)
+        end
+        {:noreply, state}
+
+      node_id ->
+        {:noreply, put_in(state.node_runtime[node_id].channel, channel)}
+    end
+  end
+
   # A streamer finished (stream closed cleanly or errored). Decide the next move
   # for its node: reconnect immediately on a healthy long-lived close, back off
   # otherwise. Ignored if the pid is no longer the current streamer.
@@ -1065,8 +1088,13 @@ defmodule Embervm.NodeRegistry do
 
     case state.node_runtime[node_id].streamer do
       {pid, _ref} ->
+        channel = state.node_runtime[node_id].channel
         state = forget_streamer(state, pid, node_id)
+
+        # Process.exit(:kill) is untrappable, so the streamer cannot release its
+        # channel in the after clause. NodeRegistry owns cleanup at this kill site.
         Process.exit(pid, :kill)
+        safe_channel_disconnect(state.disconnect_fun, channel)
         schedule_reconnect(state, node_id)
 
       nil ->
@@ -1098,6 +1126,8 @@ defmodule Embervm.NodeRegistry do
         result =
           case connect_fun.(address) do
             {:ok, channel} ->
+              send(owner, {:streamer_channel, streamer, channel})
+
               try do
                 # Artifact-decoupling Phase 2: on EVERY (re)connect, before we
                 # start consuming the WatchNode stream, PUSH the authoritative
@@ -1134,15 +1164,15 @@ defmodule Embervm.NodeRegistry do
     |> put_in([:streamers, pid], node_id)
   end
 
-  # Clear a streamer from the current-streamer index and the node runtime. Safe
-  # to call for a pid already forgotten (idempotent), which happens when the
-  # down-edge kill and the subsequent :DOWN both run.
+  # Clear a streamer and its channel from the current-streamer index and the node
+  # runtime. Safe to call for a pid already forgotten (idempotent), which happens
+  # when the down-edge kill and the subsequent :DOWN both run.
   defp forget_streamer(state, pid, node_id) do
     state = %{state | streamers: Map.delete(state.streamers, pid)}
 
     case state.node_runtime[node_id] do
       %{streamer: {^pid, _ref}} = rt ->
-        put_in(state.node_runtime[node_id], %{rt | streamer: nil})
+        put_in(state.node_runtime[node_id], %{rt | streamer: nil, channel: nil})
 
       _ ->
         state
@@ -1347,6 +1377,8 @@ defmodule Embervm.NodeRegistry do
       address: spec.address,
       # {pid, ref} of the live streamer, or nil when no stream is open.
       streamer: nil,
+      # Channel owned by the current streamer, or nil before it connects.
+      channel: nil,
       backoff_ms: base_backoff,
       # Monotonic ms the current stream opened, to tell a healthy long-lived close
       # (reconnect now) from a suspect fast close (back off).
@@ -1387,9 +1419,14 @@ defmodule Embervm.NodeRegistry do
 
     state =
       case state.node_runtime[instance_id] do
-        %{streamer: {pid, _ref}} ->
+        %{streamer: {pid, _ref}} = rt ->
+          channel = rt.channel
           state = forget_streamer(state, pid, instance_id)
+
+          # Process.exit(:kill) is untrappable, so the streamer cannot release its
+          # channel in the after clause. NodeRegistry owns cleanup at this kill site.
           Process.exit(pid, :kill)
+          safe_channel_disconnect(state.disconnect_fun, channel)
           state
 
         _ ->
@@ -1447,6 +1484,25 @@ defmodule Embervm.NodeRegistry do
   catch
     kind, reason ->
       Logger.warning("embervm node registry: channel removal for #{key} exited: #{inspect({kind, reason})}")
+      :ok
+  end
+
+  # The streamer cannot disconnect itself because Process.exit(:kill) is
+  # untrappable and skips the after clause. Ownership moves to NodeRegistry for
+  # guaranteed cleanup.
+  defp safe_channel_disconnect(_disconnect_fun, nil), do: :ok
+  defp safe_channel_disconnect(nil, _channel), do: :ok
+
+  defp safe_channel_disconnect(disconnect_fun, channel) do
+    disconnect_fun.(channel)
+    :ok
+  rescue
+    e ->
+      Logger.warning("embervm node registry: channel disconnect failed: #{inspect(e)}")
+      :ok
+  catch
+    kind, reason ->
+      Logger.warning("embervm node registry: channel disconnect exited: #{inspect({kind, reason})}")
       :ok
   end
 

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -248,6 +248,7 @@ defmodule Embervm.NodeRegistryTest do
   test "a real spawn_monitor streamer connects, publishes facts, and reconnects on clean drop" do
     {:ok, connects} = Agent.start_link(fn -> 0 end)
     on_exit(fn -> Embervm.TestProcess.stop_safely(connects) end)
+    test_pid = self()
 
     connect_fun = fn _address ->
       Agent.update(connects, &(&1 + 1))
@@ -270,7 +271,7 @@ defmodule Embervm.NodeRegistryTest do
         # the fake channel, which is not a real gRPC channel. The replay is not
         # under test here (see the dedicated reconnect-replays-registry test).
         sync_registry_fun: fn :fake_channel, _id, _request -> :ok end,
-        disconnect_fun: fn :fake_channel -> :ok end,
+        disconnect_fun: fn ch -> send(test_pid, {:disconnected, ch}) end,
         # Small backoff so the reconnect fires quickly; large age-out so the
         # real-time ticks do not race the assertions.
         base_backoff_ms: 10,
@@ -318,7 +319,7 @@ defmodule Embervm.NodeRegistryTest do
         # Stub the registry replay: the real default dials NodeService.Stub over
         # the fake channel (not a real gRPC channel); the replay is not under test.
         sync_registry_fun: fn :fake_channel, _id, _request -> :ok end,
-        disconnect_fun: fn :fake_channel -> :ok end,
+        disconnect_fun: fn ch -> send(test_pid, {:disconnected, ch}) end,
         reassign_fun: fn id -> send(test_pid, {:reassigned, id}) end,
         # Small age-out windows and backoff so the wedge is detected and the kill
         # + reconnect happen quickly, with plenty of polling margin below.
@@ -338,6 +339,7 @@ defmodule Embervm.NodeRegistryTest do
 
     # The wedged streamer was killed and a fresh connection opened (recovery).
     eventually(fn -> Agent.get(connects, & &1) >= 2 end, 200)
+    assert_receive {:disconnected, :fake_channel}, 2_000
   end
 
   # -- registry replay on (re)connect (artifact-decoupling Phase 2) ----------
@@ -371,7 +373,7 @@ defmodule Embervm.NodeRegistryTest do
         connect_fun: connect_fun,
         watch_fun: watch_fun,
         sync_registry_fun: sync_registry_fun,
-        disconnect_fun: fn :fake_channel -> :ok end,
+        disconnect_fun: fn ch -> send(test_pid, {:disconnected, ch}) end,
         base_backoff_ms: 10,
         max_backoff_ms: 10,
         age_check_ms: 60_000,
@@ -411,7 +413,7 @@ defmodule Embervm.NodeRegistryTest do
         connect_fun: fn _address -> {:ok, :fake_channel} end,
         watch_fun: watch_fun,
         sync_registry_fun: sync_registry_fun,
-        disconnect_fun: fn :fake_channel -> :ok end,
+        disconnect_fun: fn ch -> send(test_pid, {:disconnected, ch}) end,
         registry_resync_ms: 30,
         base_backoff_ms: 60_000,
         max_backoff_ms: 60_000,
@@ -457,7 +459,7 @@ defmodule Embervm.NodeRegistryTest do
           send(test_pid, {:registry_sync, request})
           :ok
         end,
-        disconnect_fun: fn :fake_channel -> :ok end,
+        disconnect_fun: fn ch -> send(test_pid, {:disconnected, ch}) end,
         age_check_ms: 60_000,
         unknown_after_ms: 60_000,
         down_after_ms: 60_000
@@ -492,7 +494,7 @@ defmodule Embervm.NodeRegistryTest do
           send(test_pid, {:registry_sync, request})
           :ok
         end,
-        disconnect_fun: fn :fake_channel -> :ok end,
+        disconnect_fun: fn ch -> send(test_pid, {:disconnected, ch}) end,
         age_check_ms: 60_000,
         unknown_after_ms: 60_000,
         down_after_ms: 60_000
@@ -533,7 +535,7 @@ defmodule Embervm.NodeRegistryTest do
           send(test_pid, {:registry_sync, request})
           :ok
         end,
-        disconnect_fun: fn :fake_channel -> :ok end,
+        disconnect_fun: fn ch -> send(test_pid, {:disconnected, ch}) end,
         age_check_ms: 60_000,
         unknown_after_ms: 60_000,
         down_after_ms: 60_000
@@ -561,7 +563,7 @@ defmodule Embervm.NodeRegistryTest do
       connect_fun: fn _address -> {:ok, :fake_channel} end,
       watch_fun: blocking_watch(),
       sync_registry_fun: sync_registry_fun,
-      disconnect_fun: fn :fake_channel -> :ok end,
+      disconnect_fun: fn ch -> send(test_pid, {:disconnected, ch}) end,
       age_check_ms: 60_000,
       unknown_after_ms: 60_000,
       down_after_ms: 60_000
@@ -897,4 +899,175 @@ defmodule Embervm.NodeRegistryTest do
     refute Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1")
     assert NodeRegistry.capacity(table) == []
   end
+
+  test "expiry disconnects the stored streamer channel" do
+    {clock, advance} = new_clock()
+    test_pid = self()
+
+    {reg, table} =
+      start_registry(
+        register_seams(
+          clock: clock,
+          disconnect_fun: fn channel -> send(test_pid, {:disconnected, channel}) end,
+          unknown_after_ms: 5_000,
+          down_after_ms: 15_000,
+          expire_after_ms: 90_000
+        )
+      )
+
+    :ok = NodeRegistry.register(reg, %{"node" => "node-4", "pod_uid" => "uid-1", "address" => "10.0.0.1:9090"})
+    eventually(fn -> NodeRegistry.capacity(table) != [] end, 200)
+
+    advance.(100_000)
+    :ok = NodeRegistry.tick(reg)
+
+    refute Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1")
+    assert NodeRegistry.capacity(table) == []
+    assert_receive {:disconnected, :fake_channel}, 2_000
+  end
+
+  test "normal streamer exit disconnects its channel exactly once" do
+    {:ok, connects} = Agent.start_link(fn -> 0 end)
+    {:ok, watches} = Agent.start_link(fn -> 0 end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(connects) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(watches) end)
+    test_pid = self()
+
+    connect_fun = fn _address ->
+      Agent.update(connects, &(&1 + 1))
+      {:ok, :fake_channel}
+    end
+
+    watch_fun = fn :fake_channel, node_id, emit ->
+      emit.(node_status(node_id: node_id))
+
+      case Agent.get_and_update(watches, fn count -> {count + 1, count + 1} end) do
+        1 -> {:ok, :closed}
+        _ -> receive do: (:never -> {:ok, :closed})
+      end
+    end
+
+    {_reg, table} =
+      start_registry(
+        watch_startup: true,
+        connect_fun: connect_fun,
+        watch_fun: watch_fun,
+        sync_registry_fun: fn :fake_channel, _id, _request -> :ok end,
+        disconnect_fun: fn channel -> send(test_pid, {:disconnected, channel}) end,
+        base_backoff_ms: 10,
+        max_backoff_ms: 10,
+        age_check_ms: 60_000,
+        unknown_after_ms: 60_000,
+        down_after_ms: 60_000
+      )
+
+    eventually(fn -> NodeRegistry.capacity(table) != [] end, 200)
+    eventually(fn -> Agent.get(connects, & &1) >= 2 end, 200)
+    assert_receive {:disconnected, :fake_channel}, 2_000
+    refute_receive {:disconnected, :fake_channel}, 200
+  end
+
+  test "ignores channel messages from superseded streamers" do
+    {clock, advance} = new_clock()
+    test_pid = self()
+
+    {reg, _table} =
+      start_registry(
+        register_seams(
+          clock: clock,
+          connect_fun: fn _address ->
+            send(test_pid, {:streamer_pid, self()})
+            {:ok, :real_channel}
+          end,
+          disconnect_fun: fn channel -> send(test_pid, {:disconnected, channel}) end,
+          unknown_after_ms: 5_000,
+          down_after_ms: 15_000,
+          expire_after_ms: 90_000
+        )
+      )
+
+    :ok = NodeRegistry.register(reg, %{"node" => "node-4", "pod_uid" => "uid-1", "address" => "10.0.0.1:9090"})
+    assert_receive {:streamer_pid, streamer_pid}, 2_000
+
+    send(reg, {:streamer_channel, "old_fake_pid", :stale_channel})
+    send(reg, {:streamer_channel, streamer_pid, :real_channel})
+    advance.(100_000)
+    :ok = NodeRegistry.tick(reg)
+
+    assert_receive {:disconnected, :real_channel}, 2_000
+    refute_receive {:disconnected, :stale_channel}, 200
+  end
+
+  test "dead superseded streamer's channel is disconnected by registry" do
+    {clock, _advance} = new_clock()
+    test_pid = self()
+
+    {reg, _table} =
+      start_registry(
+        register_seams(
+          clock: clock,
+          connect_fun: fn _address ->
+            send(test_pid, {:streamer_pid, self()})
+            {:ok, :channel_from_dead_streamer}
+          end,
+          disconnect_fun: fn channel -> send(test_pid, {:disconnected, channel}) end,
+          unknown_after_ms: 5_000,
+          down_after_ms: 15_000,
+          expire_after_ms: 90_000
+        )
+      )
+
+    :ok = NodeRegistry.register(reg, %{"node" => "node-4", "pod_uid" => "uid-1", "address" => "10.0.0.1:9090"})
+    assert_receive {:streamer_pid, _streamer_pid}, 2_000
+
+    # Simulate a dead pid sending a channel message (race: kill before message processed)
+    dead_pid = spawn(fn -> :ok end)
+    :ok = Process.sleep(10)  # Let it die
+    refute Process.alive?(dead_pid)
+
+    send(reg, {:streamer_channel, dead_pid, :channel_from_dead_streamer})
+
+    # The registry should disconnect the orphaned channel
+    assert_receive {:disconnected, :channel_from_dead_streamer}, 2_000
+  end
+
+  test "live superseded streamer's channel is not taken over" do
+    {clock, _advance} = new_clock()
+    test_pid = self()
+
+    {reg, _table} =
+      start_registry(
+        register_seams(
+          clock: clock,
+          connect_fun: fn _address ->
+            send(test_pid, {:streamer_pid, self()})
+            {:ok, :stale_channel}
+          end,
+          disconnect_fun: fn channel -> send(test_pid, {:disconnected, channel}) end,
+          unknown_after_ms: 5_000,
+          down_after_ms: 15_000,
+          expire_after_ms: 90_000
+        )
+      )
+
+    :ok = NodeRegistry.register(reg, %{"node" => "node-4", "pod_uid" => "uid-1", "address" => "10.0.0.1:9090"})
+    assert_receive {:streamer_pid, _streamer_pid}, 2_000
+
+    # Spawn a live superseded process that will send a stale channel
+    live_fake_pid = spawn(fn ->
+      receive do
+        :die -> :ok
+      end
+    end)
+
+    send(reg, {:streamer_channel, live_fake_pid, :stale_channel})
+
+    # The registry should NOT disconnect a live superseded streamer's channel
+    # (it will disconnect in its own after clause)
+    refute_receive {:disconnected, :stale_channel}, 200
+
+    # Clean up the fake pid
+    send(live_fake_pid, :die)
+  end
+
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.439
+      targetRevision: 0.1.440
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Fixes #4419. Expired node instances were redialed forever after a brick roll: five dead pod IPs, 403 failed dials in four hours.

## Root cause

The reaper was never the problem. `Embervm.NodeRegistry` expired all five instances correctly at 09:27 to 09:30Z. The leak is one step downstream.

`start_streamer` dials the WatchNode channel **inside** the `spawn_monitor`'d streamer and releases it in a `try/after`. Both teardown paths kill that process with `Process.exit(pid, :kill)`, which is untrappable, so the `after` never runs and `disconnect_fun.(channel)` is never called. The gRPC connection outlives its streamer with no owner left to invalidate it, and grpc-elixir's own reconnect loop retries the dead endpoint forever.

Resource release cannot live inside a process you reserve the right to hard-kill.

## Fix

Ownership moves to the process that does the killing:

- the streamer reports its channel to the registry immediately after connecting
- the registry stores it on the instance's `node_runtime`, guarded so a superseded streamer cannot overwrite a fresh channel
- both kill sites read the channel, forget the streamer, kill, then disconnect
- `forget_streamer` clears the stored channel, so the normal exit path still releases via the existing `after` with no double disconnect

**The `Process.exit(pid, :kill)` stays.** It is the silent-wedge recovery: a genuinely wedged streamer must not get a vote.

## Two defects caught in review

**A mailbox race would have reintroduced the leak.** The registry processes messages sequentially, so `{:streamer_channel, pid, channel}` can sit behind an `:age_check` that then kills the streamer and forgets the pid. The channel message is then dropped by the superseded guard and that channel is orphaned exactly as before. Now: if the pid is dead, nobody will ever own that channel, so release it there; if it is alive, leave it, because its own `after` still runs.

**The first version of that guard crashed the registry.** `Process.alive?/1` raises `ArgumentError` on a non-pid, and a raise inside `handle_info/2` takes the GenServer down over a message it should simply ignore. `is_pid/1` now guards first. Every other external-input path in this module is wrapped for exactly this reason.

## Tests

The bug shipped because `node_registry_test.exs` injected `disconnect_fun` in a dozen places but never asserted it FIRES. Those now report to the test pid, plus six cases:

| test | asserts |
|------|---------|
| expiry disconnects the stored streamer channel | the expire kill path releases |
| wedged streamer ages to down, reassigns, kills, reconnects | the down-edge kill path releases |
| normal streamer exit disconnects its channel exactly once | no double disconnect |
| ignores channel messages from superseded streamers | a malformed (non-pid) message cannot crash the registry |
| dead superseded streamer's channel is disconnected by registry | the race case releases |
| live superseded streamer's channel is not taken over | a live owner keeps its channel |

The fake-pid input in the superseded test is deliberate and was left alone: it is the case that proved the crash.

## Verification

`ci test`: `MIX TEST FAILED` count 0, Elixir suite `1184 tests, 0 failures, 6 skipped`. The Elixir suite runs inside a Bazel genrule, so its failures do not surface in the Bazel summary line, and an earlier revision of this branch was red against the same 1184-test corpus while `ci test` exited 0.

Carries the chart bump to 0.1.440, since the control plane must actually deploy for the reap to take effect. Post-merge check: the CP stops dialing dead endpoints after the next roll.