### PR TITLE
fix(embervm): wall-clock watchdog on assign workers, harden and arm GrpcConnectionSweeper (#4419)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.446
+version: 0.1.447

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -334,6 +334,17 @@ spec:
             - name: EMBERVM_STATEFUL_SWEEP_INTERVAL_MS
               value: {{ .Values.statefulSweeper.sweepIntervalMs | quote }}
             {{- end }}
+            {{- if .Values.grpcConnectionSweeper.enabled }}
+            # gRPC connection sweep gate (default off, dry-run logging only). "1" or "true"
+            # arms destructive orphaned connection termination.
+            - name: EMBERVM_GRPC_CONNECTION_SWEEP_ENABLED
+              value: {{ .Values.grpcConnectionSweeper.enabled | quote }}
+            {{- end }}
+            {{- if .Values.grpcConnectionSweeper.sweepIntervalMs }}
+            # gRPC connection sweep tick override (default 60000ms).
+            - name: EMBERVM_GRPC_CONNECTION_SWEEP_INTERVAL_MS
+              value: {{ .Values.grpcConnectionSweeper.sweepIntervalMs | quote }}
+            {{- end }}
             {{- if .Values.statefulSweeper.wakeMax }}
             # Per-workload wake-rate cap override (default 10/min): with a ~1s
             # idle bank every demo query is a wake, so the default cap would turn

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -731,6 +731,14 @@ statefulSweeper:
   sweepIntervalMs: ""
   wakeMax: ""
 
+# gRPC connection sweep gate for orphaned channels. Empty means off: the
+# sweeper only logs what it would clean up and leaves connections untouched.
+# Set enabled to "1" or "true" to arm the destructive sweep, which terminates
+# orphaned connections. This is a deploy values gate, not an application default.
+grpcConnectionSweeper:
+  enabled: ""
+  sweepIntervalMs: ""
+
 # Base-retention sweep gate (base-durability PR-3, control-plane env). Empty
 # (the default) leaves the reconciled sweep in dry-run: it logs what it would
 # evict and deletes nothing. "1" arms it: superseded local bases outside each

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -877,10 +877,10 @@ defmodule Embervm.Application do
 
   # The destructive gate for the GrpcConnectionSweeper, from
   # EMBERVM_GRPC_CONNECTION_SWEEP_ENABLED. UNSET or "0"/"false"/"" (the default,
-  # and what this PR ships) => the sweep runs but only logs a dry-run plan, leaving
-  # no children terminated. "1"/"true" => the sweep terminates orchestrators holding
-  # dead addresses or wedged in init. Wired here so it flips via a deploy values env
-  # change, no code change. Nothing sets it on in this PR.
+  # and what the chart defaults to) => the sweep runs but only logs a dry-run plan,
+  # leaving no children terminated. "1"/"true" => the sweep terminates orchestrators
+  # holding dead addresses or wedged in init. Wired here so it flips via a deploy
+  # values env change, no code change.
   defp grpc_connection_sweep_enabled do
     case trimmed_env("EMBERVM_GRPC_CONNECTION_SWEEP_ENABLED") do
       v when v in ["1", "true", "TRUE", "True"] -> true

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -114,6 +114,8 @@ defmodule Embervm.Dispatcher do
   @stale_after_ms 15_000
   @queue_depth_cap 10_000
   @sweep_interval_ms 5_000
+  @assign_watchdog_margin_ms 15_000
+  @assign_watchdog_ms nil
   @depth_table :embervm_queue_depth
   # The per-principal queue-depth cap is stored as a distinguished row in the
   # depth table (an atom key, never colliding with the {workload, principal}
@@ -245,6 +247,10 @@ defmodule Embervm.Dispatcher do
         Keyword.get(opts, :get_request_fun, fn tid -> Embervm.TaskStore.get_request(task_store, tid) end),
       stale_after_ms: Keyword.get(opts, :stale_after_ms, @stale_after_ms),
       queue_depth_cap: Keyword.get(opts, :queue_depth_cap, @queue_depth_cap),
+      assign_watchdog_margin_ms:
+        Keyword.get(opts, :assign_watchdog_margin_ms, @assign_watchdog_margin_ms),
+      # Test-only seam: when set, IS the watchdog budget; when nil (production), budget is transport_timeout(entry.timeout_ms) + margin. Tests use this to avoid waiting out the 5s transport headroom floor.
+      assign_watchdog_ms: Keyword.get(opts, :assign_watchdog_ms, @assign_watchdog_ms),
       share_fraction: Keyword.get(opts, :share_fraction, nil),
       sweep_interval_ms: Keyword.get(opts, :sweep_interval_ms, @sweep_interval_ms),
       # Quota enforcement (Task 12): the Metering quota-cache table and the
@@ -314,6 +320,30 @@ defmodule Embervm.Dispatcher do
   @impl true
   def handle_info({:assign_done, pid, outcome}, state) do
     {:noreply, finish_worker(state, pid, outcome, :flush)}
+  end
+
+  # A server-enforced gRPC deadline cannot fire when an orphaned channel is
+  # unreachable, so one wedged stream could consume an in-flight slot forever
+  # and silently cap the workload. This wall-clock watchdog is the last-resort
+  # recovery path for that case; the normal transport deadline gets first shot.
+  def handle_info({:worker_timeout, pid, ref}, state) do
+    case Map.get(state.workers, pid) do
+      %{ref: ^ref} = meta ->
+        elapsed_ms = System.monotonic_time(:millisecond) - meta.watchdog_started_at
+
+        Logger.warning("assign worker watchdog fired (elapsed=#{elapsed_ms}ms, budget=#{meta.watchdog_ms}ms)",
+          workload: meta.workload,
+          task_id: meta.task_id,
+          node_id: meta.node_id
+        )
+
+        Process.exit(pid, :kill)
+        {:noreply, state}
+
+      _ ->
+        # The worker completed, or this is a stale timer message for a reused pid.
+        {:noreply, state}
+    end
   end
 
   # A miss worker reports the vm_id it just primed AND the instance it primed on.
@@ -743,11 +773,27 @@ defmodule Embervm.Dispatcher do
         send(owner, {:assign_done, self(), outcome})
       end)
 
