### PR TITLE
fix(embervm): reclaim orphaned rootfs build temporaries

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.460
+version: 0.1.461

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.460
+      targetRevision: 0.1.461
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/rootfs_gc.go
+++ b/projects/embervm/noded/server/rootfs_gc.go
@@ -41,9 +41,20 @@ const (
 	// often, and each pass stats every rootfs file on the node.
 	rootfsGCInterval = 30 * time.Minute
 	// rootfsGCMinAge spares a freshly baked rootfs whose registry push has not
-	// arrived yet. Generous relative to the bake-to-sync gap (seconds to minutes).
+	// arrived yet, and prevents reclaiming a temporary from an in-progress bake.
+	// Temporaries are never in the keep-set because they are not named by a
+	// registry ref or a base's rootfsPath, so they rely entirely on this age guard.
+	// The bake is expected to complete well inside this one-hour window. A bake
+	// slower than that can have its temporary reclaimed while it is being written.
 	rootfsGCMinAge = 1 * time.Hour
 )
+
+// isReclaimableRootfs reports whether name is a completed rootfs image or an
+// abandoned build temporary that is eligible for the rootfs sweep.
+func isReclaimableRootfs(name string) bool {
+	return strings.HasPrefix(name, "rootfs-") &&
+		(strings.HasSuffix(name, ".ext4") || strings.Contains(name, ".tmp."))
+}
 
 // startRootfsGC runs the rootfs sweep on a ticker until ctx is done. It sweeps
 // once at startup too: a daemon that has just restarted is the most likely moment
@@ -105,7 +116,10 @@ func (s *Server) sweepRootfs(now time.Time) (removed int, freed int64) {
 				continue
 			}
 			name := ent.Name()
-			if !strings.HasPrefix(name, "rootfs-") || !strings.HasSuffix(name, ".ext4") {
+			// Failed bakes can leave temporary rootfs files behind. They are
+			// reclaimed only in a registry-known workload directory and only after
+			// the same min-age guard as completed rootfs images.
+			if !isReclaimableRootfs(name) {
 				continue
 			}
 			path := filepath.Join(dir, name)

--- a/projects/embervm/noded/server/rootfs_gc_test.go
+++ b/projects/embervm/noded/server/rootfs_gc_test.go
@@ -199,6 +199,79 @@ func TestSweepRootfsMinAgeGuard(t *testing.T) {
 	}
 }
 
+func TestSweepRootfsTemporaryFiles(t *testing.T) {
+	t.Run("removes old orphaned temporary and counts bytes", func(t *testing.T) {
+		// Protects against: temp files left by failed bakes not being reclaimed.
+		s := newStoreTestServer(t, newFakeStore())
+		dir := filepath.Join(t.TempDir(), "semgrep")
+		temporary := writeRootfs(t, dir, "rootfs-60cd82d81a20.ext4.tmp.1", rootfsGCMinAge+time.Minute)
+		current := filepath.Join(dir, "rootfs-current.ext4")
+
+		s.registry.sync([]workloadEntry{{Workload: "semgrep", ImageRef: "img", RootfsRef: current}})
+
+		removed, freed := s.sweepRootfs(time.Now())
+		if removed != 1 {
+			t.Fatalf("removed = %d, want 1", removed)
+		}
+		if freed != int64(len("rootfs")) {
+			t.Fatalf("freed = %d, want %d", freed, len("rootfs"))
+		}
+		if _, err := os.Stat(temporary); !os.IsNotExist(err) {
+			t.Fatalf("orphaned temporary should be gone, stat error = %v", err)
+		}
+	})
+
+	t.Run("spares young temporary", func(t *testing.T) {
+		// Protects against: deleting temporaries of in-progress bakes (the min-age guard for temporaries).
+		s := newStoreTestServer(t, newFakeStore())
+		dir := filepath.Join(t.TempDir(), "semgrep")
+		temporary := writeRootfs(t, dir, "rootfs-60cd82d81a20.ext4.tmp.1", rootfsGCMinAge-time.Minute)
+		current := filepath.Join(dir, "rootfs-current.ext4")
+
+		s.registry.sync([]workloadEntry{{Workload: "semgrep", ImageRef: "img", RootfsRef: current}})
+
+		if removed, _ := s.sweepRootfs(time.Now()); removed != 0 {
+			t.Fatalf("removed = %d, want 0 for a young temporary", removed)
+		}
+		if _, err := os.Stat(temporary); err != nil {
+			t.Fatalf("young temporary must survive the min-age guard: %v", err)
+		}
+	})
+
+	t.Run("ignores unrelated temporary name", func(t *testing.T) {
+		// Protects against: problem 1 - the loose contains predicate matching unrelated files.
+		s := newStoreTestServer(t, newFakeStore())
+		dir := filepath.Join(t.TempDir(), "semgrep")
+		unrelated := writeRootfs(t, dir, "backup.tar.tmp.1", rootfsGCMinAge+time.Minute)
+		current := filepath.Join(dir, "rootfs-current.ext4")
+
+		s.registry.sync([]workloadEntry{{Workload: "semgrep", ImageRef: "img", RootfsRef: current}})
+
+		if removed, _ := s.sweepRootfs(time.Now()); removed != 0 {
+			t.Fatalf("removed = %d, want 0 for an unrelated temporary name", removed)
+		}
+		if _, err := os.Stat(unrelated); err != nil {
+			t.Fatalf("unrelated temporary must survive: %v", err)
+		}
+	})
+
+	t.Run("keeps referenced rootfs", func(t *testing.T) {
+		// Protects against: the predicate edit accidentally widening the match to consume live images.
+		s := newStoreTestServer(t, newFakeStore())
+		dir := filepath.Join(t.TempDir(), "semgrep")
+		current := writeRootfs(t, dir, "rootfs-current.ext4", rootfsGCMinAge+time.Minute)
+
+		s.registry.sync([]workloadEntry{{Workload: "semgrep", ImageRef: "img", RootfsRef: current}})
+
+		if removed, _ := s.sweepRootfs(time.Now()); removed != 0 {
+			t.Fatalf("removed = %d, want 0 for a referenced rootfs", removed)
+		}
+		if _, err := os.Stat(current); err != nil {
+			t.Fatalf("referenced rootfs must survive: %v", err)
+		}
+	})
+}
+
 // TestReconcileBasesCheckRootfsExists proves restart reconciliation reports a base
 // with a lost backing file as NONE, which is the ONLY state the control plane acts
 // on: Embervm.BaseBuilder.node_reports_base_absent?/3 matches NONE and nothing there


