### PR TITLE
fix(embervm): reclaim orphaned build intermediates when a bake hits ENOSPC

### DIFF
--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -55,3 +55,17 @@ helm_chart(
     publish = True,
     visibility = ["//overlays:__subpackages__"],
 )
+
+# Exposed so the ENOSPC-reclaim guard in the claude runtime package can read the
+# gate default and the builder script text. Mirrors
+# projects/embervm/deploy:deploy_values, which the cleartext-lane guard reads the
+# same way. The guard lives there, not here, because a chart package has no
+# Python toolchain context.
+filegroup(
+    name = "rootfs_reclaim_sources",
+    srcs = [
+        "templates/noded-rootfs-builder-configmap.yaml",
+        "values.yaml",
+    ],
+    visibility = ["//projects/embervm/runtimes/claude:__pkg__"],
+)

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.465
+version: 0.1.466

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -75,6 +75,12 @@ initContainers:
         value: {{ include "embervm.noded.rootfsPath" (dict "wl" $wl "top" $top) | quote }}
       - name: ROOTFS_SIZE
         value: {{ $ctx.Values.rootfsBuilder.rootfsSize | quote }}
+      - name: EMBERVM_ROOTFS_RECLAIM_ENABLED
+        value: {{ $ctx.Values.rootfsReclaim.enabled | quote }}
+      - name: EMBERVM_ROOTFS_RECLAIM_SNAPSHOTS_ROOT
+        value: {{ printf "%s/embervm-noded/snapshots" $ctx.Values.noded.firecracker.nvmeRoot | quote }}
+      - name: EMBERVM_ROOTFS_RECLAIM_TARGET_FREE_BYTES
+        value: {{ $ctx.Values.rootfsReclaim.targetFreeBytes | quote }}
       {{- if $ctx.Values.imagePullSecret.enabled }}
       - name: DOCKER_CONFIG
         value: /ghcr

--- a/projects/embervm/chart/templates/noded-rootfs-builder-configmap.yaml
+++ b/projects/embervm/chart/templates/noded-rootfs-builder-configmap.yaml
@@ -30,6 +30,18 @@ data:
     set -euo pipefail
     : "${GUEST_IMAGE:?GUEST_IMAGE required}"
     : "${BASE_ROOTFS_PATH:?BASE_ROOTFS_PATH required}"
+    # Defaulted, never required. The ConfigMap lands at sync wave 0 while bricks
+    # roll later and one at a time, so a pod restarting in that window still has
+    # the OLD pod spec and none of these set. Requiring them would turn that
+    # window into a crashloop on a node with no disk problem at all. Unset simply
+    # means reclaim is unavailable. Validation lives in the reclaim function, so
+    # a malformed value disables reclaim instead of failing every bake fleetwide.
+    : "${EMBERVM_ROOTFS_RECLAIM_ENABLED:=}"
+    : "${EMBERVM_ROOTFS_RECLAIM_SNAPSHOTS_ROOT:=}"
+    : "${EMBERVM_ROOTFS_RECLAIM_TARGET_FREE_BYTES:=}"
+    # Safety constant, not a tuning knob: how long an intermediate must sit
+    # untouched before it counts as abandoned rather than in flight.
+    : "${EMBERVM_ROOTFS_RECLAIM_MIN_AGE_SECONDS:=3600}"
     size="${ROOTFS_SIZE:-2G}"
     # Registry reads (crane) can hit a transient DNS/network blip. Observed
     # 2026-07-19: a `{:connect, :no_addresses}` blip while the control plane's
@@ -52,6 +64,149 @@ data:
         attempt=$((attempt + 1))
         delay=$((delay * 2))
       done
