### PR TITLE
fix(agents): make the dispatch single-flight lock hold under races and kills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,11 @@ that implements the spec.
 
 ## Test-writing traps (each of these has cost a review round)
 
-- `projects/monolith/agent_sessions/` and `projects/monolith/knowledge/` are
-  gazelle-excluded: a new `*_test.py` there needs a hand-written `py_test`
-  target in `projects/monolith/BUILD`, or Bazel never runs it.
+- Effectively every subpackage under `projects/monolith/` is gazelle-excluded
+  (verify with `grep gazelle:exclude projects/monolith/BUILD`): any new
+  `*_test.py` under `projects/monolith/` needs a hand-written `py_test` target
+  in `projects/monolith/BUILD`, following the hundreds already there, or Bazel
+  never runs it.
 - SQLite in tests: use a file-backed database under `tmp_path`. An in-memory
   StaticPool database is ONE connection and deadlocks concurrency tests.
 - `build_app()` calls `logging.basicConfig(force=True)`, which removes
@@ -42,7 +44,9 @@ that implements the spec.
 
 - Python deps are `@pip//package` via `aspect_rules_py`. `requirement()`
   syntax does not exist in this repo.
-- Frontend is Svelte 5 runes only (`$props`, `$derived`, `$effect`). CSS is
+- The `projects/monolith/frontend/` frontend is Svelte 5 runes only (`$props`,
+  `$derived`, `$effect`); the `projects/grimoire/frontend/` frontend is React
+  19. Match the conventions of whichever frontend the task touches. CSS is
   imported from JavaScript (the route layout), never via bare `@import`
   package specifiers inside CSS: PostCSS cannot resolve them.
 - Containers are apko, never Dockerfiles: dual-arch, non-root uid 65532.

--- a/bazel/tools/codex/BUILD
+++ b/bazel/tools/codex/BUILD
@@ -1,0 +1,11 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["*.sh"]))
+
+sh_test(
+    name = "dispatch_test",
+    srcs = ["dispatch_test.sh"],
+    data = [":dispatch.sh"],
+)

--- a/bazel/tools/codex/dispatch.sh
+++ b/bazel/tools/codex/dispatch.sh
@@ -2,8 +2,8 @@
 # Deterministic wrapper for dispatching implementation work to the Codex CLI.
 #
 # Usage:
-#   bazel/tools/codex/dispatch.sh <tier> <workdir> "<task spec>"
-#   echo "<task spec>" | bazel/tools/codex/dispatch.sh <tier> <workdir> -
+#   "$WORKDIR"/bazel/tools/codex/dispatch.sh <tier> "$WORKDIR" "<task spec>"
+#   echo "<task spec>" | "$WORKDIR"/bazel/tools/codex/dispatch.sh <tier> "$WORKDIR" -
 #
 #   tier:    luna | terra | frontier
 #            luna = default (most value / $); terra = step-up; frontier/Sol = rare
@@ -96,20 +96,38 @@ mkdir -p "$RUNDIR"
 # refuse loudly instead. A lock whose pid is dead is stale and reclaimed.
 LOCK="$RUNDIR/lock"
 if ! mkdir "$LOCK" 2>/dev/null; then
-	OTHER_PID="$(cat "$LOCK/pid" 2>/dev/null || true)"
-	if [[ -n "$OTHER_PID" ]] && kill -0 "$OTHER_PID" 2>/dev/null; then
+	if ! OTHER_PID="$(cat "$LOCK/pid" 2>/dev/null)" || [[ -z "$OTHER_PID" ]]; then
+		echo "dispatch lock is being acquired for $WORKDIR" >&2
+		exit "$BUSY_EXIT"
+	fi
+	OTHER_CHILD=""
+	if [[ -e "$LOCK/child" ]]; then
+		if ! OTHER_CHILD="$(cat "$LOCK/child" 2>/dev/null)"; then
+			echo "dispatch lock metadata is unreadable for $WORKDIR" >&2
+			exit "$BUSY_EXIT"
+		fi
+		if [[ -n "$OTHER_CHILD" ]] && kill -0 "$OTHER_CHILD" 2>/dev/null; then
+			echo "dispatch child pid $OTHER_CHILD already owns $WORKDIR" >&2
+			echo "live log: $(cat "$LOCK/log" 2>/dev/null || echo unknown)" >&2
+			exit "$BUSY_EXIT"
+		fi
+	fi
+	if kill -0 "$OTHER_PID" 2>/dev/null; then
 		echo "dispatch pid $OTHER_PID already owns $WORKDIR" >&2
 		echo "live log: $(cat "$LOCK/log" 2>/dev/null || echo unknown)" >&2
 		exit "$BUSY_EXIT"
 	fi
 	rm -rf "$LOCK"