+    watchdog_ms = state.assign_watchdog_ms || (transport_timeout(entry.timeout_ms) + state.assign_watchdog_margin_ms)
+    # This must fire AFTER the normal gRPC deadline so the server-enforced path
+    # gets first shot. The client-side kill is genuinely last-resort only.
+    watchdog_ref = Process.send_after(owner, {:worker_timeout, pid, ref}, watchdog_ms)
+
     # vm_id is carried in the meta (not just the worker's ctx) so known_vm_ids can
     # see a warm-reserved VM that is out of inventory but still reported primed by
     # the node until the Assign lands; without it adopt_inventory would re-adopt an
     # in-flight VM and double-dispatch it. nil for a miss (the worker primes its own).
-    meta = %{ref: ref, task_id: task_id, workload: wl, principal: pr, node_id: node_id, mode: mode, vm_id: vm_id}
+    meta = %{
+      ref: ref,
+      task_id: task_id,
+      workload: wl,
+      principal: pr,
+      node_id: node_id,
+      mode: mode,
+      vm_id: vm_id,
+      watchdog_timer_ref: watchdog_ref,
+      watchdog_started_at: System.monotonic_time(:millisecond),
+      watchdog_ms: watchdog_ms
+    }
     %{state | workers: Map.put(state.workers, pid, meta)}
   end
 
@@ -1057,6 +1103,9 @@ defmodule Embervm.Dispatcher do
 
       {meta, workers} ->
         if flush == :flush, do: Process.demonitor(meta.ref, [:flush])
+        # Defensive cancellation: a late timer message is harmless because its
+        # monitor ref is compared against the live worker metadata above.
+        Process.cancel_timer(meta.watchdog_timer_ref)
 
         state = %{state | workers: workers}
         state = apply_outcome(state, meta, outcome)

--- a/projects/embervm/control/lib/embervm/grpc_connection_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/grpc_connection_sweeper.ex
@@ -47,16 +47,35 @@ defmodule Embervm.GrpcConnectionSweeper do
   The registry stores addresses like `"10.42.3.34:9090"`, while the
   orchestrator's state target reads `"ipv4:10.42.3.34:9090"`. Normalization
   must handle both formats defensively before comparison.
+
+  ## Strike-based confirmation: calibrated on false-positive patterns
+
+  Live logs from 46 sweeps of the control plane showed every observed false positive
+  (transient unreadable processes) persisted exactly ONE sweep, while genuine leaks
+  persisted 42 or more sweeps: 8 pids in 1 sweep (false positives), gap, then 1+2+2+2+1
+  pids spread across 42-46 consecutive sweeps. The threshold N=3 sits inside a 40-sweep
+  gap, so every real leak is caught within the first 3 sweeps of its life.
+
+  Strike counts require N=3 consecutive NON-ABORTED classifications; aborted sweeps
+  (registry down, empty keep-set) neither grant nor reset strikes. With sweep interval 60s,
+  confirmation window is 3 consecutive NON-ABORTED sweeps, so up to 3 minutes
+  if the registry stays healthy. An aborted sweep (registry down, empty keep-set)
+  neither grants nor resets strikes, so a child flagged as reapable, then
+  invisible for several sweeps due to registry outage, is not delayed further
+  once the registry recovers.
+
+  The sweeper requires strikes on both branches: unreadable (one-second :sys.get_state
+  timeout) and target-not-in-live-set, so a connection mid-TCP-establish cannot be
+  killed by a transiently unreadable state.
   """
 
   use GenServer
   require Logger
 
-  alias Embervm.NodeRegistry
-
   # Default sweep interval: 60s, balanced against the backoff_max of 120s.
   # One sweep every 60s gives a detection window of up to 120s + 60s.
   @sweep_interval_ms 60_000
+  @wedged_strikes_required 3
 
   # Short timeout for reading a child's state via :sys.get_state. The
   # wedged-in-init processes time out here, which is exactly what we need to
@@ -76,9 +95,10 @@ defmodule Embervm.GrpcConnectionSweeper do
 
   @doc """
   Run one sweep synchronously and return the list of {pid, reason} entries