+    }
+    # Plain integer, computed with shell arithmetic rather than inside awk.
+    # busybox awk can format a large integral double in scientific notation, and
+    # a non-numeric operand makes `[ -ge ]` ERROR rather than compare. In a
+    # deletion loop that reads as "never stop" instead of "stop now", so both
+    # operands are validated before any comparison happens.
+    free_bytes() {
+      local kb
+      kb="$(df -Pk "$1" 2>/dev/null | awk 'NR == 2 { print $4 }')" || return 1
+      case "$kb" in
+        "" | *[!0-9]*) return 1 ;;
+      esac
+      printf '%s\n' "$((kb * 1024))"
+    }
+    # ENOSPC orphan reclaim (#4458).
+    #
+    # Deliberately narrow: this removes ONLY abandoned build intermediates, never
+    # a published artifact. A bake writes rootfs-<digest>.ext4.tmp.<pid> and
+    # renames on success; SnapshotBase stages into bases/<key>.building and
+    # renames on success. Both are garbage by construction once nothing is
+    # writing them, so reclaiming them needs NO judgement about which base is
+    # current or which session is pinned to what.
+    #
+    # That judgement belongs to the control plane, which owns the authoritative
+    # current ref and drives eviction through noded's evictBaseLocal. An earlier
+    # draft of this script tried to make it here in bash and got it wrong three
+    # separate ways: a .building orphan looked "newest" so the LIVE base became
+    # the candidate, a failed stat won the newest slot so a vanished path was
+    # kept instead, and equal mtimes resolved by directory order. None of that
+    # arises when the only candidates are files nothing can be referencing.
+    #
+    # Age is the ONLY thing separating an abandoned intermediate from one a
+    # co-located brick is writing right now: several pods share this hostPath and
+    # there is no lock. Anything younger than the min age is left alone, and this
+    # bake's own temporary is excluded by name as well.
+    reclaim_orphans_after_enospc() {
+      local keep_path="$1"
+      local snapshots_root="$EMBERVM_ROOTFS_RECLAIM_SNAPSHOTS_ROOT"
+      local target="$EMBERVM_ROOTFS_RECLAIM_TARGET_FREE_BYTES"
+      local min_age="$EMBERVM_ROOTFS_RECLAIM_MIN_AGE_SECONDS"
+      local noded_root bases now armed free_before free_after simulated
+      local would_free path mtime age size
+      local -a candidates=()
+      armed=0
+      if [ "$EMBERVM_ROOTFS_RECLAIM_ENABLED" = "1" ]; then
+        armed=1
+      fi
+      # Every bail-out below returns 1, which the caller turns into the same
+      # non-zero exit the bake had anyway. A misconfigured reclaim must never be
+      # worse than no reclaim.
+      if [ -z "$snapshots_root" ]; then
+        echo "rootfs ENOSPC reclaim unavailable: snapshots root unset (pod spec predates this feature)" >&2
+        return 1
+      fi
+      case "$target" in
+        "" | *[!0-9]*)
+          echo "rootfs ENOSPC reclaim unavailable: target_free_bytes must be plain digits, got '$target'" >&2
+          return 1
+          ;;
+      esac
+      case "$min_age" in
+        "" | *[!0-9]*)
+          echo "rootfs ENOSPC reclaim unavailable: min_age_seconds must be plain digits, got '$min_age'" >&2
+          return 1
+          ;;
+      esac
+      if ! free_before="$(free_bytes "$snapshots_root")"; then
+        echo "rootfs ENOSPC reclaim unavailable: cannot read free space for $snapshots_root" >&2
+        return 1
+      fi
+      noded_root="$(dirname "$snapshots_root")"
+      bases="$snapshots_root/bases"
+      now="$(date +%s)"
+      # Bake temporaries, one level under each workload's scratch dir. BOTH the
+      # rootfs- prefix and the .tmp. infix are required, so a completed
+      # rootfs-<digest>.ext4 can never match: a banked session embeds the host
+      # path of the rootfs it was born on and removing one corrupts that restore.
+      while IFS= read -r -d '' path; do
+        if [ "$path" != "$keep_path" ]; then
+          candidates+=("$path")
+        fi
+      done < <(find "$noded_root" -mindepth 2 -maxdepth 2 -type f -name 'rootfs-*.ext4.tmp.*' -print0 2>/dev/null)
+      # Staging dirs left behind by a SnapshotBase that died before its rename.
+      if [ -d "$bases" ]; then
+        while IFS= read -r -d '' path; do
+          candidates+=("$path")
+        done < <(find "$bases" -mindepth 1 -maxdepth 1 -type d -name '*.building' -print0 2>/dev/null)
+      fi
+      echo "rootfs ENOSPC orphan reclaim: armed=$armed free_before=$free_before target=$target min_age_seconds=$min_age candidates=${#candidates[@]}" >&2
+      simulated="$free_before"
+      would_free=0
+      for path in "${candidates[@]}"; do
+        if [ "$armed" = "1" ]; then
+          if ! free_before="$(free_bytes "$snapshots_root")"; then
+            echo "rootfs ENOSPC orphan reclaim: lost free-space reading, stopping" >&2
+            break
+          fi
+        else
+          free_before="$simulated"
+        fi
+        # Applies in BOTH modes so the dry-run manifest stops where an armed run
+        # would. It is an ESTIMATE: a file still held open elsewhere returns its
+        # blocks only once that holder exits, so an armed run can need to go
+        # further than the manifest showed.
+        if [ "$free_before" -ge "$target" ]; then
+          break
+        fi
+        mtime="$(stat -c %Y -- "$path" 2>/dev/null || echo "")"
+        case "$mtime" in
+          "" | *[!0-9]*)
+            echo "rootfs ENOSPC orphan reclaim: skipping unreadable $path" >&2
+            continue
+            ;;
+        esac
+        age=$((now - mtime))
+        if [ "$age" -lt "$min_age" ]; then
+          echo "rootfs ENOSPC orphan reclaim: sparing $path, age ${age}s under min ${min_age}s (a co-located bake may own it)" >&2
+          continue
+        fi
+        size="$(du -sk -- "$path" 2>/dev/null | awk '{print $1}')"
+        case "$size" in
+          "" | *[!0-9]*) size=0 ;;
+        esac
+        size=$((size * 1024))
+        if [ "$armed" = "1" ]; then
+          echo "rootfs ENOSPC orphan reclaim DELETE path=$path size_bytes=$size age_seconds=$age free_before=$free_before" >&2
+          rm -rf -- "$path"
+          free_after="$(free_bytes "$snapshots_root" || echo "$free_before")"
+          echo "rootfs ENOSPC orphan reclaim DELETED path=$path size_bytes=$size free_after=$free_after" >&2
+        else
+          free_after=$((free_before + size))
+          echo "rootfs ENOSPC orphan reclaim DISARMED: WOULD DELETE path=$path size_bytes=$size age_seconds=$age free_before=$free_before free_after=$free_after" >&2
+          simulated="$free_after"
+          would_free=$((would_free + size))
+        fi
+      done
+      if [ "$armed" != "1" ]; then
+        echo "rootfs ENOSPC orphan reclaim DISARMED: would_free_bytes=$would_free, failing as before" >&2
+        return 1
+      fi
+      free_after="$(free_bytes "$snapshots_root" || echo 0)"
+      echo "rootfs ENOSPC orphan reclaim complete: free_after=$free_after target=$target" >&2
+      return 0
     }
     base_dir="$(dirname "$BASE_ROOTFS_PATH")"
     mkdir -p "$base_dir"
