### PR TITLE
fix(monolith): repoint the shared provider-key OnePasswordItem after rename

### DIFF
--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -185,14 +185,20 @@ semgrep:
   onepassword:
     itemPath: "vaults/k8s-homelab/items/semgrep-mcp"
 
-# goosecracker Discord agent (ADR 024): OnePasswordItem-backed `goosecracker`
-# Secret for the agent's config. The artifact tier now runs on in-cluster qwen,
-# so no OpenRouter key is needed here (any OpenRouter entry in the 1Password item
-# is unused and can be pruned).
+# Shared LLM provider keys, in the OnePasswordItem-backed `goosecracker` Secret.
+# The NAME is historical: this Secret long outlived the retired goosecracker
+# agent and now carries OPENROUTER_API_KEY, CEREBRAS_API_KEY, NVIDIA_API_KEY and
+# DEEPSEEK_API_KEY for the ADR 036 orchestrator, Grimoire extraction, and the
+# provider fallbacks. Do NOT delete it with the rest of goosecracker.
+#
+# The backing 1Password item was renamed goosecracker -> embervm-agent-secrets.
+# itemPath resolves by TITLE, so the old path breaks on the operator's next
+# reconcile; the existing Ready=True only reflects the last successful sync. The
+# Kubernetes Secret keeps its name so no consumer has to change.
 goosecracker:
   enabled: true
   onepassword:
-    itemPath: "vaults/k8s-homelab/items/goosecracker"
+    itemPath: "vaults/k8s-homelab/items/embervm-agent-secrets"
   # The monolith's own in-cluster progress endpoint base (goose cutover PR C).
   # The runner hands the guest "<this>/<session>"; the guest streams goose stdout
   # there through the fc-invoke egress funnel, and the Discord bot polls the


### PR DESCRIPTION
## Why this is live, not cleanup

The 1Password item backing the `goosecracker` Secret was renamed to `embervm-agent-secrets`. `itemPath` resolves by **title**, so the old path breaks on the operator's next reconcile. The current `Ready=True` only reflects the last successful sync, which is why nothing has failed yet.

**That Secret is not goosecracker's, despite the name.** Its actual contents, from the live cluster:

```
keys: ['CEREBRAS_API_KEY', 'DEEPSEEK_API_KEY', 'NVIDIA_API_KEY', 'OPENROUTER_API_KEY']
```

Live consumers: the ADR 036 orchestrator (`OPENROUTER_API_KEY`, still routing the mention/ambient path), Grimoire extraction (`GRIMOIRE_EXTRACT_API_KEY` sourced from this Secret), and the NVIDIA/Cerebras provider fallbacks. Losing it takes out the chat-vs-agent router and the Grimoire ingest jobs.

## Change

One line: `itemPath` now points at `vaults/k8s-homelab/items/embervm-agent-secrets`, which carries all four keys.

The Kubernetes Secret keeps its name, so no consumer changes. Renaming it too would touch `cronworkflows.yaml`, `deployment.yaml` and a Kyverno clone policy, and is not worth bundling with a fix for a live pointer.

The comment now records that the name is historical and that this Secret must **not** be deleted with the rest of goosecracker, since the removal PR would otherwise take it.

## Deploy

Values-only. `$values` tracks `targetRevision: HEAD`, so this applies on merge with no chart bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)