### PR TITLE
fix(embervm): the egress CA volume must be optional or it wedges the brick roll

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.451
+version: 0.1.452

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -441,6 +441,20 @@ volumes:
   - name: egress-ca
     secret:
       secretName: {{ $ctx.Values.egress.ca.secretName | default (printf "%s-egress-ca" (include "embervm.fullname" $ctx)) }}
+      # optional, for the same reason the secretRef entries above are optional:
+      # without it the kubelet fails container creation on a missing Secret and
+      # WEDGES THE BRICK ROLL (observed live at 0.1.350, and again at 0.1.451
+      # when this volume was added non-optional). cert-manager issues this
+      # Secret from a Certificate in the SAME sync that adds the mount, and
+      # ArgoCD blocks that sync waiting for the brick Deployment to go healthy,
+      # so the mount can be waiting on a Secret whose creation is waiting on the
+      # mount. Optional breaks the deadlock.
+      #
+      # Degrading is safe: the sidecar treats an unreadable CA as "no MITM lane"
+      # (newCAMinter fails, minter stays nil) and keeps injecting on the
+      # cleartext lane, so a guest loses https:// credential injection rather
+      # than all egress.
+      optional: true
 {{- end }}
   - name: dev-kvm
     hostPath:

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.451
+      targetRevision: 0.1.452
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
**Live fix.** 0.1.451 added a non-optional `egress-ca` volume and the fleet deadlocked.

```
MountVolume.SetUp failed for volume "egress-ca":
secret "embervm-embervm-egress-ca" not found
```

The kubelet fails container creation on a missing Secret, so the brick Deployment never goes healthy, so ArgoCD never advances past

```
waiting for healthy state of apps/Deployment/embervm-embervm-noded-brick-2gi
```

to apply the `Certificate` whose Secret the mount is waiting for. The mount waits on a Secret whose creation waits on the mount. Confirmed: no `Certificate` or `Issuer` exists in the namespace, and neither appears in the Application's resource list.

## The rule was already written down

The `secretRef` entries three lines above carry `optional: true` with a comment naming a live wedge at 0.1.350 for precisely this failure. I applied it to secret *keys* and not to the *volume*.

## Degrading is safe

The sidecar treats an unreadable CA as "no MITM lane": `newCAMinter` fails, `minter` stays nil, and it keeps injecting on the cleartext lane. So a guest loses `https://` credential injection until the Certificate is issued, rather than a node losing all egress. That is the same fail-direction the rest of this config already takes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)