-  that were reaped or would be reaped with the gate on. Lets a test drive the
-  sweep deterministically without the timer, and an operator preview what it
-  would reap.
+  that meet the reap threshold. This is a REAL sweep: it advances strike counts
+  and terminates children when the gate is enabled and threshold is met. It is
+  not a read-only preview. Operators wanting to preview the plan should
+  read the dry-run logs instead.
   """
   @spec sweep_now(GenServer.server()) :: [{pid(), String.t()}]
   def sweep_now(server \\ __MODULE__) do
@@ -91,13 +111,14 @@ defmodule Embervm.GrpcConnectionSweeper do
   def init(opts) do
     # Injected seams (defaults are the real NodeRegistry, real supervisor
     # enumeration, and real termination). Tests inject fakes.
-    node_registry = Keyword.get(opts, :node_registry, NodeRegistry)
+    status_fun = Keyword.get(opts, :status_fun, &Embervm.NodeRegistry.status/0)
     supervisor = Keyword.get(opts, :supervisor, GRPC.Client.Supervisor)
     terminate_child_fun = Keyword.get(opts, :terminate_child_fun, &DynamicSupervisor.terminate_child/2)
 
     # 0 disables the timer (unit-test default); production uses the module
     # default.
     sweep_interval_ms = Keyword.get(opts, :sweep_interval_ms, @sweep_interval_ms)
+    strikes_required = Keyword.get(opts, :strikes_required, @wedged_strikes_required)
 
     # Destructive gate: false (default, ships inert) means the sweep logs a
     # dry-run plan but deletes NOTHING. true means it fires the terminations.
@@ -106,11 +127,13 @@ defmodule Embervm.GrpcConnectionSweeper do
     sweep_enabled = Keyword.get(opts, :sweep_enabled, false)
 
     state = %{
-      node_registry: node_registry,
+      status_fun: status_fun,
       supervisor: supervisor,
       terminate_child_fun: terminate_child_fun,
       sweep_interval_ms: sweep_interval_ms,
-      sweep_enabled: sweep_enabled
+      sweep_enabled: sweep_enabled,
+      strikes_required: strikes_required,
+      strikes: %{}
     }
 
     schedule_sweep(state)
@@ -119,15 +142,15 @@ defmodule Embervm.GrpcConnectionSweeper do
 
   @impl true
   def handle_call(:sweep_now, _from, state) do
-    reaped = sweep(state)
-    {:reply, reaped, state}
+    {reaped, new_state} = sweep(state)
+    {:reply, reaped, new_state}
   end
 
   @impl true
   def handle_info(:sweep, state) do
-    _reaped = sweep(state)
-    schedule_sweep(state)
-    {:noreply, state}
+    {_reaped, new_state} = sweep(state)
+    schedule_sweep(new_state)
+    {:noreply, new_state}
   end
 
   def handle_info(_msg, state), do: {:noreply, state}
@@ -146,12 +169,12 @@ defmodule Embervm.GrpcConnectionSweeper do
     case keep_set do
       :unavailable ->
         Logger.info("embervm grpc connection sweeper: skipping sweep (keep-set unavailable, likely at boot)")
-        []
+        {[], state}
 
       {:ok, set} ->
         if MapSet.size(set) == 0 do
           Logger.info("embervm grpc connection sweeper: skipping sweep (no live addresses in keep-set)")
-          []
+          {[], state}
         else
           classify_and_reap(state, set)
         end
@@ -163,15 +186,42 @@ defmodule Embervm.GrpcConnectionSweeper do
   defp classify_and_reap(state, keep_set) do
     children = DynamicSupervisor.which_children(state.supervisor)
 
-    reaped =
-      children
-      |> Enum.map(&classify_child(&1, keep_set, state))
+    classifications = Enum.map(children, &classify_child(&1, keep_set, state))
+
+    strikes =
+      classifications
+      |> Enum.reduce(state.strikes, fn
+        {pid, :keep}, strikes -> Map.delete(strikes, pid)
+        {pid, _reason}, strikes -> Map.update(strikes, pid, 1, &(&1 + 1))
+      end)
+      |> Map.take(Enum.map(children, fn {:undefined, pid, _type, _modules} -> pid end))
+
+    reapable =
+      classifications
       |> Enum.filter(&should_reap?/1)
+      |> Enum.map(fn {pid, reason} ->
+        strike_count = Map.fetch!(strikes, pid)
+
+        strike_reason =
+          if strike_count >= state.strikes_required do
+            "#{reason} (reapable for #{strike_count} consecutive sweeps, threshold #{state.strikes_required})"
+          else
+            "#{reason} (strike #{strike_count} of #{state.strikes_required})"
+          end
+
+        {pid, strike_reason}
+      end)
+
+    reaped =
+      reapable
+      |> Enum.filter(fn {pid, _reason} -> Map.fetch!(strikes, pid) >= state.strikes_required end)
       |> Enum.map(fn {pid, reason} -> maybe_reap(state, pid, reason) end)
       |> Enum.filter(&(not is_nil(&1)))
 
-    log_sweep(state, reaped)
-    reaped
+    new_state = %{state | strikes: strikes}
+    log_sweep(new_state, reaped)
+    log_pending(new_state, reapable)
+    {reaped, new_state}
   end
 
   # Classify a child as reapable or keep-able. Returns {pid, reason} where
@@ -255,6 +305,12 @@ defmodule Embervm.GrpcConnectionSweeper do
   # - it shows :proc_lib.sync_start in its current function, OR
   # - it is very new and unreadable (may still be initializing)
   defp process_looks_wedged?(pid) do
+    # Note: the reductions < 100 fallback is unstable under repeated :sys.get_state
+    # probing; each probe delivers a message that increments reductions, eventually
+    # crossing 100 and flipping classification to :keep, which resets strikes. Only
+    # the proc_lib.sync_start arm is stable across extended observation. Real leaks
+    # in live logs stay flagged 42+ sweeps, indicating they are stuck in sync_start,
+    # not riding the reductions fallback.
     case :erlang.process_info(pid, [:current_function, :reductions]) do
       [{:current_function, {:proc_lib, :sync_start, 2}}, {:reductions, _}] ->
         # Definitively stuck in sync_start init
@@ -305,7 +361,7 @@ defmodule Embervm.GrpcConnectionSweeper do
   # all". Both abort the sweep, but for different reasons and logging.
   defp get_live_addresses(state) do
     try do
-      status = state.node_registry.status()
+      status = state.status_fun.()
 
       addresses =
         status
@@ -370,6 +426,22 @@ defmodule Embervm.GrpcConnectionSweeper do
     end
 
     :ok
+  end
+
+  defp log_pending(%{sweep_enabled: true}, _reapable), do: :ok
+
+  defp log_pending(state, reapable) do
+    pending =
+      reapable
+      |> Enum.filter(fn {pid, _reason} -> Map.fetch!(state.strikes, pid) < state.strikes_required end)
+
+    if not Enum.empty?(pending) do
+      Logger.info("embervm grpc connection sweeper (DRY RUN, gate off): #{length(pending)} orchestrator(s) accumulating strikes")
+
+      Enum.each(pending, fn {pid, reason} ->
+        Logger.info("  pid #{inspect(pid)}: #{reason}")
+      end)
+    end
   end
 
   defp schedule_sweep(%{sweep_interval_ms: ms}) when ms > 0 do

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -48,7 +48,17 @@ defmodule Embervm.DispatcherTest do
         assign_fun: Keyword.get(opts, :assign_fun, fn _ch, _req -> {:ok, success_resp()} end),
         prime_fun: Keyword.get(opts, :prime_fun, fn _ch, _req -> {:ok, %PrimeResponse{vm_id: "vm-#{System.unique_integer([:positive])}"}} end),
         start_sweep: false
-      ] ++ Keyword.take(opts, [:queue_depth_cap, :share_fraction, :stale_after_ms, :quota_config, :quota_table, :wall_clock])
+      ] ++
+        Keyword.take(opts, [
+          :queue_depth_cap,
+          :share_fraction,
+          :stale_after_ms,
+          :quota_config,
+          :quota_table,
+          :wall_clock,
+          :assign_watchdog_margin_ms,
+          :assign_watchdog_ms
+        ])
 
     {:ok, disp} = Dispatcher.start_link(disp_opts)
 
@@ -922,6 +932,54 @@ defmodule Embervm.DispatcherTest do
 
     assert eventually(fn -> state_of(ctx, tid) == :dead_lettered end)
     assert Agent.get(attempts, & &1) == 1
+  end
+
+  test "a wedged assign worker is killed by the watchdog and releases its cap" do
+    {:ok, assigns} = Agent.start_link(fn -> 0 end)
+
+    assign_fun = fn _ch, _req ->
+      case Agent.get_and_update(assigns, fn n -> {n, n + 1} end) do
+        0 -> :timer.sleep(:infinity)
+        _ -> {:ok, success_resp()}
+      end
+    end
+
+    ctx = start_stack(assign_fun: assign_fun, assign_watchdog_ms: 150)
+
+    put_catalog(ctx, "wl-watchdog", cap: 1, timeout_ms: 1)
+    put_facts(ctx, "wl-watchdog", free: 1, max: 8)
+
+    first = submit(ctx, "wl-watchdog", "p1")
+    assert eventually(fn -> Agent.get(assigns, & &1) == 1 end)
+    # The watchdog kills the wedged worker, which frees the in-flight slot AND
+    # lets the task retry onto a healthy assign. Retry config here comes from
+    # Retry.default_config() (max_attempts: 3), NOT the `retry:` passed to
+    # put_catalog: TaskStore.cfg_for/1 calls WorkloadCatalog.retry_config/1, the
+    # one-arg form that reads the module default table, while put_catalog writes
+    # the per-test table. So the second attempt runs and succeeds.
+    assert eventually(fn -> state_of(ctx, first) == :succeeded end, 3_000),
+           "expected :succeeded, got #{inspect(state_of(ctx, first))}"
+    # The regression this fixes: without the watchdog, a wedged worker pins
+    # inflight_wl at cap forever and every later task is silently denied :cap.
+    assert Dispatcher.stats(ctx.name).inflight_wl == %{}
+
+    second = submit(ctx, "wl-watchdog", "p1")
+    assert eventually(fn -> state_of(ctx, second) == :succeeded end, 3_000),
+           "expected :succeeded, got #{inspect(state_of(ctx, second))}"
+    assert {:ok, %{status_code: 200, body: "ok"}} = TaskStore.get_result(ctx.store, second)
+  end
+
+  test "a fast assign completes without a watchdog failure" do
+    ctx = start_stack()
+    put_catalog(ctx, "wl-fast", cap: 1)
+    put_facts(ctx, "wl-fast", free: 1, max: 8)
+
+    tid = submit(ctx, "wl-fast", "p1")
+
+    assert eventually(fn -> state_of(ctx, tid) == :succeeded end, 3_000),
+           "expected :succeeded, got #{inspect(state_of(ctx, tid))}"
+    assert {:ok, %{status_code: 200, body: "ok"}} = TaskStore.get_result(ctx.store, tid)
+    assert Dispatcher.stats(ctx.name).inflight_wl == %{}
   end
 
   # -- admit? 429 gate -------------------------------------------------------

--- a/projects/embervm/control/test/embervm/grpc_connection_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/grpc_connection_sweeper_test.exs
@@ -3,34 +3,6 @@ defmodule Embervm.GrpcConnectionSweeperTest do
 
   alias Embervm.GrpcConnectionSweeper
 
-  # A minimal node registry stub that returns a fixed set of live addresses.
-  defmodule RegistryStub do
-    use GenServer
-
-    def start_link(addresses), do: GenServer.start_link(__MODULE__, addresses)
-
-    @impl true
-    def init(addresses), do: {:ok, addresses}
-
-    @impl true
-    def handle_call(:status, _from, addresses) do
-      # Convert address list into the shape NodeRegistry.status returns
-      status =
-        addresses
-        |> Enum.with_index()
-        |> Enum.reduce(%{}, fn {addr, idx}, acc ->
-          Map.put(acc, "node-#{idx}", %{address: addr})
-        end)
-
-      {:reply, status, addresses}
-    end
-  end
-
-  defp start_registry(addresses) do
-    {:ok, pid} = RegistryStub.start_link(addresses)
-    pid
-  end
-
   # Mock supervisor that records which children were terminated
   defmodule MockSupervisor do
     use GenServer
@@ -70,6 +42,36 @@ defmodule Embervm.GrpcConnectionSweeperTest do
     pid
   end
 
+  defmodule MockChild do
+    use GenServer
+
+    def start_link(target), do: GenServer.start_link(__MODULE__, target)
+
+    def set_target(child, target), do: GenServer.call(child, {:set_target, target})
+
+    @impl true
+    def init(target), do: {:ok, %{target: target}}
+
+    @impl true
+    def handle_call({:set_target, target}, _from, _state), do: {:reply, :ok, %{target: target}}
+  end
+
+  defp mock_child(target) do
+    {:ok, pid} = MockChild.start_link(target)
+    pid
+  end
+
+  defp terminate_child_collector do
+    {:ok, calls} = Agent.start_link(fn -> [] end)
+
+    fun = fn _supervisor, pid ->
+      Agent.update(calls, &[pid | &1])
+      :ok
+    end
+
+    {fun, calls}
+  end
+
   # Helper to create a mock child specification
   defp child(pid) do
     {:undefined, pid, :worker, []}
@@ -90,12 +92,19 @@ defmodule Embervm.GrpcConnectionSweeperTest do
     pid
   end
 
-  test "address normalization strips ipv4 prefix" do
-    registry = start_registry(["10.42.3.34:9090"])
+  def wedged_init_never_acks do
+    # This init is started by proc_lib.start_link but never calls init_ack,
+    # so the process stays stuck in {proc_lib, :sync_start, 2}.
+    # Used only by test "timeout/wedged branch is protected by strikes".
+    receive do
+      :never -> :ok
+    end
+  end
 
+  test "address normalization strips ipv4 prefix" do
     sweeper =
       start_sweeper(
-        node_registry: registry,
+        status_fun: fn -> %{"node-0" => %{address: "10.42.3.34:9090"}} end,
         sweep_enabled: false
       )
 
@@ -105,11 +114,9 @@ defmodule Embervm.GrpcConnectionSweeperTest do
 
   test "address normalization leaves non-ipv4 addresses unchanged" do
     # Both formats should be treated as equivalent when normalized
-    registry = start_registry(["10.42.3.34:9090"])
-
     sweeper =
       start_sweeper(
-        node_registry: registry,
+        status_fun: fn -> %{"node-0" => %{address: "10.42.3.34:9090"}} end,
         sweep_enabled: false
       )
 
@@ -123,7 +130,6 @@ defmodule Embervm.GrpcConnectionSweeperTest do
     # This is a routine case at boot under dial-home: the registry is seeded
     # empty and fills via registration. The sweeper must abort entirely (skip
     # the sweep), not classify children against an empty set.
-    registry = start_registry([])
     supervisor = mock_supervisor()
 
     # Create a mock child with a target NOT in the live set (which is empty).
@@ -138,7 +144,7 @@ defmodule Embervm.GrpcConnectionSweeperTest do
 
     sweeper =
       start_sweeper(
-        node_registry: registry,
+        status_fun: fn -> %{} end,
         supervisor: supervisor,
         sweep_enabled: false
       )
@@ -156,7 +162,6 @@ defmodule Embervm.GrpcConnectionSweeperTest do
   test "unavailable registry aborts sweep (fail-safe)" do
     # If the registry crashes or is unreachable, we must NOT reap anything.
     # The sweeper must distinguish this from a populated keep-set.
-    bad_registry = spawn(fn -> :ok end)
     supervisor = mock_supervisor()
 
     dead_pid = spawn(fn -> :ok end)
@@ -167,7 +172,7 @@ defmodule Embervm.GrpcConnectionSweeperTest do
 
     sweeper =
       start_sweeper(
-        node_registry: bad_registry,
+        status_fun: fn -> raise "registry error" end,
         supervisor: supervisor,
         sweep_enabled: false
       )
@@ -179,8 +184,11 @@ defmodule Embervm.GrpcConnectionSweeperTest do
   end
 
   test "sweep logs summary in dry-run mode (gate off)" do
-    registry = start_registry(["10.42.3.34:9090"])
-    sweeper = start_sweeper(node_registry: registry, sweep_enabled: false)
+    sweeper =
+      start_sweeper(
+        status_fun: fn -> %{"node-0" => %{address: "10.42.3.34:9090"}} end,
+        sweep_enabled: false
+      )
 
     # The log is internal; we verify the sweeper runs without error
     result = GrpcConnectionSweeper.sweep_now(sweeper)
@@ -188,8 +196,7 @@ defmodule Embervm.GrpcConnectionSweeperTest do
   end
 
   test "sweep respects the enabled flag" do
-    registry = start_registry([])
-    sweeper = start_sweeper(node_registry: registry, sweep_enabled: false)
+    sweeper = start_sweeper(status_fun: fn -> %{} end, sweep_enabled: false)
 
     # With gate off and empty registry (sweep skipped), result is []
     result = GrpcConnectionSweeper.sweep_now(sweeper)
@@ -197,11 +204,9 @@ defmodule Embervm.GrpcConnectionSweeperTest do
   end
 
   test "sweeper can be disabled with sweep_interval_ms = 0" do
-    registry = start_registry([])
-
     sweeper =
       start_sweeper(
-        node_registry: registry,
+        status_fun: fn -> %{} end,
         sweep_interval_ms: 0,
         sweep_enabled: false
       )
@@ -213,10 +218,221 @@ defmodule Embervm.GrpcConnectionSweeperTest do
 
   test "normalize_address handles ipv4-prefixed and raw formats" do
     # Test both input formats are handled without error
-    registry = start_registry(["10.42.3.34:9090", "ipv4:10.42.1.141:9090"])
-    sweeper = start_sweeper(node_registry: registry, sweep_enabled: false)
+    sweeper =
+      start_sweeper(
+        status_fun: fn ->
+          %{
+            "node-0" => %{address: "10.42.3.34:9090"},
+            "node-1" => %{address: "ipv4:10.42.1.141:9090"}
+          }
+        end,
+        sweep_enabled: false
+      )
 
     result = GrpcConnectionSweeper.sweep_now(sweeper)
     assert is_list(result)
+  end
+
+  test "child reapable on N consecutive sweeps IS terminated on the Nth sweep, not before" do
+    supervisor = mock_supervisor()
+    target = "10.42.9.99:9090"
+    child_pid = mock_child(target)
+    MockSupervisor.set_children(supervisor, [child(child_pid)])
+    {terminate_fun, calls} = terminate_child_collector()
+
+    sweeper =
+      start_sweeper(
+        status_fun: fn -> %{"node-0" => %{address: "10.42.3.34:9090"}} end,
+        supervisor: supervisor,
+        terminate_child_fun: terminate_fun,
+        sweep_enabled: true
+      )
+
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert :sys.get_state(sweeper).strikes == %{child_pid => 1}
+    assert Agent.get(calls, & &1) == []
+
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert :sys.get_state(sweeper).strikes == %{child_pid => 2}
+    assert Agent.get(calls, & &1) == []
+
+    assert [{^child_pid, reason}] = GrpcConnectionSweeper.sweep_now(sweeper)
+    assert reason =~ "reapable for 3 consecutive sweeps"
+    assert Agent.get(calls, & &1) == [child_pid]
+  end
+
+  test "timeout/wedged branch is protected by strikes" do
+    supervisor = mock_supervisor()
+
+    # Start a process that enters proc_lib.start_link but never calls init_ack,
+    # leaving it stuck in {proc_lib, :sync_start, 2}. This is stable across
+    # repeated :sys.get_state probes because current_function is determined by
+    # call stack, not reductions. Verify the child stays wedged across sweeps
+    # with process_info assertions.
+    init_task = Task.async(fn ->
+      :proc_lib.start_link(
+        __MODULE__,
+        :wedged_init_never_acks,
+        [],
+        :infinity,
+        []
+      )
+    end)
+
+    # Give the init task time to enter sync_start before proceeding
+    Process.sleep(100)
+
+    # The task is hung in start_link waiting for init_ack; extract its pid
+    wedged_pid = init_task.pid
+
+    # Verify it is in the expected sync_start state
+    case :erlang.process_info(wedged_pid, :current_function) do
+      {:current_function, {:proc_lib, :sync_start, 2}} ->
+        :ok
+
+      other ->
+        flunk("Process not in sync_start: #{inspect(other)}, cannot continue test")
+    end
+
+    MockSupervisor.set_children(supervisor, [child(wedged_pid)])
+    {terminate_fun, calls} = terminate_child_collector()
+
+    sweeper =
+      start_sweeper(
+        status_fun: fn -> %{"node-0" => %{address: "10.42.3.34:9090"}} end,
+        supervisor: supervisor,
+        terminate_child_fun: terminate_fun,
+        sweep_enabled: true
+      )
+
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert :sys.get_state(sweeper).strikes[wedged_pid] == 1
+    assert Agent.get(calls, & &1) == []
+    assert elem(:erlang.process_info(wedged_pid, :current_function), 1) == {:proc_lib, :sync_start, 2},
+      "wedged classification must be stable across sweep 1"
+
+    # Sweep 2: strike becomes 2; verify still wedged
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert :sys.get_state(sweeper).strikes[wedged_pid] == 2
+    assert Agent.get(calls, & &1) == []
+    assert elem(:erlang.process_info(wedged_pid, :current_function), 1) == {:proc_lib, :sync_start, 2},
+      "wedged classification must be stable across sweep 2"
+
+    # Sweep 3: strike reaches threshold (3), child terminated
+    assert [{^wedged_pid, reason}] = GrpcConnectionSweeper.sweep_now(sweeper)
+    assert reason =~ "reapable for 3 consecutive sweeps"
+    assert Agent.get(calls, & &1) == [wedged_pid]
+  end
+
+  test "catch :exit aborts sweep, grants no strikes" do
+    supervisor = mock_supervisor()
+    child_pid = mock_child("10.42.9.99:9090")
+    MockSupervisor.set_children(supervisor, [child(child_pid)])
+
+    sweeper =
+      start_sweeper(
+        status_fun: fn -> exit(:noproc) end,
+        supervisor: supervisor,
+        sweep_enabled: false
+      )
+
+    result = GrpcConnectionSweeper.sweep_now(sweeper)
+    assert result == []
+    assert :sys.get_state(sweeper).strikes == %{}
+  end
+
+  test "child reapable once, then keep, then reapable again is NOT terminated" do
+    supervisor = mock_supervisor()
+    child_a = mock_child("10.42.9.99:9090")
+    child_b = mock_child("10.42.3.34:9090")
+    MockSupervisor.set_children(supervisor, [child(child_a), child(child_b)])
+    {terminate_fun, calls} = terminate_child_collector()
+
+    sweeper =
+      start_sweeper(
+        status_fun: fn -> %{"node-0" => %{address: "10.42.3.34:9090"}} end,
+        supervisor: supervisor,
+        terminate_child_fun: terminate_fun,
+        sweep_enabled: true
+      )
+
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert :sys.get_state(sweeper).strikes[child_a] == 1
+    assert :sys.get_state(sweeper).strikes[child_b] == nil
+
+    MockChild.set_target(child_a, "10.42.3.34:9090")
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert :sys.get_state(sweeper).strikes == %{}
+
+    MockChild.set_target(child_a, "10.42.9.99:9090")
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert :sys.get_state(sweeper).strikes[child_a] == 1
+    assert Agent.get(calls, & &1) == []
+  end
+
+  test "child reapable for N-1 sweeps only is NOT terminated" do
+    supervisor = mock_supervisor()
+    child_pid = mock_child("10.42.9.99:9090")
+    MockSupervisor.set_children(supervisor, [child(child_pid)])
+    {terminate_fun, calls} = terminate_child_collector()
+
+    sweeper =
+      start_sweeper(
+        status_fun: fn -> %{"node-0" => %{address: "10.42.3.34:9090"}} end,
+        supervisor: supervisor,
+        terminate_child_fun: terminate_fun,
+        sweep_enabled: true
+      )
+
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert :sys.get_state(sweeper).strikes[child_pid] == 2
+    assert Agent.get(calls, & &1) == []
+  end
+
+  test "with gate OFF, N consecutive reapable sweeps still terminate NOTHING" do
+    supervisor = mock_supervisor()
+    child_pid = mock_child("10.42.9.99:9090")
+    MockSupervisor.set_children(supervisor, [child(child_pid)])
+    {terminate_fun, calls} = terminate_child_collector()
+
+    sweeper =
+      start_sweeper(
+        status_fun: fn -> %{"node-0" => %{address: "10.42.3.34:9090"}} end,
+        supervisor: supervisor,
+        terminate_child_fun: terminate_fun,
+        sweep_enabled: false
+      )
+
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert [{^child_pid, reason}] = GrpcConnectionSweeper.sweep_now(sweeper)
+    assert reason =~ "reapable for 3 consecutive sweeps"
+    assert Agent.get(calls, & &1) == []
+  end
+
+  test "strike entries are pruned for pids that disappear from supervisor's child list" do
+    supervisor = mock_supervisor()
+    child_a = mock_child("10.42.9.99:9090")
+    child_b = mock_child("10.42.9.98:9090")
+    MockSupervisor.set_children(supervisor, [child(child_a), child(child_b)])
+
+    sweeper =
+      start_sweeper(
+        status_fun: fn -> %{"node-0" => %{address: "10.42.3.34:9090"}} end,
+        supervisor: supervisor,
+        sweep_enabled: false
+      )
+
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert map_size(:sys.get_state(sweeper).strikes) == 2
+
+    MockSupervisor.set_children(supervisor, [child(child_b)])
+    assert GrpcConnectionSweeper.sweep_now(sweeper) == []
+    assert :sys.get_state(sweeper).strikes == %{child_b => 2}
+
+    assert [{^child_b, reason}] = GrpcConnectionSweeper.sweep_now(sweeper)
+    assert reason =~ "reapable for 3 consecutive sweeps"
+    assert :sys.get_state(sweeper).strikes == %{child_b => 3}
   end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.446
+      targetRevision: 0.1.447
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -261,6 +261,12 @@ statefulSweeper:
   sweepIntervalMs: "1000"
   wakeMax: "30"
 
+# Arm orphaned gRPC connection cleanup in the deployed control plane. The
+# interval remains unset so the application default of 60s applies.
+grpcConnectionSweeper:
+  enabled: "1"
+  sweepIntervalMs: ""
+
 # Arm the base-retention sweep (base-durability PR-3): one-shot supervised
 # reclaim of ~290G of superseded base versions on node-4, then the ongoing
 # retention backstop. Every current base is confirmed durable in S3 before any


### PR DESCRIPTION
## The outage this fixes

`bazel-query` was fully down for 54 minutes today (18:30:45Z to 19:25:04Z),
surfacing as `/health` returning `{"failing":["ember_bazel"]}` and probe detail
`status 504: query timed out:`. The trigger was an ordinary chart-bump brick
roll, so this can recur on any deploy.

The chain:

1. The roll orphaned gRPC channels (#4419: `start_streamer` dials the WatchNode
   channel inside a process that `expire_instance` later
   `Process.exit(pid, :kill)`s, so the `after` block that disconnects never runs).
2. Two `bazel-query` assign workers blocked forever in `GenServer.call/3` inside
   `GRPC.Client.Adapters.Mint.StreamResponseProcess.build_stream/2`.
3. `Stub.assign(channel, req, timeout: transport_timeout(...))` did not save
   them. That sets the gRPC deadline header the SERVER enforces, and on an
   orphaned channel the server never receives the request. The client-side
   stream read has no wall clock of its own.
4. A worker that never returns and never crashes means `finish_worker` never
   runs, so `dec_inflight` never fires. `inflight_wl` stuck at
   `%{"bazel-query" => 2}`, exactly `spec.concurrency.cap: 2`.
5. `drain_loop` then hit `inflight_count(...) >= entry.cap -> bump_denial(state, :cap)`
   for every later task: 27 queued, 575 cap denials, zero dispatches.

A denial is a counter bump, not a log line, so the control plane logged
**nothing** about the workload while it was 100% down.

Blast radius is inversely proportional to `cap`. Two stuck workers killed
`bazel-query` (cap 2) while `semgrep` and `sandbox` (cap 16) rode the same
leaked channels green.

## Commit 1: wall-clock watchdog on assign workers

`dispatcher.ex` arms `Process.send_after` at dispatch, guarded by monitor-ref
comparison so a reused pid can never be mis-targeted. On fire it kills the
worker, which routes into the EXISTING `:DOWN` handler path (`finish_worker` ->
`apply_failure` -> `dec_inflight` -> `drain_all`), so there is no new recovery
logic. Budget is `transport_timeout(entry.timeout_ms) + margin` (default 15s),
strictly greater than the transport deadline so the server-enforced path always
gets first shot. Overridable via `assign_watchdog_ms` for tests only.

This is the half that makes the cap self-healing, so a wedge from any future
cause cannot permanently pin a slot.

## Commit 2: harden the sweeper predicate, then arm it

The `GrpcConnectionSweeper` landed in df42282ff and ships inert;
`EMBERVM_GRPC_CONNECTION_SWEEP_ENABLED` was never wired into the chart at all.
Arming it needs template plus values, and review caught that arming it AS
WRITTEN would have been actively harmful.

Its `:timeout` branch decided purely on `process_looks_wedged?/1`, which cannot
consult `keep_set` (the target is unreadable) and returns true for BOTH
`current_function == {:proc_lib, :sync_start, 2}` AND `reductions < 100`. A
healthy orchestrator mid-TCP-connect looks exactly like that.

Verified against the live control plane. Across 46 consecutive dry-run sweeps,
how many sweeps each flagged pid appeared in:

```
8 pid(s) flagged in 1  sweep
1 pid(s) flagged in 42 sweeps
2 pid(s) flagged in 43 sweeps
2 pid(s) flagged in 44 sweeps
2 pid(s) flagged in 45 sweeps
1 pid(s) flagged in 46 sweeps
```

Perfectly bimodal, with nothing between 2 and 41. Eight pids were flagged in
exactly ONE sweep and never again: newly spawned orchestrators mid-connect
during a roll, which resolved on their own. Armed and unhardened, the sweeper
would have terminated every one of them. The correlation is what makes it
dangerous: connections are most likely mid-establish exactly during a brick
roll, which is when the sweeper is supposed to help.

The same distribution is what calibrates the threshold. N=3 sits inside a
40-sweep gap, so it clears every observed false positive by two sweeps while
still catching a real leak within the first three sweeps of its life.

Changes:

- **Strike-based confirmation.** A child must classify reapable on N=3
  CONSECUTIVE sweeps before termination. Strikes reset on `:keep` and are pruned
  for pids that leave the supervisor's child list. Applied to BOTH reap
  branches: the "target not in live set" half is provably correct (none of the
  flagged addresses matched any live pod IP), but a freshly registered node can
  briefly be missing from a stale keep-set, and a real leak persists forever so
  a few minutes' delay costs nothing.
- **Log the discriminator.** Below threshold reads `strike N of 3`; at or above
  reads `reapable for N consecutive sweeps, threshold 3`. The count is never
  clamped. The old log showed reap COUNTS while membership churned underneath,
  which looked stable and was not; that is why this defect survived observation.
- **Seam moved to function injection.** The `node_registry` module opt became
  `status_fun`, defaulting to `&Embervm.NodeRegistry.status/0`, matching how
  `PoolManager` and `Dispatcher` inject. The old opt accepted a pid in tests
  without ever failing, because no test reached the call site.

### Why both halves

They are two cuts through the same loop. During recovery, killing the wedged
workers ALSO cleared the orphaned connections: the sweeper went from
`WOULD reap 6 orchestrator(s)` every 60s to silent, and
`GRPC.Client.Supervisor` dropped to 9 children. The leaked channel and the
wedged consumer keep each other alive, because the `StreamResponseProcess` pins
the channel and the channel never answers the stream. The sweeper attacks it
from the connection side, the watchdog from the consumer side.

## Test coverage that did not exist

Before this PR, EVERY sweeper test passed `sweep_enabled: false` and every
mock-supervisor test short-circuited on an empty keep-set, so no test produced a
non-empty reap list and `terminate_child_fun` was NEVER invoked. Six of eight
asserted only `is_list(result)`. That is how a predicate this wrong shipped.

Seven new tests drive the ARMED path and assert on the pids actually passed to
`terminate_child_fun`: termination on the Nth sweep and not before, the
strike-reset regression (reapable, then keep, then reapable is NOT terminated),
N-1 sweeps is not enough, gate-off stays inert, and strike entries are pruned
for vanished pids.

Two of those cover paths that review caught as untested and that matter most:

- **The `:timeout` / wedged branch**, which is where every observed false
  positive came from. The first five tests all used a live mock child that
  answers `:sys.get_state` promptly, so they only ever reaped via "target not in
  live set". A regression that struck one branch and reaped the other
  immediately would have passed the whole file. The new test builds a process
  genuinely stuck in `{:proc_lib, :sync_start, 2}` and re-asserts that
  classification after EVERY sweep, so a flip fails at the sweep where it
  happened rather than opaquely at the final reap.
- **The `catch :exit` fail-safe arm.** The unavailable-registry test injected a
  `raise`, which only exercises `rescue`. The production seam is
  `GenServer.call(Embervm.NodeRegistry, :status)`, which EXITS `:noproc` when the
  registry is down and `{:timeout, ...}` when saturated, so the tested path and
  the real path were disjoint. This is the single property standing between a
  registry hiccup and terminating the entire connection pool, and the gate now
  ships armed.

## Production validation

The watchdog's recovery path was validated live before this PR was opened. The
two wedged workers were killed by hand in the running control plane, scoped to
`meta.workload == "bazel-query"`, which is precisely the sequence the watchdog
automates:

| | before | after |
|---|---|---|
| `inflight_wl` | `%{"bazel-query" => 2}` | bazel-query absent |
| `queued` | 27 | 0 |
| bazel-query VM restores | none since 18:35 | 31 in 8 min, two bricks |

`/health` returned 200 with `ember_bazel: "probe ok, 204ms"`, and the latch read
`warm, 204ms`, meaning the `0 packages loaded` marker was present, so Skyframe
was genuinely warm rather than served cold.

## Notes for review

- The watchdog test uses `cap: 1` deliberately: one wedged worker exhausts it,
  which is the real-world shape of `bazel-query`'s cap of 2.
- It asserts `:succeeded`, not a dead-letter. The watchdog frees the slot AND
  lets the task retry onto a healthy assign, which is the system self-healing.
  The `inflight_wl == %{}` assertion is the one that encodes the regression.
- That test carries a comment about a harness trap: the `retry:` option passed
  to `put_catalog` never reaches TaskStore, because `TaskStore.cfg_for/1` calls
  `WorkloadCatalog.retry_config/1`, the one-arg form that reads the module
  default table, while `put_catalog` writes the per-test table. Retry config
  falls back to `Retry.default_config()` (`max_attempts: 3`). The existing test
  at `dispatcher_test.exs:899` passes only because its `max_attempts: 3`
  coincides with that default. Not fixed here.
- N=3 strikes at a 60s interval means a real leak survives up to 3 minutes.
  Harmless (leaks persist indefinitely), but worth knowing that the sweeper does
  little in the first minutes after a roll.
- `log_pending/2` no-ops when the gate is on, so armed mode shows kills but not
  strikes accumulating. Deliberate, to avoid per-sweep spam; the reaped log
  still carries the consecutive-sweep count.

Local `ci test` verified independently and run TWICE, because the Elixir suite is
seed-ordered and one green run is not evidence: `MIX TEST OK on the executor`,
`1201 tests, 0 failures, 6 skipped` on both (up from 1194 on origin/main).

That double-run is not ceremony. An earlier revision of the wedged-branch test
passed for one reviewer and failed for another on the SAME commit under a
different seed: it relied on `process_looks_wedged?/1`'s `reductions < 100`
fallback, and each sweep's own `:sys.get_state` probe delivered a message the
process had to scan and reject, so reductions climbed monotonically until the
classification flipped to `:keep` and reset its strikes. The test asserted a
property that its own observation destroyed. It now targets
`{:proc_lib, :sync_start, 2}`, which is call-stack determined and therefore
stable, and which is also the arm real leaks actually ride (nothing else explains
a pid staying flagged for 42 to 46 consecutive sweeps).

Note also that `ci test` exits 0 even when the Elixir genrule fails, because mix
runs as a bazel genrule and bazel reports its own summary separately. Judge these
runs by the `MIX TEST` line, not the exit code.

## Follow-ups, not in this PR

- #4434: `session.ex` has the identical wedge. Its invoke worker has no wall
  clock, so a wedged stream pins `worker` forever, queued invokes stack up, and
  `arm_idle_timer/1` never fires (it runs only when the queue empties with no
  worker), so the session never banks and holds its slot against the cap.
- #4419's impact section still reads "bounded but not zero ... log noise plus
  five idle connection processes per roll". It caused a total outage of a
  low-cap workload and should be re-scoped.
- On the MISS path the watchdog clock starts before `fetch_request` and
  `prime_with_retry`, so the 15s margin is fully consumed if
  `EMBERVM_PLACEMENT_RETRY` is ever armed (it is unset today). Arming it later
  would silently make the watchdog fire BEFORE the server deadline.

Rebased onto origin/main `1716008df`; chart bumped to 0.1.447.
