### PR TITLE
feat(embervm): per-phase turn timing in the guest shim

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.442
+version: 0.1.443

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.442
+      targetRevision: 0.1.443
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -1373,7 +1373,7 @@ class ClaudeProcess:
                 process is not None and process.poll() is None and not self.session_id
             )
             parked_adoption = parked_process and bool(session_id)
-            cli_ready_path = "adopt" if parked_process else "lazy_spawn"
+            cli_ready_path = None
             workspace_identity = _workspace_identity(self.workspace)
             cwd_changed = parked_process and (
                 (
@@ -1390,7 +1390,6 @@ class ClaudeProcess:
                 and process.poll() is None
                 and (model_changed or cwd_changed)
             ):
-                cli_ready_path = "remediation_respawn"
                 self._close_process(kill=False)
                 try:
                     self._spawn(
@@ -1404,6 +1403,7 @@ class ClaudeProcess:
                     raise
                 process = self.process
                 message_sent = True
+                cli_ready_path = "remediation_respawn"
             else:
                 message_sent = False
             # After a model-change respawn the first_message is already in
@@ -1411,8 +1411,6 @@ class ClaudeProcess:
             # (and bill) the same turn twice if the fresh CLI died between
             # init and this poll.
             if not message_sent and (process is None or process.poll() is not None):
-                if cli_ready_path != "remediation_respawn":
-                    cli_ready_path = "lazy_spawn"
                 if process is not None:
                     self._close_process(kill=False)
                 # A request without an id resumes the last session after an
@@ -1429,6 +1427,7 @@ class ClaudeProcess:
                     raise
                 process = self.process
                 message_sent = True
+                cli_ready_path = "lazy_spawn"
             pusher = None
             try:
                 if not self.ready():
@@ -1457,6 +1456,9 @@ class ClaudeProcess:
                             cli_ready_path = "remediation_respawn"
                     if parked_adoption:
                         self.session_id = session_id
+                        cli_ready_path = "adopt"
+                if cli_ready_path is None:
+                    cli_ready_path = "reuse"
                 _emit_elapsed("cli_ready", cli_ready_start, path=cli_ready_path)
                 if not message_sent:
                     self._turn_timing_model_start = _turn_timing_now()
@@ -1944,17 +1946,20 @@ wire_api = "responses"
             requested_session = session_id or self.session_id
             with self.process_lock:
                 process = self.process
-            cli_ready_path = "adopt"
+            cli_ready_path = None
+            process_was_unbound = not self.session_id
             if process is None or process.poll() is not None:
-                cli_ready_path = "lazy_spawn"
                 self._close_process(kill=False)
                 process = self._spawn()
                 requested_session = session_id or self.session_id
+                cli_ready_path = "lazy_spawn"
             if requested_session and (
                 requested_session not in self._server_threads
                 or requested_session != self.session_id
             ):
                 self._resume(requested_session)
+                if cli_ready_path is None and process_was_unbound:
+                    cli_ready_path = "adopt"
             elif not requested_session:
                 result = self._request(
                     "thread/start",
@@ -1967,6 +1972,10 @@ wire_api = "responses"
                 thread = result.get("thread", {}) if isinstance(result, dict) else {}
                 self.session_id = thread.get("id") if isinstance(thread, dict) else None
                 self._server_threads.add(self.session_id)
+                if cli_ready_path is None and process_was_unbound:
+                    cli_ready_path = "adopt"
+            if cli_ready_path is None:
+                cli_ready_path = "reuse"
             with self._write_lock:
                 self._turn_done.clear()
                 self._turn_id = None
@@ -2420,12 +2429,13 @@ class PiProcess:
                 )
             with self.process_lock:
                 process = self.process
-            cli_ready_path = "adopt"
+            cli_ready_path = None
+            process_was_unbound = not self.session_id
             model_name = PI_MODELS.get(model, PI_MODELS[DEFAULT_PI_MODEL])
             if process is None or process.poll() is not None:
-                cli_ready_path = "lazy_spawn"
                 self._close_process(kill=False)
                 process = self._spawn(model)
+                cli_ready_path = "lazy_spawn"
             elif self._model != model_name:
                 self._command(
                     {
@@ -2454,6 +2464,10 @@ class PiProcess:
                         "switch_session cancelled for session %s" % requested_session
                     )
                 self._state()
+                if cli_ready_path is None and process_was_unbound:
+                    cli_ready_path = "adopt"
+            if cli_ready_path is None:
+                cli_ready_path = "reuse"
             _emit_elapsed("cli_ready", cli_ready_start, path=cli_ready_path)
             result_text = ""
             usage = {}

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -44,6 +44,41 @@ VOLUME_DEVICE_ENV = "EMBER_VOLUME_DEV"
 DEFAULT_VOLUME_DEVICE = "/dev/vdb"
 
 
+def _turn_timing_now():
+    """Return a monotonic timestamp without allowing diagnostics to fail work."""
+    try:
+        return time.monotonic()
+    except Exception:
+        return None
+
+
+def _emit_turn_timing(phase, elapsed=None, path=None, status=None):
+    """Best-effort timing telemetry for a single turn phase."""
+    try:
+        if elapsed is None:
+            return
+        fields = ["ember-claude-shim: turn-timing", "phase=%s" % phase]
+        if path is not None:
+            fields.append("path=%s" % path)
+        if status is not None:
+            fields.append("status=%s" % status)
+        fields.append("ms=%s" % max(0, int(elapsed * 1000)))
+        sys.stderr.write("%s\n" % " ".join(fields))
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+
+def _emit_elapsed(phase, started, path=None, status=None):
+    """Emit elapsed monotonic time, swallowing all instrumentation failures."""
+    try:
+        finished = _turn_timing_now()
+        if started is not None and finished is not None:
+            _emit_turn_timing(phase, finished - started, path=path, status=status)
+    except Exception:
+        pass
+
+
 def _write_hydration_diagnostics(exc, checkout_dir):
     """Write hydration diagnostics to stderr when subprocess.TimeoutExpired occurs.
 
@@ -1163,6 +1198,7 @@ class ClaudeProcess:
             daemon=True,
         ).start()
         if first_message is not None:
+            self._turn_timing_model_start = _turn_timing_now()
             process.stdin.write(_user_message_line(first_message))
             process.stdin.flush()
         # Note: unparseable-line stderr writes are synchronous on the read thread
@@ -1323,6 +1359,7 @@ class ClaudeProcess:
         progress_token=None,
     ):
         with self.turn_lock:
+            cli_ready_start = _turn_timing_now()
             with self.process_lock:
                 process = self.process
             session_was_bound = bool(self.session_id)
@@ -1336,6 +1373,7 @@ class ClaudeProcess:
                 process is not None and process.poll() is None and not self.session_id
             )
             parked_adoption = parked_process and bool(session_id)
+            cli_ready_path = "adopt" if parked_process else "lazy_spawn"
             workspace_identity = _workspace_identity(self.workspace)
             cwd_changed = parked_process and (
                 (
@@ -1352,6 +1390,7 @@ class ClaudeProcess:
                 and process.poll() is None
                 and (model_changed or cwd_changed)
             ):
+                cli_ready_path = "remediation_respawn"
                 self._close_process(kill=False)
                 try:
                     self._spawn(
@@ -1372,6 +1411,8 @@ class ClaudeProcess:
             # (and bill) the same turn twice if the fresh CLI died between
             # init and this poll.
             if not message_sent and (process is None or process.poll() is not None):
+                if cli_ready_path != "remediation_respawn":
+                    cli_ready_path = "lazy_spawn"
                 if process is not None:
                     self._close_process(kill=False)
                 # A request without an id resumes the last session after an
@@ -1413,9 +1454,12 @@ class ClaudeProcess:
                             process = self.process
                             message_sent = True
                             parked_adoption = False
+                            cli_ready_path = "remediation_respawn"
                     if parked_adoption:
                         self.session_id = session_id
+                _emit_elapsed("cli_ready", cli_ready_start, path=cli_ready_path)
                 if not message_sent:
+                    self._turn_timing_model_start = _turn_timing_now()
                     message_line = _user_message_line(
                         message,
                         session_id=session_id if parked_adoption else None,
@@ -1518,6 +1562,9 @@ class ClaudeProcess:
                         record = dict(event)
                         record["voice"] = voice_summary(event.get("result", ""))
                         record["activity"] = activity_from_events(events)
+                        _emit_elapsed(
+                            "model", getattr(self, "_turn_timing_model_start", None)
+                        )
                         return record
             except Exception:
                 if parked_adoption and not session_was_bound:
@@ -1888,6 +1935,7 @@ wire_api = "responses"
         progress_token=None,
     ):
         with self.turn_lock:
+            cli_ready_start = _turn_timing_now()
             if self.session_id and session_id and session_id != self.session_id:
                 raise SessionConflictError(
                     "session_id %r does not match active session %r"
@@ -1896,7 +1944,9 @@ wire_api = "responses"
             requested_session = session_id or self.session_id
             with self.process_lock:
                 process = self.process
+            cli_ready_path = "adopt"
             if process is None or process.poll() is not None:
+                cli_ready_path = "lazy_spawn"
                 self._close_process(kill=False)
                 process = self._spawn()
                 requested_session = session_id or self.session_id
@@ -1925,6 +1975,8 @@ wire_api = "responses"
             model_name, effort = CODEX_MODELS.get(
                 model, CODEX_MODELS[DEFAULT_CODEX_MODEL]
             )
+            _emit_elapsed("cli_ready", cli_ready_start, path=cli_ready_path)
+            self._turn_timing_model_start = _turn_timing_now()
             self._send(
                 {
                     "jsonrpc": "2.0",
@@ -2034,6 +2086,9 @@ wire_api = "responses"
                             )
                         terminal_reason = (
                             "user_interrupt" if status == "interrupted" else "completed"
+                        )
+                        _emit_elapsed(
+                            "model", getattr(self, "_turn_timing_model_start", None)
                         )
                         return {
                             "result": result_text,
@@ -2357,6 +2412,7 @@ class PiProcess:
         progress_token=None,
     ):
         with self.turn_lock:
+            cli_ready_start = _turn_timing_now()
             if self.session_id and session_id and session_id != self.session_id:
                 raise SessionConflictError(
                     "session_id %r does not match active session %r"
@@ -2364,8 +2420,10 @@ class PiProcess:
                 )
             with self.process_lock:
                 process = self.process
+            cli_ready_path = "adopt"
             model_name = PI_MODELS.get(model, PI_MODELS[DEFAULT_PI_MODEL])
             if process is None or process.poll() is not None:
+                cli_ready_path = "lazy_spawn"
                 self._close_process(kill=False)
                 process = self._spawn(model)
             elif self._model != model_name:
@@ -2396,6 +2454,7 @@ class PiProcess:
                         "switch_session cancelled for session %s" % requested_session
                     )
                 self._state()
+            _emit_elapsed("cli_ready", cli_ready_start, path=cli_ready_path)
             result_text = ""
             usage = {}
             events = []
@@ -2410,6 +2469,7 @@ class PiProcess:
             except Exception:
                 pusher = None
             try:
+                self._turn_timing_model_start = _turn_timing_now()
                 self._send({"type": "prompt", "message": message})
                 while True:
                     try:
@@ -2518,6 +2578,9 @@ class PiProcess:
                             "voice": voice_summary(result_text),
                             "activity": activity_from_events(events),
                         }
+                        _emit_elapsed(
+                            "model", getattr(self, "_turn_timing_model_start", None)
+                        )
                         return record
             finally:
                 if pusher:
@@ -2691,11 +2754,14 @@ class ProcessManager:
             self._prewarm_complete = True
 
     def _hydrate_workspace(self, repo, branch):
+        hydration_start = _turn_timing_now()
         if self._hydration_status == "ok":
             if self._checkout_dir and os.path.isdir(self._checkout_dir):
                 self._hydration_status = "skipped_existing"
+                _emit_elapsed("hydration", hydration_start, status="skipped_existing")
             return
         if self._hydration_status == "skipped_existing":
+            _emit_elapsed("hydration", hydration_start, status="skipped_existing")
             return
         if self._hydration_attempts >= HYDRATION_ATTEMPT_CAP:
             return
@@ -2731,6 +2797,9 @@ class ProcessManager:
                     self.claude.workspace = checkout_dir
                     self.codex.workspace = checkout_dir
                     self.pi.workspace = checkout_dir
+                    _emit_elapsed(
+                        "hydration", hydration_start, status="skipped_existing"
+                    )
                     return
             except (OSError, subprocess.TimeoutExpired):
                 pass
@@ -2761,12 +2830,14 @@ class ProcessManager:
             checkout_dir,
         ]
         try:
+            clone_start = _turn_timing_now()
             result = subprocess.run(
                 clone_command,
                 capture_output=True,
                 timeout=GIT_CLONE_TIMEOUT_SECONDS,
                 **_cli_privilege_kwargs(),
             )
+            _emit_elapsed("hydration_clone", clone_start)
             if result.returncode != 0:
                 stderr = result.stderr
                 if isinstance(stderr, bytes):
@@ -2814,6 +2885,7 @@ class ProcessManager:
         self.claude.workspace = checkout_dir
         self.codex.workspace = checkout_dir
         self.pi.workspace = checkout_dir
+        _emit_elapsed("hydration", hydration_start, status="cloned")
 
     def _adapter(self, model):
         if model == "qwen":
@@ -2915,6 +2987,7 @@ class ProcessManager:
         branch=None,
         progress_token=None,
     ):
+        total_start = _turn_timing_now()
         with self._mount_lock:
             ensure_workspace_volume()
         if getattr(self.claude, "workspace", None):
@@ -2954,6 +3027,7 @@ class ProcessManager:
             # is still safe, and a raised turn may still have left durable-
             # worth CLI state that a later park would otherwise lose.
             _sync_session_volume()
+            _emit_elapsed("total", total_start)
 
     def interrupt(self):
         # An interrupt has no model in its request, so interrupt both adapters.

--- a/projects/embervm/runtimes/claude/shim_hydration_test.py
+++ b/projects/embervm/runtimes/claude/shim_hydration_test.py
@@ -363,6 +363,58 @@ def test_hydration_status_surfaced_in_turn(manager, monkeypatch):
     assert "workspace_hydration" not in record
 
 
+def test_hydration_timing_reports_clone_and_existing_status(
+    manager, monkeypatch, capsys
+):
+    checkout_dir = os.path.join(manager.workspace, "src")
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "clone":
+            os.makedirs(os.path.join(checkout_dir, ".git"), exist_ok=True)
+        return _GitProcess()
+
+    monkeypatch.setattr(shim.subprocess, "run", fake_run)
+    manager.turn("first", repo="owner/repo", branch="main")
+    first_lines = capsys.readouterr().err.splitlines()
+    assert any(
+        line.startswith(
+            "ember-claude-shim: turn-timing phase=hydration status=cloned ms="
+        )
+        and line.rsplit("ms=", 1)[1].isdigit()
+        for line in first_lines
+    )
+    assert any(
+        line.startswith("ember-claude-shim: turn-timing phase=hydration_clone ms=")
+        and line.rsplit("ms=", 1)[1].isdigit()
+        for line in first_lines
+    )
+    assert any(
+        line.startswith("ember-claude-shim: turn-timing phase=total ms=")
+        and line.rsplit("ms=", 1)[1].isdigit()
+        for line in first_lines
+    )
+
+    manager.turn("second", repo="owner/repo", branch="main")
+    second_lines = capsys.readouterr().err.splitlines()
+    skipped = [
+        line
+        for line in second_lines
+        if line.startswith(
+            "ember-claude-shim: turn-timing phase=hydration status=skipped_existing ms="
+        )
+    ]
+    assert len(skipped) == 1
+    assert skipped[0].rsplit("ms=", 1)[1].isdigit()
+    assert (
+        sum(
+            line.startswith("ember-claude-shim: turn-timing phase=total ms=")
+            and line.rsplit("ms=", 1)[1].isdigit()
+            for line in second_lines
+        )
+        == 1
+    )
+
+
 def test_failed_clone_leaves_no_directory(manager, monkeypatch):
     checkout_dir = os.path.join(manager.workspace, "src")
 

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -1812,6 +1812,52 @@ def test_parked_claude_model_mismatch_respawns_with_resume(tmp_path, monkeypatch
     assert calls == [{"session_id": "sid", "first_message": "hello", "model": "opus"}]
 
 
+def test_claude_turn_timing_reports_spawn_adopt_and_remediation(
+    tmp_path, monkeypatch, capsys
+):
+    manager = _parked_claude(tmp_path)
+    manager.process.returncode = 0
+
+    def spawn(session_id=None, first_message=None, model=None, **_kwargs):
+        if manager.process is None or manager.process.poll() is not None:
+            manager.process = _FakeLiveProcess()
+        manager._turn_timing_model_start = shim._turn_timing_now()
+        manager.model = model
+        manager._process_workspace = manager.workspace
+
+    monkeypatch.setattr(manager, "_spawn", spawn)
+    monkeypatch.setattr(
+        manager,
+        "_read_output",
+        lambda _process, _timeout: json.dumps(
+            {"type": "result", "result": "ok", "session_id": "sid"}
+        ).encode(),
+    )
+    monkeypatch.setattr(manager, "_parse_line", json.loads)
+    monkeypatch.setattr(manager, "ready", lambda: True)
+
+    manager.turn("first", session_id="sid")
+    assert manager.process is not None
+    first = capsys.readouterr().err
+    assert "phase=cli_ready path=lazy_spawn ms=" in first
+    assert "phase=model ms=" in first
+    assert (
+        first.split("phase=cli_ready path=lazy_spawn ms=", 1)[1]
+        .split("\n", 1)[0]
+        .isdigit()
+    )
+
+    manager.turn("second", session_id="sid")
+    relit = capsys.readouterr().err
+    assert "phase=cli_ready path=adopt ms=" in relit
+    assert "phase=model ms=" in relit
+
+    manager.turn("third", session_id="sid", model="opus")
+    remediation = capsys.readouterr().err
+    assert "phase=cli_ready path=remediation_respawn ms=" in remediation
+    assert "phase=model ms=" in remediation
+
+
 def test_turn_extracts_voice_activity_and_tolerates_malformed_json(
     tmp_path, monkeypatch
 ):

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -1812,11 +1812,10 @@ def test_parked_claude_model_mismatch_respawns_with_resume(tmp_path, monkeypatch
     assert calls == [{"session_id": "sid", "first_message": "hello", "model": "opus"}]
 
 
-def test_claude_turn_timing_reports_spawn_adopt_and_remediation(
+def test_claude_turn_timing_reports_spawn_adopt_reuse_and_remediation(
     tmp_path, monkeypatch, capsys
 ):
     manager = _parked_claude(tmp_path)
-    manager.process.returncode = 0
 
     def spawn(session_id=None, first_message=None, model=None, **_kwargs):
         if manager.process is None or manager.process.poll() is not None:
@@ -1839,20 +1838,25 @@ def test_claude_turn_timing_reports_spawn_adopt_and_remediation(
     manager.turn("first", session_id="sid")
     assert manager.process is not None
     first = capsys.readouterr().err
-    assert "phase=cli_ready path=lazy_spawn ms=" in first
+    assert "phase=cli_ready path=adopt ms=" in first
     assert "phase=model ms=" in first
     assert (
-        first.split("phase=cli_ready path=lazy_spawn ms=", 1)[1]
-        .split("\n", 1)[0]
-        .isdigit()
+        first.split("phase=cli_ready path=adopt ms=", 1)[1].split("\n", 1)[0].isdigit()
     )
 
     manager.turn("second", session_id="sid")
-    relit = capsys.readouterr().err
-    assert "phase=cli_ready path=adopt ms=" in relit
-    assert "phase=model ms=" in relit
+    reuse = capsys.readouterr().err
+    assert "phase=cli_ready path=reuse ms=" in reuse
+    assert "path=lazy_spawn" not in reuse
+    assert "phase=model ms=" in reuse
 
+    manager.process.returncode = 0
     manager.turn("third", session_id="sid", model="opus")
+    lazy_spawn = capsys.readouterr().err
+    assert "phase=cli_ready path=lazy_spawn ms=" in lazy_spawn
+    assert "phase=model ms=" in lazy_spawn
+
+    manager.turn("fourth", session_id="sid", model="sonnet")
     remediation = capsys.readouterr().err
     assert "phase=cli_ready path=remediation_respawn ms=" in remediation
     assert "phase=model ms=" in remediation


### PR DESCRIPTION
Adds per-phase timing to the guest shim so session latency can be attributed. Diagnostic only, nothing is made faster here.

## Why

With warm restore armed and the shallow clone shipped, VM start is ~2.5ms and hydration is ~11 MiB. Measured live at chart 0.1.441:

| path | time |
|------|------|
| initial repo-attached, create to answer | 43.3s |
| relit turn, prompt was literally "Reply with exactly: OK" | **25.9s** |

20+ seconds of that relit turn are unattributed inside the guest. Already ruled out: monolith dispatch is immediate (`asyncio.create_task`, no poll), no transport retry backoff fired (those log warnings, none present), VM restore is ~2.5ms, and no `initialization timed out` appeared on the guest console for that turn, so #4393's timeout was NOT the cause.

There was no timing instrumentation in the guest at all. The existing console lines carry byte counts, and the log lines are not timestamped, so elapsed time could not be reconstructed after the fact.

## Emitted

```
ember-claude-shim: turn-timing phase=cli_ready path=adopt ms=123
ember-claude-shim: turn-timing phase=hydration status=skipped_existing ms=1
ember-claude-shim: turn-timing phase=hydration_clone ms=8400
ember-claude-shim: turn-timing phase=model ms=4210
ember-claude-shim: turn-timing phase=total ms=25900
```

Monotonic clock throughout. Every emit is guarded so instrumentation can never raise into the turn path. No new locks, no extra blocking calls, no control-flow changes.

## The `path=` value is the point

Four distinct outcomes, because they demand different fixes:

| path | meaning |
|------|---------|
| `adopt` | a parked (prewarmed, unbound) process was bound to this session |
| `reuse` | an already-bound live process was used, **no spawn at all** |
| `lazy_spawn` | no usable process existed, one was genuinely spawned |
| `remediation_respawn` | a live process was torn down and respawned (model or cwd change) |

The first revision collapsed `reuse` into `lazy_spawn`, because `parked_process` requires `not self.session_id` and everything else fell into the else-branch. That was caught by its own test failing, and it mattered: production would have reported `lazy_spawn` on every relit turn whether or not a spawn occurred, which is precisely the distinction this exists to make. The label is now set at each branch where the decision is taken rather than guessed up front and patched, so a missed case is structurally impossible.

## Tests

Assert on captured stderr, so removing the instrumentation turns them red. All four paths covered, plus hydration clone-vs-skipped and a digit check on the ms value.

## Verification

`ci test`: `Executed 1 out of 758 tests: 758 tests pass`, `MIX TEST FAILED` count 0, no FLAKY.

Carries the chart bump to 0.1.443, since the guest shim must deploy and the base must rebuild for this to take effect.

Follow-up: this is also the fallback if the OTLP exporter in #4426 (ADR agents/053) proves unreliable over the vsock lane while #4417 is open.