### PR TITLE
fix(embervm): install the egress CA per turn, and give gh a login gate

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.452
+version: 0.1.453

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.452
+      targetRevision: 0.1.453
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/claude/guest-init/cmd/main.go
@@ -196,6 +196,21 @@ func setDefaultEnv(logger *slog.Logger) {
 		// for every adapter including future ones, and it does not depend on
 		// $HOME/.gitconfig surviving the HOME bind-mount from the session volume.
 		// _configure_git stays as belt-and-braces for the claude path.
+		// A LOGIN GATE DUMMY for gh, exactly like CLAUDE_CODE_OAUTH_TOKEN above and
+		// for the same reason: gh refuses to issue any request while it believes
+		// it has no credentials ("To get started with GitHub CLI, please run: gh
+		// auth login"), so it never reaches the sidecar that would credential it.
+		// Observed live: gh made no API call at all, returning exit 4 without a
+		// single request leaving the guest.
+		//
+		// The value is inert and is DISCARDED: the egress-proxy sets the
+		// Authorization header itself on the way out (ADR 023 phase 6b), so a
+		// prompt-injected guest cannot authenticate as anyone by supplying a
+		// token of its own. gh auth status still reports "not logged in", which
+		// is correct and expected: it inspects local credentials, and the real
+		// one is never local.
+		"GH_TOKEN": "ember-guest-login-gate-dummy-not-a-credential",
+
 		"GIT_AUTHOR_NAME":     "EmberAgent",
 		"GIT_AUTHOR_EMAIL":    "agent@jomcgi.dev",
 		"GIT_COMMITTER_NAME":  "EmberAgent",

--- a/projects/embervm/runtimes/claude/guest-init/cmd/main_test.go
+++ b/projects/embervm/runtimes/claude/guest-init/cmd/main_test.go
@@ -104,6 +104,7 @@ func TestSetDefaultEnvSetsGitIdentityForEveryAdapter(t *testing.T) {
 		"EMBER_GIT_USER_NAME", "EMBER_GIT_USER_EMAIL",
 		"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
 		"GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
+		"GH_TOKEN",
 	}
 	previous := make(map[string]string, len(keys))
 	wasSet := make(map[string]bool, len(keys))
@@ -123,6 +124,12 @@ func TestSetDefaultEnvSetsGitIdentityForEveryAdapter(t *testing.T) {
 	setDefaultEnv(logger)
 
 	const name, email = "EmberAgent", "agent@jomcgi.dev"
+	// gh refuses to issue any request while it believes it has no credentials,
+	// so it never reaches the sidecar that would credential it. The value is
+	// inert and discarded on the way out; only its PRESENCE matters.
+	if got := os.Getenv("GH_TOKEN"); got == "" {
+		t.Error("GH_TOKEN must be set to a login-gate dummy, or gh makes no request at all")
+	}
 	want := map[string]string{
 		"EMBER_GIT_USER_NAME": name, "EMBER_GIT_USER_EMAIL": email,
 		"GIT_AUTHOR_NAME": name, "GIT_AUTHOR_EMAIL": email,

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -316,6 +316,38 @@ def fetch_egress_ca(timeout=EGRESS_VSOCK_CONNECT_TIMEOUT_SECONDS):
     return pem if b"BEGIN CERTIFICATE" in pem else None
 
 
+def apply_egress_ca_trust():
+    """Fetch + install the egress CA and export the trust variables.
+
+    Called PER TURN, not at startup. A session guest is restored from a shared
+    snapshot, so its process memory is cloned with main() long since finished:
+    anything done there runs once, at base-build time, on a different machine,
+    and can never run again for a real session. At base-build time the egress
+    lane is not open either, so the fetch there fails with ECONNRESET and the
+    trust is simply absent for every session that base ever serves.
+
+    A turn is the first moment that is guaranteed to be post-restore with the
+    lane live, which is why ensure_workspace_volume() is called from the same
+    place. Re-running is cheap (one vsock round trip) and is what keeps a CA
+    rotation from needing a fleet base rebuild.
+    """
+    bundle = install_egress_ca()
+    if not bundle:
+        return None
+    os.environ.update(
+        {
+            # OpenSSL/python, curl, git and node/bun each read a different
+            # variable for the same thing. gh is Go, which reads SSL_CERT_FILE.
+            "SSL_CERT_FILE": bundle,
+            "REQUESTS_CA_BUNDLE": bundle,
+            "CURL_CA_BUNDLE": bundle,
+            "GIT_SSL_CAINFO": bundle,
+            "NODE_EXTRA_CA_CERTS": bundle,
+        }
+    )
+    return bundle
+
+
 def install_egress_ca():
     """Write system-trust + egress CA to CA_BUNDLE_PATH; return the path or None.
 
@@ -3081,6 +3113,10 @@ class ProcessManager:
         total_start = _turn_timing_now()
         with self._mount_lock:
             ensure_workspace_volume()
+        # Per turn, for the same reason ensure_workspace_volume is: this is the
+        # first point guaranteed to be post-restore with the egress lane live.
+        # Doing it at startup put it at base-build time, where the lane is shut.
+        apply_egress_ca_trust()
         if getattr(self.claude, "workspace", None):
             _ensure_cli_dir(self.claude.workspace)
         if repo is not None and branch is not None:
@@ -3298,31 +3334,6 @@ def build_server(manager):
 
 def main():
     install_child_reaper()
-    # Trust the egress CA before any adapter spawns, in THIS process's
-    # environment rather than one adapter's child_env, so every CLI and
-    # everything they shell out to (git, gh, curl) inherits it. The claude
-    # adapter's env is not the boundary: gh and git are run by the model, not by
-    # the shim, and they are the tools that need this.
-    #
-    # Without it the sidecar can only blind-tunnel TLS, and blind-tunnelled
-    # bytes cannot be credentialed, which is why gh could not authenticate at
-    # all. With it, ordinary https:// works everywhere and no tool needs an
-    # http:// special case.
-    bundle = install_egress_ca()
-    if bundle:
-        os.environ.update(
-            {
-                # OpenSSL/python, curl, git, and node/bun each read a different
-                # variable for the same thing. gh is Go, which reads SSL_CERT_FILE.
-                "SSL_CERT_FILE": bundle,
-                "REQUESTS_CA_BUNDLE": bundle,
-                "CURL_CA_BUNDLE": bundle,
-                "GIT_SSL_CAINFO": bundle,
-                "NODE_EXTRA_CA_CERTS": bundle,
-            }
-        )
-        sys.stderr.write("ember-claude-shim: egress CA installed at %s\n" % bundle)
-        sys.stderr.flush()
     manager = ProcessManager(
         claude_executable="claude", codex_executable="codex", pi_executable="pi"
     )

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -3727,3 +3727,41 @@ def test_fetch_egress_ca_rejects_a_non_pem_response(monkeypatch):
     monkeypatch.setattr(shim.socket, "socket", lambda *a, **k: _Sock())
     monkeypatch.setattr(shim, "VSOCK_ADDRESS_FAMILY", 40)
     assert shim.fetch_egress_ca() is None
+
+
+def test_apply_egress_ca_trust_exports_every_tool_variable(tmp_path, monkeypatch):
+    """One bundle, five variables, because each tool reads a different one.
+
+    gh is Go (SSL_CERT_FILE), git is curl (GIT_SSL_CAINFO), the CLI is bun
+    (NODE_EXTRA_CA_CERTS). Missing any one leaves that tool unable to verify the
+    sidecar's minted leaf, which surfaces as "self-signed certificate in
+    certificate chain" rather than as a missing credential.
+    """
+    bundle = tmp_path / "bundle.crt"
+    monkeypatch.setattr(shim, "install_egress_ca", lambda: str(bundle))
+    for key in (
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "GIT_SSL_CAINFO",
+        "NODE_EXTRA_CA_CERTS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    assert shim.apply_egress_ca_trust() == str(bundle)
+    for key in (
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "GIT_SSL_CAINFO",
+        "NODE_EXTRA_CA_CERTS",
+    ):
+        assert os.environ[key] == str(bundle), key
+
+
+def test_apply_egress_ca_trust_sets_nothing_without_a_ca(monkeypatch):
+    """No CA means leave the stock trust store alone, not point at a missing file."""
+    monkeypatch.setattr(shim, "install_egress_ca", lambda: None)
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    assert shim.apply_egress_ca_trust() is None
+    assert "SSL_CERT_FILE" not in os.environ


### PR DESCRIPTION
Two reasons a guest still could not use GitHub after 0.1.452. Both found by probing a live session, not by reading config.

## 1. The CA install only ever ran at base-build time

It was in `main()`. A session guest is **restored from a shared snapshot**, so its process memory is cloned with `main()` long since finished — startup work runs once, on another machine, and can never run again for a real session.

Worse, at base-build time the egress lane is not open, so the fetch failed there and every session that base served inherited no trust at all:

```
ember-claude-shim: egress CA fetch failed: [Errno 104] Connection reset by peer
```

which surfaced in the guest as:

```
fatal: unable to access 'https://github.com/jomcgi/homelab.git/':
SSL certificate ... self-signed certificate in certificate chain (19)
```

That error is also the **proof the MITM lane works**: git was handed a leaf minted from our CA and simply did not trust it. Credential injection was never the problem.

The install now runs from `turn()`, beside `ensure_workspace_volume()` — the existing precedent for work that must derive from post-restore state. A turn is the first moment guaranteed to be post-restore with the lane live. Re-running costs one vsock round trip, and is what keeps a CA rotation from needing a fleet base rebuild.

## 2. gh never made a request at all

It refuses to issue anything while it believes it has no credentials, so it never reached the sidecar that would credential it (exit 4, no request left the guest). `guest-init` now sets `GH_TOKEN` to an inert login-gate dummy, exactly as it already does for `CLAUDE_CODE_OAUTH_TOKEN`. The value is discarded on the way out, so a prompt-injected guest still cannot authenticate as anyone by supplying a token of its own.

**`gh auth status` will still report "not logged in", and that is correct.** It inspects *local* credentials, and the real one is never local by design. Whether a request succeeds is the only meaningful check for this lane — worth knowing before anyone treats it as a health signal.

## Test

`Executed 7 out of 758 tests: 758 tests pass`. Covers all five trust variables being exported from one bundle, the no-CA degrade leaving the stock store alone, and `GH_TOKEN` being present after `setDefaultEnv`.

Carries a fleet base rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)