### PR DESCRIPTION
## Problem

On 2026-08-07 node-3's 34.2G loop-mounted brick scratch hit 100% full. Bricks could not build rootfs images ("No space left on device"), two pods sat in `Init:CrashLoopBackOff` for roughly 8 hours, and the embervm app went Degraded. The node itself had 241G free and reported `DiskPressure=False`, because the full filesystem is a loop-mounted file the kubelet cannot see. Nothing alerted and nothing self-healed.

Part of the waste was an orphan left by the build that died on ENOSPC:

```
/var/lib/embervm/scratch/embervm-noded/runtime-claude/rootfs-60cd82d81a20.ext4.tmp.1   4.0G
```

A bake writes `<name>.tmp.N` and renames on success, so a bake that dies leaves its temporary behind forever. The existing rootfs GC (#4088) sweeps completed `rootfs-*.ext4` images and skips temporaries entirely.

## Change

Extend the existing sweep to also reclaim build temporaries, gated on the `rootfs-` prefix:

```go
func isReclaimableRootfs(name string) bool {
	return strings.HasPrefix(name, "rootfs-") &&
		(strings.HasSuffix(name, ".ext4") || strings.Contains(name, ".tmp."))
}
```

The prefix requirement is deliberate. A bare `strings.Contains(name, ".tmp.")` would match unrelated files that happen to live in a workload scratch dir, and the real artifact carries the prefix anyway.

## The min-age guard now carries a second meaning

`rootfsGCMinAge` documented itself as sparing "a freshly baked rootfs whose registry push has not arrived yet". For temporaries it means something heavier: it is the ONLY thing preventing this sweep from deleting the temporary of a bake that is still running. An in-progress temporary is indistinguishable from an orphan except by age, because temporaries are never named by a registry ref nor by a base's `rootfsPath`, so unlike completed images they have no keep-set protection at all. The comment now records that, and the assumption it rests on: a bake completes well inside the one-hour window.

## Scope

This is only the rootfs temporary cleanup. Base bundle reclamation is a separate and larger problem tracked in #4458: `evictBaseLocal` already exists in noded and the control plane records `superseded_refs`, but nothing consumes them. A noded-side base GC was explored here and deliberately dropped, because identifying the current base is the control plane's job.

## Testing

Four sub-tests in the existing `rootfs_gc_test.go`:

- an orphaned `rootfs-*.ext4.tmp.1` older than min-age is removed and its bytes counted in `freed`
- a temporary younger than min-age is spared (the in-progress bake guard)
- a `.tmp.` file without the `rootfs-` prefix is never removed (the tightening above)
- the referenced `rootfs-*.ext4` is still never removed

Note: a local `ci test` run on this branch hit an unrelated async failure in `session_manager_test.exs:657` (expected `:failed`, observed `:running`), which is Elixir control plane and cannot be affected by this Go change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)