### PR TITLE
fix(monolith): keep agent thread turns on the session model and post full output

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.369
+version: 0.89.370
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.369
+      targetRevision: 0.89.370
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -70,7 +70,14 @@ async def send_to_thread_session(thread_id: str, message: str) -> dict | None:
     if row is None:
         return None
     model_family(row.model)
-    turn = await asyncio.to_thread(_persist_pending_message, session_id, message, None)
+    # row.model, NOT None. None is not "unset", it resolves to the CLAUDE family
+    # (model_family(None) == "claude"), so a None here ran the claude adapter
+    # against a session whose CLI transcript belongs to codex and died with
+    # "claude exited before init / No conversation found with session ID".
+    # Every follow-up turn must stay inside the family the session pinned.
+    turn = await asyncio.to_thread(
+        _persist_pending_message, session_id, message, row.model
+    )
     await asyncio.to_thread(_set_session_status, session_id, "running")
     _schedule_next_message(session_id)
     return {"action": "queued", "session_id": session_id, "turn": turn}

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -175,6 +175,39 @@ def _turn_status(turn: Turn) -> str:
     return "completed"
 
 
+# Discord's hard per-message limit is 2000; leave room for a status prefix and
+# the outbox's own formatting.
+_DISCORD_CHUNK = 1800
+# Cap on how many messages one turn may post into a thread. A long agent turn
+# can run to tens of KB, and pasting all of it would bury the thread.
+_MAX_THREAD_CHUNKS = 4
+
+
+def _chunk_for_discord(text: str) -> list[str]:
+    """Split a turn result into Discord-sized messages, preferring line breaks.
+
+    Bounded by _MAX_THREAD_CHUNKS with an explicit truncation marker, so a huge
+    turn is visibly cut rather than silently losing its tail.
+    """
+    text = text.strip()
+    if not text:
+        return []
+    chunks: list[str] = []
+    while text and len(chunks) < _MAX_THREAD_CHUNKS:
+        if len(text) <= _DISCORD_CHUNK:
+            chunks.append(text)
+            text = ""
+            break
+        split = text.rfind("\n", 0, _DISCORD_CHUNK)
+        if split <= 0:
+            split = _DISCORD_CHUNK
+        chunks.append(text[:split].rstrip())
+        text = text[split:].lstrip()
+    if text:
+        chunks[-1] = chunks[-1][: _DISCORD_CHUNK - 40].rstrip() + "\n\n... (truncated)"
+    return chunks
+
+
 async def _notify_terminal(
     turn: Turn, summary: str, status: str, row: AgentSession | None = None
 ) -> None:
