### PR TITLE
feat(agent-sessions): split sandbox and caller system prompts, voice for MCP only

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.454
+version: 0.1.458

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.454
+      targetRevision: 0.1.458
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -242,11 +242,34 @@ DEFAULT_CLI_GID = 65532
 PERSISTENCE_MOUNT_PATH_ENV = "EMBER_PERSISTENCE_MOUNT_PATH"
 DEFAULT_PERSISTENCE_MOUNT_PATH = "/session"
 GUEST_INIT_PATH = "/usr/local/bin/ember-runtime-guest-init"
-VOICE_PROMPT = (
-    "End every response with a single line: <voice>One or two plain sentences, "
-    "no markdown, that a person could hear read aloud: what you did and anything "
-    "you need from them.</voice>"
+SANDBOX_PROMPT = (
+    "Facts about the sandbox you are running in. They override any assumption "
+    "you would otherwise make, and none of them are problems to debug.\n"
+    "- You are alone in a disposable Firecracker microVM. There is no "
+    "interactive terminal: you cannot prompt mid-turn, so a question ends your "
+    "turn and is read asynchronously.\n"
+    "- When the session has a repo, the checkout is at /workspace/src. It is a "
+    "depth-1 single-branch clone, so history before the tip commit is absent. "
+    "git log beyond HEAD, git bisect and git blame on older lines will fail, "
+    "and unshallowing is not supported here.\n"
+    "- origin points at an internal read-only mirror, not at GitHub. The mirror "
+    "accepts pushes only under refs/agents/**.\n"
+    "- Your git identity is already configured. Do not set user.name or "
+    "user.email.\n"
+    "- All network egress is proxied. The public internet is reachable and "
+    "in-cluster services are not. You hold no credentials: the proxy attaches "
+    "them on the way out, so no token is readable from in here.\n"
+    "- gh reaches GitHub even though `gh auth status` reports you are not "
+    "logged in. That report is expected, because it inspects local credentials "
+    "and the real one is never local. Judge by whether the request succeeds.\n"
 )
+
+
+def compose_system_prompt(caller_prompt=None):
+    """Join the shim-owned sandbox prompt with an optional caller prompt."""
+    if caller_prompt and caller_prompt.strip():
+        return SANDBOX_PROMPT + "\n" + caller_prompt.strip()
+    return SANDBOX_PROMPT
 
 
 def _workspace_identity(path):
@@ -1180,6 +1203,7 @@ class ClaudeProcess:
         self.fatal_error = None
         self.session_id = None
         self.model = None
+        self.system_prompt = None
         self._process_workspace = None
         self._process_uses_legacy_cwd = False
         self._process_workspace_identity = _workspace_identity(self.workspace)
@@ -1219,7 +1243,12 @@ class ClaudeProcess:
                 raise StartupError("git config failed for %s: %s" % (key, detail))
 
     def _spawn(
-        self, session_id=None, first_message=None, model=None, init_timeout=None
+        self,
+        session_id=None,
+        first_message=None,
+        model=None,
+        init_timeout=None,
+        system_prompt=None,
     ):
         if self.fatal_error is not None:
             raise StartupError(self.fatal_error)
@@ -1258,7 +1287,7 @@ class ClaudeProcess:
             command.extend(["--model", CLAUDE_MODELS.get(model, model)])
         if session_id:
             command.extend(["--resume", session_id])
-        command.extend(["--append-system-prompt", VOICE_PROMPT])
+        command.extend(["--append-system-prompt", compose_system_prompt(system_prompt)])
         egress_port = os.environ.get(EGRESS_PORT_ENV, str(DEFAULT_EGRESS_PORT))
         proxy_url = "http://%s:%s" % (EGRESS_LOCALHOST, egress_port)
         child_env = os.environ.copy()
@@ -1342,6 +1371,7 @@ class ClaudeProcess:
                 elif session_id:
                     self.session_id = session_id
                 self.model = model
+                self.system_prompt = system_prompt
                 if event.get("apiKeySource") != "none":
                     message = "apiKeySource must be none, got %r" % event.get(
                         "apiKeySource"
@@ -1466,6 +1496,7 @@ class ClaudeProcess:
         session_id=None,
         model=None,
         progress_token=None,
+        system_prompt=None,
     ):
         with self.turn_lock:
             cli_ready_start = _turn_timing_now()
@@ -1478,6 +1509,7 @@ class ClaudeProcess:
                     % (session_id, self.session_id)
                 )
             model_changed = model is not None and model != self.model
+            system_prompt_changed = system_prompt != self.system_prompt
             parked_process = (
                 process is not None and process.poll() is None and not self.session_id
             )
@@ -1497,14 +1529,18 @@ class ClaudeProcess:
             if (
                 process is not None
                 and process.poll() is None
-                and (model_changed or cwd_changed)
+                and (model_changed or cwd_changed or system_prompt_changed)
             ):
