### PR TITLE
fix(embervm): give pi's context window headroom for estimate error

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.459
+version: 0.1.460

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.459
+      targetRevision: 0.1.460
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/pi_context_window_sync_test.py
+++ b/projects/embervm/runtimes/claude/pi_context_window_sync_test.py
@@ -1,8 +1,10 @@
-"""Guard that PI_CONTEXT_WINDOW stays in sync with vLLM configuration.
+"""Guard that PI_CONTEXT_WINDOW and PI_CONTEXT_WINDOW_HEADROOM satisfy the invariant.
 
-A stale PI_CONTEXT_WINDOW value silently re-arms the bug where pi's
-clampMaxTokensToContext computes available output tokens using a false
-budget. This guard verifies the constant tracks the source of truth.
+PI_CONTEXT_WINDOW is deliberately set below vLLM's --max-model-len to absorb
+pi's estimate error. A too-large window (matching vLLM's real limit exactly)
+silently re-arms the bug where pi's clampMaxTokensToContext computes available
+output tokens using a false budget. A too-small window defeats the headroom's
+purpose. This guard verifies both the upper bound and minimum headroom.
 """
 
 import os
@@ -24,13 +26,15 @@ def _repo_path(*parts: str) -> Path:
     raise FileNotFoundError(f"{rel} not found at {candidate} or {here}")
 
 
-def test_pi_context_window_matches_inference_config():
-    """PI_CONTEXT_WINDOW must match vLLM's maxModelLen in inference config.
+def test_pi_context_window_stays_under_inference_config():
+    """PI_CONTEXT_WINDOW must be below vLLM's maxModelLen with minimum headroom.
 
-    A stale PI_CONTEXT_WINDOW re-arms the bug where pi's
-    clampMaxTokensToContext computes available output tokens using a false
-    budget. This test prevents silent de-synchronization by verifying the
-    constant tracks the source of truth in projects/inference/deploy/values.yaml.
+    PI_CONTEXT_WINDOW is deliberately set below vLLM's --max-model-len to absorb
+    pi's estimate error. The gap converts pi's fixed safety margin into a larger
+    effective margin that accounts for the chars/4 estimation heuristic. Measured
+    in prod on 2026-08-07, a turn with repetitive-ASCII tool results undercounted
+    by 4097 tokens. This test ensures pi can never believe it has more room than
+    the model actually provides, and that the headroom gap is sufficient.
     """
     import yaml
 
@@ -39,11 +43,24 @@ def test_pi_context_window_matches_inference_config():
     with open(values_path) as stream:
         config = yaml.safe_load(stream)
 