-	mkdir "$LOCK"
+	if ! mkdir "$LOCK" 2>/dev/null; then
+		echo "dispatch lock was claimed by another invocation for $WORKDIR" >&2
+		exit "$BUSY_EXIT"
+	fi
 fi
+echo $$ >"$LOCK/pid"
 
-STAMP="$(date +%Y%m%dT%H%M%S)"
+STAMP="$(date +%Y%m%dT%H%M%S).$$"
 LOG="$RUNDIR/$STAMP.log"
 LAST="$RUNDIR/$STAMP.last-message.txt"
-echo $$ >"$LOCK/pid"
 echo "$LOG" >"$LOCK/log"
 
 # If the harness kills this wrapper (timeout, user interrupt), take the codex
@@ -118,13 +136,17 @@ echo "$LOG" >"$LOCK/log"
 CHILD=""
 cleanup() {
 	if [[ -n "$CHILD" ]]; then
-		kill -TERM "$CHILD" 2>/dev/null || true
+		kill -TERM -- -$CHILD 2>/dev/null || true
+		wait "$CHILD" 2>/dev/null || true
+		CHILD=""
 	fi
 	rm -rf "$LOCK"
 }
 trap cleanup EXIT
 trap 'cleanup; trap - TERM; exit 143' TERM INT
 
+rm -f "$LAST"
+set -m
 set +e
 codex exec \
 	--model "$MODEL" \
@@ -136,6 +158,7 @@ codex exec \
 	-C "$WORKDIR" \
 	"${SPEC}${GUARDRAILS}" >"$LOG" 2>&1 &
 CHILD=$!
+echo "$CHILD" >"$LOCK/child"
 wait "$CHILD"
 CODE=$?
 CHILD=""
@@ -146,7 +169,7 @@ set -e
 # non-zero exit so a task spec that merely mentions rate limits or 429s
 # does not false-positive.
 if [[ "$CODE" -ne 0 ]] &&
-	grep -qiE 'usage limit|rate limit|too many requests|429|quota|plan limit' "$LOG"; then
+	grep -qiE 'usage limit|plan limit|rate limit|too many requests|quota exceeded|http/?[12]?[.0-9]* 429|status(:)? 429' "$LOG"; then
 	echo "CODEX_QUOTA_EXHAUSTED model=$MODEL log=$LOG" >&2
 	exit "$QUOTA_EXIT"
 fi