@@ -95,7 +250,57 @@ data:
       }
       rm -f "$cache.tmp.$$"
       retry export_rootfs
-      mkfs.ext4 -q -F -L embervmbase -d /work/root "$cache.tmp.$$" "$size"
+      mkfs_output="$(mktemp)"
+      set +e
+      mkfs.ext4 -q -F -L embervmbase -d /work/root "$cache.tmp.$$" "$size" >"$mkfs_output" 2>&1
+      mkfs_status=$?
+      set -e
+      if [ "$mkfs_status" -ne 0 ]; then
+        cat "$mkfs_output" >&2
+        # TWO signals, because the message text alone is not dependable.
+        # e2fsprogs reports host-filesystem exhaustion variously as "No space
+        # left on device", as a short write, or as a failure to allocate a
+        # block, and the exact wording has never been confirmed against a real
+        # wedged node. A free-space floor does not depend on wording at all, so
+        # a missed message cannot leave the node deadlocked the way it did on
+        # 2026-08-07. grep -E rather than BRE alternation: this is busybox grep.
+        enospc=0
+        if grep -qiE 'ENOSPC|No space left on device|short write|Could not allocate block' "$mkfs_output"; then
+          enospc=1
+        elif free_now="$(free_bytes "$EMBERVM_ROOTFS_RECLAIM_SNAPSHOTS_ROOT")" &&
+          [ "$free_now" -lt "$EMBERVM_ROOTFS_RECLAIM_TARGET_FREE_BYTES" ] 2>/dev/null; then
+          echo "rootfs bake failed with free space $free_now under target; treating as ENOSPC" >&2
+          enospc=1
+        fi
+        if [ "$enospc" -eq 1 ]; then
+          echo "rootfs bake hit ENOSPC" >&2
+          if [ "$EMBERVM_ROOTFS_RECLAIM_ENABLED" != "1" ]; then
+            echo "rootfs ENOSPC orphan reclaim is DISARMED; dry-run manifest follows" >&2
+          fi
+          # Status captured explicitly for legibility. Note this does NOT restore
+          # errexit inside the function: `set +e` around the call suppresses it
+          # for the whole body exactly as `if ! reclaim ...` would. Nothing in
+          # reclaim_orphans_after_enospc relies on errexit; every bail-out is an
+          # explicit `return 1`, and the values it computes are validated before
+          # they are compared, which is what makes that safe.
+          set +e
+          reclaim_orphans_after_enospc "$cache.tmp.$$"
+          reclaim_status=$?
+          set -e
+          rm -f "$mkfs_output"
+          if [ "$reclaim_status" -ne 0 ]; then
+            exit 1
+          fi
+          rm -f "$cache.tmp.$$"
+          echo "rootfs ENOSPC orphan reclaim retry: mkfs.ext4 once" >&2
+          mkfs.ext4 -q -F -L embervmbase -d /work/root "$cache.tmp.$$" "$size"
+        else
+          echo "mkfs.ext4 failed and free space looks fine; reclaim not attempted" >&2
+          rm -f "$mkfs_output"
+          exit "$mkfs_status"
+        fi
+      fi
+      rm -f "$mkfs_output"
       mv -f "$cache.tmp.$$" "$cache"
       echo "rootfs baked at $cache ($size)"
     fi

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -813,6 +813,38 @@ rootfsBuilder:
   # fc-invoke's 4G). The ext4 is sparse, so an oversized fs costs little.
   rootfsSize: 4G
 
