### PR TITLE
fix(embervm): shallow hydration clone, 249 MiB to 11 MiB

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.440
+version: 0.1.441

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.440
+      targetRevision: 0.1.441
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -2746,10 +2746,17 @@ class ProcessManager:
             "--config",
             "core.gitProxy=%s" % GIT_PROXY_PATH,
             "--single-branch",
-            # Deliberately a FULL clone, not --filter=blob:none: a blob filter
-            # makes checkout open a SECOND lane connection for the lazy blob
-            # fetch, and connection #2 through the vsock lane wedges (#4389).
-            # One fetch on one connection moves ~12 MB more and works.
+            "--depth=1",
+            # --depth=1 shallow clone reduces transfer from 249.40 MiB (full) to
+            # ~11.2 MiB (working tree only), saving ~37s of hydration time. Shallow
+            # clones are single-connection because the tip commit's blobs ride in the
+            # same packfile as the objects, so checkout is satisfied entirely from
+            # one fetch with no lazy blob loads on a second connection.
+            # Not using --filter=blob:none (which would reopen #4417): blob filters
+            # defer blobs, making checkout lazy-fetch them on a second connection
+            # that wedges. History is available on demand via git fetch --unshallow
+            # or --deepen=N, though such fetches also open a second connection and
+            # remain subject to #4417 until that is fixed.
             "git://git-mirror.monolith.svc.cluster.local:9418/%s" % repo,
             checkout_dir,
         ]

--- a/projects/embervm/runtimes/claude/shim_hydration_test.py
+++ b/projects/embervm/runtimes/claude/shim_hydration_test.py
@@ -222,10 +222,44 @@ def test_git_command_shape(manager, monkeypatch):
             "--config",
             "core.gitProxy=/tmp/ember-git-proxy",
             "--single-branch",
+            "--depth=1",
             "git://git-mirror.monolith.svc.cluster.local:9418/owner/repo",
             checkout_dir,
         ],
     ]
+
+
+def test_git_clone_regression_guards(manager, monkeypatch):
+    """Verify critical clone command properties to prevent regressions."""
+    processes = [_GitProcess(), _GitProcess()]
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "clone":
+            commands.append(command)
+        return processes.pop(0)
+
+    monkeypatch.setattr(shim.subprocess, "run", fake_run)
+
+    manager.turn("first", repo="owner/repo", branch="main")
+
+    assert len(commands) == 1
+    command = commands[0]
+
+    # Regression guard: --depth=1 must be present (shallow clone)
+    assert "--depth=1" in command, "clone command missing --depth=1"
+
+    # Regression guard: --filter must NOT be present (no blob filter)
+    # A blob filter causes second connection on checkout, wedging vsock (#4417)
+    assert not any("--filter" in arg for arg in command), (
+        "clone command must not contain --filter argument"
+    )
+
+    # Verify load-bearing flags remain
+    assert "--single-branch" in command, "clone command missing --single-branch"
+    assert any("core.gitProxy=" in arg for arg in command), (
+        "clone command missing core.gitProxy config"
+    )
 
 
 def test_cli_cwd_set_to_checkout(manager, monkeypatch):
@@ -276,6 +310,7 @@ def test_hydration_works_for_non_default_branch(manager, monkeypatch):
         "--config",
         "core.gitProxy=/tmp/ember-git-proxy",
         "--single-branch",
+        "--depth=1",
         "git://git-mirror.monolith.svc.cluster.local:9418/owner/repo",
         checkout_dir,
     ]


### PR DESCRIPTION
Cuts workspace hydration transfer roughly 20x by making the clone shallow, without reintroducing the second lane connection a blob filter causes.

## Measurement

With warm restore armed, VM start is ~2.5ms, so the first message is now dominated by hydration and CLI init. Measured A/B on two live sessions:

| session | shape | create to answer |
|---|---|---|
| 108 | no repo | 33.9s |
| 109 | repo attached | 70.6s |
| | **clone cost** | **~36.7s** |

Against a **249.40 MiB** pack, which is ~6.8 MiB/s through the vsock lane. The working tree at HEAD is **11.2 MiB**.

## Why depth-1 and not blob:none

The existing full clone is a workaround, and its constraint still holds: `--filter=blob:none` defers blobs, so checkout lazy-fetches them on a SECOND lane connection, and connection #2 wedges (#4417).

`--depth=1` avoids that without the filter. A shallow clone's single packfile already contains the tip commit plus its trees AND its blobs, so checkout is satisfied entirely from that pack and git never opens a second connection.

| | connections | transfer |
|---|---|---|
| full clone (before) | 1 | 249.40 MiB |
| `--filter=blob:none` | 2 (wedges) | small + lazy fetch |
| `--depth=1` (this PR) | **1** | **~11.2 MiB** |

The comment being replaced estimated the full clone cost "~12 MB more". Measured, it is ~238 MiB more.

## History

Available on demand via `git fetch --unshallow` or `--deepen=N`. Such a fetch does open a second connection, so it remains subject to #4417 until that is fixed. The difference is that this is now off the first-message path and paid only by agents that actually want history.

## Tests

Added a regression guard asserting the clone command contains `--depth=1`, does NOT contain any `--filter` argument, and still carries `--single-branch` and `core.gitProxy`. The `--filter` assertion is the load-bearing one: reintroducing the blob filter is the specific mistake this design forbids, and it would fail loudly rather than silently wedging in production.

## Verification

`ci test`: `Executed 1 out of 758 tests: 758 tests pass`, `MIX TEST FAILED` count 0.

Note: `//projects/embervm/runtimes/claude:shim_test` reported FLAKY in that run (failed attempt 1, passed attempt 2). Filed separately rather than ignored. The new test follows the same fixture pattern as four existing sibling tests and asserts on state `turn()` returns synchronously, so it is unlikely to be the cause, but it is not yet attributed.

Carries the chart bump to 0.1.441 since the guest shim must deploy.