--- a/bazel/tools/codex/dispatch_test.sh
+++ b/bazel/tools/codex/dispatch_test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT="${BASH_SOURCE[0]%/*}/dispatch.sh"
+[[ -f "$SCRIPT" ]] || exit 1
+TMP="${TEST_TMPDIR:-$(mktemp -d)}"
+BIN="$TMP/bin"
+mkdir -p "$BIN"
+cat >"$BIN/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+last=""
+while (($#)); do
+  if [[ "$1" == --output-last-message ]]; then last="$2"; shift 2; else shift; fi
+done
+printf 'run\n' >>"${STUB_COUNTER:?}"
+sleep "${STUB_SLEEP:-0.1}"
+[[ -z "${STUB_OUTPUT:-}" ]] || printf '%s\n' "$STUB_OUTPUT"
+if [[ "${STUB_WRITE_LAST:-1}" == 1 ]]; then
+  mkdir -p "${last%/*}"
+  printf '%s\n' "${STUB_MESSAGE:-stub final message}" >"$last"
+fi
+exit "${STUB_EXIT:-0}"
+EOF
+chmod +x "$BIN/codex"
+
+run_dispatch() {
+	local workdir="$1"
+	PATH="$BIN:$PATH" STUB_COUNTER="$TMP/counter" \
+		STUB_SLEEP="${STUB_SLEEP:-0.1}" STUB_EXIT="${STUB_EXIT:-0}" \
+		STUB_MESSAGE="${STUB_MESSAGE:-stub final message}" STUB_WRITE_LAST="${STUB_WRITE_LAST:-1}" \
+		STUB_OUTPUT="${STUB_OUTPUT:-}" bash "$SCRIPT" luna "$workdir" test-spec
+}
+assert_eq() {
+	[[ "$2" == "$3" ]] || {
+		echo "FAIL: $1" >&2
+		exit 1
+	}
+	echo "PASS: $1"
+}
+wait_for_file() {
+	for _ in {1..100}; do
+		[[ -s "$1" ]] && return
+		sleep 0.01
+	done
+	echo "FAIL: timeout" >&2
+	exit 1
+}
+reset() {
+	: >"$TMP/counter"
+	STUB_SLEEP=0.1 STUB_EXIT=0 STUB_MESSAGE="stub final message" STUB_WRITE_LAST=1 STUB_OUTPUT=
+}
+
+reset
+WORK="$TMP/happy"
+mkdir -p "$WORK"
+out=$(run_dispatch "$WORK")
+assert_eq "happy exit" 0 "$?"
+grep -q "stub final message" <<<"$out"
+log=$(sed -n 's/.*transcript: \([^)]*\).*/\1/p' <<<"$out")
+[[ -f "$log" ]] || exit 1
+echo "PASS: happy output and transcript"
+
+reset
+WORK="$TMP/held"
+mkdir -p "$WORK"
+STUB_SLEEP=0.7 run_dispatch "$WORK" >"$TMP/holder.out" 2>&1 &
+holder=$!
+wait_for_file "$WORK/.codex-dispatch/lock/child"
+set +e
+held_out=$(run_dispatch "$WORK" 2>&1)
+held_rc=$?
+set -e
+wait "$holder"
+assert_eq "held lock exit" 65 "$held_rc"
+assert_eq "held lock worker count" 1 "$(wc -l <"$TMP/counter" | tr -d ' ')"
+grep -q "live log:" <<<"$held_out"
+echo "PASS: held lock"
+
+reset
+WORK="$TMP/concurrent"
+mkdir -p "$WORK"
+pids=()
+for _ in {1..8}; do
+	STUB_SLEEP=0.5 run_dispatch "$WORK" >"$TMP/out.$RANDOM" 2>&1 &
+	pids+=("$!")
+done
+rcs=()
+for pid in "${pids[@]}"; do
+	set +e
+	wait "$pid"
+	rcs+=("$?")
+	set -e
+done
+assert_eq "concurrency worker count" 1 "$(wc -l <"$TMP/counter" | tr -d ' ')"
+busy=0
+for rc in "${rcs[@]}"; do
+	if [[ "$rc" == 65 ]]; then busy=$((busy + 1)); else assert_eq "concurrency winner exit" 0 "$rc"; fi
+done
+assert_eq "concurrency busy count" 7 "$busy"
+echo "PASS: concurrency"
+
+reset
+WORK="$TMP/stale"
+mkdir -p "$WORK/.codex-dispatch/lock"
+sleep 0.01 &
+dead=$!
+wait "$dead"
+printf '%s\n' "$dead" >"$WORK/.codex-dispatch/lock/pid"
+printf '%s\n' "$dead" >"$WORK/.codex-dispatch/lock/child"
+printf '%s\n' old.log >"$WORK/.codex-dispatch/lock/log"
+set +e
+run_dispatch "$WORK" >/dev/null
+stale_rc=$?
+set -e
+assert_eq "stale reclaim exit" 0 "$stale_rc"
+sleep 1 &
+live_child=$!
+mkdir -p "$WORK/.codex-dispatch/lock"
+printf '%s\n' "$dead" >"$WORK/.codex-dispatch/lock/pid"
+printf '%s\n' "$live_child" >"$WORK/.codex-dispatch/lock/child"
+set +e
+live_out=$(run_dispatch "$WORK" 2>&1)
+live_rc=$?
+set -e
+wait "$live_child"
+assert_eq "live stale child exit" 65 "$live_rc"
+grep -q "pid $live_child" <<<"$live_out"
+echo "PASS: stale reclaim"
+
+reset
+WORK="$TMP/rerun"
+mkdir -p "$WORK"
+first_out=$(STUB_MESSAGE=first-message run_dispatch "$WORK")
+old_log=$(sed -n 's/.*transcript: \([^)]*\).*/\1/p' <<<"$first_out")
+set +e
+second_out=$(STUB_EXIT=3 STUB_WRITE_LAST=0 run_dispatch "$WORK" 2>&1)
+second_rc=$?
+set -e
+assert_eq "failed rerun exit" 3 "$second_rc"
+! grep -q first-message <<<"$second_out"
+[[ -f "$old_log" ]] || exit 1
+echo "PASS: same-second rerun"
+
+reset
+WORK="$TMP/quota"
+mkdir -p "$WORK"
+set +e
+STUB_EXIT=1 STUB_WRITE_LAST=0 STUB_OUTPUT="pytest collected 429 items" run_dispatch "$WORK" >"$TMP/plain.out" 2>&1
+plain_rc=$?
+set -e
+assert_eq "bare 429 is not quota" 1 "$plain_rc"
+set +e
+STUB_EXIT=1 STUB_WRITE_LAST=0 STUB_OUTPUT="429 Too Many Requests" run_dispatch "$WORK" >"$TMP/framed.out" 2>&1
+framed_rc=$?
+set -e
+assert_eq "framed 429 is quota" 42 "$framed_rc"
+echo "PASS: quota regex"
+echo "All dispatch tests passed"


### PR DESCRIPTION
Follow-up to #4454. The Opus review reproduced three lock defects empirically with a stubbed codex; this PR fixes all review findings in one batched round (per the correction-round rule #4454 itself introduced).

## Fixes

1. **Lock acquisition race:** pid is now written as the first statement after a successful `mkdir` on both acquisition paths; an empty or unreadable pid file reads as HELD (exit 65), never stale; the reclaim `mkdir` is guarded so a lost race exits 65 instead of dying bare under `set -e`. Previously 8 concurrent dispatches yielded 4 live workers.
2. **Orphan double-dispatch:** the child pid is recorded in the lock; a lock is stale only when wrapper AND child are both dead, so a SIGKILLed wrapper with a live worker now yields exit 65 with the live log path instead of a second worker. `cleanup` TERMs the process group (`set -m`) and waits for the child before releasing the lock.
3. **Stale output:** stamps include `$$` so a same-second rerun cannot print the previous worker's final message or clobber its transcript; `$LAST` is removed before launch.
4. **Quota false-positive:** the exit-42 grep no longer matches bare `429` or `quota` (a `pytest collected 429 items` line plus any nonzero exit triggered a spurious Discord warn and Sonnet fallback); it now anchors on codex's own error framing.
5. **AGENTS.md accuracy:** the gazelle bullet now states that effectively every subpackage under `projects/monolith/` is excluded (47 directives), not just two dirs; the Svelte-5 claim is scoped to the monolith frontend with grimoire identified as React 19.
6. **Coverage:** new hermetic `sh_test` (stub codex, 16 assertions) pins the lock, concurrency, stale-reclaim, rerun, and quota-regex behavior, wired like `bump_chart_test`.

Non-deploying: root `AGENTS.md` is not indexed by the docs manifests and `bazel/tools/` ships in no image, so no chart bumps ride along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)