+# ENOSPC orphan reclaim in the rootfs builder (#4458). Last-resort deadlock
+# breaker, not a GC. When a brick's scratch is full the bake fails with ENOSPC,
+# so noded never starts, so the control plane's base retention sweep (which
+# reaches nodes over RPC) cannot see or reclaim anything there, so the disk stays
+# full. Observed 2026-08-07: 8 hours, 77 restarts, no self-healing.
+#
+# It removes ONLY abandoned build intermediates: rootfs-<digest>.ext4.tmp.<pid>
+# left by a dead bake, and bases/<key>.building left by a dead SnapshotBase.
+# Never a published rootfs or base, so it needs no judgement about which base is
+# current. Anything younger than the min age is spared, because a co-located
+# brick sharing this hostPath may be writing it right now.
+rootfsReclaim:
+  # "1" arms deletion. Default "" logs a dry-run manifest of what it WOULD
+  # delete and then fails the bake exactly as before, which is what you read
+  # before arming. Rollback is setting this back to "" and bumping the chart.
+  enabled: ""
+  # Stop deleting once this much scratch is free.
+  #
+  # MUST exceed rootfsBuilder.rootfsSize (4G) with headroom for ext4
+  # metadata, and rootfs_reclaim_guard_test asserts that. It is not a comfort
+  # margin, it is the livelock rail: this same constant is both the loop's stop
+  # condition and the ENOSPC floor, so a value below the bake size lets reclaim
+  # free one orphan, stop, fail the retry, and then on the next restart see free
+  # space already above target and break before deleting anything. The brick
+  # would crashloop forever with reclaimable garbage sitting on disk. It also
+  # truncates the dry-run manifest, under-reporting what actually needs to go.
+  #
+  # MUST be a quoted string: an unquoted integer this large is rendered by Helm
+  # in scientific notation, and the shell comparison then errors rather than
+  # compares, which in a deletion loop reads as "never stop".
+  targetFreeBytes: "6442450944"
+
 # embervm-noded: the node daemon (gRPC NodeService) that owns Firecracker microVM
 # lifecycle on node-4. A SECOND Deployment in this chart, privileged and node-
 # pinned, forked from the fc-invoke node layer (ADR embervm/001). It coexists with

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.465
+      targetRevision: 0.1.466
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -2,6 +2,18 @@
 # pinned into the chart at build time (helm_chart images=), so it is not set
 # here. Defaults in the chart are sized small to start (SigNoz 7-day-peak
 # resizing later).
