### PR TITLE
feat(agent-sessions): tell the user to approve a Codex login instead of failing opaquely

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.397
+version: 0.89.398
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.397
+      targetRevision: 0.89.398
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 from sqlmodel import Session
 
 from agent_sessions import model_family, store
+from agent_sessions.codex_login import codex_login_gate
 from agent_sessions.mcp import (
     _load_session_row,
     _persist_pending_message,
@@ -21,7 +22,7 @@ from goosecracker.api import REPO_CATALOG
 
 async def start_session_for_thread(
     thread_id: str, prompt: str, repo: str | None, model: str = "luna"
-) -> int:
+) -> int | dict:
     """Create a model session bound to a Discord thread and queue its first turn.
 
     ``thread_id`` identifies the Discord thread that should receive terminal
@@ -33,6 +34,9 @@ async def start_session_for_thread(
     if repo is not None and repo not in REPO_CATALOG:
         raise ValueError(f"unknown repo {repo}; catalog: {', '.join(REPO_CATALOG)}")
     model_family(model)
+    login = await codex_login_gate(model)
+    if login is not None:
+        return login
     row = await asyncio.to_thread(
         _persist_session,
         str(uuid4()),
@@ -70,6 +74,9 @@ async def send_to_thread_session(thread_id: str, message: str) -> dict | None:
     if row is None:
         return None
     model_family(row.model)
+    login = await codex_login_gate(row.model)
+    if login is not None:
+        return login
     # row.model, NOT None. None is not "unset", it resolves to the CLAUDE family
     # (model_family(None) == "claude"), so a None here ran the claude adapter
     # against a session whose CLI transcript belongs to codex and died with

--- a/projects/monolith/agent_sessions/codex_login.py
+++ b/projects/monolith/agent_sessions/codex_login.py
@@ -1,0 +1,67 @@
+"""Preflight checks for Codex-family agent sessions."""
+
+from __future__ import annotations
+
+import httpx
+
+from agent_sessions import model_family
+from agent_sessions import mcp
+
+_DEFAULT_GRANT = mcp._DEFAULT_GRANT
+
+
+async def codex_login_gate(
+    model: str | None, grant: str = _DEFAULT_GRANT
+) -> dict | None:
+    """Return a user-facing login response when a Codex grant is not ready.
+
+    Non-Codex sessions skip the broker entirely. Broker failures are returned as
+    login responses because a preflight check must not turn into a 500 response.
+    """
+    family = model_family(model)
+    grant = mcp._grant_or_raise(grant)
+    if family != "codex":
+        return None
+
+    try:
+        status = await mcp._broker_request("GET", f"/grants/{grant}/login/status")
+    except Exception as exc:
+        return {
+            "login_required": True,
+            "error": str(exc) or exc.__class__.__name__,
+            "grant": grant,
+            "message": "Codex login could not be checked. Try again after checking the token broker.",
+        }
+    if status.get("state") == "granted":
+        return None
+
+    try:
+        data = await mcp._broker_request("POST", f"/grants/{grant}/login/start")
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 409:
+            return {
+                "login_required": True,
+                "pending": True,
+                "grant": grant,
+                "message": "Device flow already in flight. Check your browser.",
+            }
+        return {
+            "login_required": True,
+            "error": str(exc) or exc.__class__.__name__,
+            "grant": grant,
+            "message": "Codex login could not be checked. Try again after checking the token broker.",
+        }
+    except Exception as exc:
+        return {
+            "login_required": True,
+            "error": str(exc) or exc.__class__.__name__,
+            "grant": grant,
+            "message": "Codex login could not be checked. Try again after checking the token broker.",
+        }
+    return {
+        "login_required": True,
+        "verification_url": data.get("verification_url"),
+        "user_code": data.get("user_code"),
+        "grant": grant,
+        "message": "Approve the Codex login in your browser within about 15 minutes.",
+    }

--- a/projects/monolith/agent_sessions/codex_login.py
+++ b/projects/monolith/agent_sessions/codex_login.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+
 import httpx
 
 from agent_sessions import model_family
 from agent_sessions import mcp
 
 _DEFAULT_GRANT = mcp._DEFAULT_GRANT
+logger = logging.getLogger(__name__)
 
 
 async def codex_login_gate(
@@ -15,8 +18,8 @@ async def codex_login_gate(
 ) -> dict | None:
     """Return a user-facing login response when a Codex grant is not ready.
 
