### PR TITLE
fix(embervm): tell pi Qwen's real context window

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.458
+version: 0.1.459

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.458
+      targetRevision: 0.1.459
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/BUILD
+++ b/projects/embervm/runtimes/claude/BUILD
@@ -140,6 +140,21 @@ py_test(
     ],
 )
 
+# Guard: pi must be told Qwen's real context window. A stale value re-arms
+# the 400 that killed guest turns (see PI_CONTEXT_WINDOW in shim.py).
+# Hand-registered: gazelle does not generate py_test here.
+py_test(
+    name = "pi_context_window_sync_test",
+    srcs = ["pi_context_window_sync_test.py"],
+    data = ["//projects/inference/deploy:values_yaml"],
+    imports = ["."],
+    deps = [
+        ":shim_lib",
+        "@pip//pytest",
+        "@pip//pyyaml",
+    ],
+)
+
 platform_transition_filegroup(
     name = "guest_init_amd64_bin",
     srcs = ["//projects/embervm/runtimes/claude/guest-init/cmd"],

--- a/projects/embervm/runtimes/claude/pi_context_window_sync_test.py
+++ b/projects/embervm/runtimes/claude/pi_context_window_sync_test.py
@@ -1,0 +1,49 @@
+"""Guard that PI_CONTEXT_WINDOW stays in sync with vLLM configuration.
+
+A stale PI_CONTEXT_WINDOW value silently re-arms the bug where pi's
+clampMaxTokensToContext computes available output tokens using a false
+budget. This guard verifies the constant tracks the source of truth.
+"""
+
+import os
+from pathlib import Path
+
+import shim
+
+
+def _repo_path(*parts: str) -> Path:
+    """Resolve a repo-relative path, in-bazel (TEST_SRCDIR) or standalone."""
+    rel = Path(*parts)
+    candidate = Path(os.environ.get("TEST_SRCDIR", "")) / "_main" / rel
+    if candidate.exists():
+        return candidate
+    # Direct run: this file lives at projects/embervm/runtimes/claude/.
+    here = Path(__file__).resolve().parents[4] / rel
+    if here.exists():
+        return here
+    raise FileNotFoundError(f"{rel} not found at {candidate} or {here}")
+
+
+def test_pi_context_window_matches_inference_config():
+    """PI_CONTEXT_WINDOW must match vLLM's maxModelLen in inference config.
+
+    A stale PI_CONTEXT_WINDOW re-arms the bug where pi's
+    clampMaxTokensToContext computes available output tokens using a false
+    budget. This test prevents silent de-synchronization by verifying the
+    constant tracks the source of truth in projects/inference/deploy/values.yaml.
+    """
+    import yaml
+
+    values_path = _repo_path("projects", "inference", "deploy", "values.yaml")
+
+    with open(values_path) as stream:
+        config = yaml.safe_load(stream)
+
+    expected_window = config.get("vllm", {}).get("maxModelLen")
+    assert expected_window is not None, "vllm.maxModelLen not found in values.yaml"
+    assert shim.PI_CONTEXT_WINDOW == expected_window, (
+        "PI_CONTEXT_WINDOW (%s) does not match inference vllm.maxModelLen (%s). "
+        "Edit projects/embervm/runtimes/claude/shim.py to match, or update "
+        "projects/inference/deploy/values.yaml if the vLLM setting intentionally changed."
+        % (shim.PI_CONTEXT_WINDOW, expected_window)
+    )

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -185,6 +185,41 @@ PI_MODELS = {
     "qwen": "qwen3.6-27b",
 }
 DEFAULT_PI_MODEL = "qwen"
+
+# PI context configuration. These values must be kept in sync with vLLM's
+# --max-model-len (projects/inference/deploy/values.yaml:195). A stale
+# contextWindow value here re-arms the bug where pi's clampMaxTokensToContext
+# computes available output tokens using a false budget, leading to a loud
+# 400 error as soon as input tokens reach exactly half the real window.
+PI_CONTEXT_WINDOW = 32768
+# pi's hardcoded safety margin in clampMaxTokensToContext.
+PI_CONTEXT_SAFETY_TOKENS = 4096
+
+# Maximum output tokens pi will attempt to generate. This caps reply length to
+# prevent bloated answers that waste the context window. It also caps pi's
+# compaction summary at PI_MAX_OUTPUT_TOKENS via
+# min(floor(0.8 * reserveTokens), model.maxTokens).
+# pi's estimateContextTokens anchors on the provider's real usage.totalTokens
+# from the last assistant message and only chars/4-estimates messages after it,
+# so the exposure is one turn's trailing tool results, not the whole
+# conversation. This is why PI_MAX_OUTPUT_TOKENS matters for compaction but not
+# for 400-safety.
+PI_MAX_OUTPUT_TOKENS = 4096
+
+# Compaction reserve in tokens. This must exceed PI_MAX_OUTPUT_TOKENS plus
+# PI_CONTEXT_SAFETY_TOKENS so pi starts compacting while there is still room for
+# a full response at turn boundaries. pi checks compaction at agent_end and
+# before a prompt, not between tool iterations, so a run that approaches the
+# reserve mid-execution can still produce short replies.
+PI_COMPACTION_RESERVE_TOKENS = 10240
+
+# Tokens to keep after compaction. pi's default keepRecentTokens (20000)
+# exceeds the usable budget after pi's default 16384 reserve (32768 - 16384 =
+# 16384), so post-compaction context would land straight back above the
+# threshold. This value must be less than
+# (PI_CONTEXT_WINDOW - PI_COMPACTION_RESERVE_TOKENS) so compaction actually
+# helps when it fires.
+PI_COMPACTION_KEEP_RECENT_TOKENS = 8000
 MAX_REQUEST_BODY_BYTES = 1 << 20
 MAX_TOOL_INPUT_BYTES = 4096
 # Cap on the proxy request head the egress forwarder reads before it knows the
@@ -2408,12 +2443,58 @@ class PiProcess:
                         "supportsDeveloperRole": False,
                         "supportsReasoningEffort": False,
                     },
