### PR TITLE
fix(embervm): protocol-aware completion in the git proxy, removing the 10s clone tax

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.447
+version: 0.1.448

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.447
+      targetRevision: 0.1.448
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -313,7 +313,46 @@ def _pump_stdin_to_socket(source, sock):
 LAST_RX = [time.monotonic()]
 
 
-def _pump_socket_to_stdout(sock, destination):
+class _PktLineCompletionParser:
+    "Observe git's pkt-line stream without changing the forwarded bytes."
+
+    def __init__(self):
+        self.buffer = bytearray()
+        self.complete = False
+        self.watchdog_only = False
+
+    def feed(self, data):
+        self.buffer.extend(data)
+        while not self.complete and not self.watchdog_only:
+            if len(self.buffer) < 4:
+                return
+
+            header = bytes(self.buffer[:4])
+            if header == b"PACK":
+                # A non-sideband upload-pack response switches to raw pack
+                # data here, so there is no framing marker we can trust.
+                self.watchdog_only = True
+                return
+            if any(byte not in b"0123456789abcdefABCDEF" for byte in header):
+                self.watchdog_only = True
+                return
+
+            length = int(header, 16)
+            if length == 0:
+                del self.buffer[:4]
+                self.complete = True
+                return
+            if length in (1, 2, 3):
+                frame_length = 4
+            else:
+                frame_length = length
+            if len(self.buffer) < frame_length:
+                return
+            del self.buffer[:frame_length]
+
+
+def _pump_socket_to_stdout(sock, destination, response_complete):
+    parser = _PktLineCompletionParser()
     try:
         while True:
             data = sock.recv(65536)
@@ -322,6 +361,10 @@ def _pump_socket_to_stdout(sock, destination):
             LAST_RX[0] = time.monotonic()
             destination.write(data)
             destination.flush()
+            parser.feed(data)
+            if parser.complete:
+                response_complete.set()
+                break
     except OSError:
         pass
 
@@ -377,22 +420,34 @@ def main():
         stdin_pump = threading.Thread(
             target=_pump_stdin_to_socket, args=(sys.stdin.buffer, sock), daemon=True
         )
+        response_complete = threading.Event()
         stdout_pump = threading.Thread(
-            target=_pump_socket_to_stdout, args=(sock, sys.stdout.buffer), daemon=True
+            target=_pump_socket_to_stdout,
+            args=(sock, sys.stdout.buffer, response_complete),
+            daemon=True,
         )
         stdin_pump.start()
         stdout_pump.start()
         stdin_pump.join()
-        # git half-closes stdin right after its request and then reads the
-        # response, so stdin EOF says nothing about completion. The response
-        # side has no EOF either: the lane deliberately never propagates the
-        # half-close onto vsock (#4389), so the server-held connection stays
-        # open forever and git waits for THIS process to exit. Once the
-        # response has been idle past the deadline, close up and leave; a
-        # mid-response server pause shorter than the deadline is unaffected.
+        # Firecracker hybrid vsock cannot propagate the response half-close,
+        # so git cannot otherwise see that a clone is complete. A sideband
+        # response has a flush-pkt, which lets us leave as soon as its protocol
+        # is structurally complete. Raw PACK data has no framing information,
+        # so the idle watchdog remains the safe fallback for that case.
         LAST_RX[0] = time.monotonic()
         while stdout_pump.is_alive():
-            stdout_pump.join(timeout=0.5)
+            if response_complete.wait(timeout=0.5):
+                # shutdown, not just close: close() does not wake a thread
+                # blocked in recv, SHUT_RDWR does.
+                try:
+                    sock.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+                break
             if not stdout_pump.is_alive():
                 break
             if time.monotonic() - LAST_RX[0] > idle_exit:

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -2891,6 +2891,169 @@ def test_git_proxy_helper_sets_tcp_nodelay(tmp_path, monkeypatch):
     )
 
 
