### PR TITLE
feat(embervm): GitHub egress credentials with Basic encoding and the TLS-MITM lane

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.450
+version: 0.1.451

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -384,9 +384,9 @@ containers:
       {{- fail (printf "egress.secrets entry for %v must set exactly one of secretRef or brokerGrant, and secretRef entries need env" $s.egressTo) }}
       {{- end }}
       {{- if $hasBrokerGrant }}
-      {{- $catalog = append $catalog (dict "header" $s.header "valuePrefix" ($s.valuePrefix | default "") "brokerGrant" $s.brokerGrant "egressTo" $s.egressTo "claimHeader" ($s.claimHeader | default "") "claimPath" ($s.claimPath | default "") "injectAlwaysPaths" ($s.injectAlwaysPaths | default (list))) }}
+      {{- $catalog = append $catalog (dict "header" $s.header "valuePrefix" ($s.valuePrefix | default "") "basicUser" ($s.basicUser | default "") "brokerGrant" $s.brokerGrant "egressTo" $s.egressTo "claimHeader" ($s.claimHeader | default "") "claimPath" ($s.claimPath | default "") "injectAlwaysPaths" ($s.injectAlwaysPaths | default (list))) }}
       {{- else }}
-      {{- $catalog = append $catalog (dict "header" $s.header "valuePrefix" ($s.valuePrefix | default "") "env" $s.env "egressTo" $s.egressTo "claimHeader" ($s.claimHeader | default "") "claimPath" ($s.claimPath | default "") "injectAlwaysPaths" ($s.injectAlwaysPaths | default (list))) }}
+      {{- $catalog = append $catalog (dict "header" $s.header "valuePrefix" ($s.valuePrefix | default "") "basicUser" ($s.basicUser | default "") "env" $s.env "egressTo" $s.egressTo "claimHeader" ($s.claimHeader | default "") "claimPath" ($s.claimPath | default "") "injectAlwaysPaths" ($s.injectAlwaysPaths | default (list))) }}
       {{- end }}
       {{- end }}
       - name: EGRESS_SECRETS