-                    "models": [{"id": PI_MODELS[DEFAULT_PI_MODEL]}],
+                    "models": [
+                        {
+                            "id": PI_MODELS[DEFAULT_PI_MODEL],
+                            "contextWindow": PI_CONTEXT_WINDOW,
+                            "maxTokens": PI_MAX_OUTPUT_TOKENS,
+                        }
+                    ],
                 }
             }
         }
         with open(os.path.join(agent_dir, "models.json"), "w") as stream:
             json.dump(config, stream)
+
+    def _write_settings_json(self, pi_home):
+        """Write pi's settings.json with compaction configuration.
+
+        pi may persist unrelated keys in settings.json, so this method reads
+        any existing file, merges the compaction block, and writes back. If
+        the file is missing, unreadable, or contains invalid JSON, fall back
+        to writing just the compaction block without crashing the spawn.
+        """
+        agent_dir = os.path.join(pi_home, "agent")
+        _ensure_cli_dir(agent_dir)
+        settings_path = os.path.join(agent_dir, "settings.json")
+
+        existing_settings = {}
+        try:
+            with open(settings_path, "r") as stream:
+                existing_settings = json.load(stream)
+        except (OSError, ValueError):
+            # ValueError covers both json.JSONDecodeError and UnicodeDecodeError.
+            # A torn write on the durable workspace volume can produce invalid UTF-8.
+            pass
+
+        if not isinstance(existing_settings, dict):
+            existing_settings = {}
+
+        existing_settings["compaction"] = {
+            "enabled": True,
+            "reserveTokens": PI_COMPACTION_RESERVE_TOKENS,
+            "keepRecentTokens": PI_COMPACTION_KEEP_RECENT_TOKENS,
+        }
+
+        try:
+            with open(settings_path, "w") as stream:
+                json.dump(existing_settings, stream)
+        except OSError as exc:
+            sys.stderr.write(
+                "ember-claude-shim: warning: failed to write %s: %s\n"
+                % (settings_path, exc)
+            )
+            sys.stderr.flush()
 
     def _spawn(self, model, system_prompt=None):
         if not os.path.isdir(self.workspace):