+def _pkt_line(payload):
+    return ("%04x" % (len(payload) + 4)).encode() + payload
+
+
+def _run_git_proxy_response(tmp_path, monkeypatch, response, idle_exit, hold_open=True):
+    helper_path = tmp_path / "ember-git-proxy"
+    monkeypatch.setattr(shim, "GIT_PROXY_PATH", str(helper_path))
+    shim._write_git_proxy_helper()
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind((shim.EGRESS_LOCALHOST, 0))
+    listener.listen()
+    accepted = []
+    release_server = threading.Event()
+
+    def serve_connection():
+        connection, _ = listener.accept()
+        accepted.append(connection)
+        connection.recv(4096)
+        connection.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        connection.recv(4096)
+        connection.sendall(response)
+        if hold_open:
+            release_server.wait()
+        else:
+            connection.shutdown(socket.SHUT_WR)
+
+    accept_thread = threading.Thread(target=serve_connection, daemon=True)
+    accept_thread.start()
+    environment = os.environ.copy()
+    environment[shim.EGRESS_PORT_ENV] = str(listener.getsockname()[1])
+    environment["EMBER_GIT_PROXY_IDLE_EXIT_SECONDS"] = str(idle_exit)
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            [sys.executable, str(helper_path), "example.com", "9418"],
+            input=b"request",
+            env=environment,
+            capture_output=True,
+            timeout=5,
+        )
+    finally:
+        release_server.set()
+        listener.close()
+        for connection in accepted:
+            connection.close()
+        accept_thread.join(timeout=1)
+    return result, time.monotonic() - started
+
+
+def test_git_proxy_helper_exits_early_on_sideband_flush_pkt(tmp_path, monkeypatch):
+    pack_like_payload = (b"PACK" + bytes(range(256))) * 12000
+    response = b"".join(
+        [_pkt_line(b"0008NAK\n"), _pkt_line(b"\x02counting objects\n")]
+        + [
+            _pkt_line(b"\x01" + pack_like_payload[offset : offset + 65515])
+            for offset in range(0, len(pack_like_payload), 65515)
+        ]
+        + [_pkt_line(b"\x02done\n"), b"0000"]
+    )
+
+    result, elapsed = _run_git_proxy_response(
+        tmp_path, monkeypatch, response, idle_exit=30
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == response
+    assert elapsed < 3
+
+
+def test_git_proxy_helper_handles_frame_straddling_recv_boundary(tmp_path, monkeypatch):
+    helper_path = tmp_path / "ember-git-proxy"
+    monkeypatch.setattr(shim, "GIT_PROXY_PATH", str(helper_path))
+    shim._write_git_proxy_helper()
+    response_chunks = [
+        b"HTTP/1.1 200 Connection Established\r\n\r\n",
+        b"000",
+        b"9hello",
+        b"0000",
+    ]
+    sent = []
+
+    class FakeConnection:
+        def setsockopt(self, *args):
+            pass
+
+        def settimeout(self, *args):
+            pass
+
+        def sendall(self, data):
+            sent.append(data)
+
+        def recv(self, size):
+            return response_chunks.pop(0) if response_chunks else b""
+
+        def shutdown(self, how):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        socket,
+        "create_connection",
+        lambda *args, **kwargs: FakeConnection(),
+    )
+    stdin_buffer = io.BytesIO(b"request")
+    stdout_buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdin", io.TextIOWrapper(stdin_buffer))
+    monkeypatch.setattr(sys, "stdout", io.TextIOWrapper(stdout_buffer))
+    monkeypatch.setattr(sys, "argv", [str(helper_path), "example.com", "9418"])
+
+    with pytest.raises(SystemExit) as exit_info:
+        runpy.run_path(str(helper_path), run_name="__main__")
+
+    assert exit_info.value.code == 0
+    assert stdout_buffer.getvalue() == b"0009hello0000"
+    assert sent[0].startswith(b"CONNECT example.com:9418")
+
+
+def test_git_proxy_helper_falls_back_to_watchdog_on_raw_pack(tmp_path, monkeypatch):
+    response = _pkt_line(b"0008NAK\n") + b"PACK" + b"raw pack bytes" * 100
+
+    result, elapsed = _run_git_proxy_response(
+        tmp_path, monkeypatch, response, idle_exit=0.2
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == response
+    assert elapsed >= 0.15
+
+
+def test_git_proxy_helper_handles_shallow_clone(tmp_path, monkeypatch):
+    response = b"".join(
+        [
+            _pkt_line(b"shallow 0123456789abcdef0123456789abcdef01234567\n"),
+            _pkt_line(b"unshallow fedcba9876543210fedcba9876543210fedcba98\n"),
+            _pkt_line(b"\x01PACK" + b"pack data"),
+            b"0000",
+        ]
+    )
+
+    result, elapsed = _run_git_proxy_response(
+        tmp_path, monkeypatch, response, idle_exit=30
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == response
+    assert elapsed < 3
+
+
+def test_git_proxy_helper_still_exits_on_stalled_server(tmp_path, monkeypatch):
+    response = _pkt_line(b"shallow 0123456789abcdef0123456789abcdef01234567\n")
+
+    result, elapsed = _run_git_proxy_response(
+        tmp_path, monkeypatch, response, idle_exit=0.2
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == response
+    assert elapsed >= 0.15
+
+
 def test_git_proxy_helper_blocks_after_handshake_timeout(tmp_path, monkeypatch):
     helper_path = tmp_path / "ember-git-proxy"
     monkeypatch.setattr(shim, "GIT_PROXY_PATH", str(helper_path))


### PR DESCRIPTION
The real fix for #4429. Removes a flat ~10 second timeout from every hydration clone.

## The problem

The git proxy helper cannot see the end of a response. #4412 stopped propagating half-close onto the vsock leg, because Firecracker hybrid vsock has none and propagating it killed in-flight responses (load-bearing for #4389). With no EOF on the response side the server-held connection never closes, and as the helper's own comment says, "git waits for THIS process to exit". So #4415 added an idle watchdog with a 10 second deadline, and that deadline is charged to every clone after its last byte lands.

## Measured

| | time |
|---|---|
| mirror serves the clone, loopback, no lane | **1.3s** |
| in-guest clone `--depth=1` (11.8 MiB) | **11.331s** |
| in-guest clone `--depth=50` (11.9 MiB) | **11.325s** |
| instrumented `phase=hydration_clone` | **11.380s** |

10s deadline plus ~1.3s of real transfer. `user 0m0.328s / sys 0m0.080s` on the in-guest clone: git burns no CPU, it is idle-waiting.

## The fix

Parse git's pkt-line framing and exit as soon as the response is structurally complete, rather than inferring completion from silence.

- incremental and stateful across `recv` boundaries, since a frame header or body can straddle any number of 64 KiB chunks
- **pure passthrough**: every byte is written and flushed to stdout BEFORE the parser is fed and before any completion check, so the final chunk can never be dropped
- raw `PACK` magic (non-sideband, no framing) or a non-hex length header sets watchdog-only mode
- **the idle watchdog stays** as the backstop for the non-sideband case, an unrecognised protocol shape, and a genuinely stalled server. The parser answers "the server finished"; the watchdog answers "the server stopped talking". Those are different questions.

## Why this rather than tuning the deadline

#4435 tried exactly that, setting `EMBER_GIT_PROXY_IDLE_EXIT_SECONDS: "2"` in `initEnv`. **It is inert.** The value reaches the workload CR and the base rebuilt, but it never reaches the process that reads it: in a guest shell the variable is empty, and conclusively the shim's own hydration clone (11,380ms) and an agent-shell clone (11,331ms) are identical, when a working 2s deadline would separate them by about 8 seconds.

So this path has a real config-delivery gap (tracked on #4429). The parser does not depend on env delivery at all, which makes it strictly better than the interim rather than merely more correct.

## Tests

- sideband response with a terminating flush-pkt exits promptly, asserted against a deliberately long deadline so the assertion is unambiguous
- a frame straddling a `recv` boundary parses correctly
- raw PACK magic falls back to the watchdog and still completes
- a stalled server still exits via the watchdog

`ci test`: `MIX TEST FAILED` count 0, no FAILED or FLAKY, 758 tests pass.

Carries the chart bump to 0.1.448. Expected: initial repo-attached session from ~15.2s to roughly 5s, with the clone dropping from 11.4s to near the mirror's 1.3s. I will measure and post the result on #4429.