### PR TITLE
fix(embervm): cut the git proxy idle deadline from 10s to 2s

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -477,6 +477,25 @@ claudeRuntimeWorkload:
     # only the claude-runtime base at the next chart bump. Prewarm failure fails
     # the base build by design.
     EMBER_PREWARM_CLIS: "claude"
+    # Interim speed knob for #4429, pending protocol-aware completion.
+    #
+    # The git proxy helper cannot see the end of a response: #4412 stopped
+    # propagating half-close onto the vsock leg (Firecracker hybrid vsock has
+    # none, and propagating it killed in-flight responses), so the server-held
+    # connection never closes and git blocks until the helper exits. The helper
+    # therefore infers completion from silence, and its default deadline is 10s,
+    # which is charged to EVERY clone after the last byte arrives.
+    #
+    # Measured: fitting t = a + b*bytes across an 11.24 MiB shallow clone (11.5s)
+    # and a 249.40 MiB full clone (~37s) gives 9.3 MiB/s marginal throughput and
+    # a 10.3s fixed cost. The lane is fast; the constant is this timeout.
+    #
+    # 2s, not lower: the mirror serves this entire clone in 1.3s over loopback,
+    # so this leaves roughly 2x margin over the whole server-side operation
+    # rather than over one gap. If the deadline ever does fire early the pack
+    # fails git's own checksum, so hydration errors loudly and retries rather
+    # than leaving a silently truncated checkout.
+    EMBER_GIT_PROXY_IDLE_EXIT_SECONDS: "2"
   # ON. The ADR 027 memory:false/filesystem:true quadrant: sessions ride
   # per-lineage workspace volumes with park/rejoin instead of memory-snapshot
   # banking, and raw files in S3 replace multi-GiB snapshots.


### PR DESCRIPTION
Interim fix for #4429. Recovers roughly 8 of the 10 seconds every hydration clone currently wastes. Values-only, no chart bump.

## The finding

The lane is NOT slow. Fitting `t = a + b*bytes` across two measured clones of the same repo:

| pack | time |
|------|------|
| 11.24 MiB (`--depth=1`) | 11.5s |
| 249.40 MiB (full) | ~37s |

gives **9.3 MiB/s marginal throughput** and a **10.3 second fixed cost**. 22x the bytes bought only 3.2x the time, because a constant dominates. The apparent "1 MB/s" was that constant divided into a small payload.

## The constant

`EMBER_GIT_PROXY_IDLE_EXIT_SECONDS`, default 10, in the generated git proxy helper.

The helper cannot see the end of a response. #4412 stopped propagating half-close onto the vsock leg, because Firecracker hybrid vsock has none and propagating it killed in-flight responses (that fix is load-bearing for #4389). With no EOF on the response side, the server-held connection never closes, and the helper's own comment spells out the consequence:

> git waits for THIS process to exit. Once the response has been idle past the deadline, close up and leave.

So #4415 added an idle watchdog as the completion detector. It works. Its deadline is simply charged to every clone after the last byte lands.

This also explains why #4430 (TCP_NODELAY) moved nothing: there is no per-round-trip penalty to remove. The `~55ms per 64 KiB chunk` figure was a large constant smeared across 180 chunks by averaging, and it matched the 40ms delayed-ACK timer by coincidence.

## Why 2s, and why the risk is bounded

The mirror serves this entire clone in **1.3s** over loopback, so 2s leaves roughly 2x margin over the whole server-side operation rather than over a single mid-stream gap.

If the deadline ever does fire early, the pack is truncated and **git's own checksum rejects it**. Every packfile carries a SHA trailer over its contents. So the failure mode is a loud, retryable hydration error, not a silently corrupt checkout, and hydration already has an attempt cap with retries.

## This is interim, not the answer

The correct fix is protocol-aware completion: parse git's pkt-line framing (with sideband demux) and exit as soon as the response is structurally complete, removing the timeout from the path entirely. That is a substantial change and is tracked on #4429. This knob is a tuning value.

## Mechanics

`initEnv` participates in the base signature, so this re-keys and rebuilds the claude-runtime base, which is the intended mechanism. The `helm template` diff is exactly one added line.

`ci test`: `Executed 1 out of 758 tests: 758 tests pass`, `MIX TEST FAILED` count 0, no FLAKY.

Expected: initial repo-attached session from ~15.2s to roughly 7s. I will measure and post the result on #4429.