--- a/projects/embervm/chart/templates/egress-ca.yaml
+++ b/projects/embervm/chart/templates/egress-ca.yaml
@@ -1,0 +1,62 @@
+{{- if and .Values.egress.enabled .Values.egress.ca.enabled }}
+{{- $caSecret := .Values.egress.ca.secretName | default (printf "%s-egress-ca" (include "embervm.fullname" .)) }}
+# The egress CA (ADR 023 phase 6b, TLS-MITM lane).
+#
+# The sidecar terminates a guest's TLS with a leaf it mints from this CA, reads
+# the plaintext request, sets the credential header, and originates a FRESH
+# verified TLS connection to the real destination. That is what lets a tool
+# which only ever speaks https:// (gh, and any normal HTTP client) receive an
+# injected credential: without it the sidecar can only blind-tunnel TLS, and
+# blind-tunnelled bytes cannot be credentialed.
+#
+# cert-manager mints only the CA here. The sidecar signs per-destination leaves
+# itself at request time (caMinter), because the set of hosts is whatever the
+# catalog covers and issuing a Certificate per host would put cert-manager in
+# the request path.
+#
+# The PRIVATE key never leaves this Secret, which is mounted read-only into the
+# sidecar alone. The guest receives only the public certificate, and fetches it
+# from the sidecar over its host-local vsock rather than having it baked into
+# the base image: that keeps a CA rotation from requiring a fleet base rebuild,
+# and the fetch is not a trust hole because the process serving the certificate
+# is the same process that is the trust anchor, reached over a link with no
+# network segment on it.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "embervm.fullname" . }}-egress-selfsigned
+  labels:
+    {{- include "embervm.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "embervm.fullname" . }}-egress-ca
+  labels:
+    {{- include "embervm.labels" . | nindent 4 }}
+spec:
+  isCA: true
+  commonName: {{ include "embervm.fullname" . }}-egress-ca
+  secretName: {{ $caSecret }}
+  # Long-lived because a rotation re-mints every leaf the sidecar has cached and
+  # every guest must re-fetch the public cert. renewBefore leaves a wide window
+  # so a rotation is never a cliff.
+  duration: 8760h # 1 year
+  renewBefore: 720h # 30 days
+  privateKey:
+    algorithm: RSA
+    size: 2048
+    # Rotate the key on renewal: a CA that renews onto the same key gains
+    # nothing from renewing.
+    rotationPolicy: Always
+  usages:
+    - cert sign
+    - crl sign
+    - digital signature
+  issuerRef:
+    name: {{ include "embervm.fullname" . }}-egress-selfsigned
+    kind: Issuer
+    group: cert-manager.io
+{{- end }}

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.450
+      targetRevision: 0.1.451
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -439,11 +439,44 @@ egress:
       # opt-in, and claim-resolution failure still denies (issue #4298).
       injectAlwaysPaths:
         - /backend-api/ps/mcp
-  # Shared with the monolith gardener, which reads the same item. Read-only sync,
-  # so two consumers is fine; the field label CLAUDE_AUTH_TOKEN becomes the key.
+    # GitHub, in TWO shapes of the SAME token, because git and the API disagree
+    # about how to carry it. Verified against github.com with a real PAT:
+    # git-receive-pack 401s on Bearer and 200s on Basic, while api.github.com
+    # 200s on Bearer. basicUser makes the sidecar do the RFC 7617 encoding, so
+    # the vault holds one credential rather than a derived base64 copy that
+    # would silently outlive a rotation of the value it came from.
+    #
+    # Both are reachable only in CLEARTEXT from the guest: the sidecar injects
+    # on a plaintext request and originates the verified TLS to :443 itself. A
+    # guest speaking https:// to a credentialed host blind-tunnels with NO
+    # injection (ca.enabled is false), so the remote must be
+    # http://github.com/... and API calls must use http://api.github.com. That
+    # is also why gh cannot be credentialed here (it is https-only); curl plus
+    # jq are the PR-opening path.
+    - header: Authorization
+      basicUser: "x-access-token"
+      env: EMBER_GITHUB_GIT_TOKEN
+      egressTo:
+        - github.com
+      secretRef:
+        name: embervm-embervm-egress
+        key: GH_AUTH_TOKEN
+    - header: Authorization
+      valuePrefix: "Bearer "
+      env: EMBER_GITHUB_API_TOKEN
+      egressTo:
+        - api.github.com
+      secretRef:
+        name: embervm-embervm-egress
+        key: GH_AUTH_TOKEN
+  # embervm-agent-secrets carries CLAUDE_AUTH_TOKEN and GH_AUTH_TOKEN together,
+  # so every guest credential comes from one item. Field labels become the keys.
+  # A key missing here DENIES its egressTo hosts rather than tunnelling them
+  # (see the fail-closed arm in the sidecar's handle), so this repoint and the
+  # entries above have to land together.
   onepassword:
     name: embervm-embervm-egress
-    itemPath: "vaults/k8s-homelab/items/litellm-claude-auth"
+    itemPath: "vaults/k8s-homelab/items/embervm-agent-secrets"
 
 # Voice-drivable Claude Code agent sessions (issue #4055). The monolith addresses
 # this workload by name, so it must exist before agent_sessions can create a

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -446,13 +446,12 @@ egress:
     # the vault holds one credential rather than a derived base64 copy that
     # would silently outlive a rotation of the value it came from.
     #
-    # Both are reachable only in CLEARTEXT from the guest: the sidecar injects
-    # on a plaintext request and originates the verified TLS to :443 itself. A
-    # guest speaking https:// to a credentialed host blind-tunnels with NO
-    # injection (ca.enabled is false), so the remote must be
-    # http://github.com/... and API calls must use http://api.github.com. That
-    # is also why gh cannot be credentialed here (it is https-only); curl plus
-    # jq are the PR-opening path.
+    # Reached over ordinary https://. With ca.enabled below, the sidecar
+    # terminates the guest's TLS using a leaf minted from the egress CA, injects
+    # the header, and originates a FRESH verified TLS connection to the real
+    # destination. Without that CA it could only blind-tunnel TLS, and
+    # blind-tunnelled bytes cannot be credentialed, which is why gh (https-only,
+    # no way to address a host in cleartext) could not authenticate at all.
     - header: Authorization
       basicUser: "x-access-token"
       env: EMBER_GITHUB_GIT_TOKEN
@@ -474,6 +473,18 @@ egress:
   # A key missing here DENIES its egressTo hosts rather than tunnelling them
   # (see the fail-closed arm in the sidecar's handle), so this repoint and the
   # entries above have to land together.
+  # TLS-MITM lane (ADR 023 phase 6b). ON, because a credential can only be
+  # injected into bytes the sidecar can read: a guest speaking https:// to a
+  # credentialed host is blind-tunnelled otherwise, so gh and every ordinary
+  # HTTP client go out unauthenticated. cert-manager mints the CA
+  # (templates/egress-ca.yaml); the sidecar signs per-destination leaves at
+  # request time; the guest fetches the PUBLIC cert over its host-local vsock at
+  # spawn, so rotating the CA does not require a fleet base rebuild.
+  #
+  # The private key is mounted into the sidecar alone and never reaches a guest.
+  ca:
+    enabled: true
+
   onepassword:
     name: embervm-embervm-egress
     itemPath: "vaults/k8s-homelab/items/embervm-agent-secrets"

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -270,6 +270,78 @@ def _cli_privilege_kwargs():
 
 GIT_PROXY_PATH = "/tmp/ember-git-proxy"
 
+# The egress CA the sidecar mints MITM leaves from, and the reserved preamble
+# name it serves that certificate on. Fetched at spawn rather than baked into
+# the guest image so a CA rotation does not require a fleet base rebuild.
+CA_FETCH_HOST = "ca.egress.internal:80"
+CA_BUNDLE_PATH = "/tmp/ember-ca-bundle.crt"
+# Where the image's own trust store lives (apko ca-certificates-bundle). The
+# fetched CA is APPENDED to a copy of it rather than replacing it: the guest
+# still has to verify the real public internet on any host the sidecar merely
+# tunnels.
+SYSTEM_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+
+
+def fetch_egress_ca(timeout=EGRESS_VSOCK_CONNECT_TIMEOUT_SECONDS):
+    """Return the egress CA certificate in PEM, or None when there is no CA.
+
+    Speaks the same one-line preamble the forwarder uses, directly on the vsock,
+    because this runs before any HTTP client exists to proxy through. A sidecar
+    with no CA loaded closes without writing, which reads here as None and
+    leaves the guest on its unmodified system trust store.
+    """
+    if VSOCK_ADDRESS_FAMILY == -1:
+        return None
+    sock = socket.socket(VSOCK_ADDRESS_FAMILY, socket.SOCK_STREAM)
+    try:
+        sock.settimeout(timeout)
+        sock.connect((VSOCK_EGRESS_CID, VSOCK_EGRESS_PORT))
+        sock.sendall(("%s\n" % CA_FETCH_HOST).encode("latin-1"))
+        chunks = []
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    except OSError as exc:
+        sys.stderr.write("ember-claude-shim: egress CA fetch failed: %s\n" % exc)
+        sys.stderr.flush()
+        return None
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+    pem = b"".join(chunks)
+    return pem if b"BEGIN CERTIFICATE" in pem else None
+
+
+def install_egress_ca():
+    """Write system-trust + egress CA to CA_BUNDLE_PATH; return the path or None.
+
+    Returning None means "leave every trust variable unset", which keeps the
+    guest on its stock trust store. That is the correct degrade: a guest that
+    trusted a CA it failed to fetch would fail every TLS handshake instead.
+    """
+    pem = fetch_egress_ca()
+    if not pem:
+        return None
+    try:
+        system = b""
+        if os.path.exists(SYSTEM_CA_BUNDLE):
+            with open(SYSTEM_CA_BUNDLE, "rb") as stream:
+                system = stream.read()
+        with open(CA_BUNDLE_PATH, "wb") as stream:
+            stream.write(system)
+            if system and not system.endswith(b"\n"):
+                stream.write(b"\n")
+            stream.write(pem)
+    except OSError as exc:
+        sys.stderr.write("ember-claude-shim: egress CA install failed: %s\n" % exc)
+        sys.stderr.flush()
+        return None
+    return CA_BUNDLE_PATH
+
 
 def _write_git_proxy_helper():
     """Install the stdlib-only git proxy used by session guests."""
@@ -3226,6 +3298,31 @@ def build_server(manager):
 
 def main():
     install_child_reaper()
+    # Trust the egress CA before any adapter spawns, in THIS process's
+    # environment rather than one adapter's child_env, so every CLI and
+    # everything they shell out to (git, gh, curl) inherits it. The claude
+    # adapter's env is not the boundary: gh and git are run by the model, not by
+    # the shim, and they are the tools that need this.
+    #
+    # Without it the sidecar can only blind-tunnel TLS, and blind-tunnelled
+    # bytes cannot be credentialed, which is why gh could not authenticate at
+    # all. With it, ordinary https:// works everywhere and no tool needs an
+    # http:// special case.
+    bundle = install_egress_ca()
+    if bundle:
+        os.environ.update(
+            {
+                # OpenSSL/python, curl, git, and node/bun each read a different
+                # variable for the same thing. gh is Go, which reads SSL_CERT_FILE.
+                "SSL_CERT_FILE": bundle,
+                "REQUESTS_CA_BUNDLE": bundle,
+                "CURL_CA_BUNDLE": bundle,
+                "GIT_SSL_CAINFO": bundle,
+                "NODE_EXTRA_CA_CERTS": bundle,
+            }
+        )
+        sys.stderr.write("ember-claude-shim: egress CA installed at %s\n" % bundle)
+        sys.stderr.flush()
     manager = ProcessManager(
         claude_executable="claude", codex_executable="codex", pi_executable="pi"
     )

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -3663,3 +3663,67 @@ def test_codex_auth_json_is_parseable_and_inert(tmp_path, monkeypatch):
         "expiry must be far future so the guest never self-refreshes"
     )
     manager._close_process()
+
+
+def test_install_egress_ca_appends_to_system_bundle(tmp_path, monkeypatch):
+    """The fetched CA is APPENDED to the image's trust store, never replaces it.
+
+    The guest still has to verify the real public internet on every host the
+    sidecar merely tunnels, so replacing the bundle would trade one MITM lane for
+    a guest that trusts nothing else.
+    """
+    system = tmp_path / "system.crt"
+    system.write_bytes(
+        b"-----BEGIN CERTIFICATE-----\nSYSTEM\n-----END CERTIFICATE-----\n"
+    )
+    out = tmp_path / "bundle.crt"
+    monkeypatch.setattr(shim, "SYSTEM_CA_BUNDLE", str(system))
+    monkeypatch.setattr(shim, "CA_BUNDLE_PATH", str(out))
+    monkeypatch.setattr(
+        shim,
+        "fetch_egress_ca",
+        lambda *a, **k: (
+            b"-----BEGIN CERTIFICATE-----\nEGRESS\n-----END CERTIFICATE-----\n"
+        ),
+    )
+
+    assert shim.install_egress_ca() == str(out)
+    written = out.read_bytes()
+    assert b"SYSTEM" in written
+    assert b"EGRESS" in written
+
+
+def test_install_egress_ca_returns_none_without_a_ca(tmp_path, monkeypatch):
+    """No CA served means leave every trust variable unset.
+
+    A guest that trusted a CA it failed to fetch would fail every TLS handshake;
+    staying on the stock trust store only loses credential injection.
+    """
+    monkeypatch.setattr(shim, "CA_BUNDLE_PATH", str(tmp_path / "bundle.crt"))
+    monkeypatch.setattr(shim, "fetch_egress_ca", lambda *a, **k: None)
+    assert shim.install_egress_ca() is None
+
+
+def test_fetch_egress_ca_rejects_a_non_pem_response(monkeypatch):
+    """A sidecar with no CA closes without writing; anything that is not a
+    certificate must read as absent rather than be written into the bundle."""
+
+    class _Sock:
+        def settimeout(self, _):
+            pass
+
+        def connect(self, _):
+            pass
+
+        def sendall(self, _):
+            pass
+
+        def recv(self, _):
+            return b""
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(shim.socket, "socket", lambda *a, **k: _Sock())
+    monkeypatch.setattr(shim, "VSOCK_ADDRESS_FAMILY", 40)
+    assert shim.fetch_egress_ca() is None

--- a/projects/firecracker/substrate/egress-proxy/cmd/main.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/main.go
@@ -148,6 +148,12 @@ func main() {
 
 const defaultListenAddr = "127.0.0.1:8888"
 
+// caFetchHost is the reserved preamble name a guest uses to fetch the egress
+// CA's PUBLIC certificate. It is never resolved and never dialled: handle
+// answers it directly, before routing, so it cannot collide with a real
+// destination or escape the node.
+const caFetchHost = "ca.egress.internal"
+
 // proxy holds the split-horizon posture, the secret catalog, and the CA minter.
 type proxy struct {
 	// externalAllow permits public (non-internal) destinations.
@@ -191,6 +197,28 @@ func (p *proxy) handle(client net.Conn) {
 		return
 	}
 	dest := net.JoinHostPort(host, port)
+
+	// CA bootstrap. The guest cannot verify a MITM leaf until it trusts this CA,
+	// and it cannot be given the CA over TLS, so it asks for it in the clear on a
+	// reserved name that never leaves the node.
+	//
+	// This is not a trust hole: the link is a host-local vsock with no network
+	// segment on it, and the process answering IS the trust anchor the guest is
+	// about to rely on for every byte of egress. There is no weaker party to
+	// impersonate. Fetching rather than baking also means a CA rotation does not
+	// require rebuilding the fleet's guest base.
+	if host == caFetchHost {
+		if p.minter == nil {
+			p.logger.Warn("egress: CA fetch requested but no CA is loaded", "dest", dest)
+			return
+		}
+		if _, err := client.Write(p.minter.caCertPEM()); err != nil {
+			p.logger.Warn("egress: CA fetch write failed", "err", err)
+			return
+		}
+		p.logger.Info("egress: served CA certificate to guest")
+		return
+	}
 
 	// Resolve + classify + pin. dialAddr is the exact ip:port we will connect to,
 	// so the policy decision and the connect cannot diverge (no DNS-rebind race).

--- a/projects/firecracker/substrate/egress-proxy/cmd/swap.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/swap.go
@@ -130,7 +130,22 @@ type secretEntry struct {
 	// Header is the request header to set, e.g. "Authorization".
 	Header string `json:"header"`
 	// ValuePrefix is prepended to the resolved value, e.g. "Bearer ".
-	ValuePrefix string   `json:"valuePrefix"`
+	ValuePrefix string `json:"valuePrefix"`
+	// BasicUser, when set, emits RFC 7617 Basic instead of ValuePrefix+value:
+	// "Basic " + base64(BasicUser + ":" + value).
+	//
+	// This exists because git over HTTPS and the GitHub API want the SAME token
+	// in two different shapes. Verified against github.com with a real PAT:
+	//
+	//   git-receive-pack + "Authorization: Bearer <tok>"                 -> 401
+	//   git-receive-pack + "Authorization: Basic base64(user:<tok>)"     -> 200
+	//   api.github.com   + "Authorization: Bearer <tok>"                 -> 200
+	//
+	// Encoding HERE rather than storing a pre-encoded second secret keeps ONE
+	// credential in the vault. A stored base64 blob would be a derived copy that
+	// silently outlives a rotation of the value it was derived from, and nothing
+	// would detect the drift until a push started failing.
+	BasicUser   string   `json:"basicUser"`
 	Env         string   `json:"env"`
 	BrokerGrant string   `json:"brokerGrant"`
 	EgressTo    []string `json:"egressTo"`
@@ -214,6 +229,17 @@ func (e *secretEntry) resolve() error {
 	return nil
 }
 
+// headerValue renders what the sidecar SETS on the request: Basic when the
+// entry names a user, otherwise the prefix form. One place, so the two callers
+// (claim-bearing and plain) cannot diverge on encoding.
+func (e *secretEntry) headerValue() string {
+	value := e.resolvedValue()
+	if e.BasicUser != "" {
+		return "Basic " + base64.StdEncoding.EncodeToString([]byte(e.BasicUser+":"+value))
+	}
+	return e.ValuePrefix + value
+}
+
 func (e *secretEntry) resolvedValue() string {
 	if e.mu != nil {
 		e.mu.RLock()
@@ -255,6 +281,15 @@ func loadSecretsWithBroker(logger *slog.Logger, brokerURL string) []secretEntry 
 		hasSecret := (e.Env != "") != (e.BrokerGrant != "")
 		if e.Header == "" || len(e.EgressTo) == 0 || !hasSecret {
 			logger.Error("invalid secret catalog entry (needs exactly one of env or brokerGrant, plus header and egressTo); refusing to start", "env", e.Env, "brokerGrant", e.BrokerGrant)
+			exitFn(1)
+			return nil
+		}
+		// basicUser and valuePrefix are two different encodings of the same
+		// header, so setting both is a config error rather than a precedence
+		// question. Failing at load beats guessing and injecting the wrong shape,
+		// which surfaces later as an opaque 401 from the destination.
+		if e.BasicUser != "" && e.ValuePrefix != "" {
+			logger.Error("secret catalog entry sets both basicUser and valuePrefix; refusing to start", "egressTo", e.EgressTo)
 			exitFn(1)
 			return nil
 		}
@@ -564,7 +599,7 @@ func injectRequest(req *http.Request, sec *secretEntry) bool {
 		// claim here rather than trusting the guest: they cannot drift, and a
 		// valid token paired with a stale account id is exactly the failure this
 		// fixes (the provider rejects the pair and calls it token_expired).
-		req.Header.Set(sec.Header, sec.ValuePrefix+sec.resolvedValue())
+		req.Header.Set(sec.Header, sec.headerValue())
 		req.Header.Set(sec.ClaimHeader, claim)
 		return true
 	}
@@ -576,7 +611,7 @@ func injectRequest(req *http.Request, sec *secretEntry) bool {
 	if !requested {
 		return false
 	}
-	req.Header.Set(sec.Header, sec.ValuePrefix+sec.resolvedValue())
+	req.Header.Set(sec.Header, sec.headerValue())
 	return true
 }
 

--- a/projects/firecracker/substrate/egress-proxy/cmd/swap_test.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/swap_test.go
@@ -694,3 +694,40 @@ func TestSwapPumpInjectsOnThePlaintextLane(t *testing.T) {
 		t.Errorf("response not relayed to the guest: %q", back.String())
 	}
 }
+
+// git over HTTPS and the GitHub API want the SAME token in two shapes. Verified
+// against github.com with a real PAT: git-receive-pack 401s on Bearer and 200s
+// on Basic, while api.github.com 200s on Bearer. Encoding in the sidecar keeps
+// ONE credential in the vault instead of a derived base64 copy that would
+// silently outlive a rotation.
+func TestHeaderValueEncodesBasicWhenUserIsSet(t *testing.T) {
+	basic := secretEntry{Header: "Authorization", BasicUser: "x-access-token", value: "ghp_example"}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:ghp_example"))
+	if got := basic.headerValue(); got != want {
+		t.Errorf("headerValue() = %q, want %q", got, want)
+	}
+
+	bearer := secretEntry{Header: "Authorization", ValuePrefix: "Bearer ", value: "ghp_example"}
+	if got, want := bearer.headerValue(), "Bearer ghp_example"; got != want {
+		t.Errorf("headerValue() = %q, want %q", got, want)
+	}
+
+	// Same secret, two lanes, two shapes: this is the whole point.
+	if basic.headerValue() == bearer.headerValue() {
+		t.Error("basic and bearer encodings of the same token must differ")
+	}
+}
+
+func TestLoadSecretsRejectsBothBasicUserAndValuePrefix(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	called := 0
+	prev := exitFn
+	exitFn = func(int) { called++ }
+	defer func() { exitFn = prev }()
+
+	t.Setenv("EGRESS_SECRETS", `[{"header":"Authorization","valuePrefix":"Bearer ","basicUser":"x-access-token","env":"TOK","egressTo":["github.com"]}]`)
+	loadSecrets(logger)
+	if called == 0 {
+		t.Error("an entry setting both encodings must refuse to start, not pick one")
+	}
+}


### PR DESCRIPTION
Makes a guest able to push a branch and open a PR, with the credential never entering the guest.

## Two shapes of one token

git over HTTPS and the GitHub API disagree about how to carry the same token. Verified against `github.com` with a real PAT:

| Request | Result |
|---|---|
| `git-receive-pack` + `Authorization: Bearer <tok>` | **401** |
| `git-receive-pack` + `Authorization: Basic base64("x-access-token:<tok>")` | **200** |
| `api.github.com/user` + `Authorization: Bearer <tok>` | **200** |

A catalog entry may now set `basicUser`, and the sidecar renders RFC 7617 Basic itself. That keeps **one** credential in the vault: a pre-encoded base64 field would be a derived copy that silently outlives a rotation of the value it came from, with nothing detecting the drift until a push started failing.

Setting both `basicUser` and `valuePrefix` refuses to start. Two encodings of one header is a config error, not a precedence question, and guessing surfaces later as an opaque 401.

## Why the CA lane is in the same PR

A credential can only be injected into bytes the sidecar can read. A guest speaking `https://` to a credentialed host was blind-tunnelled, so **`gh` could not authenticate at all** — it is https-only with no way to address a host in cleartext. Shipping `gh` without this would have been pointless.

`terminateAndSwap` and `caMinter` already existed; the lane was gated off because nothing owned the CA's route into the guest trust store. This closes that:

- **cert-manager mints the CA** (`templates/egress-ca.yaml`), following the cilium-hubble precedent already in the cluster. Only the CA: the sidecar signs per-destination leaves at request time, since the host set is whatever the catalog covers and issuing per host would put cert-manager in the request path.
- **The guest fetches the public cert over its host-local vsock**, on a reserved preamble name answered before routing so it can never be resolved or dialled. Fetching rather than baking means **a CA rotation does not require a fleet base rebuild**. Not a trust hole: the link has no network segment, and the process serving the certificate *is* the trust anchor the guest is about to rely on for all egress.
- **The shim installs trust in its own environment**, not one adapter's `child_env`. `gh` and `git` are run by the model, not the shim, so scoping this to the claude adapter would miss exactly the tools that need it. `SSL_CERT_FILE` covers Go (`gh`) and OpenSSL; `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE` cover the rest.

Two deliberate degrades: the fetched CA is **appended** to the image trust store rather than replacing it, so the guest still verifies the real internet on tunnelled hosts; and a failed fetch leaves every trust variable unset, because a guest trusting a CA it did not get would fail *every* TLS handshake, while staying on the stock store only loses injection.

## Also

The egress secret moves to `embervm-agent-secrets`, which carries `CLAUDE_AUTH_TOKEN` and `GH_AUTH_TOKEN` together. A key missing from the secret **denies** its `egressTo` hosts rather than tunnelling them, so the repoint and the new entries have to land together.

`_noded-pod.tpl` builds its catalog from an explicit field list, so `basicUser` had to be added there too. Without it the entry rendered with neither prefix nor Basic and would have 401'd. Caught by parsing the rendered `EGRESS_SECRETS`, not by reading `values.yaml` — worth noting that any future catalog field needs the same two-place edit.

## Test

`Executed 5 out of 758 tests: 758 tests pass`. Covers both encodings, the both-set rejection, CA append-not-replace, and the no-CA degrade.

**Carries a fleet base rebuild** (shim change), so the rollout needs a session probe, not just a pod check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)