@@ -184,15 +217,32 @@ async def _notify_terminal(
         level = "info"
     else:
         level = "warn"
+
+    thread = row.discord_thread if row is not None else None
+    if thread:
+        # A thread is a reading surface, so post the VERBATIM result. The voice
+        # summary is the first sentence capped at 200 chars, which is right for
+        # the voice lane and useless here: it turned a multi-paragraph answer
+        # into "The workspace is clean." with the rest silently dropped.
+        body = turn.result or summary
+        chunks = _chunk_for_discord(body) or [summary or "(no output)"]
+        if status == "needs_input":
+            chunks[0] = f"**Needs input**\n{chunks[0]}"
+        elif status != "completed":
+            chunks[0] = f"**Turn ended: {status}**\n{chunks[0]}"
+        for chunk in chunks:
+            await agent_api.notify(chunk, level=level, channel=thread)
+        return
+
+    # No thread bound (MCP or /agents UI): the short voice summary is the right
+    # shape for the default channel, which is a notification surface. The status
+    # prefix stays gated on `row` exactly as before, so this change is confined
+    # to the thread lane.
     if row is not None and status == "needs_input":
         summary = f"Needs input: {summary}"
     elif row is not None and status == "warn":
         summary = f"Warning: {summary}"
-    summary = summary[:2000]
-    if row is not None and row.discord_thread:
-        await agent_api.notify(summary, level=level, channel=row.discord_thread)
-    else:
-        await agent_api.notify(summary, level=level, channel=None)
+    await agent_api.notify(summary[:2000], level=level, channel=None)
 
 
 def _get_pending_message_sync(session_id: int, turn_seq: int):

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.444
+version: 0.285.445
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -18,7 +18,7 @@ from sqlmodel.pool import StaticPool
 from agent_sessions import api as agent_session_api
 from agent_sessions import mcp as agent_session_mcp
 from agent_sessions import store as agent_session_store
-from agent_sessions.models import AgentSession
+from agent_sessions.models import AgentSession, PendingMessage
 from agent_sessions.transport import Turn
 from chat.bot import ChatBot, create_bot, should_respond
 from chat.models import ReactionEvent
@@ -562,6 +562,87 @@ async def test_terminal_notification_routes_to_thread_or_default_channel(monkeyp
 
     assert calls[0][1]["channel"] == "555"
     assert calls[1][1]["channel"] is None
+
+
+@pytest.mark.asyncio
+async def test_thread_delivery_posts_the_verbatim_result_not_the_voice_summary(
+    monkeypatch,
+):
+    """A bound thread gets the whole answer; the default channel gets the summary.
+
+    voice.extract_voice_summary is the first sentence capped at 200 chars, which
+    is right for the voice lane and wrong for a thread: it turned a
+    multi-paragraph answer into one sentence and silently dropped the rest.
+    """
+    calls = []
+
+    async def notify(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(agent_session_mcp.agent_api, "notify", notify)
+    body = "First sentence. Second paragraph with the actual detail."
+    turn = Turn(body, "completed", "end_turn", False, [], 1, "s", {}, 0, 1, [])
+    bound = AgentSession(
+        local_session_id="s", workspace="w", branch="main", discord_thread="555"
+    )
+    default = AgentSession(local_session_id="d", workspace="w", branch="main")
+
+    await agent_session_mcp._notify_terminal(
+        turn, "First sentence.", "completed", bound
+    )
+    await agent_session_mcp._notify_terminal(
+        turn, "First sentence.", "completed", default
+    )
+
+    assert calls[0][0][0] == body
+    assert calls[1][0][0] == "First sentence."
+
+
+@pytest.mark.asyncio
+async def test_long_thread_result_is_chunked_and_marked_when_truncated(monkeypatch):
+    """A huge turn splits into bounded messages and says so when it is cut."""
+    calls = []
+
+    async def notify(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(agent_session_mcp.agent_api, "notify", notify)
+    body = "\n".join(f"line {i} " + "x" * 100 for i in range(200))
+    turn = Turn(body, "completed", "end_turn", False, [], 1, "s", {}, 0, 1, [])
+    bound = AgentSession(
+        local_session_id="s", workspace="w", branch="main", discord_thread="777"
+    )
+
+    await agent_session_mcp._notify_terminal(turn, "sum", "completed", bound)
+
+    assert len(calls) == agent_session_mcp._MAX_THREAD_CHUNKS
+    assert all(len(c[0][0]) <= 2000 for c in calls)
+    assert all(c[1]["channel"] == "777" for c in calls)
+    assert calls[-1][0][0].endswith("... (truncated)")
+
+
+@pytest.mark.asyncio
+async def test_follow_up_turn_keeps_the_session_pinned_model(monkeypatch, engine):
+    """A thread reply must run the session's own model, never the claude default.
+
+    Passing None here is not "unset": model_family(None) is the claude family, so
+    a luna session's follow-up ran the claude adapter against a codex transcript
+    and died with "claude exited before init / No conversation found".
+    """
+    for module in (agent_session_api, agent_session_mcp, agent_session_store):
+        monkeypatch.setattr(module, "get_engine", lambda: engine)
+    monkeypatch.setattr(agent_session_api, "_schedule_next_message", lambda _id: None)
+    with Session(engine) as session:
+        agent_session_store.create_session(
+            session, "pinned", "<guest>", "main", "luna", discord_thread="888"
+        )
+
+    result = await agent_session_api.send_to_thread_session("888", "and now the tests")
+
+    assert result is not None
+    with Session(engine) as session:
+        queued = session.exec(select(PendingMessage)).all()
+    assert [m.model for m in queued] == ["luna"]
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.444
+      targetRevision: 0.285.445
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Two bugs from the `/agent` session wiring, both observed on a live `luna` session.

## 1. Every follow-up turn in a thread failed with a 422

```
claude exited before init, exit code 1
CLI stderr: No conversation found with session ID: 019fd98c-...
```

`send_to_thread_session` queued the turn with `model=None`. `None` is not "unset": `model_family(None)` is the **claude** family. So turn 1 ran `luna` (codex) and turn 2 ran claude, which then tried to `--resume` a CLI session id that only exists in the codex adapter's transcript store.

It now queues `row.model`, so a turn can never leave the family its session pinned. The MCP send path already did this via `model or row.model`; the facade dropped it, and family pinning is enforced at the MCP tool boundary rather than inside the facade, so nothing caught it.

## 2. A thread showed only the first sentence of the answer

Delivery posted the voice summary, which is `extract_voice_summary`: the first sentence capped at 200 chars. Correct for the voice lane, wrong for a thread. A multi-paragraph answer arrived as `The workspace is clean.` with the rest silently dropped.

A bound thread now gets the verbatim `turn.result`, split on line boundaries into Discord-sized messages, capped at 4 with an explicit `... (truncated)` marker so a very long turn is visibly cut rather than losing its tail. Unbound sessions (MCP, `/agents` UI) keep the summary: the default channel is a notification surface, not a reading one. The status-prefix behaviour on that path is deliberately left byte-identical, so this change is confined to the thread lane.

## Test

`Executed 59 out of 758 tests: 758 tests pass`.

New coverage: a bound thread receives the whole body while the default channel receives the summary; a long result chunks and marks truncation; and a follow-up on a `luna` session queues with `model == "luna"` (the regression that caused the 422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)