@@ -2422,6 +2503,7 @@ class PiProcess:
         child_env = self._child_env()
         pi_home = child_env["PI_HOME"]
         self._write_model_config(pi_home)
+        self._write_settings_json(pi_home)
         command = [
             self.executable,
             "--mode",

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -3725,6 +3725,183 @@ def test_pi_argv_constrains_the_context_budget(tmp_path, monkeypatch):
     manager._close_process()
 
 
+def test_pi_models_json_declares_correct_context_window(tmp_path, monkeypatch):
+    """models.json must declare contextWindow and maxTokens matching vLLM.
+
+    If these values are wrong, pi's clampMaxTokensToContext computes available
+    tokens using a false budget. With contextWindow=128000 (pi's hardcoded
+    default), pi believes available tokens is about 107k even when the real
+    window is 32768, leading to a loud 400 error as soon as input tokens
+    exceed 32768 - 16384 = 16384 (exactly half the real window). The arithmetic
+    must ensure that input + max_output_tokens <= real_budget for all inputs.
+    """
+    manager = _pi_manager(tmp_path, monkeypatch)
+    manager.turn("hello", model="qwen")
+
+    assert (
+        shim.PI_CONTEXT_WINDOW
+        - shim.PI_MAX_OUTPUT_TOKENS
+        - shim.PI_CONTEXT_SAFETY_TOKENS
+        > 0
+    ), "Context window too small: max output tokens plus safety margin exceeds budget"
+    assert shim.PI_CONTEXT_WINDOW == 32768
+
+    models_path = tmp_path / "workspace" / ".pi" / "agent" / "models.json"
+    models = json.loads(models_path.read_text())
+    model_dict = models["providers"]["openai-completions"]["models"][0]
+
+    assert model_dict["contextWindow"] == shim.PI_CONTEXT_WINDOW
+    assert model_dict["maxTokens"] == shim.PI_MAX_OUTPUT_TOKENS
+
+    manager._close_process()
+
+
+def test_pi_settings_json_compaction_reserve_exceeds_max_output(tmp_path, monkeypatch):
+    """Compaction reserve must exceed max output plus pi's safety margin."""
+    assert (
+        shim.PI_COMPACTION_RESERVE_TOKENS
+        > shim.PI_MAX_OUTPUT_TOKENS + shim.PI_CONTEXT_SAFETY_TOKENS
+    ), "Compaction reserve too small: full response may not fit when compaction fires"
+
+
+def test_pi_settings_json_keep_recent_smaller_than_usable_window(tmp_path, monkeypatch):
+    """keepRecentTokens must be less than the usable window after compaction."""
+    usable_after_reserve = shim.PI_CONTEXT_WINDOW - shim.PI_COMPACTION_RESERVE_TOKENS
+    assert shim.PI_COMPACTION_KEEP_RECENT_TOKENS < usable_after_reserve, (
+        "keepRecentTokens exceeds usable window: compaction will not reduce context"
+    )
+
+
+def test_pi_settings_json_is_written_with_compaction_block(tmp_path, monkeypatch):
+    """settings.json must contain pi's compaction configuration."""
+    manager = _pi_manager(tmp_path, monkeypatch)
+    manager.turn("hello", model="qwen")
+
+    settings_path = tmp_path / "workspace" / ".pi" / "agent" / "settings.json"
+    settings = json.loads(settings_path.read_text())
+
+    assert "compaction" in settings
+    assert settings["compaction"]["enabled"] is True
+    assert settings["compaction"]["reserveTokens"] == shim.PI_COMPACTION_RESERVE_TOKENS
+    assert (
+        settings["compaction"]["keepRecentTokens"]
+        == shim.PI_COMPACTION_KEEP_RECENT_TOKENS
+    )
+
+    manager._close_process()
+
+
+def test_pi_settings_json_merge_preserves_unrelated_keys(tmp_path, monkeypatch):
+    """Existing settings.json unrelated keys must survive spawn."""
+    manager = _pi_manager(tmp_path, monkeypatch)
+
+    settings_dir = tmp_path / "workspace" / ".pi" / "agent"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = settings_dir / "settings.json"
+    settings_path.write_text(json.dumps({"custom": {"key": "value"}}))
+
+    manager.turn("hello", model="qwen")
+
+    settings = json.loads(settings_path.read_text())
+    assert settings["custom"] == {"key": "value"}, (
+        "Merge did not preserve unrelated key"
+    )
+    assert "compaction" in settings, "Merge did not add compaction block"
+
+    manager._close_process()
+
+
+def test_pi_settings_json_corrupt_file_does_not_break_spawn(tmp_path, monkeypatch):
+    """Corrupt settings.json must not break spawn."""
+    manager = _pi_manager(tmp_path, monkeypatch)
+
+    settings_dir = tmp_path / "workspace" / ".pi" / "agent"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = settings_dir / "settings.json"
+    settings_path.write_text("{invalid json content")
+
+    manager.turn("hello", model="qwen")
+
+    settings = json.loads(settings_path.read_text())
+    assert "compaction" in settings, "Corrupt file was not replaced with fresh content"
+
+    manager._close_process()
+
+
+def test_pi_settings_json_invalid_utf8_does_not_crash(tmp_path, monkeypatch):
+    """Invalid UTF-8 in settings.json must not crash _write_settings_json.
+
+    A torn write on the durable workspace volume can produce invalid UTF-8 bytes.
+    UnicodeDecodeError must be caught and handled gracefully without crashing the
+    spawn.
+    """
+    manager = _pi_manager(tmp_path, monkeypatch)
+
+    settings_dir = tmp_path / "workspace" / ".pi" / "agent"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = settings_dir / "settings.json"
+    # Write genuinely invalid UTF-8 bytes
+    settings_path.write_bytes(b"\xff\xfe\x00garbage")
+
+    # This should not crash; the spawn should proceed
+    manager.turn("hello", model="qwen")
+
+    settings = json.loads(settings_path.read_text())
+    assert "compaction" in settings, (
+        "Invalid UTF-8 should be replaced with fresh content"
+    )
+
+    manager._close_process()
+
+
+def test_pi_settings_json_valid_non_object_json_does_not_crash(tmp_path, monkeypatch):
+    """Valid JSON that is not an object must not crash _write_settings_json.
+
+    json.load succeeds on [], "hello", null, and 3. The method must guard
+    against these and fall back to a fresh dict without crashing the spawn.
+    """
+    manager = _pi_manager(tmp_path, monkeypatch)
+
+    settings_dir = tmp_path / "workspace" / ".pi" / "agent"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = settings_dir / "settings.json"
+    settings_path.write_text(json.dumps([1, 2, 3]))
+
+    manager.turn("hello", model="qwen")
+
+    settings = json.loads(settings_path.read_text())
+    assert isinstance(settings, dict), "Non-dict JSON should be replaced with dict"
+    assert "compaction" in settings
+
+    manager._close_process()
+
+
+def test_pi_settings_json_existing_compaction_block_replaced(tmp_path, monkeypatch):
+    """A pre-existing compaction block must be replaced wholesale, not merged."""
+    manager = _pi_manager(tmp_path, monkeypatch)
+
+    settings_dir = tmp_path / "workspace" / ".pi" / "agent"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = settings_dir / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "compaction": {"enabled": False, "reserveTokens": 1000},
+                "custom": {"key": "value"},
+            }
+        )
+    )
+
+    manager.turn("hello", model="qwen")
+
+    settings = json.loads(settings_path.read_text())
+    assert settings["compaction"]["enabled"] is True
+    assert settings["compaction"]["reserveTokens"] == shim.PI_COMPACTION_RESERVE_TOKENS
+    assert settings["custom"] == {"key": "value"}
+
+    manager._close_process()
+
+
 def test_codex_auth_json_is_parseable_and_inert(tmp_path, monkeypatch):
     """The CLI parses these tokens, so shape matters more than content."""
     import base64 as _b64