+                # Prewarm parks a CLI started without a caller prompt. Since
+                # append-system-prompt is spawn-time only, adoption must respawn
+                # when this turn carries a different prompt.
                 self._close_process(kill=False)
                 try:
                     self._spawn(
                         self.session_id or session_id,
                         first_message=message,
                         model=model,
+                        system_prompt=system_prompt,
                     )
                 except Exception:
                     if parked_adoption and not session_was_bound:
@@ -1529,6 +1565,7 @@ class ClaudeProcess:
                         session_id or self.session_id,
                         first_message=message,
                         model=model,
+                        system_prompt=system_prompt,
                     )
                 except Exception:
                     if parked_adoption and not session_was_bound:
@@ -1553,7 +1590,10 @@ class ClaudeProcess:
                             self._close_process(kill=False)
                             try:
                                 self._spawn(
-                                    session_id, first_message=message, model=model
+                                    session_id,
+                                    first_message=message,
+                                    model=model,
+                                    system_prompt=system_prompt,
                                 )
                             except Exception:
                                 if parked_adoption and not session_was_bound:
@@ -1995,12 +2035,13 @@ wire_api = "responses"
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise RuntimeError("codex emitted invalid JSON: %s" % exc) from exc
 
-    def _resume(self, session_id):
+    def _resume(self, session_id, system_prompt=None):
         params = {
             "threadId": session_id,
             "cwd": self.workspace,
             "approvalPolicy": "never",
             "sandbox": "danger-full-access",
+            "developerInstructions": compose_system_prompt(system_prompt),
         }
         try:
             result = self._request("thread/resume", params, timeout=INIT_READ_TIMEOUT)
@@ -2044,6 +2085,7 @@ wire_api = "responses"
         session_id=None,
         model=DEFAULT_CODEX_MODEL,
         progress_token=None,
+        system_prompt=None,
     ):
         with self.turn_lock:
             cli_ready_start = _turn_timing_now()
@@ -2066,7 +2108,9 @@ wire_api = "responses"
                 requested_session not in self._server_threads
                 or requested_session != self.session_id
             ):
-                self._resume(requested_session)
+                # Resume repeats the developer instructions so a restarted
+                # app-server thread receives the same prompt without duplication.
+                self._resume(requested_session, system_prompt=system_prompt)
                 if cli_ready_path is None and process_was_unbound:
                     cli_ready_path = "adopt"
             elif not requested_session:
@@ -2076,6 +2120,7 @@ wire_api = "responses"
                         "cwd": self.workspace,
                         "approvalPolicy": "never",
                         "sandbox": "danger-full-access",
+                        "developerInstructions": compose_system_prompt(system_prompt),
                     },
                 )
                 thread = result.get("thread", {}) if isinstance(result, dict) else {}
@@ -2322,6 +2367,7 @@ class PiProcess:
         self._turn_done.set()
         self._in_flight = False
         self._model = None
+        self._system_prompt = None
         self._session_file = None
 
     def ready(self):
@@ -2369,7 +2415,7 @@ class PiProcess:
         with open(os.path.join(agent_dir, "models.json"), "w") as stream:
             json.dump(config, stream)
 
-    def _spawn(self, model):
+    def _spawn(self, model, system_prompt=None):
         if not os.path.isdir(self.workspace):
             raise StartupError("workspace does not exist: %s" % self.workspace)
         model_name = PI_MODELS.get(model, PI_MODELS[DEFAULT_PI_MODEL])
@@ -2385,7 +2431,7 @@ class PiProcess:
             "--model",
             model_name,
             "--system-prompt",
-            "You are a focused coding agent. " + VOICE_PROMPT,
+            "You are a focused coding agent. " + compose_system_prompt(system_prompt),
             "--no-context-files",
             "--no-extensions",
             "--no-skills",
@@ -2409,6 +2455,7 @@ class PiProcess:
             self.process = process
             self._stdout_queue = output_queue
             self._model = model
+            self._system_prompt = system_prompt
             _managed_child_pids.add(process.pid)
         threading.Thread(
             target=self._pump_pi_stdout,
@@ -2528,6 +2575,7 @@ class PiProcess:
         session_id=None,
         model=DEFAULT_PI_MODEL,
         progress_token=None,
+        system_prompt=None,
     ):
         with self.turn_lock:
             cli_ready_start = _turn_timing_now()
@@ -2543,8 +2591,12 @@ class PiProcess:
             model_name = PI_MODELS.get(model, PI_MODELS[DEFAULT_PI_MODEL])
             if process is None or process.poll() is not None:
                 self._close_process(kill=False)
-                process = self._spawn(model)
+                process = self._spawn(model, system_prompt=system_prompt)
                 cli_ready_path = "lazy_spawn"