-    Non-Codex sessions skip the broker entirely. Broker failures are returned as
-    login responses because a preflight check must not turn into a 500 response.
+    Non-Codex sessions skip the broker entirely. An unreachable broker does not
+    block the turn, since the sidecar may still have a cached token.
     """
     family = model_family(model)
     grant = mcp._grant_or_raise(grant)
@@ -26,12 +29,11 @@ async def codex_login_gate(
     try:
         status = await mcp._broker_request("GET", f"/grants/{grant}/login/status")
     except Exception as exc:
-        return {
-            "login_required": True,
-            "error": str(exc) or exc.__class__.__name__,
-            "grant": grant,
-            "message": "Codex login could not be checked. Try again after checking the token broker.",
-        }
+        # If we cannot ask the broker, proceed so a cached sidecar token can
+        # still serve the turn. Only a positive non-granted response blocks.
+        reason = str(exc) or exc.__class__.__name__
+        logger.warning("Could not check Codex login status: %s", reason)
+        return None
     if status.get("state") == "granted":
         return None
 

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from sqlmodel import Session, func, select
 
 from agent_sessions import model_family, store
+from agent_sessions.codex_login import codex_login_gate
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.mcp import (
     _clear_ember_bindings_for,
@@ -294,6 +295,9 @@ async def start_session(request: StartRequest) -> dict:
         model_family(request.model)
     except ValueError as exc:
         return {"accepted": False, "error": str(exc)}
+    login = await codex_login_gate(request.model)
+    if login is not None:
+        return {"accepted": False, **login}
     row = await asyncio.to_thread(
         _persist_session,
         str(uuid4()),
@@ -426,6 +430,9 @@ async def send_message(session_id: int, request: MessageRequest) -> dict:
             ),
         }
     effective_model = request.model or row.model
+    login = await codex_login_gate(effective_model)
+    if login is not None:
+        return {"accepted": False, **login}
     turn = await asyncio.to_thread(
         _persist_pending_message, session_id, request.prompt, effective_model
     )

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -11,6 +11,7 @@ from sqlmodel import Session, SQLModel, create_engine
 
 from agent_sessions import api, store
 from agent_sessions import mcp
+from agent_sessions.codex_login import codex_login_gate
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.router import router
 from core.db import get_session
@@ -466,6 +467,207 @@ def test_send_message_model_family_mismatch(client, session, monkeypatch):
     assert "Model family mismatch" in body["error"]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["opus", "qwen"])
+async def test_codex_login_gate_skips_broker_for_non_codex_models(monkeypatch, model):
+    calls = []
+
+    async def broker_request(*args):
+        calls.append(args)
+        raise AssertionError("non-Codex models must not call the broker")
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+
+    assert await codex_login_gate(model) is None
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_codex_login_gate_granted_does_not_start_login(monkeypatch):
+    calls = []
+
+    async def broker_request(method, path):
+        calls.append((method, path))
+        return {"state": "granted"}
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+
+    assert await codex_login_gate("luna") is None
+    assert calls == [("GET", "/grants/codex-cluster/login/status")]
+
+
+@pytest.mark.asyncio
+async def test_codex_login_gate_none_returns_device_login(monkeypatch):
+    calls = []
+
+    async def broker_request(method, path):
+        calls.append((method, path))
+        if method == "GET":
+            return {"state": "none"}
+        return {"verification_url": "https://example.test", "user_code": "CODE"}
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+
+    result = await codex_login_gate("luna")
+    assert result["login_required"] is True
+    assert result["verification_url"] == "https://example.test"
+    assert result["user_code"] == "CODE"
+    assert calls == [
+        ("GET", "/grants/codex-cluster/login/status"),
+        ("POST", "/grants/codex-cluster/login/start"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_codex_login_gate_login_pending_is_not_an_error(monkeypatch):
+    async def broker_request(method, path):
+        if method == "GET":
+            return {"state": "none"}
+        response = httpx.Response(409, request=httpx.Request("POST", "https://broker"))
+        raise httpx.HTTPStatusError(
+            "login pending", request=response.request, response=response
+        )
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+
+    result = await codex_login_gate("luna")
+    assert result["pending"] is True
+    assert result["login_required"] is True
+
+
+@pytest.mark.asyncio
+async def test_codex_login_gate_broker_failure_returns_login_error(monkeypatch):
+    async def broker_request(*args):
+        raise Exception("broker offline")
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+
+    result = await codex_login_gate("luna")
+    assert result["login_required"] is True
+    assert result["error"] == "broker offline"
+
+
+@pytest.mark.asyncio
+async def test_codex_login_gate_does_not_swallow_unknown_model(monkeypatch):
+    async def broker_request(*args):
+        raise AssertionError("model validation must happen before broker I/O")
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+
+    with pytest.raises(ValueError, match="Unknown model"):
+        await codex_login_gate("unknown")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("grant", ["INVALID", "-invalid"])
+async def test_codex_login_gate_does_not_swallow_invalid_grant(monkeypatch, grant):
+    async def broker_request(*args):
+        raise AssertionError("grant validation must happen before broker I/O")
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+
+    with pytest.raises(ValueError, match="invalid grant name"):
+        await codex_login_gate("luna", grant)
+
+
+def test_send_message_gates_on_effective_model(client, session, monkeypatch):
+    row = _session(session, "pinned-codex", model="luna", status="completed")
+    seen = []
+
+    async def fake_gate(model):
+        seen.append(model)
+        return None
+
+    monkeypatch.setattr("agent_sessions.router._load_session_row", lambda _: row)
+    monkeypatch.setattr("agent_sessions.router.codex_login_gate", fake_gate)
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_pending_message",
+        lambda session_id, prompt, model: (
+            store.create_pending_message(session, session_id, prompt, model).seq
+        ),
+    )
+    monkeypatch.setattr(
+        "agent_sessions.router._set_session_status",
+        lambda session_id, status: store.update_session_status(
+            session, session_id, status
+        ),
+    )
+    monkeypatch.setattr("agent_sessions.router._schedule_next_message", lambda _: None)
+
+    body = client.post(
+        f"/api/agents/sessions/{row.id}/messages",
+        json={"prompt": "follow up", "model": "terra"},
+    ).json()
+    assert body["accepted"] is True
+    assert seen == ["terra"]
+
+
+@pytest.mark.parametrize("model", ["opus", "qwen"])
+def test_router_start_non_codex_models_enqueue_without_broker(
+    client, session, monkeypatch, model
+):
+    calls = []
+
+    async def broker_request(*args):
+        calls.append(args)
+        raise AssertionError("non-Codex models must not call the broker")
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_session",
+        lambda local, workspace, branch, selected_model, repo: store.create_session(
+            session, local, workspace, branch, selected_model, repo
+        ),
+    )
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_pending_message",
+        lambda session_id, prompt, selected_model: (
+            store.create_pending_message(
+                session, session_id, prompt, selected_model
+            ).seq
+        ),
+    )
+    monkeypatch.setattr("agent_sessions.router._schedule_next_message", lambda _: None)
+
+    body = client.post(
+        "/api/agents/sessions",
+        json={"prompt": "Hello", "model": model},
+    ).json()
+
+    assert body["accepted"] is True
+    assert body["turn"] == 1
+    assert calls == []
+
+
+def test_router_start_codex_login_required_does_not_enqueue(client, monkeypatch):
+    calls = []
+
+    async def broker_request(method, path):
+        calls.append((method, path))
+        if method == "GET":
+            return {"state": "none"}
+        return {"verification_url": "https://example.test", "user_code": "CODE"}
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_session",
+        lambda *args, **kwargs: pytest.fail("login-required session was persisted"),
+    )
+
+    body = client.post(
+        "/api/agents/sessions", json={"prompt": "Hello", "model": "luna"}
+    ).json()
+
+    assert body["accepted"] is False
+    assert body["login_required"] is True
+    assert body["verification_url"] == "https://example.test"
+    assert body["user_code"] == "CODE"
+    assert calls == [
+        ("GET", "/grants/codex-cluster/login/status"),
+        ("POST", "/grants/codex-cluster/login/start"),
+    ]
+
+
 def test_send_message_session_not_found(client, monkeypatch):
     monkeypatch.setattr("agent_sessions.router._load_session_row", lambda _: None)
     body = client.post(
@@ -553,6 +755,10 @@ def test_start_session_marks_message_ui_originated(client, session, monkeypatch)
 
 
 def test_start_session_for_discord_thread_has_no_system_prompt(session, monkeypatch):
+    async def broker_request(*args):
+        return {"state": "granted"}
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
     monkeypatch.setattr(api, "_persist_pending_message", lambda *_args: 1)
     monkeypatch.setattr(api, "_schedule_next_message", lambda _session_id: None)
     monkeypatch.setattr(
@@ -572,6 +778,43 @@ def test_start_session_for_discord_thread_has_no_system_prompt(session, monkeypa
     row = store.get_session(session, session_id)
     assert row.discord_thread == "thread-1"
     assert row.system_prompt is None
+
+
+@pytest.mark.parametrize("model", ["opus", "qwen"])
+def test_send_to_thread_session_queues_without_broker_for_non_codex(
+    session, monkeypatch, model
+):
+    row = _session(session, "thread-send", model=model)
+    calls = []
+
+    async def broker_request(*args):
+        calls.append(args)
+        raise AssertionError("Non-Codex sessions must not call the broker")
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+    monkeypatch.setattr(api, "session_id_for_thread", lambda _: row.id)
+    monkeypatch.setattr(api, "_load_session_row", lambda _: row)
+    monkeypatch.setattr(
+        api,
+        "_persist_pending_message",
+        lambda session_id, prompt, model: (
+            store.create_pending_message(session, session_id, prompt, model).seq
+        ),
+    )
+    monkeypatch.setattr(
+        api,
+        "_set_session_status",
+        lambda session_id, status: store.update_session_status(
+            session, session_id, status
+        ),
+    )
+    monkeypatch.setattr(api, "_schedule_next_message", lambda _: None)
+
+    result = asyncio.run(api.send_to_thread_session("thread-1", "follow up"))
+
+    assert result["action"] == "queued"
+    assert result["turn"] == 1
+    assert calls == []
 
 
 def test_send_message_marks_message_ui_originated(client, session, monkeypatch):

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -542,9 +542,14 @@ async def test_codex_login_gate_broker_failure_returns_login_error(monkeypatch):
 
     monkeypatch.setattr(mcp, "_broker_request", broker_request)
 
-    result = await codex_login_gate("luna")
-    assert result["login_required"] is True
-    assert result["error"] == "broker offline"
+    assert await codex_login_gate("luna") is None
+
+
+@pytest.mark.asyncio
+async def test_codex_login_gate_unset_broker_url_proceeds(monkeypatch):
+    monkeypatch.delenv("EMBER_TOKENBROKER_URL", raising=False)
+
+    assert await codex_login_gate("luna") is None
 
 
 @pytest.mark.asyncio

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.472
+version: 0.285.473
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -274,6 +274,22 @@ _CHECKLIST_COLLAPSE_AT = 1900
 GOOSECRACKER_CHECKLIST_MIN_EDIT_INTERVAL = 2.0  # coalesce checklist edits
 
 
+def _format_codex_login_message(result: dict) -> str:
+    """Explain the broker action needed before a Codex turn can run."""
+    message = (
+        result.get("message") or "Codex login is required before this session can run."
+    )
+    verification_url = result.get("verification_url")
+    user_code = result.get("user_code")
+    if verification_url and user_code:
+        return f"🔐 {message}\nApprove in your browser: {verification_url}\nUser code: `{user_code}`"
+    if result.get("pending"):
+        return f"🔐 {message}"
+    if result.get("error"):
+        return f"🔐 {message}\nBroker error: {result['error']}"
+    return f"🔐 {message}"
+
+
 @dataclass
 class AgentFlowOutcome:
     """Result of ``start_agent_flow`` after the ADR 036 orchestrator verdict.