-    expected_window = config.get("vllm", {}).get("maxModelLen")
-    assert expected_window is not None, "vllm.maxModelLen not found in values.yaml"
-    assert shim.PI_CONTEXT_WINDOW == expected_window, (
-        "PI_CONTEXT_WINDOW (%s) does not match inference vllm.maxModelLen (%s). "
-        "Edit projects/embervm/runtimes/claude/shim.py to match, or update "
-        "projects/inference/deploy/values.yaml if the vLLM setting intentionally changed."
-        % (shim.PI_CONTEXT_WINDOW, expected_window)
+    max_model_len = config.get("vllm", {}).get("maxModelLen")
+    assert max_model_len is not None, "vllm.maxModelLen not found in values.yaml"
+
+    # (a) PI_CONTEXT_WINDOW must never exceed the model's real capacity
+    assert shim.PI_CONTEXT_WINDOW <= max_model_len, (
+        "PI_CONTEXT_WINDOW (%s) exceeds vllm.maxModelLen (%s). "
+        "Lower PI_CONTEXT_WINDOW in projects/embervm/runtimes/claude/shim.py or "
+        "raise vllm.maxModelLen in projects/inference/deploy/values.yaml."
+        % (shim.PI_CONTEXT_WINDOW, max_model_len)
+    )
+
+    # (b) Headroom must be at least the declared minimum
+    actual_headroom = max_model_len - shim.PI_CONTEXT_WINDOW
+    assert actual_headroom >= shim.PI_CONTEXT_WINDOW_HEADROOM, (
+        "Headroom (%s tokens) falls below PI_CONTEXT_WINDOW_HEADROOM (%s). "
+        "Lower PI_CONTEXT_WINDOW in shim.py to widen the gap, or lower "
+        "PI_CONTEXT_WINDOW_HEADROOM if a smaller margin is genuinely justified. "
+        "The gap must absorb pi's estimate error, which measured at ~4097 tokens "
+        "for repetitive ASCII tool results."
+        % (actual_headroom, shim.PI_CONTEXT_WINDOW_HEADROOM)
     )

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -186,15 +186,30 @@ PI_MODELS = {
 }
 DEFAULT_PI_MODEL = "qwen"
 
-# PI context configuration. These values must be kept in sync with vLLM's
-# --max-model-len (projects/inference/deploy/values.yaml:195). A stale
-# contextWindow value here re-arms the bug where pi's clampMaxTokensToContext
-# computes available output tokens using a false budget, leading to a loud
-# 400 error as soon as input tokens reach exactly half the real window.
-PI_CONTEXT_WINDOW = 32768
+# PI context configuration. This constant is deliberately set BELOW vLLM's
+# --max-model-len (projects/inference/deploy/values.yaml) because pi's
+# clampMaxTokensToContext computes available output tokens by subtracting a
+# fixed CONTEXT_SAFETY_TOKENS margin, and pi's estimateContextTokens uses a
+# chars/4 heuristic rather than a tokenizer. The gap between PI_CONTEXT_WINDOW
+# and the real vLLM limit absorbs estimate error. Measured in prod on
+# 2026-08-07, a turn carrying two 50 KiB repetitive-ASCII tool results
+# undercounted by 4097 tokens against pi's fixed 4096 margin, failing with a
+# 400 error by one token. Setting PI_CONTEXT_WINDOW to 30000 converts the fixed
+# 4096 margin into an effective margin of (32768 - 30000) + 4096 = 6864 tokens,
+# approximately 1.7x the observed worst-case undercount. This gap also lowers
+# the compaction trigger from 22528 to 19760 tokens, providing more mid-run
+# runway before the window fills. This matters because pi does not check
+# compaction between tool iterations. Do NOT "correct" this value upward to
+# match vLLM's --max-model-len; the gap is the point.
+PI_CONTEXT_WINDOW = 30000
+# MINIMUM required gap between PI_CONTEXT_WINDOW and vLLM's real
+# --max-model-len, enforced by pi_context_window_sync_test. It is a floor, not
+# the actual gap: today the real gap is 32768 - 30000 = 2768. Lowering this
+# constant weakens the guard, so treat a test failure against it as a signal to
+# lower PI_CONTEXT_WINDOW rather than to lower this floor.
+PI_CONTEXT_WINDOW_HEADROOM = 2048
 # pi's hardcoded safety margin in clampMaxTokensToContext.
 PI_CONTEXT_SAFETY_TOKENS = 4096
-
 # Maximum output tokens pi will attempt to generate. This caps reply length to
 # prevent bloated answers that waste the context window. It also caps pi's
 # compaction summary at PI_MAX_OUTPUT_TOKENS via

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -3732,7 +3732,7 @@ def test_pi_models_json_declares_correct_context_window(tmp_path, monkeypatch):
     tokens using a false budget. With contextWindow=128000 (pi's hardcoded
     default), pi believes available tokens is about 107k even when the real
     window is 32768, leading to a loud 400 error as soon as input tokens
-    exceed 32768 - 16384 = 16384 (exactly half the real window). The arithmetic
+    exceed 30000 - 4096 (exactly half the real window). The arithmetic
     must ensure that input + max_output_tokens <= real_budget for all inputs.
     """
     manager = _pi_manager(tmp_path, monkeypatch)
@@ -3744,7 +3744,7 @@ def test_pi_models_json_declares_correct_context_window(tmp_path, monkeypatch):
         - shim.PI_CONTEXT_SAFETY_TOKENS
         > 0
     ), "Context window too small: max output tokens plus safety margin exceeds budget"
-    assert shim.PI_CONTEXT_WINDOW == 32768
+    assert shim.PI_CONTEXT_WINDOW == 30000
 
     models_path = tmp_path / "workspace" / ".pi" / "agent" / "models.json"
     models = json.loads(models_path.read_text())
@@ -3754,6 +3754,26 @@ def test_pi_models_json_declares_correct_context_window(tmp_path, monkeypatch):
     assert model_dict["maxTokens"] == shim.PI_MAX_OUTPUT_TOKENS
 
     manager._close_process()
+
+
+def test_pi_context_window_headroom_relationship():
+    """PI_CONTEXT_WINDOW plus PI_CONTEXT_WINDOW_HEADROOM must not exceed vLLM capacity.
+
+    The headroom gap absorbs pi's estimate error. This test uses only constants,
+    so it runs without file I/O or temporary paths, and verifies the invariant
+    even without the Bazel data dependency.
+    """
+    # vLLM is configured to serve 32768 tokens in projects/inference/deploy/values.yaml
+    vllm_max_model_len = 32768
+    declared_window = shim.PI_CONTEXT_WINDOW
+    declared_headroom = shim.PI_CONTEXT_WINDOW_HEADROOM
+
+    total = declared_window + declared_headroom
+    assert total <= vllm_max_model_len, (
+        "PI_CONTEXT_WINDOW (%s) + PI_CONTEXT_WINDOW_HEADROOM (%s) = %s exceeds "
+        "vLLM capacity (%s). Raise vLLM's --max-model-len or lower PI_CONTEXT_WINDOW."
+        % (declared_window, declared_headroom, total, vllm_max_model_len)
+    )
 
 
 def test_pi_settings_json_compaction_reserve_exceeds_max_output(tmp_path, monkeypatch):


### PR DESCRIPTION
Follow-up to #4456, driven by a live failure after that fix shipped.

## What #4456 fixed, and what it did not

#4456 set `PI_CONTEXT_WINDOW = 32768` to match vLLM's `--max-model-len`, which re-armed pi's `clampMaxTokensToContext` guard. That worked, and is verified in prod:

| | output tokens requested | input tokens |
|---|---|---|
| before | `16384` (flat) | 16385 |
| after | `1451` (clamped) | 31318 |

`max_tokens` went from a constant to a per-request clamp, and turns now carry nearly twice the context.

Equality was still not enough. pi's clamp subtracts a fixed 4096, but `estimateContextTokens` is a chars/4 heuristic anchored on the last real `usage.totalTokens`, not a tokenizer. Working the clamp backwards from that live 400: pi estimated `32768 - 4096 - 1451 = 27221` against a real 31318, an undercount of **4097 against a 4096 margin**. It failed by one token.

The trigger was two 50 KiB repetitive-ASCII bash tool results (pi truncates each tool result at 50 KiB), which is close to the worst case for chars/4.

## Change

`PI_CONTEXT_WINDOW` 32768 to 30000, deliberately below the served limit. The real gap of 2768 turns pi's fixed 4096 into an effective 6864, about 1.7x the observed undercount. `PI_CONTEXT_WINDOW_HEADROOM = 2048` is the enforced floor on that gap, not the gap itself.

A second benefit falls out: the compaction trigger is `contextWindow - reserveTokens`, so it drops from 22528 to 19760 and buys more mid-run runway. That matters because pi checks compaction only at `agent_end` and before a prompt, never between tool iterations, which is how a single tool result blew the window inside one turn.

## Guard

The sync test asserted `PI_CONTEXT_WINDOW == maxModelLen`. Equality was never the real invariant, and it left zero headroom. Replaced with the two that matter:

- (a) `PI_CONTEXT_WINDOW <= maxModelLen`, so pi can never believe it has more room than vLLM serves. Violating this is the original bug.
- (b) `maxModelLen - PI_CONTEXT_WINDOW >= PI_CONTEXT_WINDOW_HEADROOM`, so the gap is real headroom and not a hairline match.

Verified failing in both directions: 32768 fails (b), 40000 fails (a).

## Testing

- `ci lint` clean
- `ci test`: `Executed 6 out of 760 tests: 760 tests pass` (count up from 759, the new constant-only headroom test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)