--- a/projects/inference/deploy/BUILD
+++ b/projects/inference/deploy/BUILD
@@ -1,5 +1,11 @@
 load("//bazel/helm:defs.bzl", "helm_chart")
 
+filegroup(
+    name = "values_yaml",
+    srcs = ["values.yaml"],
+    visibility = ["//projects/embervm/runtimes/claude:__pkg__"],
+)
+
 helm_chart(
     name = "chart",
     visibility = ["//overlays:__subpackages__"],


### PR DESCRIPTION
## Problem

Guest turns on the pi + Qwen adapter died with a vLLM 400:

> maximum context length is 32768 tokens. However, you requested 16384 output tokens and your prompt contains at least 16385 input tokens, for a total of at least 32769 tokens.

The shim declared the model to pi with only an `id`, so pi (v0.83.0, pinned in `MODULE.bazel`) applied its own defaults: `contextWindow ?? 128000` and `maxTokens ?? 16384`. Qwen is served at `--max-model-len 32768`.

## Why the wrong number was worse than no number

pi already has a guard: `clampMaxTokensToContext` caps each request at `contextWindow - estimatedInput - 4096`. A believed 128000 made the available budget ~107k, so `min(16384, 107k)` returned 16384 unchanged and the clamp never bit. Every request asked for 16384 output tokens, so vLLM rejected once input passed `32768 - 16384`, exactly half the real window.

Declaring the real `contextWindow` re-arms that guard. `maxTokens` does not contribute to 400-safety (the clamp floors at 1); it caps reply length and the compaction summary, so it is set explicitly for those reasons.

## Compaction

The same false window disabled compaction, which fires at `contextWindow - reserveTokens` and so sat at 111616 against a real wall of 32768. It has therefore never fired in this deployment. This adds a `settings.json` writer with a reserve that clears max output plus pi's own 4096 safety margin, and a `keepRecentTokens` under the usable budget (pi's default 20000 exceeds what remains after its default reserve, so compaction would have landed straight back above the threshold).

## Robustness

`settings.json` is merged rather than truncated, since pi persists unrelated keys there. The read tolerates a missing, unreadable, corrupt, or valid-but-not-an-object file, and the write warns instead of raising. This runs on every spawn against a durable volume, so an exception here would wedge every subsequent turn on the session permanently.

## Guard

`pi_context_window_sync_test` pins `PI_CONTEXT_WINDOW` to `vllm.maxModelLen` in `projects/inference/deploy/values.yaml` through a Bazel cross-package data dep. That value has already moved once (49152 to 32768, for KV headroom on a 24GB card) and its own comment invites moving again; lowering it would silently re-arm this bug.

Verified in both directions: with `PI_CONTEXT_WINDOW = 16384` the guard fails with the intended mismatch message, and passes at 32768.

## Testing

- `ci lint` clean
- `ci test`: `Executed 4 out of 759 tests: 759 tests pass`
- 28 pi tests pass against the post-#4453 shim

## Notes

- Rebased on top of #4453, which touches the same `_spawn`. Conflict was the signature only.
- Chart bumped to 0.1.459 from the current main tip.
- Verify on a freshly created session, not a resumed one: `turn()` respawns pi only when the process is dead, so parked sessions keep their snapshotted pi process and its old in-memory settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)