@@ -1338,12 +1354,15 @@ class ChatBot(discord.Client):
             # which reaches chat.api and then chat.bot during startup.
             from agent_sessions.api import start_session_for_thread
 
-            await start_session_for_thread(
+            start_result = await start_session_for_thread(
                 str(thread.id),
                 prompt,
                 effective_repo or None,
                 model=model,
             )
+            if isinstance(start_result, dict) and start_result.get("login_required"):
+                await thread.send(_format_codex_login_message(start_result))
+                return AgentFlowOutcome(thread=thread)
             # ADR 036: the orchestrator wrote its telemetry row BEFORE this
             # thread existed (it decides whether to open one), so the row's
             # thread_id is null. Backfill it now that the thread id is known, so
@@ -1717,6 +1736,11 @@ class ChatBot(discord.Client):
         if result is None:
             # Lost a race with session teardown; let normal handling take it.
             return False
+
+        if result.get("login_required"):
+            await message.channel.send(_format_codex_login_message(result))
+            await asyncio.to_thread(self._complete_lock, msg_id)
+            return True
 
         try:
             await message.add_reaction("⏳")

--- a/projects/monolith/chat/bot_test.py
+++ b/projects/monolith/chat/bot_test.py
@@ -4,10 +4,42 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from chat.bot import (
+    _format_codex_login_message,
     _render_goosecracker_progress,
     download_image_attachments,
     should_respond,
 )
+
+
+def test_format_codex_login_message_with_url_and_code():
+    result = {
+        "message": "Approve the login.",
+        "verification_url": "https://example.test/device",
+        "user_code": "ABCD-1234",
+    }
+    assert _format_codex_login_message(result) == (
+        "🔐 Approve the login.\n"
+        "Approve in your browser: https://example.test/device\n"
+        "User code: `ABCD-1234`"
+    )
+
+
+def test_format_codex_login_message_pending():
+    assert (
+        _format_codex_login_message({"pending": True, "message": "Already pending."})
+        == "🔐 Already pending."
+    )
+
+
+def test_format_codex_login_message_error():
+    assert (
+        _format_codex_login_message(
+            {"error": "broker offline", "message": "Try again."}
+        )
+        == "🔐 Try again.\nBroker error: broker offline"
+    )
+
+
 from chat.goosecracker_progress import Progress
 
 

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.472
+      targetRevision: 0.285.473
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
A Codex-family turn whose broker grant has lapsed used to die as a generic
error at zero model cost, with nothing indicating that the real fix is "a human
must approve a device code in a browser". The guest holds only a placeholder
credential, the sidecar fails closed when the broker returns `no_grant`, and
none of that reaches the person who could fix it.

`/agent` and the agents web UI both have a human present, so they now check the
grant before enqueueing and hand back the verification URL and user code.

Deliberately NOT held open across the approval: the turn is not enqueued, and
you re-send once approved. Parking a pending-message row across a multi-minute
browser approval would fight the claim and lease machinery for a rare event.

### Fails open on "cannot ask", closed only on "definitely not granted"

This is the part worth reviewing. The gate must not turn the broker into a hard
dependency of the turn path. Before this change the monolith never called the
broker to run a turn, so a broker outage was harmless: the egress sidecar caches
access tokens per grant with a 60 second refresh margin and turns kept working.

So an unreachable or unconfigured broker logs a warning and PROCEEDS. Only a
positive not-granted answer blocks. We never claim the user is logged in, we
just decline to block on an answer we could not obtain.

An earlier revision of this branch got that backwards and blocked on any broker
exception. `chat_bot_on_message_test` caught it, because those tests do not set
`EMBER_TOKENBROKER_URL`: every Discord agent session stopped being created. Both
of those tests pass here unmodified, which is the real regression guard.

### Also fixed on review

- The grant name now goes through `_grant_or_raise` before riding a URL path, as
  the existing broker tools already do. It names a Kubernetes Secret suffix.
- `send_message` gates on the model that will actually run (`effective_model`),
  not `row.model`. Equivalent only because the family-mismatch check above
  happens to reject cross-family requests first, which is an accident rather
  than a guarantee.
- `model_family` and grant validation sit outside the catch, so an unknown model
  reports as an unknown model rather than as "Codex login could not be checked".

### Scope

Claude and pi families never touch the broker at all, asserted in tests. The MCP
tools are unchanged; the helper is importable so they can adopt it later.

### Verification

Full `ci test` green: `Executed 3 out of 760 tests: 759 tests pass`, no FAILED
targets, verified by re-running the suite independently rather than trusting a
focused run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QMcj7QnV7bvZo6vhWCHAj