+            elif self._system_prompt != system_prompt:
+                self._close_process(kill=False)
+                process = self._spawn(model, system_prompt=system_prompt)
+                cli_ready_path = "remediation_respawn"
             elif self._model != model_name:
                 self._command(
                     {
@@ -3109,6 +3161,7 @@ class ProcessManager:
         repo=None,
         branch=None,
         progress_token=None,
+        system_prompt=None,
     ):
         total_start = _turn_timing_now()
         with self._mount_lock:
@@ -3124,16 +3177,20 @@ class ProcessManager:
         adapter = self._adapter(model)
         try:
             extra = {"progress_token": progress_token} if progress_token else {}
+            prompt = {"system_prompt": system_prompt} if system_prompt else {}
             if adapter is self.pi:
                 record = adapter.turn(
-                    message, session_id, model or DEFAULT_PI_MODEL, **extra
+                    message, session_id, model or DEFAULT_PI_MODEL, **(extra | prompt)
                 )
             elif adapter is self.codex:
                 record = adapter.turn(
-                    message, session_id, model or DEFAULT_CODEX_MODEL, **extra
+                    message,
+                    session_id,
+                    model or DEFAULT_CODEX_MODEL,
+                    **(extra | prompt),
                 )
             else:
-                record = adapter.turn(message, session_id, model, **extra)
+                record = adapter.turn(message, session_id, model, **(extra | prompt))
             # Only Claude can recover a Claude prewarm failure. Codex and pi
             # turns must not clear the manager's Claude fatal state.
             if adapter is self.claude:
@@ -3248,6 +3305,12 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
         ):
             self._send(400, {"error": "progress_token must be a non-empty string"})
             return
+        system_prompt = payload.get("system_prompt")
+        if system_prompt is not None and (
+            not isinstance(system_prompt, str) or not system_prompt.strip()
+        ):
+            self._send(400, {"error": "system_prompt must be a non-empty string"})
+            return
         if "session_id" in payload:
             sid = payload.get("session_id")
             if sid is not None and (not isinstance(sid, str) or not sid.strip()):
@@ -3261,11 +3324,12 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
             progress = (
                 {"progress_token": progress_token.strip()} if progress_token else {}
             )
+            prompt = {"system_prompt": system_prompt.strip()} if system_prompt else {}
             record = self.manager.turn(
                 message,
                 session_id,
                 payload.get("model"),
-                **(hydration | progress),
+                **(hydration | progress | prompt),
             )
             if repo is not None and isinstance(record, dict):
                 if getattr(self.manager, "_hydration_error", None):

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -300,7 +300,7 @@ assert sys.argv[sys.argv.index("--model") + 1] == "qwen3.6-27b"
 for flag in ("--no-context-files", "--no-extensions", "--no-skills", "--no-prompt-templates"):
     assert flag in sys.argv
 assert sys.argv[sys.argv.index("--tools") + 1] == "read,bash,edit,write"
-assert "End every response with a single line" in sys.argv[sys.argv.index("--system-prompt") + 1]
+assert "disposable Firecracker microVM" in sys.argv[sys.argv.index("--system-prompt") + 1]
 rpc_path = os.environ.get("FAKE_PI_RPC")
 state = {"sessionId": "pi-session", "model": {"id": "qwen3.6-27b"}}
 def record(value):
@@ -814,10 +814,12 @@ def test_codex_app_server_second_turn_no_respawn(tmp_path, monkeypatch):
 
 def test_codex_resume_by_thread_id(tmp_path, monkeypatch):
     manager = _codex_manager(tmp_path, monkeypatch)
-    manager.turn("first", model="luna")
+    manager.turn("first", model="luna", system_prompt="CALLER-MARKER")
     session_id = manager.session_id
     manager.session_id = None