+# ENOSPC orphan reclaim (#4458). DISARMED deliberately: land it, wait for a
+# brick to hit ENOSPC, read the dry-run manifest it logs ("WOULD DELETE ...
+# would_free_bytes=N"), and arm only once that manifest names what you expect.
+# Same sequence baseRetention was armed by.
+#
+# Arming deletes abandoned build intermediates only (rootfs-*.ext4.tmp.* from a
+# dead bake, bases/*.building from a dead SnapshotBase), never a published rootfs
+# or base, and never anything younger than the min age. Rollback is setting this
+# back to "" and bumping the chart.
+rootfsReclaim:
+  enabled: ""
+
 opLog:
   # Postgres op-log tier (ADR embervm/007), hosted as its own database on the
   # existing monolith-pg CNPG cluster. This retires the node-pinned RWO SQLite

--- a/projects/embervm/runtimes/claude/BUILD
+++ b/projects/embervm/runtimes/claude/BUILD
@@ -169,6 +169,25 @@ tar(
     ],
 )
 
+# Guard (#4458): the ENOSPC reclaim deletes base bundles on a wedged brick, so
+# it must ship disarmed and its stop condition must be able to evaluate. Reads
+# the chart via a cross-package data dep because a chart package has no Python
+# toolchain context.
+# Hand-registered: gazelle does not generate py_test here.
+py_test(
+    name = "rootfs_reclaim_guard_test",
+    srcs = ["rootfs_reclaim_guard_test.py"],
+    data = [
+        "//projects/embervm/chart:rootfs_reclaim_sources",
+        "//projects/embervm/deploy:deploy_values",
+    ],
+    imports = ["."],
+    deps = [
+        "@pip//pytest",
+        "@pip//pyyaml",
+    ],
+)
+
 # Guard (ADR 023 6b): the guest points its API client at an http:// URL, so the
 # sidecar MUST have a credential entry for that host. Without one the connection
 # blind-tunnels and the whole prompt leaves the cluster unencrypted.

