### PR TITLE
fix(monolith): /agent skips the chat-vs-agent orchestrator

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.368
+version: 0.89.369
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.368
+      targetRevision: 0.89.369
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.443
+version: 0.285.444
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -1208,7 +1208,11 @@ class ChatBot(discord.Client):
             return
 
         await interaction.response.defer(thinking=True)
-        outcome = await self.start_agent_flow(channel, interaction.user, prompt, repo)
+        # route_via_orchestrator=False: running /agent IS the decision that this
+        # is agent work, so the chat-vs-agent verdict does not get to overrule it.
+        outcome = await self.start_agent_flow(
+            channel, interaction.user, prompt, repo, route_via_orchestrator=False
+        )
         if outcome.chat_reply is not None:
             # ADR 036: the orchestrator routed this to chat, so reply inline
             # instead of opening a session thread. Text + any chart go in ONE
@@ -1241,16 +1245,23 @@ class ChatBot(discord.Client):
         prompt: str,
         repo: str,
         trigger_message: discord.Message | None = None,
+        route_via_orchestrator: bool = True,
     ) -> AgentFlowOutcome:
         """Shared agent dispatch for the /agent slash command AND mention/ambient
-        triggers (ADR 035), routed through the ADR 036 orchestrator.
+        triggers (ADR 035).
 
-        The orchestrator verdict selects the branch:
+        ``route_via_orchestrator`` decides whether the ADR 036 chat-vs-agent
+        verdict runs at all:
 
-        - ``chat`` - no thread, no session, no checklist: produce a
-          conversational reply (local Qwen) and return it for the caller to post.
-        - A non-chat verdict opens a durable EmberVM session thread and queues
-          the raw prompt for the selected repo.
+        - True (the mention/ambient path): the bot has to judge whether a message
+          aimed at it is a task or conversation, so a ``chat`` verdict returns a
+          conversational reply and opens no thread.
+        - False (the ``/agent`` slash command): the invoker already made that
+          judgement by running the command and choosing a repo, so ALWAYS open a
+          thread and start a session. Letting a model overrule an explicit
+          invocation is how a deliberate ``/agent`` ends up answered with a chat
+          summary and no session. Skipping the call also removes a paid
+          OpenRouter round trip from every ``/agent``.
 
         Does not send origin-channel acknowledgements. Returns an
         :class:`AgentFlowOutcome`.
@@ -1262,19 +1273,22 @@ class ChatBot(discord.Client):
         guild_id = str(channel.guild.id) if channel.guild else ""
         channel_id = str(channel.id)
 
-        verdict = await self._orchestrator_verdict(
-            guild_id, channel_id, user, prompt, repo
-        )
+        if route_via_orchestrator:
+            verdict = await self._orchestrator_verdict(
+                guild_id, channel_id, user, prompt, repo
+            )
 
-        if isinstance(verdict, orchestrator.ChatVerdict):
-            reply, files, proposals = await self._orchestrator_chat_reply(
-                channel_id, prompt, verdict, str(user.id)
-            )
-            return AgentFlowOutcome(
-                chat_reply=reply,
-                generated_files=files,
-                pending_proposal=proposals,
-            )
+            if isinstance(verdict, orchestrator.ChatVerdict):
+                reply, files, proposals = await self._orchestrator_chat_reply(
+                    channel_id, prompt, verdict, str(user.id)
+                )
+                return AgentFlowOutcome(
+                    chat_reply=reply,
+                    generated_files=files,
+                    pending_proposal=proposals,
+                )
+        else:
+            verdict = None
 
         # Agent sessions use the selected repo directly. The orchestrator's
         # conversational verdict above remains unchanged.

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -1514,6 +1514,47 @@ class TestStartAgentFlowOrchestrator:
         channel.create_thread.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_slash_path_skips_the_orchestrator_entirely(self):
+        """/agent always opens a session, and never pays for a route call.
+
+        Running /agent IS the decision that this is agent work, so a chat verdict
+        must not be able to overrule it. Before this, an explicit /agent with a
+        repo selected could be answered with a conversational summary and no
+        session at all.
+        """
+        bot = _make_bot()
+        channel = _flow_channel()
+        thread = MagicMock()
+        thread.id = 909
+        thread.send = AsyncMock()
+        channel.create_thread = AsyncMock(return_value=thread)
+
+        with (
+            patch.object(bot, "_orchestrator_verdict", AsyncMock()) as verdict_call,
+            patch.object(bot, "_orchestrator_chat_reply", AsyncMock()) as chat_call,
+            patch("chat.bot.acl.is_owner", return_value=True),
+            patch(
+                "agent_sessions.api.start_session_for_thread", new_callable=AsyncMock
+            ) as start_session,
+        ):
+            outcome = await bot.start_agent_flow(
+                channel,
+                MagicMock(),
+                "fix the flaky test",
+                "jomcgi/homelab",
+                route_via_orchestrator=False,
+            )
+
+        assert outcome.thread is thread
+        assert outcome.chat_reply is None
+        # Not merely ignored: never called, so /agent costs no OpenRouter round trip.
+        verdict_call.assert_not_awaited()
+        chat_call.assert_not_awaited()
+        start_session.assert_awaited_once_with(
+            "909", "fix the flaky test", "jomcgi/homelab"
+        )
+
+    @pytest.mark.asyncio
     async def test_plan_verdict_opens_thread_and_submits_raw_prompt(
         self,
     ):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.443
+      targetRevision: 0.285.444
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

Running `/agent` with a prompt and a repo returned a conversational summary and opened **no session at all**. Confirmed against prod: the invocation created no `agent_sessions` row.

The ADR 036 route call returned a `ChatVerdict`, so `start_agent_flow` posted an inline reply and never created a thread.

## Why the old behaviour was wrong

That verdict exists for the ADR 035 mention/ambient path, where the bot genuinely has to judge whether a message aimed at it is a task or conversation. On an explicit `/agent` invocation the invoker has already made that judgement, by running the command and choosing a repo from the autocomplete. Letting a model overrule an explicit invocation is the wrong tradeoff.

It got worse when the plan half was retired. The orchestrator used to earn its place on this path by compiling a plan the runner consumed; with plans gone and the repo picked from a dropdown, its only remaining effect on `/agent` was the power to refuse.

## Change

The slash path passes `route_via_orchestrator=False`, and the orchestrator is **not consulted at all** rather than consulted-and-ignored. That also drops a paid OpenRouter round trip from every `/agent`. The mention/ambient path is unchanged.

The owner gate stays ahead of the branch, so it still covers both entry points. On the skip path `verdict` is `None`, and the ADR 036 telemetry backfill reads it via `getattr(verdict, "brief_id", None)`, so `link_thread` is correctly skipped rather than raising.

## Test

`Executed 213 out of 758 tests: 758 tests pass`.

The new test asserts the orchestrator is never *called*, not merely that its verdict is ignored, so a later refactor cannot quietly restore the cost while preserving the behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)