-    manager.turn("second", session_id=session_id, model="luna")
+    manager.turn(
+        "second", session_id=session_id, model="luna", system_prompt="CALLER-MARKER"
+    )
     assert manager.session_id == session_id
     requests = [
         json.loads(line)
@@ -836,6 +838,10 @@ def test_codex_resume_by_thread_id(tmp_path, monkeypatch):
     assert "sandboxPolicy" not in thread_start["params"]
     assert thread_resume["params"]["sandbox"] == "danger-full-access"
     assert "sandboxPolicy" not in thread_resume["params"]
+    for request in (thread_start, thread_resume):
+        instructions = request["params"]["developerInstructions"]
+        assert shim.SANDBOX_PROMPT in instructions
+        assert "CALLER-MARKER" in instructions
     manager._close_process()
 
 
@@ -1159,6 +1165,7 @@ def _parked_claude(tmp_path):
     manager.fatal_error = None
     manager.session_id = None
     manager.model = None
+    manager.system_prompt = None
     manager._process_workspace = manager.workspace
     stat = os.stat(manager.workspace)
     manager._process_workspace_identity = (stat.st_dev, stat.st_ino)
@@ -1565,7 +1572,7 @@ def test_legacy_adoption_respawns_for_workspace_change(tmp_path, monkeypatch):
     new_process = _FakeLiveProcess()
     spawn_calls = []
 
-    def fake_spawn(session_id, first_message, model):
+    def fake_spawn(session_id, first_message, model, **_kwargs):
         spawn_calls.append((session_id, first_message, model, manager.workspace))
         manager.process = new_process
 
@@ -1810,7 +1817,14 @@ def test_parked_claude_model_mismatch_respawns_with_resume(tmp_path, monkeypatch
     monkeypatch.setattr(manager, "ready", lambda: True)
 
     manager.turn("hello", session_id="sid", model="opus")
-    assert calls == [{"session_id": "sid", "first_message": "hello", "model": "opus"}]
+    assert calls == [
+        {
+            "session_id": "sid",
+            "first_message": "hello",
+            "model": "opus",
+            "system_prompt": None,
+        }
+    ]
 
 
 def test_claude_turn_timing_reports_spawn_adopt_reuse_and_remediation(
@@ -1950,6 +1964,49 @@ def test_claude_spawn_includes_include_partial_messages(tmp_path, monkeypatch):
     manager._close_process(kill=True)
 
 
+def test_claude_system_prompt_is_composed_at_spawn(tmp_path, monkeypatch):
+    args_path = tmp_path / "args.json"
+    monkeypatch.setenv("FAKE_ARGS", str(args_path))
+    manager = _manager(tmp_path, monkeypatch)
+    manager.turn("make changes", system_prompt="CALLER-MARKER")
+    argv = json.loads(args_path.read_text())
+    value = argv[argv.index("--append-system-prompt") + 1]
+    assert "disposable Firecracker microVM" in value
+    assert "CALLER-MARKER" in value
+    manager._close_process(kill=True)
+
+
+def test_claude_prewarm_adoption_respawns_for_system_prompt(tmp_path, monkeypatch):
+    manager = _parked_claude(tmp_path)
+    calls = []
+
+    def respawn(session_id=None, **kwargs):
+        calls.append({"session_id": session_id, **kwargs})
+        manager.process = _FakeLiveProcess()
+        manager._process_workspace = manager.workspace
+        manager.system_prompt = kwargs.get("system_prompt")
+
+    monkeypatch.setattr(manager, "_close_process", lambda **_kwargs: None)
+    monkeypatch.setattr(manager, "_spawn", respawn)
+    monkeypatch.setattr(
+        manager,
+        "_read_output",
+        lambda _process, _timeout: json.dumps(
+            {
+                "type": "result",
+                "result": "ok",
+                "terminal_reason": "end_turn",
+                "session_id": "sid",
+            }
+        ).encode(),
+    )
+    monkeypatch.setattr(manager, "_parse_line", json.loads)
+    monkeypatch.setattr(manager, "ready", lambda: True)
+
+    manager.turn("hello", session_id="sid", system_prompt="CALLER-MARKER")
+    assert calls[0]["system_prompt"] == "CALLER-MARKER"
+
+
 def test_malformed_assistant_events_are_skipped(tmp_path, monkeypatch):
     """Malformed assistant shapes do not abort the turn or poison the stream."""
     monkeypatch.setenv("FAKE_MALFORMED", "1")
@@ -2013,7 +2070,15 @@ def test_progress_pusher_collapses_rapid_events_to_latest():
     assert pushed == ["second"]
 
 
-def test_progress_token_validation():
+def test_compose_system_prompt():
+    assert shim.compose_system_prompt(None) == shim.SANDBOX_PROMPT
+    assert shim.compose_system_prompt("  ") == shim.SANDBOX_PROMPT
+    composed = shim.compose_system_prompt("X")
+    assert composed.startswith(shim.SANDBOX_PROMPT + "\n")
+    assert "X" in composed
+
+
+def test_system_prompt_validation_and_forwarding():
     class _Headers:
         def __init__(self, length):
             self.length = length
@@ -2048,9 +2113,22 @@ def test_progress_token_validation():
     assert manager.calls[0][1] == {"progress_token": "abc123"}
 
     manager = _Manager()
+    assert post({"message": "hello", "system_prompt": "  CALLER  "}, manager) == [
+        (200, {"result": "ok"})
+    ]
+    assert manager.calls[0][1] == {"system_prompt": "CALLER"}
+
+    manager = _Manager()
     assert post({"message": "hello"}, manager) == [(200, {"result": "ok"})]
     assert manager.calls[0][1] == {}
 
+    for token in ("", 123):
+        manager = _Manager()
+        responses = post({"message": "hello", "system_prompt": token}, manager)
+        assert responses == [
+            (400, {"error": "system_prompt must be a non-empty string"})
+        ]
+        assert manager.calls == []
     for token in ("", 123):
         manager = _Manager()
         responses = post({"message": "hello", "progress_token": token}, manager)
@@ -2077,9 +2155,16 @@ def test_progress_token_forwarded_to_claude_adapter(monkeypatch):
     manager.codex = FakeAdapter()
     manager.pi = FakeAdapter()
 
-    manager.turn("msg", session_id="s1", model=None, progress_token="token123")
+    manager.turn(
+        "msg",
+        session_id="s1",
+        model=None,
+        progress_token="token123",
+        system_prompt="CALLER-MARKER",
+    )
     assert len(calls) == 1
     assert calls[0][1].get("progress_token") == "token123"
+    assert calls[0][1].get("system_prompt") == "CALLER-MARKER"
 
     calls.clear()
     manager.turn("msg", session_id="s1", model=None)
@@ -3328,7 +3413,7 @@ def test_cli_crash_is_422(tmp_path, monkeypatch):
     manager = _manager(tmp_path, monkeypatch)
     original = manager._spawn
 
-    def crash_spawn(session_id=None, first_message=None, model=None):
+    def crash_spawn(session_id=None, first_message=None, model=None, **_kwargs):
         raise RuntimeError("claude crashed during turn, exit code 7")
 
     manager._spawn = crash_spawn
@@ -3611,13 +3696,16 @@ def test_pi_argv_constrains_the_context_budget(tmp_path, monkeypatch):
     prompt instead of the task, and the answers quietly get worse.
     """
     manager = _pi_manager(tmp_path, monkeypatch)
-    manager.turn("hello", model="qwen")
+    manager.turn("hello", model="qwen", system_prompt="CALLER-MARKER")
     argv = json.loads((tmp_path / "pi-args.jsonl").read_text().splitlines()[0])
 
     # --system-prompt REPLACES pi's default coding prompt (it does not append),
     # which is what keeps the scaffolding down to a couple of hundred tokens.
     assert "--system-prompt" in argv
-    assert shim.VOICE_PROMPT in argv[argv.index("--system-prompt") + 1]
+    system_prompt = argv[argv.index("--system-prompt") + 1]
+    assert "You are a focused coding agent." in system_prompt
+    assert shim.SANDBOX_PROMPT in system_prompt
+    assert "CALLER-MARKER" in system_prompt
 
     # Discovery of every kind is off: context files (AGENTS.md/CLAUDE.md),
     # extensions, skills and prompt templates all inject tokens we did not

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.377
+version: 0.89.383
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.377
+      targetRevision: 0.89.383
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -40,7 +40,7 @@ async def start_session_for_thread(
         "main",
         model,
         repo,
-        thread_id,
+        discord_thread=thread_id,
     )
     await asyncio.to_thread(_persist_pending_message, row.id, prompt, model)
     _schedule_next_message(row.id)

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -151,7 +151,9 @@ def _persist_session(
     branch: str,
     model: str | None,
     repo: str | None = None,
+    *,
     discord_thread: str | None = None,
+    system_prompt: str | None = None,
 ) -> AgentSession:
     with Session(get_engine()) as db_session:
         return store.create_session(
@@ -162,6 +164,7 @@ def _persist_session(
             model,
             repo,
             discord_thread=discord_thread,
+            system_prompt=system_prompt,
         )
 
 
@@ -450,6 +453,8 @@ async def _execute_pending_message(session_id: int) -> None:
             if session_row.repo is not None:
                 deliver_kwargs["repo"] = session_row.repo
                 deliver_kwargs["branch"] = session_row.branch
+            if session_row.system_prompt is not None:
+                deliver_kwargs["system_prompt"] = session_row.system_prompt
             turn, ember = await _transport.deliver(
                 existing_ember,
                 cli_session_id,
@@ -618,7 +623,14 @@ async def monolith_agent_session_start(prompt: str, model: str | None = None) ->
     local_session_id = str(uuid4())
     workspace = "<guest>"  # Workspace is in the guest, not the pod
     row = await asyncio.to_thread(
-        _persist_session, local_session_id, workspace, "main", model, None
+        _persist_session,
+        local_session_id,
+        workspace,
+        "main",
+        model,
+        None,
+        discord_thread=None,
+        system_prompt=voice.VOICE_INSTRUCTION,
     )
     turn = await asyncio.to_thread(_persist_pending_message, row.id, prompt, model)
     _schedule_next_message(row.id)

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -6,7 +6,7 @@ import pytest
 from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
-from agent_sessions import mcp, model_family, store
+from agent_sessions import mcp, model_family, store, voice
 from agent_sessions.models import AgentSession, AgentTurn
 from agent_sessions.transport import EmberSession, EmberSessionGone, Turn
 from faas.embervm_client import EmberVMTransportError
@@ -44,6 +44,44 @@ def test_session_start_stores_model_on_session_and_pending(monkeypatch, session,
     pending = store.get_pending_message(session, row.id, result["turn"])
     assert row.model == model
     assert pending.model == model
+
+
+def test_session_start_stores_voice_system_prompt(monkeypatch, session):
+    monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
+
+    result = asyncio.run(mcp.monolith_agent_session_start("hello"))
+
+    row = store.get_session(session, result["session_id"])
+    assert row.system_prompt == voice.VOICE_INSTRUCTION
+
+
+def test_execute_pending_message_forwards_system_prompt_only_when_set(
+    monkeypatch, session
+):
+    delivered = []
+
+    async def mock_deliver(*args, **kwargs):
+        delivered.append(kwargs)
+        return _completed_delivery(args[2])
+
+    async def mock_notify(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(mcp._transport, "deliver", mock_deliver)
+    monkeypatch.setattr(mcp.agent_api, "notify", mock_notify)
+    monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
+
+    prompted = store.create_session(
+        session, "prompted", "/workspace", "main", system_prompt="X"
+    )
+    store.create_pending_message(session, prompted.id, "hello")
+    asyncio.run(mcp._execute_pending_message(prompted.id))
+    assert delivered[-1]["system_prompt"] == "X"
+
+    unprompted = store.create_session(session, "unprompted", "/workspace", "main")
+    store.create_pending_message(session, unprompted.id, "hello")
+    asyncio.run(mcp._execute_pending_message(unprompted.id))
+    assert "system_prompt" not in delivered[-1]
 
 
 @pytest.fixture
@@ -150,6 +188,7 @@ def test_same_family_override_reaches_transport_and_turn(monkeypatch, session):
         repo=None,
         branch=None,
         progress_token=None,
+        system_prompt=None,
     ):
         delivered_models.append(model)
         return _completed_delivery(message)
@@ -189,6 +228,7 @@ def test_session_start_returns_immediately(monkeypatch, session):
         repo=None,
         branch=None,
         progress_token=None,
+        system_prompt=None,
     ):
         started.set()
         await asyncio.Event().wait()
@@ -225,6 +265,7 @@ def test_session_start_happy_path_persists_result(monkeypatch, session):
         repo=None,
         branch=None,
         progress_token=None,
+        system_prompt=None,
     ):
         return _completed_delivery(message)
 
@@ -299,6 +340,7 @@ def test_concurrent_executors_on_first_turn_run_once(monkeypatch, session):
         repo=None,
         branch=None,
         progress_token=None,
+        system_prompt=None,
     ):
         executions.append(message)
         await asyncio.sleep(0.01)
@@ -395,6 +437,7 @@ def test_pending_message_executed_in_background(monkeypatch, session):
         repo=None,
         branch=None,
         progress_token=None,
+        system_prompt=None,
     ):
         return _completed_delivery(message)
 
@@ -438,6 +481,7 @@ def test_failed_delivery_clears_reused_ember_session(monkeypatch, session):
         repo=None,
         branch=None,
         progress_token=None,
+        system_prompt=None,
     ):
         raise EmberSessionGone("terminal invoke failure")
 
@@ -476,6 +520,7 @@ def test_clear_ember_session_not_called_when_fresh_binding_persisted(
         repo=None,
         branch=None,
         progress_token=None,
+        system_prompt=None,
     ):
         heir = EmberSession("heir-id", "heir-token", None)
         if on_create is not None:

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -41,6 +41,11 @@ class AgentSession(SQLModel, table=True):
     prior_ember_lineage_id: str | None = Field(default=None)
     prior_cli_session_id: str | None = Field(default=None)
     progress_token: str | None = Field(default=None)
+    # The CALLER's system prompt for this session, appended to the guest shim's
+    # own sandbox prompt. Only the MCP lane sets it (to the voice instruction);
+    # a Discord thread posts the turn result verbatim, so voice markup there is
+    # noise rather than signal.
+    system_prompt: str | None = Field(default=None)
     # BigInteger, not the default Integer: this is epoch MILLISECONDS from the
     # control plane, which overflows int4. The migration already declares BIGINT,
     # but SQLModel maps a plain int to sqlalchemy Integer and emits an explicit

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine
 
-from agent_sessions import store
+from agent_sessions import api, store
 from agent_sessions import mcp
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.router import router
@@ -419,8 +419,10 @@ def test_mcp_tools_still_work(session, monkeypatch):
     monkeypatch.setattr(
         mcp,
         "_persist_session",
-        lambda local, workspace, branch, model, repo=None: store.create_session(
-            session, local, workspace, branch, model, repo
+        lambda local, workspace, branch, model, repo=None, **kwargs: (
+            store.create_session(
+                session, local, workspace, branch, model, repo, **kwargs
+            )
         ),
     )
     monkeypatch.setattr(
@@ -455,8 +457,31 @@ def test_start_session_marks_message_ui_originated(client, session, monkeypatch)
     monkeypatch.setattr("agent_sessions.router._schedule_next_message", lambda _: None)
 
     body = client.post("/api/agents/sessions", json={"prompt": "Hello"}).json()
+    assert store.get_session(session, body["session_id"]).system_prompt is None
     assert mcp._consume_ui_originated(body["session_id"], body["turn"]) is True
     mcp._ui_originated.clear()
+
+
+def test_start_session_for_discord_thread_has_no_system_prompt(session, monkeypatch):
+    monkeypatch.setattr(api, "_persist_pending_message", lambda *_args: 1)
+    monkeypatch.setattr(api, "_schedule_next_message", lambda _session_id: None)
+    monkeypatch.setattr(
+        api,
+        "_persist_session",
+        lambda local, workspace, branch, model, repo=None, **kwargs: (
+            store.create_session(
+                session, local, workspace, branch, model, repo, **kwargs
+            )
+        ),
+    )
+
+    session_id = asyncio.run(
+        api.start_session_for_thread("thread-1", "Hello", repo=None)
+    )
+
+    row = store.get_session(session, session_id)
+    assert row.discord_thread == "thread-1"
+    assert row.system_prompt is None
 
 
 def test_send_message_marks_message_ui_originated(client, session, monkeypatch):

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -27,6 +27,7 @@ def create_session(
     repo: str | None = None,
     *,
     discord_thread: str | None = None,
+    system_prompt: str | None = None,
 ) -> AgentSession:
     row = AgentSession(
         local_session_id=local_session_id,
@@ -36,6 +37,7 @@ def create_session(
         discord_thread=discord_thread,
         model=model,
         progress_token=secrets.token_urlsafe(32),
+        system_prompt=system_prompt,
     )
     session.add(row)
     session.commit()

--- a/projects/monolith/agent_sessions/store_test.py
+++ b/projects/monolith/agent_sessions/store_test.py
@@ -72,6 +72,25 @@ def test_write_progress_sync_updates_claimed_row(monkeypatch, tmp_path):
         _restore_schemas(schemas)
 
 
+def test_create_session_persists_optional_system_prompt(monkeypatch, tmp_path):
+    engine, schemas = _database(monkeypatch, tmp_path)
+    try:
+        with Session(engine) as session:
+            prompted = store.create_session(
+                session,
+                "prompted",
+                "<guest>",
+                "main",
+                system_prompt="X",
+            )
+            unprompted = store.create_session(session, "unprompted", "<guest>", "main")
+
+            assert prompted.system_prompt == "X"
+            assert unprompted.system_prompt is None
+    finally:
+        _restore_schemas(schemas)
+
+
 def test_write_progress_sync_stores_activities(monkeypatch, tmp_path):
     engine, schemas = _database(monkeypatch, tmp_path)
     activities = [{"type": "tool", "name": "shell"}]

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -138,6 +138,7 @@ class ShimTransport(Protocol):
         repo: str | None = None,
         branch: str | None = None,
         progress_token: str | None = None,
+        system_prompt: str | None = None,
     ) -> tuple[Turn, EmberSession]: ...
 
 
@@ -357,6 +358,7 @@ class EmberVmShimTransport:
         repo: str | None = None,
         branch: str | None = None,
         progress_token: str | None = None,
+        system_prompt: str | None = None,
     ) -> tuple[Turn, EmberSession]:
         """Execute one turn on the guest session and return the result.
 
@@ -368,6 +370,8 @@ class EmberVmShimTransport:
                 only actually sent once the restore is confirmed to have
                 recovered the workspace (see restore_from below).
             message: User message / prompt to send to Claude.
+            system_prompt: The caller's system prompt, appended to the shim's
+                own sandbox prompt. Omitted from the payload if None.
             restore_from: A prior LINEAGE handle to inherit the guest
                 workspace from when ember is None (#4306 slice 5: the
                 binding-was-cleared path, e.g. after an EmberSessionGone or
@@ -442,6 +446,8 @@ class EmberVmShimTransport:
                 payload["branch"] = branch or "main"
             if progress_token is not None:
                 payload["progress_token"] = progress_token
+            if system_prompt is not None:
+                payload["system_prompt"] = system_prompt
             body = json.dumps(payload)
             url = f"{EMBERVM_URL}/v1/sessions/{current.session_id}/invoke"
             headers = {

--- a/projects/monolith/agent_sessions/transport_test.py
+++ b/projects/monolith/agent_sessions/transport_test.py
@@ -261,6 +261,41 @@ def test_deliver_omits_progress_token_when_none(monkeypatch):
     assert "progress_token" not in json.loads(requests[0].content)
 
 
+def test_deliver_includes_system_prompt_when_present(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return _turn_response(request)
+
+    _client(monkeypatch, handler)
+    asyncio.run(
+        transport.EmberVmShimTransport().deliver(
+            transport.EmberSession("s1", "t1", None),
+            "cli-1",
+            "hello",
+            system_prompt="X",
+        )
+    )
+    assert json.loads(requests[0].content)["system_prompt"] == "X"
+
+
+def test_deliver_omits_system_prompt_when_none(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return _turn_response(request)
+
+    _client(monkeypatch, handler)
+    asyncio.run(
+        transport.EmberVmShimTransport().deliver(
+            transport.EmberSession("s1", "t1", None), "cli-1", "hello"
+        )
+    )
+    assert "system_prompt" not in json.loads(requests[0].content)
+
+
 def test_invoke_retryable_502_is_retried_and_succeeds(monkeypatch):
     requests = []
     sleeps = []

--- a/projects/monolith/agent_sessions/voice.py
+++ b/projects/monolith/agent_sessions/voice.py
@@ -4,6 +4,15 @@ import re
 
 _VOICE_RE = re.compile(r"<voice>(.*?)</voice>", re.IGNORECASE | re.DOTALL)
 
+# Pairs with extract_voice_summary, which falls back to the first sentence
+# when the tag is absent, so sessions without this prompt still get a usable
+# summary.
+VOICE_INSTRUCTION = (
+    "End every response with a single line: <voice>One or two plain sentences, "
+    "no markdown, that a person could hear read aloud: what you did and anything "
+    "you need from them.</voice>"
+)
+
 
 def extract_voice_summary(result_text: str) -> str:
     if not result_text:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.452
+version: 0.285.458
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260807000000_agent_sessions_system_prompt.sql
+++ b/projects/monolith/chart/migrations/20260807000000_agent_sessions_system_prompt.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agent_sessions.agent_sessions
+    ADD COLUMN system_prompt TEXT;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:5ASiIIugXYdOlSLfZIIt9hXYWdaoxSfAlJbRG9/RupI=
+h1:kJl0E1y57xctZsqJ6KkWRrS+w85p+af7+xtfwAa0/HM=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -154,3 +154,4 @@ h1:5ASiIIugXYdOlSLfZIIt9hXYWdaoxSfAlJbRG9/RupI=
 20260804180000_agent_sessions_progress.sql h1:kBebvB7KOtRDZlGnv0cVSocBulNSyhcSThZMBHzMEHQ=
 20260804180100_agent_sessions_partial_activities.sql h1:7pn5RdzO2CtsdU0TgaMLLeEflS5C0YZtqBxyerEjHyY=
 20260806090000_agent_sessions_discord_thread.sql h1:9V+mX3YJfQhNe+5UqL6OSf+6hUxNPXbMnwO7yCnfqSg=
+20260807000000_agent_sessions_system_prompt.sql h1:yXxvvTBu8bpsxP0gvWha+tx+HVDckAgIGwKg474B4Lg=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.452
+      targetRevision: 0.285.458
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Two system prompts now reach the guest, from the two places that actually know
the facts they carry.

**The shim owns the sandbox prompt.** A new `SANDBOX_PROMPT` constant covers what
only the guest knows: the depth-1 single-branch checkout at `/workspace/src`, the
mirror-only `origin` that accepts pushes under `refs/agents/**`, the preset git
identity, the proxied egress with credentials attached on the way out, and the
fact that `gh auth status` reporting "not logged in" is correct rather than a
fault to debug. It is injected for all three adapters, unconditionally.

**The monolith owns the caller prompt.** A new `system_prompt` column on
`agent_sessions` rides through `transport.deliver` into the `/shim/turn` payload,
where the shim appends it to its own prompt. Only `monolith_agent_session_start`
sets it, to the voice instruction. Discord and the /agents UI set nothing, which
is the actual fix: `VOICE_PROMPT` used to be unconditional in the shim, so
`<voice>` markup leaked into every Discord thread, where the turn result is
posted verbatim.

### The codex adapter had no prompt at all

It does now. `thread/start` and `thread/resume` both take `developerInstructions`,
verified against codex-cli 0.146.0 rather than assumed:

- `codex app-server generate-json-schema` lists the field on both param types.
- Pointing `model_providers.<p>.base_url` at a local capture server and running a
  turn shows it arriving as a `developer`-role message in the Responses request
  `input`, ahead of codex's own permissions block.
- Re-passing it on resume after a process restart does NOT duplicate it: exactly
  one developer message carries it in turn 2. So the shim passes it on both calls
  and stays correct across a relight.

No `AGENTS.md` is written anywhere, so nothing lands above or inside the checkout
and no diff is polluted.

### The prewarm trap

`--append-system-prompt` is spawn-time only, and `_prewarm` parks a Claude CLI
spawned without a caller prompt. Adopting that parked process would have silently
dropped the prompt on the first turn, so `system_prompt_changed` joins the
existing `model_changed or cwd_changed` respawn condition. Pi gets the same
treatment, ordered ahead of its `set_model` branch since a respawn already has
the requested model. Codex needs none of this: its seam is per-request.

### Deploy ordering is safe either way

Old shim with new monolith: the shim reads specific payload keys, so an unknown
`system_prompt` is ignored and the old unconditional `VOICE_PROMPT` still applies.
New shim with old monolith: sandbox prompt only, and voice summaries fall back to
first-sentence extraction, which `extract_voice_summary` already does.

Sessions created before this migration carry a NULL `system_prompt`, so an
in-flight MCP session loses the voice tag on its next turn and falls back the same
way. New sessions are unaffected.

### Verification

`ci test` green. The five changed test targets were then re-run with
`--nocache_test_results` to prove execution rather than cache reuse:
`Executed 5 out of 5 tests: 5 tests pass`.

Regression guards are explicit in both directions: MCP sessions assert
`system_prompt == VOICE_INSTRUCTION`, Discord and UI sessions assert it is None,
and the transport asserts the key is omitted entirely when None.

Charts bumped for embervm (the shim rides in the guest runtime image) and
monolith plus monolith-public (the migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QMcj7QnV7bvZo6vhWCHAj