--- a/projects/embervm/runtimes/claude/rootfs_reclaim_guard_test.py
+++ b/projects/embervm/runtimes/claude/rootfs_reclaim_guard_test.py
@@ -1,0 +1,173 @@
+"""Guards on the ENOSPC reclaim gate in the noded rootfs builder (#4458).
+
+The reclaim deletes abandoned build intermediates on a wedged brick, so what is
+worth pinning is that it ships disarmed, that its stop condition can actually
+evaluate, and above all that it never widens beyond orphans into selecting
+among published bases.
+
+Lives in this package rather than in the chart package because a chart package
+has no Python toolchain context; it reads the chart files through a
+cross-package data dep, the same way cleartext_lane_guard_test reads the deploy
+values.
+"""
+
+import os
+import re
+from pathlib import Path
+
+import yaml
+
+DIGITS = re.compile(r"^[0-9]+$")
+
+
+def _repo_path(*parts: str) -> Path:
+    """Resolve a repo-relative path, in-bazel (TEST_SRCDIR) or standalone."""
+    rel = Path(*parts)
+    candidate = Path(os.environ.get("TEST_SRCDIR", "")) / "_main" / rel
+    if candidate.exists():
+        return candidate
+    # Direct run: this file lives at projects/embervm/runtimes/claude/.
+    here = Path(__file__).resolve().parents[4] / rel
+    if here.exists():
+        return here
+    raise FileNotFoundError(f"{rel} not found at {candidate} or {here}")
+
+
+def _chart_values() -> dict:
+    return yaml.safe_load(_repo_path("projects/embervm/chart/values.yaml").read_text())
+
+
+def test_target_free_bytes_is_a_quoted_string():
+    """An unquoted integer here renders in scientific notation and breaks the stop condition.
+
+    Helm promotes a large unquoted YAML integer to a float, so
+    `targetFreeBytes: 2147483648` reaches the container as "2.147483648e+09".
+    The script compares with `[ "$free" -ge "$target" ]`, which then errors with
+    "integer expression expected" and returns 2 rather than a truthy or falsy
+    result, so the loop never breaks. In a deletion loop, a stop condition that
+    can never fire means delete every candidate instead of stopping once the
+    target is met. Keeping the value a QUOTED string is what prevents the
+    coercion, so this asserts the YAML type and not just the digits.
+    """
+    reclaim = _chart_values()["rootfsReclaim"]
+    target = reclaim["targetFreeBytes"]
+    assert isinstance(target, str), (
+        "rootfsReclaim.targetFreeBytes must be a quoted string, got %r (%s). "
+        "An unquoted int is rendered by Helm as scientific notation, which the "
+        "shell comparison in the rootfs builder cannot parse."
+        % (target, type(target).__name__)
+    )
+    assert DIGITS.match(target), (
+        "rootfsReclaim.targetFreeBytes must be plain digits, got %r" % target
+    )
+
+
+def _deploy_values() -> dict:
+    return yaml.safe_load(_repo_path("projects/embervm/deploy/values.yaml").read_text())
+
+
+def _effective(key: str):
+    """Chart default, overridden by the deploy overlay when it sets the key.
+
+    The chart default is not what runs. Arming happens in the overlay, so the
+    guards below have to judge the effective value, the way cleartext_lane_guard
+    reads the deploy values rather than the chart's.
+    """
+    chart = _chart_values()["rootfsReclaim"]
+    deploy = (_deploy_values() or {}).get("rootfsReclaim") or {}
+    return deploy[key] if key in deploy else chart[key]
+
+
+def _size_to_bytes(text: str) -> int:
+    units = {"K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
+    text = str(text).strip()
+    if text and text[-1].upper() in units:
+        return int(float(text[:-1]) * units[text[-1].upper()])
+    return int(text)
+
+
+def test_target_free_bytes_exceeds_the_bake_size():
+    """A target below the rootfs size livelocks the very wedge this exists to break.
+
+    The same constant is BOTH the loop's stop condition and the ENOSPC floor. Set
+    it under the bake size and reclaim frees one orphan, stops, fails the retry,
+    and on the next restart sees free space already above target and breaks
+    before deleting anything. The brick then crashloops forever with reclaimable
+    garbage on disk, which is the original incident with extra steps. It also
+    truncates the dry-run manifest that arming is decided from.
+    """
+    target = int(_effective("targetFreeBytes"))
+    bake = _size_to_bytes(_chart_values()["rootfsBuilder"]["rootfsSize"])
+    assert target > bake, (
+        "rootfsReclaim.targetFreeBytes (%d) must exceed rootfsBuilder.rootfsSize "
+        "(%s = %d bytes) with headroom for ext4 metadata, or reclaim stops short of "
+        "what the retry bake needs and the brick crashloops with garbage still on disk."
+        % (target, _chart_values()["rootfsBuilder"]["rootfsSize"], bake)
+    )
+
+
+def test_gate_value_is_a_recognised_setting():
+    """Only "" and "1" mean anything; anything else silently reads as disarmed.
+
+    Checks the EFFECTIVE value, so a typo in the deploy overlay (the file where
+    arming happens) cannot look armed while behaving as disarmed.
+    """
+    assert _effective("enabled") in ("", "1")
+
+
+def test_reclaim_ships_disarmed_by_default():
+    """The chart default must never delete. Arming is a deliberate act on deploy values.
+
+    This mirrors how baseRetention was armed: read a live dry-run manifest
+    first, then set the gate. A chart that defaulted to armed would delete base
+    bundles on any cluster installing it without an override.
+    """
+    assert _chart_values()["rootfsReclaim"]["enabled"] == ""
+
+
+def test_reclaim_stays_orphans_only():
+    """The reclaim must never select among published bases, only abandoned intermediates.
+
+    A first draft picked the newest base per workload and deleted the rest. It
+    was wrong three ways: a `.building` staging orphan looked newest so the LIVE
+    base became the candidate, a failed stat won the newest slot so a vanished
+    path was retained instead, and equal mtimes resolved by directory order.
+    Selecting among published artifacts requires knowing which is current, and
+    that is the control plane's job, not a bash script's on a shared hostPath
+    with no lock.
+
+    So this asserts the SHAPE of the candidate set rather than any comment: file
+    candidates must require both the rootfs- prefix and the .tmp. infix, and
+    directory candidates must require the .building suffix. If someone
+    reintroduces workload-grouped selection, the negative assertion below fails.
+    """
+    script = _repo_path(
+        "projects/embervm/chart/templates/noded-rootfs-builder-configmap.yaml"
+    ).read_text()
+
+    assert "-name 'rootfs-*.ext4.tmp.*'" in script, (
+        "bake-temporary candidates must require BOTH the rootfs- prefix and the "
+        ".tmp. infix, so a completed rootfs-<digest>.ext4 can never match"
+    )
+    assert "-name '*.building'" in script, (
+        "staging-orphan candidates must require the .building suffix"
+    )
+    assert "newest_path" not in script and "newest_mtime" not in script, (
+        "the reclaim must not select among published bases by mtime; that is the "
+        "rejected design that deleted live bases (see the comment in the script)"
+    )
+
+
+def test_min_age_guard_is_present():
+    """Age is the only thing separating an abandoned intermediate from a live one.
+
+    Several brick pods share this hostPath and there is no lock, so a temporary
+    a co-located bake is writing right now looks identical to one abandoned
+    hours ago. Removing the min-age check would make the reclaim delete another
+    pod's in-flight bake.
+    """
+    script = _repo_path(
+        "projects/embervm/chart/templates/noded-rootfs-builder-configmap.yaml"
+    ).read_text()
+    assert "EMBERVM_ROOTFS_RECLAIM_MIN_AGE_SECONDS" in script
+    assert "$min_age" in script, "the min-age guard is not applied to candidates"


### PR DESCRIPTION
Closes #4458.

## The deadlock

A full brick scratch deadlocks its own recovery. The rootfs bake fails with ENOSPC, so the init container never completes, so `noded` never starts, so the control plane's base retention sweep (which reaches nodes over RPC and evicts via `EvictArtifact`) can see and reclaim nothing there, so the disk stays full.

Observed on node-3 2026-08-07: two brick pods in `Init:CrashLoopBackOff` for roughly 8 hours across 77 and 83 restarts, embervm Degraded, no self-healing.

Invisible to Kubernetes: the full filesystem is a loop-mounted file inside the node, so the kubelet reports `DiskPressure=False` with 241G free on the host. Nothing alerts.

## Scope: orphans only

Removes ONLY abandoned build intermediates:

- `rootfs-<digest>.ext4.tmp.<pid>` left by a bake that died
- `bases/<key>.building` left by a SnapshotBase that died before its rename

Both are garbage by construction once nothing is writing them, so reclaiming them requires **no judgement about which base is current or which session is pinned to what**. No published rootfs or base is ever a candidate.

**What it does and does not fix.** It recovers a wedge caused by abandoned intermediates. That is narrower than the node-3 incident: the 15.5G freed there by hand was mostly superseded base generations, which this deliberately will not touch. Bases still grow monotonically between rollouts and remain the control plane's job.

## Why not the wider version

An earlier draft picked the newest base per workload and deleted the rest. Review found three ways it deleted the LIVE base instead:

- a `.building` staging orphan has the newest mtime, so it was retained as "newest" and the published bundle became the candidate
- a failed `stat` left an empty mtime that still won the newest slot, so a vanished path was kept and the real base deleted
- equal mtimes resolved by directory order, and an S3 hydration re-dates a superseded bundle above a current one

It also had a fail-open safety gate: it checked `snapshots/sessions/`, but on bricks sessions live under `snapshots/i/<uid>/sessions`, so on every brick it concluded "no sessions" and opened.

Identifying the current base is the control plane's job, exactly as noded's `evictBaseLocal` already argues. Narrowing to orphans removes the need for that judgement, and with it all four defects.

## The one remaining judgement

Age. Several brick pods share this hostPath with no lock, so an intermediate a co-located bake is writing right now looks identical to one abandoned hours ago. Anything under an hour old is spared, matching `rootfs_gc.go`'s existing min-age for the same file class, and this bake's own temporary is excluded by name. When the guard is wrong the cost is a spared file, not a destroyed base.

## The livelock rail

`targetFreeBytes` must exceed `rootfsBuilder.rootfsSize`, and a test asserts it. The same constant is both the loop's stop condition and the ENOSPC floor, so a value below the bake size lets reclaim free one orphan, stop, fail the retry, and then on the next restart see free space already above target and break before deleting anything, leaving the brick crashlooping with reclaimable garbage on disk. Caught in review at 2 GiB against a 4G bake; now 6 GiB.

## Safety

- **Ships DISARMED.** Disarmed it logs the manifest it would have deleted and fails the bake as before. That manifest is what arming is decided from, the same sequence `baseRetention` was armed by.
- Both stop-condition operands validated as plain digits. An unquoted `targetFreeBytes` renders in scientific notation and the comparison then errors rather than compares, which in a deletion loop reads as "never stop".
- Free space computed in shell arithmetic, not awk: busybox awk can format large values the same way.
- Env vars defaulted rather than required, so a pod restarting before its Deployment rolls does not crashloop on a node with no disk problem.
- A malformed value disables reclaim rather than failing every bake fleetwide.
- ENOSPC detected by a free-space floor as well as message text, because the e2fsprogs wording was never confirmed against a real wedged node.

## Verification

Exercised against a tree of published bases, a published rootfs, old orphans, a young orphan, and the current bake's temporary:

| Fixture | Result |
|---|---|
| old `.tmp.` orphans | deleted |
| young `.tmp.` (co-located bake in flight) | spared, reason logged |
| old `.building` orphan | deleted |
| current bake's own tmp | excluded by name |
| published `rootfs-*.ext4` | never a candidate |
| live `*__live` bases | never candidates |

The livelock guard was verified to fail against the previously shipped 2 GiB value.

- `helm template` renders, `bash -n` clean
- `ci lint` clean
- `ci test`: `Executed 3 out of 761 tests: 761 tests pass`

## Follow-up

- Bases still grow monotonically; only rootfs images self-limit.
- `bases/<ref>/memfile.restore.tmp` from an interrupted S3 hydration is a multi-GB orphan class this does not match (it sits at depth 3-4, outside both predicates). `isCompleteBase` already treats it as incomplete, so the daemon knows it is garbage.
- Three new pod-env vars mean landing this rolls the brick fleet once (disarmed), and arming rolls it again. Templating the values into the ConfigMap body instead would avoid both, and would let an arming change reach a crashlooping brick without touching its Deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)