### PR TITLE
feat(monolith): run Discord /agent on EmberVM agent sessions, owner only

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.367
+version: 0.89.368
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.367
+      targetRevision: 0.89.368
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -3145,8 +3145,8 @@ py_test(
     srcs = ["chat/bot_on_message_test.py"],
     imports = ["."],
     deps = [
-        ":pkg_cyclegroup",
         ":pkg_agent_sessions",
+        ":pkg_cyclegroup",
         "@pip//discord_py",
         "@pip//pydantic_ai_slim",
         "@pip//pytest",
@@ -3609,8 +3609,8 @@ py_test(
     srcs = ["chat/bot_agent_prompt_echo_test.py"],
     imports = ["."],
     deps = [
-        ":pkg_cyclegroup",
         ":pkg_agent_sessions",
+        ":pkg_cyclegroup",
         "@pip//discord_py",
         "@pip//pytest",
         "@pip//pytest_asyncio",

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -3146,6 +3146,7 @@ py_test(
     imports = ["."],
     deps = [
         ":pkg_cyclegroup",
+        ":pkg_agent_sessions",
         "@pip//discord_py",
         "@pip//pydantic_ai_slim",
         "@pip//pytest",
@@ -3609,6 +3610,7 @@ py_test(
     imports = ["."],
     deps = [
         ":pkg_cyclegroup",
+        ":pkg_agent_sessions",
         "@pip//discord_py",
         "@pip//pytest",
         "@pip//pytest_asyncio",

--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -1,1 +1,88 @@
-"""Public API marker for the agent_sessions domain."""
+"""Public API for Discord and other external agent session callers."""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+from sqlmodel import Session
+
+from agent_sessions import model_family, store
+from agent_sessions.mcp import (
+    _load_session_row,
+    _persist_pending_message,
+    _persist_session,
+    _schedule_next_message,
+    _set_session_status,
+)
+from core.db import get_engine
+from goosecracker.api import REPO_CATALOG
+
+
+async def start_session_for_thread(
+    thread_id: str, prompt: str, repo: str | None, model: str = "luna"
+) -> int:
+    """Create a model session bound to a Discord thread and queue its first turn.
+
+    ``thread_id`` identifies the Discord thread that should receive terminal
+    notifications, ``prompt`` is the initial user request, ``repo`` selects
+    the checkout or leaves it empty for an artifact run, and ``model`` selects
+    the adapter family.  The returned integer is the durable session id, which
+    callers use to correlate later turns and database records.
+    """
+    if repo is not None and repo not in REPO_CATALOG:
+        raise ValueError(f"unknown repo {repo}; catalog: {', '.join(REPO_CATALOG)}")
+    model_family(model)
+    row = await asyncio.to_thread(
+        _persist_session,
+        str(uuid4()),
+        "<guest>",
+        "main",
+        model,
+        repo,
+        thread_id,
+    )
+    await asyncio.to_thread(_persist_pending_message, row.id, prompt, model)
+    _schedule_next_message(row.id)
+    return row.id
+
+
+async def send_to_thread_session(thread_id: str, message: str) -> dict | None:
+    """Queue a follow-up message for the session bound to a Discord thread.
+
+    ``thread_id`` scopes the message to an existing thread-owned session and
+    ``message`` is the owner's next turn.  The result describes the queued turn,
+    or is ``None`` when no session is bound, so callers can fall through to
+    ordinary chat handling instead of claiming an unrelated thread.
+
+    Async, and deliberately not a sync function the caller wraps in
+    ``asyncio.to_thread``: ``_schedule_next_message`` calls
+    ``asyncio.create_task``, which needs a running event loop on the calling
+    thread. Off the loop it raises RuntimeError AFTER the turn is already
+    persisted, so the owner would see a send failure for a turn that the 5s
+    sweep then runs anyway. The blocking database calls get their own
+    ``to_thread`` hops instead, matching ``start_session_for_thread``.
+    """
+    session_id = await asyncio.to_thread(session_id_for_thread, thread_id)
+    if session_id is None:
+        return None
+    row = await asyncio.to_thread(_load_session_row, session_id)
+    if row is None:
+        return None
+    model_family(row.model)
+    turn = await asyncio.to_thread(_persist_pending_message, session_id, message, None)
+    await asyncio.to_thread(_set_session_status, session_id, "running")
+    _schedule_next_message(session_id)
+    return {"action": "queued", "session_id": session_id, "turn": turn}
+
+
+def session_id_for_thread(thread_id: str) -> int | None:
+    """Find the durable session id for a Discord thread, if one is bound.
+
+    ``thread_id`` is the Discord thread identifier.  Returning ``None`` for an
+    unbound thread lets message routing distinguish agent turns from normal
+    conversation without creating session state as a side effect.
+    """
+    with Session(get_engine()) as db_session:
+        row = store.get_session_by_discord_thread(db_session, thread_id)
+        return row.id if row else None

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -151,10 +151,17 @@ def _persist_session(
     branch: str,
     model: str | None,
     repo: str | None = None,
+    discord_thread: str | None = None,
 ) -> AgentSession:
     with Session(get_engine()) as db_session:
         return store.create_session(
-            db_session, local_session_id, workspace, branch, model, repo
+            db_session,
+            local_session_id,
+            workspace,
+            branch,
+            model,
+            repo,
+            discord_thread=discord_thread,
         )
 
 
@@ -168,14 +175,24 @@ def _turn_status(turn: Turn) -> str:
     return "completed"
 
 
-async def _notify_terminal(turn: Turn, summary: str, status: str) -> None:
+async def _notify_terminal(
+    turn: Turn, summary: str, status: str, row: AgentSession | None = None
+) -> None:
     if turn.permission_denials or status == "needs_input":
         level = "warn"  # Needs user action
     elif status == "completed":
         level = "info"
     else:
         level = "warn"
-    await agent_api.notify(summary, level=level)
+    if row is not None and status == "needs_input":
+        summary = f"Needs input: {summary}"
+    elif row is not None and status == "warn":
+        summary = f"Warning: {summary}"
+    summary = summary[:2000]
+    if row is not None and row.discord_thread:
+        await agent_api.notify(summary, level=level, channel=row.discord_thread)
+    else:
+        await agent_api.notify(summary, level=level, channel=None)
 
 
 def _get_pending_message_sync(session_id: int, turn_seq: int):
@@ -452,7 +469,7 @@ async def _execute_pending_message(session_id: int) -> None:
             return
         await asyncio.to_thread(_delete_pending_message_sync, session_id, claimed_seq)
         if not ui_originated:
-            await _notify_terminal(turn, summary, status)
+            await _notify_terminal(turn, summary, status, session_row)
         # This session's next message could not be claimed while this one was
         # outstanding, so nudge the queue now that it is not. Without this the
         # follow-up waits for the sweep, which is correct but adds its interval

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -1094,7 +1094,7 @@ def test_notify_terminal_with_no_terminal_reason_warns(monkeypatch):
 
     notify_calls = []
 
-    async def mock_notify(summary, level):
+    async def mock_notify(summary, level, channel=None):
         notify_calls.append((summary, level))
 
     monkeypatch.setattr(mcp.agent_api, "notify", mock_notify)

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -15,6 +15,11 @@ class AgentSession(SQLModel, table=True):
     workspace: str
     branch: str
     repo: str | None = None
+    # The Discord thread this session is bound to, or None for a session started
+    # from the /agents UI or an MCP tool. Unique so a thread can never fan out to
+    # two sessions; Postgres allows many NULLs under a unique constraint, so the
+    # unbound sessions are unaffected.
+    discord_thread: str | None = Field(default=None, unique=True, index=True)
     model: str | None = Field(default=None)
     cli_session_id: str | None = Field(
         default=None

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -25,12 +25,15 @@ def create_session(
     branch: str,
     model: str | None = None,
     repo: str | None = None,
+    *,
+    discord_thread: str | None = None,
 ) -> AgentSession:
     row = AgentSession(
         local_session_id=local_session_id,
         workspace=workspace,
         branch=branch,
         repo=repo,
+        discord_thread=discord_thread,
         model=model,
         progress_token=secrets.token_urlsafe(32),
     )
@@ -47,6 +50,14 @@ def get_session(session: Session, session_id: int) -> AgentSession | None:
 def get_session_by_local_id(session: Session, local_id: str) -> AgentSession | None:
     return session.exec(
         select(AgentSession).where(AgentSession.local_session_id == local_id)
+    ).first()
+
+
+def get_session_by_discord_thread(
+    session: Session, thread_id: str
+) -> AgentSession | None:
+    return session.exec(
+        select(AgentSession).where(AgentSession.discord_thread == thread_id)
     ).first()
 
 

--- a/projects/monolith/agent_sessions/store_test.py
+++ b/projects/monolith/agent_sessions/store_test.py
@@ -1,5 +1,8 @@
 import json
 
+import pytest
+from sqlalchemy.exc import IntegrityError
+
 from sqlmodel import Session, SQLModel, create_engine, select
 
 from agent_sessions import store
@@ -167,5 +170,38 @@ def test_write_progress_sync_falls_back_to_unclaimed_row(monkeypatch, tmp_path):
             ).all()
             assert rows[0].partial_text == "working"
             assert rows[1].partial_text is None
+    finally:
+        _restore_schemas(schemas)
+
+
+def test_discord_thread_binds_at_most_one_session(monkeypatch, tmp_path):
+    """A thread can never fan out to two sessions.
+
+    The unique constraint is what makes session_id_for_thread a lookup rather
+    than a choice: without it a second /agent in the same thread would create a
+    rival session and turns would land in whichever one the query happened to
+    return first.
+    """
+    engine, schemas = _database(monkeypatch, tmp_path)
+    try:
+        with Session(engine) as session:
+            store.create_session(
+                session, "local-1", "<guest>", "main", "luna", discord_thread="t-1"
+            )
+            with pytest.raises(IntegrityError):
+                store.create_session(
+                    session, "local-2", "<guest>", "main", "luna", discord_thread="t-1"
+                )
+            session.rollback()
+
+        # Unbound sessions are unaffected: many NULLs are allowed under the
+        # constraint, which is what keeps the UI and MCP lanes working.
+        with Session(engine) as session:
+            store.create_session(session, "local-3", "<guest>", "main", "luna")
+            store.create_session(session, "local-4", "<guest>", "main", "luna")
+            rows = session.exec(
+                select(AgentSession).where(AgentSession.discord_thread.is_(None))
+            ).all()
+            assert len(rows) == 2
     finally:
         _restore_schemas(schemas)

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.442
+version: 0.285.443
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260806090000_agent_sessions_discord_thread.sql
+++ b/projects/monolith/chart/migrations/20260806090000_agent_sessions_discord_thread.sql
@@ -1,0 +1,5 @@
+ALTER TABLE agent_sessions.agent_sessions
+    ADD COLUMN discord_thread TEXT;
+
+CREATE UNIQUE INDEX agent_sessions_discord_thread_key
+    ON agent_sessions.agent_sessions (discord_thread);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:HSBizG78iK1PkzWOG7s01TwdxvOyViBQxe+hvNlY2MY=
+h1:5ASiIIugXYdOlSLfZIIt9hXYWdaoxSfAlJbRG9/RupI=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -153,3 +153,4 @@ h1:HSBizG78iK1PkzWOG7s01TwdxvOyViBQxe+hvNlY2MY=
 20260804170000_agent_sessions_repo.sql h1:fO8QWpDxjjrGvGWe7TBK8BDjIG0NYbiIqcLRF1/EnZ4=
 20260804180000_agent_sessions_progress.sql h1:kBebvB7KOtRDZlGnv0cVSocBulNSyhcSThZMBHzMEHQ=
 20260804180100_agent_sessions_partial_activities.sql h1:7pn5RdzO2CtsdU0TgaMLLeEflS5C0YZtqBxyerEjHyY=
+20260806090000_agent_sessions_discord_thread.sql h1:9V+mX3YJfQhNe+5UqL6OSf+6hUxNPXbMnwO7yCnfqSg=

--- a/projects/monolith/chat/acl.py
+++ b/projects/monolith/chat/acl.py
@@ -29,6 +29,23 @@ logger = logging.getLogger(__name__)
 LOOM_GUILD_ID = "1512814732392927463"
 
 
+def owner_id() -> str:
+    """Return the configured Discord owner id, or an empty id when unset."""
+    return os.environ.get("OWNER_DISCORD_USER_ID", "")
+
+
+def is_owner(user_id: int | str) -> bool:
+    """Return whether ``user_id`` is the configured owner.
+
+    This fails closed when ``OWNER_DISCORD_USER_ID`` is unset because agent
+    runs execute arbitrary code in a microVM and spend model budget. An absent
+    owner configuration must never turn that expensive capability into an
+    accidentally public one.
+    """
+    owner = owner_id()
+    return bool(owner) and str(user_id) == owner
+
+
 def _norm(value: object) -> str:
     """Discord ids arrive as int or str; grants store strings, "" for absent."""
     return "" if value is None else str(value)

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -890,7 +890,7 @@ class ChatBot(discord.Client):
         # instead of going to the chat agent. Only threads can be goosecracker
         # sessions, so the DB lookup is skipped for ordinary channels.
         if isinstance(message.channel, discord.Thread):
-            if await self._maybe_handle_goosecracker_reply(message):
+            if await self._maybe_handle_agent_thread_reply(message):
                 return
 
         # Trust safeguards (ADR chat/003): heuristic signals update the
@@ -1198,27 +1198,7 @@ class ChatBot(discord.Client):
         requires that the caller hold some agent grant in this server, so a
         repo-less run is permitted wherever /agent is; a non-empty repo must be
         in the server's grants."""
-        guild_id = interaction.guild_id
         repo = repo.strip()
-        if not await asyncio.to_thread(acl.feature_enabled, guild_id, "agent"):
-            await interaction.response.send_message(
-                "/agent isn't enabled in this server.", ephemeral=True
-            )
-            return
-        if not await asyncio.to_thread(
-            acl.is_granted, guild_id, interaction.user.id, "agent", repo
-        ):
-            scopes = await asyncio.to_thread(
-                acl.allowed_scopes, guild_id, interaction.user.id, "agent"
-            )
-            allowed = ", ".join(sorted(scopes)) or "none"
-            target = f"'{repo}'" if repo else "an artifact (no repo)"
-            await interaction.response.send_message(
-                f"This server can't run /agent on {target}. Allowed here: {allowed}.",
-                ephemeral=True,
-            )
-            return
-
         channel = interaction.channel
         if not isinstance(channel, discord.TextChannel):
             await interaction.response.send_message(
@@ -1269,22 +1249,16 @@ class ChatBot(discord.Client):
 
         - ``chat`` - no thread, no session, no checklist: produce a
           conversational reply (local Qwen) and return it for the caller to post.
-        - ``goose`` (a :class:`~chat.orchestrator.PlanVerdict`) - open a session
-          thread as today, but hand the guest the raw user prompt (the plan
-          supersedes the advisory brief, so it is never prepended) plus the
-          validated runtime :class:`~chat.orchestrator_plan.Plan`: the runner
-          delivers a rendered router + plan file via ``injectedContext``
-          instead of the baked ``recipe="agent"`` path (Task 6 of the
-          runtime-recipes plan). Pre-renders the checklist from the plan's
-          steps.
-        - ``FailOpen`` (disabled, ungranted, unreachable, unparseable, or an
-          unusable/invalid plan) - EXACT pre-036 behaviour: open a thread and
-          submit the raw prompt with no plan, i.e. the baked ``recipe="agent"``
-          path. This is the safety net (Design invariant 2).
+        - A non-chat verdict opens a durable EmberVM session thread and queues
+          the raw prompt for the selected repo.
 
-        Does NOT do ACL checks or send origin-channel acks (the caller owns
-        those). Returns an :class:`AgentFlowOutcome`.
+        Does not send origin-channel acknowledgements. Returns an
+        :class:`AgentFlowOutcome`.
         """
+        if not acl.is_owner(user.id):
+            return AgentFlowOutcome(
+                chat_reply="Only the configured owner can start or continue agent sessions."
+            )
         guild_id = str(channel.guild.id) if channel.guild else ""
         channel_id = str(channel.id)
 
@@ -1302,20 +1276,9 @@ class ChatBot(discord.Client):
                 pending_proposal=proposals,
             )
 
-        # A PlanVerdict seeds the guest with a runtime plan; FailOpen (or any
-        # other non-plan verdict) keeps today's baked recipe="agent" raw path.
-        plan_verdict = (
-            verdict if isinstance(verdict, orchestrator.PlanVerdict) else None
-        )
-        # The plan already carries the ADR 029 out-of-scope repo replacement
-        # (orchestrator.compile substitutes the invoker's own scope when the
-        # model named a repo outside its grants); fall back to the invoker
-        # -supplied repo when the plan named none.
-        effective_repo = (
-            plan_verdict.repo
-            if plan_verdict is not None and plan_verdict.repo
-            else repo
-        )
+        # Agent sessions use the selected repo directly. The orchestrator's
+        # conversational verdict above remains unchanged.
+        effective_repo = repo
 
         name = f"agent: {prompt}"[:90]
         try:
@@ -1325,20 +1288,14 @@ class ChatBot(discord.Client):
                 thread = await channel.create_thread(
                     name=name, type=discord.ChannelType.public_thread
                 )
-            # The plan supersedes the advisory brief: the task the guest
-            # executes is just the raw user prompt (ground truth), never
-            # brief-markdown-prefixed. The runtime router (built from the plan)
-            # is what actually drives the run, delivered via injectedContext.
-            # For failopen it is exactly the raw prompt too, so that path is
-            # byte-for-byte today's behaviour.
-            await asyncio.to_thread(
-                goosecracker.start_agent_session,
+            # Keep this import lazy because agent_sessions.api imports mcp,
+            # which reaches chat.api and then chat.bot during startup.
+            from agent_sessions.api import start_session_for_thread
+
+            await start_session_for_thread(
                 str(thread.id),
-                effective_repo,
                 prompt,
-                channel_id,
-                task=prompt,
-                plan=plan_verdict.plan if plan_verdict is not None else None,
+                effective_repo or None,
             )
             # ADR 036: the orchestrator wrote its telemetry row BEFORE this
             # thread existed (it decides whether to open one), so the row's
@@ -1352,7 +1309,7 @@ class ChatBot(discord.Client):
                     orchestrator.link_thread, brief_id, str(thread.id)
                 )
         except Exception:
-            logger.exception("goosecracker: failed to start agent session")
+            logger.exception("agent_sessions: failed to start agent session")
             return AgentFlowOutcome()
 
         try:
@@ -1361,39 +1318,11 @@ class ChatBot(discord.Client):
             # not the intro (which the progress stream live-edits and would clobber).
             await thread.send(_format_agent_prompt_echo(user, prompt))
         except Exception:
-            logger.exception("goosecracker: failed to post agent prompt echo")
+            logger.exception("agent_sessions: failed to post agent prompt echo")
         try:
-            # ADR 035: a bare "Planning..." placeholder, not a progress claim.
-            # For a PlanVerdict, pre-render the checklist from the plan's ordered
-            # steps (using the same stage-title mapping the rendered router's
-            # progress markers use, so the checklist matches) so the owner sees
-            # the plan before the guest's own ::stages:: markers arrive;
-            # render_checklist then takes over.
-            intro_content = "🤖 Planning..."
-            if plan_verdict is not None and plan_verdict.plan.steps:
-                # Cross-domain: reach goosecracker only through its api facade
-                # (import_boundaries_test). Kept lazy because this module
-                # (chat.bot) already imports chat.orchestrator at module load,
-                # so a top-level goosecracker.api import risks a circular-import
-                # shape. Distinct name from the `chat.goosecracker` module this
-                # file imports as `goosecracker`, to avoid shadowing it.
-                from goosecracker.api import stage_title
-
-                synthetic = goosecracker_progress.Progress(
-                    stages=[
-                        goosecracker_progress.Stage(
-                            index=i, title=stage_title(step), state="pending"
-                        )
-                        for i, step in enumerate(plan_verdict.plan.steps)
-                    ]
-                )
-                rendered = render_checklist(synthetic)
-                if rendered:
-                    intro_content = rendered
-            intro = await thread.send(intro_content)
-            self._start_goosecracker_stream(str(thread.id), intro, kind="agent")
+            await thread.send("🤖 Planning...")
         except Exception:
-            logger.exception("goosecracker: failed to post agent thread intro")
+            logger.exception("agent_sessions: failed to post agent thread intro")
         return AgentFlowOutcome(thread=thread)
 
     async def _orchestrator_verdict(
@@ -1696,14 +1625,23 @@ class ChatBot(discord.Client):
                 gp.clear(artifact_id)
                 return
 
-    async def _maybe_handle_goosecracker_reply(self, message: discord.Message) -> bool:
-        """Handle a reply inside a goosecracker thread (Model B re-run).
+    async def _maybe_handle_agent_thread_reply(self, message: discord.Message) -> bool:
+        """Queue an owner reply for the agent session bound to its thread.
 
-        Returns True when the message was a goosecracker thread message (handled,
-        so the caller skips the chat agent), False otherwise.
+        Looks up the session bound to the message thread, gates continuation on
+        the configured owner, and queues a turn. Returns True when the message
+        was handled and the caller should skip the chat agent, and False when
+        this thread has no bound agent session.
         """
+        # Import lazily because agent_sessions.api imports mcp, which reaches
+        # chat.api and then chat.bot during startup.
+        import agent_sessions.api
+
         thread_id = str(message.channel.id)
-        if not await asyncio.to_thread(goosecracker.is_goosecracker_thread, thread_id):
+        session_id = await asyncio.to_thread(
+            agent_sessions.api.session_id_for_thread, thread_id
+        )
+        if session_id is None:
             return False
 
         msg_id = str(message.id)
@@ -1712,39 +1650,20 @@ class ChatBot(discord.Client):
         if message.author.bot:
             await asyncio.to_thread(self._complete_lock, msg_id)
             return True
-        # Goosecracker threads are per-server ACL gated on the session's own repo
-        # scope (ADR 035 Phase 2): steering or continuing an in-flight turn needs
-        # the same `agent` grant that opened it. A repo-less run (an artifact the
-        # agent built with no repo) uses the empty scope.
-        guild_id = message.guild.id if message.guild else None
-        repo = await asyncio.to_thread(goosecracker.session_scope, thread_id) or ""
-        if not await asyncio.to_thread(
-            acl.is_granted, guild_id, message.author.id, "agent", repo
-        ):
-            scopes = await asyncio.to_thread(
-                acl.allowed_scopes, guild_id, message.author.id, "agent"
-            )
-            allowed = ", ".join(sorted(scopes)) or "none"
-            roast = await goosecracker.build_roast(message.content)
-            target = f"`{repo}`" if repo else "this"
+        if not acl.is_owner(message.author.id):
             await message.reply(
-                f"{roast}\nYou'd need an `agent` grant for {target} in this "
-                f"server to steer here. Allowed here: {allowed}."
+                "Only the configured owner can continue agent sessions."
             )
             await asyncio.to_thread(self._complete_lock, msg_id)
             return True
 
         try:
-            result = await asyncio.to_thread(
-                goosecracker.continue_session,
-                thread_id,
-                message.content,
-                msg_id,
-                author_id=str(message.author.id),
+            result = await agent_sessions.api.send_to_thread_session(
+                thread_id, message.content
             )
         except Exception:
-            logger.exception("goosecracker: failed to continue session")
-            await message.reply("Couldn't rebuild that one. Check the logs.")
+            logger.exception("agent_sessions: failed to continue session")
+            await message.reply("Couldn't send that to the session. Check the logs.")
             await asyncio.to_thread(self._complete_lock, msg_id)
             return True
 
@@ -1752,66 +1671,38 @@ class ChatBot(discord.Client):
             # Lost a race with session teardown; let normal handling take it.
             return False
 
-        action = result.get("action") if isinstance(result, dict) else None
-
-        if action == "queued":
-            # A turn is already running; the reply was queued for the next turn.
-            # Acknowledge with a ⏳ reaction on the user's own message instead of a
-            # text reply, so a burst of replies does not spam the thread. The
-            # runner flips it ⏳ → 👀 → ✅/❌ as the queued turn runs and finishes.
-            try:
-                await message.add_reaction(goosecracker.REACTION_QUEUED)
-            except discord.HTTPException:
-                logger.exception("goosecracker: failed to react queued on %s", msg_id)
-            await asyncio.to_thread(self._complete_lock, msg_id)
-            return True
-
-        if action == "steering":
-            # A turn is already running; the reply was enqueued as steering
-            # (ADR 035 Phase 2) rather than queued behind the turn. Acknowledge
-            # with 👀 directly (no ⏳ stage: it is not waiting for a slot, it will
-            # be picked up by the running guest at its next stage boundary).
-            try:
-                await message.add_reaction(goosecracker.REACTION_RUNNING)
-            except discord.HTTPException:
-                logger.exception("goosecracker: failed to react steering on %s", msg_id)
-            await asyncio.to_thread(self._complete_lock, msg_id)
-            return True
-
-        # Otherwise a new turn was dispatched (session was idle or reclaimed).
-        # ADR 035: see the matching comment in _handle_agent_command.
-        progress_msg = await message.reply("🤖 Planning...")
-        self._start_goosecracker_stream(thread_id, progress_msg, kind="agent")
+        try:
+            await message.add_reaction("⏳")
+        except discord.HTTPException:
+            logger.exception("agent_sessions: failed to react queued on %s", msg_id)
         await asyncio.to_thread(self._complete_lock, msg_id)
         return True
 
-    async def _engage_agent(self, message: discord.Message) -> None:
+    async def _engage_agent(self, message: discord.Message) -> AgentFlowOutcome | None:
         """A mention/reply/ambient engage: run the /agent flow (repo-less) off
-        this message, applying the same agent ACL check as ``/agent``. On a
-        missing grant, an EXPLICIT trigger (mention/reply) gets a short
-        refusal; an ambient engage stays silent (no spam in a channel nobody
-        asked the bot into). Marks the message lock completed either way.
+        this message, applying the owner-only agent gate. On a non-owner, an
+        EXPLICIT trigger (mention/reply) gets a short refusal; an ambient engage
+        stays silent (no spam in a channel nobody asked the bot into). Marks the
+        message lock completed either way.
+
+        The gate is duplicated here and in ``start_agent_flow`` on purpose. The
+        one in the shared flow is the security chokepoint, covering the slash
+        command too; this one exists so an ambient engage can be refused
+        SILENTLY, which the shared flow cannot express (it returns a chat_reply
+        its callers post).
         """
-        guild_id = message.guild.id if message.guild else None
         user = message.author
-        granted = await asyncio.to_thread(
-            acl.feature_enabled, guild_id, "agent"
-        ) and await asyncio.to_thread(acl.is_granted, guild_id, user.id, "agent", "")
-        explicit = should_respond(message, self.user)
-        if not granted:
-            if explicit:
-                scopes = await asyncio.to_thread(
-                    acl.allowed_scopes, guild_id, user.id, "agent"
-                )
-                allowed = ", ".join(sorted(scopes)) or "none"
+        if not acl.is_owner(user.id):
+            outcome = AgentFlowOutcome(
+                chat_reply="Only the configured owner can start or continue agent sessions."
+            )
+            if should_respond(message, self.user):
                 try:
-                    await message.reply(
-                        f"I can't run the agent for you here. Allowed: {allowed}."
-                    )
+                    await message.reply(outcome.chat_reply)
                 except discord.HTTPException:
-                    logger.exception("agent: failed to send refusal")
+                    logger.exception("agent: failed to send owner-only refusal")
             await asyncio.to_thread(self._complete_lock, str(message.id))
-            return
+            return outcome
 
         channel = message.channel
         if not isinstance(channel, discord.TextChannel):
@@ -1891,12 +1782,13 @@ class ChatBot(discord.Client):
                     )
             except discord.HTTPException:
                 logger.exception("orchestrator: failed to send chat reply")
-        elif outcome.thread is None and explicit:
+        elif outcome.thread is None:
             try:
                 await message.reply("Couldn't start that one. Check the logs.")
             except discord.HTTPException:
                 logger.exception("agent: failed to send start-failure reply")
         await asyncio.to_thread(self._complete_lock, str(message.id))
+        return outcome
 
     def _complete_lock(self, msg_id: str) -> None:
         """Mark a message lock completed (sync; call via asyncio.to_thread)."""

--- a/projects/monolith/chat/bot_agent_prompt_echo_test.py
+++ b/projects/monolith/chat/bot_agent_prompt_echo_test.py
@@ -4,10 +4,8 @@ The prompt otherwise survives only in the ~90-char thread title, so the echo
 posts it in full. Covers attribution, code-fence escaping (the prompt is
 user-controlled and must not break out of the block), and the 2000-char cap.
 
-Also covers the ADR 035 ack/checklist split in _handle_agent_command: the
-prompt echo (message A) must never be the message handed to the streaming
-progress editor (message B), so the echo stays put while the checklist
-above it gets live-edited.
+Also covers the durable agent-session path: the prompt echo and planning
+placeholder remain separate from session creation.
 """
 
 from types import SimpleNamespace
@@ -16,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import pytest
 
+from chat import orchestrator
 from chat.bot import ChatBot, _PROMPT_ECHO_MAX, _format_agent_prompt_echo
 
 _USER = SimpleNamespace(mention="<@123>")
@@ -61,11 +60,8 @@ def _make_bot() -> ChatBot:
 
 
 @pytest.mark.asyncio
-async def test_handle_agent_command_never_streams_the_prompt_echo():
-    """The prompt echo (message A) and the streamed checklist placeholder
-    (message B) are two distinct thread.send() calls, and only B is handed to
-    _start_goosecracker_stream. This locks in the split an earlier PR (#3096)
-    already made, so a future edit can't collapse them back into one message."""
+async def test_handle_agent_command_starts_session_after_prompt_echo():
+    """The owner starts an EmberVM session after the prompt echo and intro."""
     bot = _make_bot()
     bot._start_goosecracker_stream = MagicMock()
 
@@ -83,23 +79,29 @@ async def test_handle_agent_command_never_streams_the_prompt_echo():
     thread.id = 777
     thread.mention = "<#777>"
     echo_msg = MagicMock(name="echo_msg")
-    intro_msg = MagicMock(name="intro_msg")
-    thread.send = AsyncMock(side_effect=[echo_msg, intro_msg])
+    thread.send = AsyncMock(side_effect=[echo_msg, MagicMock(name="intro_msg")])
     channel.create_thread = AsyncMock(return_value=thread)
 
     with (
-        patch("chat.bot.acl.feature_enabled", return_value=True),
-        patch("chat.bot.acl.is_granted", return_value=True),
-        patch("chat.bot.goosecracker.start_agent_session"),
+        patch("chat.bot.acl.is_owner", return_value=True),
+        patch.object(
+            bot,
+            "_orchestrator_verdict",
+            AsyncMock(return_value=orchestrator.FailOpen("test")),
+        ),
+        patch(
+            "agent_sessions.api.start_session_for_thread", new_callable=AsyncMock
+        ) as start_session,
     ):
-        await bot._handle_agent_command(interaction, "add a health check", "some/repo")
+        await bot._handle_agent_command(
+            interaction, "add a health check", "jomcgi/homelab"
+        )
 
     assert thread.send.call_count == 2
     echo_call_content = thread.send.call_args_list[0][0][0]
     assert echo_call_content.startswith("Prompt from <@42>:")
 
-    # Only the second thread.send() result (the placeholder) is streamed; the
-    # ack is never touched by the editor.
-    bot._start_goosecracker_stream.assert_called_once_with(
-        str(thread.id), intro_msg, kind="agent"
+    start_session.assert_awaited_once_with(
+        str(thread.id), "add a health check", "jomcgi/homelab"
     )
+    bot._start_goosecracker_stream.assert_not_called()

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -15,6 +15,11 @@ from pydantic_ai import (
 from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
+from agent_sessions import api as agent_session_api
+from agent_sessions import mcp as agent_session_mcp
+from agent_sessions import store as agent_session_store
+from agent_sessions.models import AgentSession
+from agent_sessions.transport import Turn
 from chat.bot import ChatBot, create_bot, should_respond
 from chat.models import ReactionEvent
 
@@ -349,8 +354,7 @@ class TestStreamResponseContext:
 
 
 # ---------------------------------------------------------------------------
-# ChatBot._maybe_handle_goosecracker_reply -- agent-thread ACL gate + steering
-# (ADR 035 Phase 2)
+# ChatBot._maybe_handle_agent_thread_reply -- owner-only agent-session routing
 # ---------------------------------------------------------------------------
 
 
@@ -369,58 +373,195 @@ def _make_goosecracker_mock(**overrides) -> MagicMock:
     return mock
 
 
-class TestGoosecrackerReplySteering:
+class TestAgentSessionReplyOwnership:
     @pytest.mark.asyncio
-    async def test_permitted_user_steering_gets_running_reaction(self):
-        """A user holding the agent grant for the thread's repo steers a running
-        turn: 👀 reaction, no text reply, continue_session is called."""
+    async def test_owner_reply_is_queued_for_the_bound_session(
+        self, monkeypatch, engine
+    ):
+        """Only the configured owner can queue a follow-up agent turn."""
+        for module in (agent_session_api, agent_session_mcp, agent_session_store):
+            monkeypatch.setattr(module, "get_engine", lambda: engine)
+        with Session(engine) as session:
+            agent_session_store.create_session(
+                session,
+                "bound-thread",
+                "<guest>",
+                "main",
+                "luna",
+                discord_thread="555",
+            )
         bot = _make_bot()
         message = _make_message(content="also add tests", channel_id=555, msg_id=7)
         message.add_reaction = AsyncMock()
 
-        mock_gc = _make_goosecracker_mock()
-        mock_acl = MagicMock()
-        mock_acl.is_granted = MagicMock(return_value=True)
-
         with (
-            patch("chat.bot.goosecracker", mock_gc),
-            patch("chat.bot.acl", mock_acl),
+            patch("chat.bot.acl.is_owner", return_value=True),
+            patch(
+                "agent_sessions.api.send_to_thread_session",
+                AsyncMock(return_value={"action": "queued"}),
+            ) as send,
             patch.object(bot, "_complete_lock", MagicMock()),
         ):
-            handled = await bot._maybe_handle_goosecracker_reply(message)
+            handled = await bot._maybe_handle_agent_thread_reply(message)
 
         assert handled is True
-        mock_gc.continue_session.assert_called_once()
-        message.add_reaction.assert_called_once_with(mock_gc.REACTION_RUNNING)
+        send.assert_awaited_once_with("555", "also add tests")
+        message.add_reaction.assert_awaited_once_with("⏳")
         message.reply.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_unpermitted_user_gets_refusal_and_nothing_enqueued(self):
-        """A user without the agent grant for the thread's repo gets a refusal
-        reply naming the missing grant; continue_session is never called."""
+    async def test_non_owner_gets_owner_only_refusal_and_nothing_enqueued(self):
+        """A non-owner cannot continue a bound session, regardless of repo ACLs."""
         bot = _make_bot()
         message = _make_message(content="also add tests", channel_id=555, msg_id=7)
         message.add_reaction = AsyncMock()
 
-        mock_gc = _make_goosecracker_mock()
-        mock_acl = MagicMock()
-        mock_acl.is_granted = MagicMock(return_value=False)
-        mock_acl.allowed_scopes = MagicMock(return_value={"otherrepo"})
-
         with (
-            patch("chat.bot.goosecracker", mock_gc),
-            patch("chat.bot.acl", mock_acl),
+            patch("chat.bot.acl.is_owner", return_value=False),
+            patch("agent_sessions.api.session_id_for_thread", return_value=3),
+            patch("agent_sessions.api.send_to_thread_session", AsyncMock()) as send,
             patch.object(bot, "_complete_lock", MagicMock()),
         ):
-            handled = await bot._maybe_handle_goosecracker_reply(message)
+            handled = await bot._maybe_handle_agent_thread_reply(message)
 
         assert handled is True
-        mock_gc.continue_session.assert_not_called()
-        message.reply.assert_called_once()
-        refusal = message.reply.call_args[0][0]
-        assert "homelab" in refusal
-        assert "otherrepo" in refusal
+        send.assert_not_awaited()
+        message.reply.assert_awaited_once_with(
+            "Only the configured owner can continue agent sessions."
+        )
         message.add_reaction.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_owner_ambient_engage_returns_refusal_without_session(
+    monkeypatch, engine
+):
+    monkeypatch.setenv("OWNER_DISCORD_USER_ID", "999")
+    bot = _make_bot()
+    bot._complete_lock = MagicMock()
+    bot.start_agent_flow = AsyncMock()
+    message = _make_message(content="build it")
+    message.channel = MagicMock(spec=discord.TextChannel)
+    message.channel.id = 99
+    message.channel.guild = None
+
+    outcome = await bot._engage_agent(message)
+
+    assert outcome is not None
+    assert outcome.chat_reply == (
+        "Only the configured owner can start or continue agent sessions."
+    )
+    bot.start_agent_flow.assert_not_awaited()
+    with Session(engine) as session:
+        assert len(session.exec(select(AgentSession)).all()) == 0
+    # AMBIENT (no mention, no reply-to-bot): refused SILENTLY. A channel that
+    # merely opted into ambient mode must not fill with refusals aimed at people
+    # who were not addressing the bot.
+    message.reply.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_owner_explicit_mention_gets_spoken_refusal(monkeypatch, engine):
+    """An EXPLICIT trigger is refused out loud, unlike the ambient case above."""
+    monkeypatch.setenv("OWNER_DISCORD_USER_ID", "999")
+    bot = _make_bot()
+    bot._complete_lock = MagicMock()
+    bot.start_agent_flow = AsyncMock()
+    message = _make_message(content="build it", mentions=[bot.user])
+    message.channel = MagicMock(spec=discord.TextChannel)
+    message.channel.id = 99
+    message.channel.guild = None
+
+    outcome = await bot._engage_agent(message)
+
+    bot.start_agent_flow.assert_not_awaited()
+    message.reply.assert_awaited_once_with(outcome.chat_reply)
+    with Session(engine) as session:
+        assert len(session.exec(select(AgentSession)).all()) == 0
+
+
+@pytest.mark.asyncio
+async def test_non_owner_slash_agent_returns_refusal_without_session(
+    monkeypatch, engine
+):
+    monkeypatch.setenv("OWNER_DISCORD_USER_ID", "999")
+    bot = _make_bot()
+    interaction = MagicMock()
+    interaction.user.id = 42
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.response.defer = AsyncMock()
+    interaction.followup.send = AsyncMock()
+
+    await bot._handle_agent_command(interaction, "build it", "")
+
+    with Session(engine) as session:
+        assert len(session.exec(select(AgentSession)).all()) == 0
+    interaction.followup.send.assert_awaited_once_with(
+        "Only the configured owner can start or continue agent sessions."
+    )
+
+
+@pytest.mark.asyncio
+async def test_owner_slash_flow_creates_luna_session_bound_to_thread(
+    monkeypatch, engine
+):
+    monkeypatch.setenv("OWNER_DISCORD_USER_ID", "42")
+    for module in (agent_session_api, agent_session_mcp, agent_session_store):
+        monkeypatch.setattr(module, "get_engine", lambda: engine)
+    monkeypatch.setattr(agent_session_api, "_schedule_next_message", lambda _id: None)
+    bot = _make_bot()
+    bot._orchestrator_verdict = AsyncMock(
+        return_value=__import__("chat.orchestrator", fromlist=["FailOpen"]).FailOpen(
+            "test"
+        )
+    )
+    channel = _flow_channel()
+    thread = MagicMock(id=555, mention="<#555>")
+    thread.send = AsyncMock()
+    channel.create_thread = AsyncMock(return_value=thread)
+
+    outcome = await bot.start_agent_flow(
+        channel, SimpleNamespace(id=42, mention="<@42>"), "build it", "jomcgi/homelab"
+    )
+
+    assert outcome.thread is thread
+    with Session(engine) as session:
+        row = session.exec(select(AgentSession)).one()
+        assert row.model == "luna"
+        assert row.repo == "jomcgi/homelab"
+        assert row.discord_thread == "555"
+
+
+@pytest.mark.asyncio
+async def test_unbound_agent_thread_reply_falls_through(monkeypatch, engine):
+    for module in (agent_session_api, agent_session_mcp, agent_session_store):
+        monkeypatch.setattr(module, "get_engine", lambda: engine)
+    bot = _make_bot()
+    message = _make_message(content="continue")
+    message.channel.id = 555
+
+    assert await bot._maybe_handle_agent_thread_reply(message) is False
+
+
+@pytest.mark.asyncio
+async def test_terminal_notification_routes_to_thread_or_default_channel(monkeypatch):
+    calls = []
+
+    async def notify(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(agent_session_mcp.agent_api, "notify", notify)
+    turn = Turn("done", "completed", "end_turn", False, [], 1, "s", {}, 0, 1, [])
+    bound = AgentSession(
+        local_session_id="s", workspace="w", branch="main", discord_thread="555"
+    )
+    default = AgentSession(local_session_id="default", workspace="w", branch="main")
+
+    await agent_session_mcp._notify_terminal(turn, "done", "completed", bound)
+    await agent_session_mcp._notify_terminal(turn, "done", "completed", default)
+
+    assert calls[0][1]["channel"] == "555"
+    assert calls[1][1]["channel"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -430,12 +571,15 @@ class TestGoosecrackerReplySteering:
 
 class TestAttentionGate:
     @pytest.mark.asyncio
-    async def test_mention_in_ambient_channel_with_grant_starts_agent_flow(self):
-        """A mention in an AMBIENT channel where the author holds the agent
-        grant runs the shared agent flow off the trigger message, and
+    async def test_mention_in_ambient_channel_by_owner_starts_agent_flow(
+        self, monkeypatch
+    ):
+        """A mention in an AMBIENT channel from the owner runs the shared agent
+        flow off the trigger message, and
         completes the lock (Phase 3 containment: agent-triggering only fires
         in opted-in channels)."""
         bot = _make_bot()
+        monkeypatch.setenv("OWNER_DISCORD_USER_ID", "42")
         bot_user = bot.user
 
         message = _make_message(content="hey bot help", mentions=[bot_user])
@@ -453,14 +597,16 @@ class TestAttentionGate:
             patch("chat.bot.acl.ambient_channels", return_value={"99"}),
             patch("chat.bot.directives.get_active", return_value=""),
             patch("chat.bot.directives.get_active_version", return_value=0),
-            patch("chat.bot.acl.feature_enabled", return_value=True),
-            patch("chat.bot.acl.is_granted", return_value=True),
             patch("chat.bot.attention_log.log_decision", MagicMock()),
             patch(
                 "chat.bot.attention.needs_agent", AsyncMock(return_value=True)
             ) as mock_needs_agent,
             patch.object(
-                bot, "start_agent_flow", AsyncMock(return_value=MagicMock())
+                bot,
+                "start_agent_flow",
+                AsyncMock(
+                    return_value=SimpleNamespace(chat_reply=None, thread=MagicMock())
+                ),
             ) as mock_start_flow,
             patch.object(bot, "_complete_lock", MagicMock()) as mock_complete_lock,
         ):
@@ -602,11 +748,13 @@ class TestAttentionGate:
             mock_engage_agent.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_mention_in_ambient_channel_without_grant_gets_refusal(self):
-        """A mention in an ambient channel from a user lacking the agent grant
-        gets a refusal reply naming the allowed scopes; start_agent_flow is
-        never called."""
+    async def test_mention_in_ambient_channel_by_non_owner_gets_refusal(
+        self, monkeypatch
+    ):
+        """A non-owner ambient mention gets the owner-only refusal without
+        reaching the session-start flow."""
         bot = _make_bot()
+        monkeypatch.setenv("OWNER_DISCORD_USER_ID", "999")
         bot_user = bot.user
 
         message = _make_message(content="hey bot help", mentions=[bot_user])
@@ -624,9 +772,6 @@ class TestAttentionGate:
             patch("chat.bot.acl.ambient_channels", return_value={"99"}),
             patch("chat.bot.directives.get_active", return_value=""),
             patch("chat.bot.directives.get_active_version", return_value=0),
-            patch("chat.bot.acl.feature_enabled", return_value=True),
-            patch("chat.bot.acl.is_granted", return_value=False),
-            patch("chat.bot.acl.allowed_scopes", return_value={"homelab"}),
             patch("chat.bot.attention_log.log_decision", MagicMock()),
             patch("chat.bot.attention.needs_agent", AsyncMock(return_value=True)),
             patch.object(bot, "start_agent_flow", AsyncMock()) as mock_start_flow,
@@ -639,9 +784,9 @@ class TestAttentionGate:
             await bot.on_message(message)
 
             mock_start_flow.assert_not_called()
-            message.reply.assert_called_once()
-            refusal = message.reply.call_args[0][0]
-            assert "homelab" in refusal
+            message.reply.assert_awaited_once_with(
+                "Only the configured owner can start or continue agent sessions."
+            )
             mock_complete_lock.assert_called_once_with(str(message.id))
 
     @pytest.mark.asyncio
@@ -1359,7 +1504,7 @@ class TestStartAgentFlowOrchestrator:
                 "_orchestrator_chat_reply",
                 AsyncMock(return_value=("here is a friendly answer", [], [])),
             ),
-            patch("chat.bot.goosecracker.start_agent_session") as mock_start_session,
+            patch("chat.bot.acl.is_owner", return_value=True),
         ):
             outcome = await bot.start_agent_flow(channel, user, "name my boat", "")
 
@@ -1367,16 +1512,18 @@ class TestStartAgentFlowOrchestrator:
         assert outcome.generated_files == []
         assert outcome.thread is None
         channel.create_thread.assert_not_called()
-        mock_start_session.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_plan_verdict_submits_raw_task_and_prerenders_checklist_from_plan(
+    async def test_plan_verdict_opens_thread_and_submits_raw_prompt(
         self,
     ):
-        """A PlanVerdict opens a thread, submits the RAW prompt as the task (the
-        plan supersedes the advisory brief, so no brief markdown is prepended),
-        threads the plan through to start_agent_session, and pre-renders the
-        checklist from the plan's step stage-titles."""
+        """A PlanVerdict opens a thread and submits the RAW prompt.
+
+        The plan itself is no longer consumed: its only reader was the retired
+        goosecracker runner, which delivered it to the guest via injectedContext.
+        Agent sessions take the prompt alone, so a PlanVerdict now behaves
+        exactly like a FailOpen here. Kept as a regression test that a non-chat
+        verdict still opens a thread rather than silently doing nothing."""
         from chat import orchestrator
         from chat.orchestrator_plan import Plan, PlanStep
 
@@ -1404,24 +1551,26 @@ class TestStartAgentFlowOrchestrator:
         )
         with (
             patch.object(bot, "_orchestrator_verdict", AsyncMock(return_value=verdict)),
-            patch("chat.bot.goosecracker.start_agent_session") as mock_start_session,
-            patch.object(bot, "_start_goosecracker_stream") as mock_stream,
+            patch("chat.bot.acl.is_owner", return_value=True),
+            patch(
+                "agent_sessions.api.start_session_for_thread", new_callable=AsyncMock
+            ) as start_session,
         ):
             outcome = await bot.start_agent_flow(channel, user, "raw prompt", "")
 
         assert outcome.thread is thread
         # The submitted task is the raw prompt (ground truth), never brief-prefixed.
-        task = mock_start_session.call_args.kwargs["task"]
-        assert task == "raw prompt"
-        assert "Task brief" not in task
-        # The validated plan is threaded through so the runner renders the router.
-        assert mock_start_session.call_args.kwargs["plan"] is plan
-        # The checklist is pre-rendered from the plan's step stage-titles (the
-        # same mapping the rendered router's progress markers use: query ->
-        # "Answering", implement -> "Implementing").
+        # None, not "", because start_session_for_thread validates a non-None repo
+        # against REPO_CATALOG.
+        start_session.assert_awaited_once_with("555", "raw prompt", None)
+        # The echo is an attributed, FENCED block (_format_agent_prompt_echo), so
+        # match on the prompt being inside it rather than on the exact framing.
+        # The checklist that used to be pre-rendered here from the plan's steps is
+        # gone with the plan itself, so the intro is now the bare placeholder.
         sent_bodies = [c.args[0] for c in thread.send.call_args_list]
-        assert any("Answering" in b and "Implementing" in b for b in sent_bodies)
-        mock_stream.assert_called_once()
+        assert sent_bodies[0].startswith("Prompt from ")
+        assert "raw prompt" in sent_bodies[0]
+        assert sent_bodies[1] == "🤖 Planning..."
 
     @pytest.mark.asyncio
     async def test_failopen_preserves_raw_prompt_submit(self):
@@ -1440,13 +1589,17 @@ class TestStartAgentFlowOrchestrator:
         verdict = orchestrator.FailOpen("orchestrator disabled")
         with (
             patch.object(bot, "_orchestrator_verdict", AsyncMock(return_value=verdict)),
-            patch("chat.bot.goosecracker.start_agent_session") as mock_start_session,
-            patch.object(bot, "_start_goosecracker_stream"),
+            patch("chat.bot.acl.is_owner", return_value=True),
+            patch(
+                "agent_sessions.api.start_session_for_thread", new_callable=AsyncMock
+            ) as start_session,
         ):
             outcome = await bot.start_agent_flow(channel, user, "raw prompt", "")
 
         assert outcome.thread is thread
-        assert mock_start_session.call_args.kwargs["task"] == "raw prompt"
+        # A repo-less run passes None, not "": start_session_for_thread validates
+        # any non-None repo against REPO_CATALOG, and "" is not in it.
+        start_session.assert_awaited_once_with("777", "raw prompt", None)
         sent_bodies = [c.args[0] for c in thread.send.call_args_list]
         assert "🤖 Planning..." in sent_bodies
 

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -25,6 +25,7 @@ from sqlmodel import Session, select
 
 from core.db import get_engine
 from chat.models import GoosecrackerSession, GoosecrackerSteering, Message
+from chat.acl import is_owner, owner_id
 
 if TYPE_CHECKING:
     from chat import orchestrator_plan
@@ -63,22 +64,6 @@ AGENT_TIER = ""
 # Shown when the owner gate rejects someone and the qwen roast path is
 # unavailable (model down), so a non-owner always gets a clear refusal.
 _FALLBACK_ROAST = "Nice try. You need an agent grant to drive that thread."
-
-
-def owner_id() -> str:
-    """The configured owner Discord user id, or "" when unset."""
-    return os.environ.get("OWNER_DISCORD_USER_ID", "")
-
-
-def is_owner(user_id: int | str) -> bool:
-    """True only when an owner id is configured and matches.
-
-    Fails closed: an unset OWNER_DISCORD_USER_ID rejects everyone rather than
-    opening the agent (which runs arbitrary code in a microVM and spends model
-    budget) to the whole server.
-    """
-    owner = owner_id()
-    return bool(owner) and str(user_id) == owner
 
 
 def _join_transcript(existing: str, message: str) -> str:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.442
+      targetRevision: 0.285.443
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Why

`/agent` has been dead in production since `be8a5c88f` retired the goose coding agents. `chat/goosecracker.py` lazily imports `submit` from `goosecracker.api`; that symbol no longer exists, and the `ImportError` is swallowed by `start_agent_flow`'s `except`, so every invocation replied "Couldn't start that one. Check the logs." `goosecracker_test.py` monkeypatches `submit`, which is why CI stayed green over a broken command.

That commit named the replacement itself: *"Discord-triggered agent work now belongs to EmberVM's claude-runtime sessions."* This wires it up.

## What

- **Thread == session, 1:1.** New unique `discord_thread` column on `agent_sessions`, with migration. `/agent` opens a thread and starts a session; replies in that thread queue follow-up turns; terminal turns post back into the thread through the existing notify outbox (a thread id is a valid channel id, so no new delivery path).
- **Owner-only**, via `OWNER_DISCORD_USER_ID`, replacing the ADR 029 per-repo grant gate for this feature. The gate sits on `start_agent_flow`, not the slash handler, because the ADR 035 mention/ambient path at `bot.py` is a second caller any user can trigger. `_engage_agent` keeps its own copy so an ambient engage can be refused *silently*, which the shared flow cannot express (it returns a `chat_reply` its callers post).
- **Default model `luna`** (codex family). Repo hydration already worked (ADR 050); this just gives it a Discord entry point.
- **Orchestrator:** `ChatVerdict` unchanged. `PlanVerdict` handling dropped, because the plan's only reader was the retired runner's `injectedContext` path.

## Notable fixes found while building this

- `send_to_thread_session` is **async** on purpose. It calls `_schedule_next_message`, which calls `asyncio.create_task` and so needs a running event loop. A sync version invoked through `asyncio.to_thread` raised `RuntimeError` *after* the turn was persisted, meaning every follow-up reply would report failure for work that the 5s sweep then ran anyway.
- Restored the explicit/ambient split on the owner refusal. An ambient engage stays silent, so a channel that merely opted into ambient mode does not fill with refusals aimed at people who were not addressing the bot.

## Not in this PR

Removing the now-unreachable goosecracker code, and the GitHub push/PR lane for guests. Both follow.

## Test

`Executed 214 out of 759 tests: 759 tests pass` on BuildBuddy. 12 agent-session tests in `bot_on_message_test.py` (both non-owner refusal paths, including the ambient bypass asserted directly) plus the unique-constraint test in `store_test.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)