### PR TITLE
feat(monolith): redesign agents console, add qwen session names

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.383
+version: 0.89.384
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.383
+      targetRevision: 0.89.384
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -7073,6 +7073,18 @@ py_test(
 )
 
 py_test(
+    name = "agent_sessions_titles_test",
+    srcs = ["agent_sessions/titles_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_agent_sessions",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "agent_sessions_mcp_test",
     srcs = ["agent_sessions/mcp_test.py"],
     imports = ["."],

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -55,6 +55,11 @@ class AgentSession(SQLModel, table=True):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     last_turn_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     voice_summary: str | None = Field(default=None)
+    # Qwen-generated display name (titles.py). title_turn_seq is the turn
+    # the name was generated from; the leader loop refreshes the name when
+    # newer turns land. The router falls back to the first prompt when unset.
+    title: str | None = Field(default=None)
+    title_turn_seq: int | None = Field(default=None)
 
 
 class AgentTurn(SQLModel, table=True):

--- a/projects/monolith/agent_sessions/module.py
+++ b/projects/monolith/agent_sessions/module.py
@@ -14,10 +14,11 @@ def _register_mcp() -> None:
 
 
 async def _leader_start(app):
-    """Start the leader-owned pending-message recovery sweep."""
+    """Start the leader-owned pending-message sweep and title refresh."""
     from agent_sessions.mcp import start_pending_message_sweep
+    from agent_sessions.titles import start_title_refresh_loop
 
-    return start_pending_message_sweep()
+    return start_pending_message_sweep() + start_title_refresh_loop()
 
 
 MODULE = _Module(

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -80,16 +80,18 @@ def _aggregate_statement(status: str | None = None, session_id: int | None = Non
     pending = pending_statement.group_by(PendingMessage.session_id).subquery()
     # The session list renders a human title (the first prompt) instead of
     # the raw UUID; sessions whose first turn has not completed yet fall
-    # back to the first queued prompt.
+    # back to the first queued prompt. Truncated in SQL: the list is polled
+    # every 2s while a session is active, and _fallback_title only keeps
+    # 140 chars, so shipping whole prompt TEXT columns would be waste.
     first_turn_prompt = (
-        select(AgentTurn.prompt)
+        select(func.substr(AgentTurn.prompt, 1, 200))
         .where(AgentTurn.session_id == AgentSession.id)
         .order_by(AgentTurn.seq)
         .limit(1)
         .scalar_subquery()
     )
     first_pending_prompt = (
-        select(PendingMessage.message_text)
+        select(func.substr(PendingMessage.message_text, 1, 200))
         .where(PendingMessage.session_id == AgentSession.id)
         .order_by(PendingMessage.seq)
         .limit(1)

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -78,12 +78,31 @@ def _aggregate_statement(status: str | None = None, session_id: int | None = Non
             PendingMessage.session_id == session_id
         )
     pending = pending_statement.group_by(PendingMessage.session_id).subquery()
+    # The session list renders a human title (the first prompt) instead of
+    # the raw UUID; sessions whose first turn has not completed yet fall
+    # back to the first queued prompt.
+    first_turn_prompt = (
+        select(AgentTurn.prompt)
+        .where(AgentTurn.session_id == AgentSession.id)
+        .order_by(AgentTurn.seq)
+        .limit(1)
+        .scalar_subquery()
+    )
+    first_pending_prompt = (
+        select(PendingMessage.message_text)
+        .where(PendingMessage.session_id == AgentSession.id)
+        .order_by(PendingMessage.seq)
+        .limit(1)
+        .scalar_subquery()
+    )
     statement = (
         select(
             AgentSession,
             func.coalesce(turns.c.turn_count, 0),
             func.coalesce(turns.c.total_cost_usd, 0),
             func.coalesce(pending.c.pending_count, 0),
+            first_turn_prompt,
+            first_pending_prompt,
         )
         .outerjoin(turns, turns.c.session_id == AgentSession.id)
         .outerjoin(pending, pending.c.session_id == AgentSession.id)
@@ -94,8 +113,20 @@ def _aggregate_statement(status: str | None = None, session_id: int | None = Non
     return statement
 
 
+def _fallback_title(
+    first_turn_prompt: str | None, first_pending_prompt: str | None
+) -> str:
+    text = (first_turn_prompt or first_pending_prompt or "").strip()
+    return text.split("\n")[0][:140]
+
+
 def _session_payload(
-    row: AgentSession, turn_count: int, total_cost_usd: float, pending_count: int
+    row: AgentSession,
+    turn_count: int,
+    total_cost_usd: float,
+    pending_count: int,
+    first_turn_prompt: str | None = None,
+    first_pending_prompt: str | None = None,
 ) -> dict:
     return {
         "id": row.id,
@@ -105,6 +136,7 @@ def _session_payload(
         "repo": row.repo,
         "model": row.model,
         "status": row.status,
+        "title": row.title or _fallback_title(first_turn_prompt, first_pending_prompt),
         "created_at": _iso(row.created_at),
         "last_turn_at": _iso(row.last_turn_at),
         "voice_summary": row.voice_summary,
@@ -119,10 +151,7 @@ def _rows(session: Session, status: str | None = None, limit: int | None = None)
     if limit is not None:
         statement = statement.limit(limit)
     results = session.exec(statement).all()
-    return [
-        _session_payload(result[0], result[1], result[2], result[3])
-        for result in results
-    ]
+    return [_session_payload(*result) for result in results]
 
 
 class StartRequest(BaseModel):
@@ -158,7 +187,7 @@ def get_session_detail(
     ).first()
     if result is None:
         raise HTTPException(status_code=404, detail="Agent session not found")
-    row, turn_count, total_cost_usd, pending_count = result
+    row, turn_count, total_cost_usd, pending_count, first_turn, first_pending = result
     turns_statement = select(AgentTurn).where(AgentTurn.session_id == session_id)
     if after_seq is not None:
         turns_statement = turns_statement.where(AgentTurn.seq > after_seq)
@@ -169,7 +198,9 @@ def get_session_detail(
         .order_by(PendingMessage.seq)
     ).all()
     return {
-        "session": _session_payload(row, turn_count, total_cost_usd, pending_count),
+        "session": _session_payload(
+            row, turn_count, total_cost_usd, pending_count, first_turn, first_pending
+        ),
         "turns": [
             {
                 "seq": turn.seq,

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -114,6 +114,30 @@ def test_list_sessions_aggregates(client, session):
     assert item["turn_count"] == 2
     assert item["pending_count"] == 1
     assert item["total_cost_usd"] == pytest.approx(0.1)
+    assert item["title"] == "one"
+
+
+def test_list_sessions_title_falls_back_to_pending_prompt(client, session):
+    pending_only = _session(session, "pending-only")
+    session.add(
+        PendingMessage(
+            session_id=pending_only.id,
+            seq=1,
+            message_text="First line\nsecond line",
+        )
+    )
+    _session(session, "empty")
+    session.commit()
+
+    _session(session, "named", title="Qwen picked this name")
+    body = client.get("/api/agents/sessions").json()
+    titles = {item["local_session_id"]: item["title"] for item in body}
+    # No completed turn yet: the queued prompt names the session, first
+    # line only. A session with no turns and no queue has no title, and a
+    # Qwen-generated name always wins over the prompt fallback.
+    assert titles["pending-only"] == "First line"
+    assert titles["empty"] == ""
+    assert titles["named"] == "Qwen picked this name"
 
 
 def test_get_session_detail(client, session):
@@ -153,6 +177,7 @@ def test_get_session_detail(client, session):
     assert body["session"]["turn_count"] == 2
     assert body["session"]["pending_count"] == 1
     assert body["session"]["total_cost_usd"] == 0
+    assert body["session"]["title"] == "one"
     assert [turn["seq"] for turn in body["turns"]] == [1, 2]
     assert body["turns"][1]["usage"] == {"activities": ["shell"]}
     assert body["pending_queue"][0]["prompt"] == "next"

--- a/projects/monolith/agent_sessions/titles.py
+++ b/projects/monolith/agent_sessions/titles.py
@@ -95,9 +95,7 @@ def pick_stale_sessions(session: Session, limit: int = BATCH_LIMIT) -> list[dict
     return candidates
 
 
-def store_title(
-    session: Session, session_id: int, title: str, turn_seq: int
-) -> None:
+def store_title(session: Session, session_id: int, title: str, turn_seq: int) -> None:
     row = session.get(AgentSession, session_id)
     if row is None:
         return

--- a/projects/monolith/agent_sessions/titles.py
+++ b/projects/monolith/agent_sessions/titles.py
@@ -116,14 +116,18 @@ def build_title_prompt(candidate: dict) -> str:
     )
 
 
+# Quotes, backticks, and periods in either order (LLMs emit both
+# `"name".` and `"name."`), plus whitespace.
+_TRIM_CHARS = " \"'`“”‘’."
+
+
 def sanitize_title(raw: str) -> str:
-    text = " ".join(str(raw or "").split())
-    text = text.strip().strip("\"'`“”‘’").rstrip(".")
+    text = " ".join(str(raw or "").split()).strip(_TRIM_CHARS)
     return text[:TITLE_MAX_CHARS].strip()
 
 
 async def _call_qwen(prompt: str) -> str:
-    url = os.environ.get("LLAMA_CPP_URL", "")
+    url = os.environ.get("LLAMA_CPP_URL", "").rstrip("/")
     async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
         resp = await client.post(
             f"{url}/v1/chat/completions",

--- a/projects/monolith/agent_sessions/titles.py
+++ b/projects/monolith/agent_sessions/titles.py
@@ -1,0 +1,199 @@
+"""Qwen-generated session names for the /agents UI.
+
+The leader runs a small refresh loop: any session whose newest turn is
+beyond the turn its title was generated from (``title_turn_seq``) gets
+renamed from its transcript. Qwen is self-hosted, so the calls are free;
+the loop stays out of the turn-execution path entirely and a failed pass
+simply leaves the session stale for the next tick. Sessions without a
+title fall back to their first prompt in the router.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+import httpx
+from sqlmodel import Session, func, select
+
+from agent_sessions.models import AgentSession, AgentTurn
+from core.db import get_engine
+from framework import log_task_exception
+
+logger = logging.getLogger(__name__)
+
+# One pass every 20s names a fresh session within a couple of UI poll
+# cycles without hammering the shared vLLM.
+REFRESH_INTERVAL_SECONDS = 20
+BATCH_LIMIT = 3
+TITLE_MAX_CHARS = 80
+# Short name only. Thinking is disabled in the request, so the budget is
+# spent on the name itself.
+_LLM_MAX_TOKENS = 40
+
+_TITLE_PROMPT = """You name coding-agent sessions for a session list.
+Write a short name (3 to 8 words) for the session below. Describe the
+task, not the outcome. Plain text only: no quotes, no markdown, no
+trailing period.
+
+First request:
+{first_prompt}
+
+Latest request:
+{latest_prompt}
+
+Latest result summary:
+{latest_summary}
+
+Name:"""
+
+_title_task: asyncio.Task | None = None
+
+
+def pick_stale_sessions(session: Session, limit: int = BATCH_LIMIT) -> list[dict]:
+    """Sessions whose newest turn postdates their title, freshest first."""
+    max_seq = (
+        select(AgentTurn.session_id, func.max(AgentTurn.seq).label("max_seq"))
+        .group_by(AgentTurn.session_id)
+        .subquery()
+    )
+    rows = session.exec(
+        select(AgentSession, max_seq.c.max_seq)
+        .join(max_seq, max_seq.c.session_id == AgentSession.id)
+        .where(func.coalesce(AgentSession.title_turn_seq, 0) < max_seq.c.max_seq)
+        .order_by(AgentSession.last_turn_at.desc())
+        .limit(limit)
+    ).all()
+    candidates = []
+    for row, latest_seq in rows:
+        first_turn = session.exec(
+            select(AgentTurn)
+            .where(AgentTurn.session_id == row.id)
+            .order_by(AgentTurn.seq)
+            .limit(1)
+        ).first()
+        latest_turn = session.exec(
+            select(AgentTurn)
+            .where(AgentTurn.session_id == row.id)
+            .order_by(AgentTurn.seq.desc())  # type: ignore[union-attr]
+            .limit(1)
+        ).first()
+        candidates.append(
+            {
+                "session_id": row.id,
+                "turn_seq": int(latest_seq),
+                "first_prompt": first_turn.prompt if first_turn else "",
+                "latest_prompt": latest_turn.prompt if latest_turn else "",
+                "latest_summary": (
+                    (latest_turn.voice_summary or latest_turn.result_text)
+                    if latest_turn
+                    else ""
+                ),
+            }
+        )
+    return candidates
+
+
+def store_title(
+    session: Session, session_id: int, title: str, turn_seq: int
+) -> None:
+    row = session.get(AgentSession, session_id)
+    if row is None:
+        return
+    row.title = title
+    row.title_turn_seq = turn_seq
+    session.add(row)
+    session.commit()
+
+
+def build_title_prompt(candidate: dict) -> str:
+    def clip(value, limit: int = 400) -> str:
+        return " ".join(str(value or "").split())[:limit]
+
+    return _TITLE_PROMPT.format(
+        first_prompt=clip(candidate.get("first_prompt")),
+        latest_prompt=clip(candidate.get("latest_prompt")),
+        latest_summary=clip(candidate.get("latest_summary"), 300),
+    )
+
+
+def sanitize_title(raw: str) -> str:
+    text = " ".join(str(raw or "").split())
+    text = text.strip().strip("\"'`“”‘’").rstrip(".")
+    return text[:TITLE_MAX_CHARS].strip()
+
+
+async def _call_qwen(prompt: str) -> str:
+    url = os.environ.get("LLAMA_CPP_URL", "")
+    async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
+        resp = await client.post(
+            f"{url}/v1/chat/completions",
+            json={
+                "model": "qwen3.6-27b",
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": _LLM_MAX_TOKENS,
+                # A thinking response spends the budget on <think> and
+                # returns content: null behind a 200, so disable it.
+                "chat_template_kwargs": {"enable_thinking": False},
+            },
+        )
+        resp.raise_for_status()
+        content = resp.json()["choices"][0]["message"]["content"]
+        if not content:
+            raise RuntimeError("LLM returned empty content")
+        return content
+
+
+def _pick_stale_sessions_sync(limit: int = BATCH_LIMIT) -> list[dict]:
+    with Session(get_engine()) as session:
+        return pick_stale_sessions(session, limit)
+
+
+def _store_title_sync(session_id: int, title: str, turn_seq: int) -> None:
+    with Session(get_engine()) as session:
+        store_title(session, session_id, title, turn_seq)
+
+
+async def refresh_titles_once(call_llm=_call_qwen) -> int:
+    """Name up to BATCH_LIMIT stale sessions; returns how many were named."""
+    if not os.environ.get("LLAMA_CPP_URL"):
+        return 0
+    candidates = await asyncio.to_thread(_pick_stale_sessions_sync, BATCH_LIMIT)
+    named = 0
+    for candidate in candidates:
+        try:
+            raw = await call_llm(build_title_prompt(candidate))
+        except (httpx.HTTPError, RuntimeError, KeyError, IndexError, ValueError) as exc:
+            logger.warning(
+                "Session naming failed for %s: %s", candidate["session_id"], exc
+            )
+            continue
+        title = sanitize_title(raw)
+        if not title:
+            continue
+        await asyncio.to_thread(
+            _store_title_sync, candidate["session_id"], title, candidate["turn_seq"]
+        )
+        named += 1
+    return named
+
+
+async def _title_refresh_loop() -> None:
+    while True:
+        await asyncio.sleep(REFRESH_INTERVAL_SECONDS)
+        try:
+            await refresh_titles_once()
+        except Exception:
+            # Never let one bad pass kill the leader task; the stale
+            # sessions are retried on the next tick.
+            logger.exception("Session title refresh pass failed")
+
+
+def start_title_refresh_loop() -> list[asyncio.Task]:
+    """Start the leader-owned title refresh loop and return its task."""
+    global _title_task
+    if _title_task is None or _title_task.done():
+        _title_task = asyncio.create_task(_title_refresh_loop())
+        _title_task.add_done_callback(log_task_exception)
+    return [_title_task]

--- a/projects/monolith/agent_sessions/titles_test.py
+++ b/projects/monolith/agent_sessions/titles_test.py
@@ -100,6 +100,7 @@ def test_sessions_without_turns_are_not_candidates(session):
 
 def test_sanitize_title():
     assert titles.sanitize_title('"Fix the CI  pipeline."') == "Fix the CI pipeline"
+    assert titles.sanitize_title('"Fix it".') == "Fix it"
     assert titles.sanitize_title("Name:\nplan the demo") == "Name: plan the demo"
     assert titles.sanitize_title(None) == ""
     assert len(titles.sanitize_title("x" * 500)) == titles.TITLE_MAX_CHARS

--- a/projects/monolith/agent_sessions/titles_test.py
+++ b/projects/monolith/agent_sessions/titles_test.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from agent_sessions import titles
+from agent_sessions.models import AgentSession, AgentTurn
+
+
+@pytest.fixture(name="session")
+def session_fixture(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'titles_test.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _session_with_turns(session: Session, name: str = "s1") -> AgentSession:
+    row = AgentSession(local_session_id=name, workspace="<guest>", branch="main")
+    session.add(row)
+    session.commit()
+    session.refresh(row)
+    session.add_all(
+        [
+            AgentTurn(
+                session_id=row.id,
+                seq=1,
+                prompt="Find events in Vancouver",
+                result_text="a list of events",
+            ),
+            AgentTurn(
+                session_id=row.id,
+                seq=2,
+                prompt="Now narrow to Saturday",
+                result_text="narrowed",
+                voice_summary="Narrowed the list to Saturday.",
+            ),
+        ]
+    )
+    session.commit()
+    return row
+
+
+def test_pick_stale_sessions_builds_candidate(session):
+    row = _session_with_turns(session)
+
+    candidates = titles.pick_stale_sessions(session)
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate["session_id"] == row.id
+    assert candidate["turn_seq"] == 2
+    assert candidate["first_prompt"] == "Find events in Vancouver"
+    assert candidate["latest_prompt"] == "Now narrow to Saturday"
+    # voice_summary preferred over raw result text.
+    assert candidate["latest_summary"] == "Narrowed the list to Saturday."
+
+
+def test_stored_title_marks_session_fresh_until_next_turn(session):
+    row = _session_with_turns(session)
+
+    titles.store_title(session, row.id, "Vancouver weekend events", 2)
+    assert titles.pick_stale_sessions(session) == []
+
+    session.refresh(row)
+    assert row.title == "Vancouver weekend events"
+    assert row.title_turn_seq == 2
+
+    # A new turn makes the title stale again: refresh-on-activity.
+    session.add(
+        AgentTurn(session_id=row.id, seq=3, prompt="Add Sunday", result_text="ok")
+    )
+    session.commit()
+    stale = titles.pick_stale_sessions(session)
+    assert [c["session_id"] for c in stale] == [row.id]
+    assert stale[0]["turn_seq"] == 3
+
+
+def test_sessions_without_turns_are_not_candidates(session):
+    session.add(
+        AgentSession(local_session_id="empty", workspace="<guest>", branch="main")
+    )
+    session.commit()
+    assert titles.pick_stale_sessions(session) == []
+
+
+def test_sanitize_title():
+    assert titles.sanitize_title('"Fix the CI  pipeline."') == "Fix the CI pipeline"
+    assert titles.sanitize_title("Name:\nplan the demo") == "Name: plan the demo"
+    assert titles.sanitize_title(None) == ""
+    assert len(titles.sanitize_title("x" * 500)) == titles.TITLE_MAX_CHARS
+
+
+def test_build_title_prompt_clips_and_includes_context():
+    prompt = titles.build_title_prompt(
+        {
+            "first_prompt": "Find events",
+            "latest_prompt": "Narrow it",
+            "latest_summary": "y" * 1000,
+        }
+    )
+    assert "Find events" in prompt
+    assert "Narrow it" in prompt
+    assert "y" * 300 in prompt
+    assert "y" * 301 not in prompt
+
+
+def test_refresh_titles_once_names_and_stores(monkeypatch):
+    monkeypatch.setenv("LLAMA_CPP_URL", "http://qwen.test")
+    stored = []
+    monkeypatch.setattr(
+        titles,
+        "_pick_stale_sessions_sync",
+        lambda limit: [
+            {
+                "session_id": 7,
+                "turn_seq": 4,
+                "first_prompt": "a",
+                "latest_prompt": "b",
+                "latest_summary": "c",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        titles,
+        "_store_title_sync",
+        lambda session_id, title, turn_seq: stored.append(
+            (session_id, title, turn_seq)
+        ),
+    )
+
+    async def fake_llm(prompt):
+        assert "a" in prompt and "b" in prompt
+        return '"Demo session name."'
+
+    named = asyncio.run(titles.refresh_titles_once(call_llm=fake_llm))
+    assert named == 1
+    assert stored == [(7, "Demo session name", 4)]
+
+
+def test_refresh_titles_once_survives_llm_failure(monkeypatch):
+    monkeypatch.setenv("LLAMA_CPP_URL", "http://qwen.test")
+    monkeypatch.setattr(
+        titles,
+        "_pick_stale_sessions_sync",
+        lambda limit: [
+            {
+                "session_id": 7,
+                "turn_seq": 4,
+                "first_prompt": "a",
+                "latest_prompt": "b",
+                "latest_summary": "c",
+            }
+        ],
+    )
+    stored = []
+    monkeypatch.setattr(
+        titles,
+        "_store_title_sync",
+        lambda *args: stored.append(args),
+    )
+
+    async def broken_llm(prompt):
+        raise RuntimeError("qwen is down")
+
+    named = asyncio.run(titles.refresh_titles_once(call_llm=broken_llm))
+    assert named == 0
+    assert stored == []
+
+
+def test_refresh_titles_once_skips_without_llm_url(monkeypatch):
+    monkeypatch.delenv("LLAMA_CPP_URL", raising=False)
+
+    def explode(limit):
+        raise AssertionError("should not query the database")
+
+    monkeypatch.setattr(titles, "_pick_stale_sessions_sync", explode)
+    assert asyncio.run(titles.refresh_titles_once()) == 0

--- a/projects/monolith/app/main_extra_test.py
+++ b/projects/monolith/app/main_extra_test.py
@@ -128,7 +128,9 @@ class TestSingletonBotClose:
         ):
             await _start_singletons(app)
 
-        assert len(tasks) == 5  # bot + outbox + ships + agent_sessions + lock sweeps
+        assert (
+            len(tasks) == 6
+        )  # bot + outbox + ships + agent_sessions + lock sweeps + title refresh
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/app/main_lifespan_discord_test.py
+++ b/projects/monolith/app/main_lifespan_discord_test.py
@@ -84,12 +84,15 @@ class TestSingletons:
         ):
             await _start_singletons(app)
 
-        assert len(created) == 5  # bot + outbox + ships + agent_sessions + lock sweeps
+        assert (
+            len(created) == 6
+        )  # bot + outbox + ships + agent_sessions + lock sweeps + title refresh
 
     @pytest.mark.asyncio
     async def test_start_singletons_one_task_without_token(self):
-        """Without a token: ships + agent_sessions sweeps = 2 tasks (no bot, no drain, no sweep; the
-        scheduler dispatch loop was removed - jobs run as Argo CronWorkflows)."""
+        """Without a token: ships + agent_sessions sweep + title refresh = 3 tasks
+        (no bot, no drain, no lock sweep; the scheduler dispatch loop was
+        removed - jobs run as Argo CronWorkflows)."""
         created, cap = _capture()
         env = {k: v for k, v in os.environ.items() if k != "DISCORD_BOT_TOKEN"}
         env["DISCORD_BOT_TOKEN"] = ""
@@ -105,7 +108,7 @@ class TestSingletons:
         ):
             await _start_singletons(app)
 
-        assert len(created) == 2  # ships + agent_sessions sweeps
+        assert len(created) == 3  # ships + agent_sessions sweep + title refresh
 
     @pytest.mark.asyncio
     async def test_stop_singletons_closes_and_cancels(self):

--- a/projects/monolith/app/main_lock_sweep_test.py
+++ b/projects/monolith/app/main_lock_sweep_test.py
@@ -220,11 +220,12 @@ class TestSweepTaskRegistration:
         ):
             await _start_singletons(app)
 
-        # 2 tasks: ships ingest and the agent_sessions pending-message sweep.
-        # The scheduler dispatch loop was removed (batch jobs run as Argo
-        # CronWorkflows) and the Discord bot is patched out here, so those two
-        # leader-elected singletons are the whole set.
-        assert len(tasks_created) == 2
+        # 3 tasks: ships ingest, the agent_sessions pending-message sweep, and
+        # the agent_sessions title refresh. The scheduler dispatch loop was
+        # removed (batch jobs run as Argo CronWorkflows) and the Discord bot is
+        # patched out here, so those three leader-elected singletons are the
+        # whole set.
+        assert len(tasks_created) == 3
         messages = [str(c) for c in mock_logger.info.call_args_list]
         assert not any("Message lock sweep started" in m for m in messages)
 

--- a/projects/monolith/app/main_sidecar_test.py
+++ b/projects/monolith/app/main_sidecar_test.py
@@ -477,7 +477,8 @@ async def test_start_bot_when_ready_not_scheduled_when_no_token():
     ):
         await _start_singletons(app)
 
-    # Ships and agent_sessions ingest tasks (no bot; scheduler loop removed).
-    assert len(created_tasks) == 2, (
-        f"Expected 2 tasks without a bot token, got {len(created_tasks)}"
+    # Ships ingest plus the agent_sessions sweep and title refresh (no bot;
+    # scheduler loop removed).
+    assert len(created_tasks) == 3, (
+        f"Expected 3 tasks without a bot token, got {len(created_tasks)}"
     )

--- a/projects/monolith/app/main_summary_test.py
+++ b/projects/monolith/app/main_summary_test.py
@@ -141,10 +141,11 @@ class TestChatStartupHook:
         ):
             await _start_singletons(app)
 
-        # Tasks: bot, outbox drain, ships ingest, message lock sweep, and the
-        # agent_sessions pending-message sweep. The scheduler dispatch loop was
-        # removed (batch jobs run as Argo CronWorkflows).
-        assert len(task_mocks) == 5
+        # Tasks: bot, outbox drain, ships ingest, message lock sweep, the
+        # agent_sessions pending-message sweep, and the agent_sessions title
+        # refresh. The scheduler dispatch loop was removed (batch jobs run as
+        # Argo CronWorkflows).
+        assert len(task_mocks) == 6
         # Assert the invariant rather than indexing a hand-numbered list: what
         # matters is that EVERY singleton gets the done callback, so a task that
         # crashes is logged. Indexing meant this broke whenever a singleton was

--- a/projects/monolith/app/main_test.py
+++ b/projects/monolith/app/main_test.py
@@ -207,7 +207,7 @@ async def test_lifespan_creates_one_background_task_on_startup():
         with patches[0], patches[1], patches[2], patches[3], patches[4]:
             await _start_singletons(app)
 
-    assert len(created_tasks) == 2  # ships + agent_sessions sweeps
+    assert len(created_tasks) == 3  # ships + agent_sessions sweep + title refresh
 
 
 @pytest.mark.asyncio
@@ -230,7 +230,7 @@ async def test_lifespan_cancels_all_tasks_on_shutdown():
             await _start_singletons(app)
             await _stop_singletons(app)
 
-    assert len(mock_tasks) == 2  # ships + agent_sessions sweeps
+    assert len(mock_tasks) == 3  # ships + agent_sessions sweep + title refresh
     for task in mock_tasks:
         task.cancel.assert_called_once()
 
@@ -253,7 +253,7 @@ async def test_lifespan_no_tasks_cancelled_before_shutdown():
     with patch("asyncio.create_task", side_effect=capture_create_task):
         with patches[0], patches[1], patches[2], patches[3], patches[4]:
             await _start_singletons(app)
-            assert len(mock_tasks) == 2  # ships + agent_sessions sweeps
+            assert len(mock_tasks) == 3  # ships + agent_sessions sweep + title refresh
             for task in mock_tasks:
                 task.cancel.assert_not_called()
             await _stop_singletons(app)
@@ -513,8 +513,8 @@ async def test_lifespan_creates_four_tasks_when_discord_token_set():
                 await _start_singletons(app)
 
     assert (
-        len(created_tasks) == 5
-    )  # bot + outbox + ships + agent_sessions + lock sweeps
+        len(created_tasks) == 6
+    )  # bot + outbox + ships + agent_sessions + lock sweeps + title refresh
 
 
 @pytest.mark.asyncio

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.458
+version: 0.285.459
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260807200000_agent_sessions_title.sql
+++ b/projects/monolith/chart/migrations/20260807200000_agent_sessions_title.sql
@@ -1,0 +1,6 @@
+-- Qwen-generated session display name; title_turn_seq records the turn
+-- the name was generated from so the leader loop can refresh it when
+-- newer turns land.
+ALTER TABLE agent_sessions.agent_sessions
+    ADD COLUMN title TEXT,
+    ADD COLUMN title_turn_seq INTEGER;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:kJl0E1y57xctZsqJ6KkWRrS+w85p+af7+xtfwAa0/HM=
+h1:rRojVgTDLk5Y6eG9ZirUbbxdoJ5QpuE5iJsfilbPzsM=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -155,3 +155,4 @@ h1:kJl0E1y57xctZsqJ6KkWRrS+w85p+af7+xtfwAa0/HM=
 20260804180100_agent_sessions_partial_activities.sql h1:7pn5RdzO2CtsdU0TgaMLLeEflS5C0YZtqBxyerEjHyY=
 20260806090000_agent_sessions_discord_thread.sql h1:9V+mX3YJfQhNe+5UqL6OSf+6hUxNPXbMnwO7yCnfqSg=
 20260807000000_agent_sessions_system_prompt.sql h1:yXxvvTBu8bpsxP0gvWha+tx+HVDckAgIGwKg474B4Lg=
+20260807200000_agent_sessions_title.sql h1:DsUTRT8wNkVtobGtUKt6VHLaV5CcC/fzQRjPnevFbpM=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.458
+      targetRevision: 0.285.459
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -619,7 +619,10 @@
           >
             <span class="snippet">{result.snippet}</span>
             <span class="result-meta mono"
-              >turn {result.seq} · {relativeTime(result.created_at)}</span
+              >{String(result.local_session_id || result.workspace || "").slice(
+                0,
+                8,
+              )} · turn {result.seq} · {relativeTime(result.created_at)}</span
             >
           </button>
         {:else}<div class="empty">No matching turns</div>{/each}
@@ -719,6 +722,9 @@
                 <span>{turn.model || selectedSession.model || "luna"}</span>
                 <span>{relativeTime(turn.created_at)}</span>
                 {#if cost(turn.cost_usd)}<span>{cost(turn.cost_usd)}</span>{/if}
+                {#if turn.stop_reason && turn.stop_reason !== "end_turn"}
+                  <span>{turn.stop_reason}</span>
+                {/if}
                 {#if turnFailed(turn)}<span class="badge-failed">failed</span
                   >{/if}
               </div>
@@ -733,10 +739,7 @@
                 <span class="role">you</span>
                 <div class="prompt-text">{entry.prompt}</div>
               </div>
-              <div
-                class={`live-line ${state === "working" ? "" : "quiet"}`}
-                aria-live="polite"
-              >
+              <div class={`live-line ${state === "working" ? "" : "quiet"}`}>
                 <span class="live-dot" aria-hidden="true"></span>
                 {#if state === "working"}
                   {#if partial?.partial_activities?.length}
@@ -922,11 +925,11 @@
       </form>
     </section>
   {/if}
-</main>
 
-{#if errorMessage}<div class="error-banner" role="status">
-    {errorMessage}
-  </div>{/if}
+  {#if errorMessage}<div class="error-banner" role="status">
+      {errorMessage}
+    </div>{/if}
+</main>
 
 {#snippet sessionRow(session)}
   <button
@@ -1005,14 +1008,12 @@
     font-family: var(--font-ui);
   }
   .console .mono,
-  .console code,
   .console pre,
   .console input.mono,
   .console select.mono {
     font-family: var(--font-mono);
   }
   .mono,
-  code,
   pre {
     font-size: var(--size-body-mono);
   }

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1,9 +1,14 @@
 <script>
+  import { tick } from "svelte";
+  import { renderAgentMarkdown } from "./markdown.js";
   import { statusClass, statusLabel } from "./status.js";
+  import "./agents-theme.css";
 
   let { data } = $props();
 
   const MODELS = ["opus", "fable", "sonnet", "luna", "terra", "sol", "qwen"];
+  const RECENT_HISTORY_MS = 24 * 60 * 60 * 1000;
+  const ATTENTION_MS = 60 * 60 * 1000;
 
   let selectedId = $state(null);
   let sidebarCollapsed = $state(false);
@@ -25,6 +30,7 @@
   let sending = $state(false);
   let creating = $state(false);
   let showNewPanel = $state(false);
+  let showAllHistory = $state(false);
   let repos = $state([]);
   let branches = $state([]);
   let repoLoading = $state(false);
@@ -44,6 +50,7 @@
   let searchController = null;
   let requestSequence = 0;
   let renderedPending = $state({});
+  let turnsEl = $state(null);
 
   const selectedSession = $derived(
     sessions.find((session) => String(session.id) === String(selectedId)) ??
@@ -56,6 +63,14 @@
   const historySessions = $derived(
     sessions.filter((session) => !isActive(session)).sort(compareSessions),
   );
+  const recentHistorySessions = $derived(
+    historySessions.filter(
+      (session) => Date.now() - lastActiveAt(session) < RECENT_HISTORY_MS,
+    ),
+  );
+  const visibleHistorySessions = $derived(
+    showAllHistory ? historySessions : recentHistorySessions,
+  );
   const visibleSearchResults = $derived(searchResults ?? []);
   const hasActiveSessions = $derived(
     sessions.some((session) => isActive(session)) ||
@@ -63,6 +78,12 @@
         sessions.find((session) => String(session.id) === String(selectedId))
           ?.pending_count,
       ) > 0,
+  );
+  const headerTitle = $derived(
+    firstLine(selectedSession?.title) ||
+      firstLine(detail?.turns?.[0]?.prompt) ||
+      firstLine(detail?.pending_queue?.[0]?.prompt) ||
+      sessionTitle(selectedSession),
   );
 
   function isActive(session) {
@@ -75,6 +96,13 @@
     return (
       (Number.isNaN(bTime) ? 0 : bTime) - (Number.isNaN(aTime) ? 0 : aTime)
     );
+  }
+
+  function lastActiveAt(session) {
+    const at = Date.parse(
+      timestamp(session?.last_turn_at ?? session?.created_at),
+    );
+    return Number.isNaN(at) ? 0 : at;
   }
 
   function timestamp(value) {
@@ -100,33 +128,105 @@
     return `${Math.floor(months / 12)}y`;
   }
 
-  function displayName(session) {
+  function firstLine(value) {
+    return String(value || "")
+      .trim()
+      .split("\n")[0];
+  }
+
+  function shortId(session) {
+    return String(session?.local_session_id || session?.id || "session").slice(
+      0,
+      8,
+    );
+  }
+
+  function sessionTitle(session) {
     return (
-      session?.local_session_id ||
-      `${session?.workspace || "workspace"}/${session?.branch || "branch"}`
+      firstLine(session?.title) ||
+      (session?.repo ? `${session.repo}@${session.branch || "main"}` : "") ||
+      shortId(session)
     );
   }
 
   function formatRepoContext(session) {
-    if (session?.repo) return `${session.repo}@${session.branch || "main"}`;
-    return `${session?.workspace || "workspace"} / ${session?.branch || "branch"}`;
+    if (session?.repo) return `${session.repo} @ ${session.branch || "main"}`;
+    if (session?.workspace && session.workspace !== "<guest>") {
+      return session.workspace;
+    }
+    return "scratch workspace";
+  }
+
+  function sidebarDot(session) {
+    const cls = statusClass(session);
+    if (cls === "running" || cls === "working" || cls === "needs_input") {
+      return cls;
+    }
+    if (cls === "warn" && Date.now() - lastActiveAt(session) < ATTENTION_MS) {
+      return "warn";
+    }
+    return "idle";
   }
 
   function cost(value) {
-    return `$${Number(value || 0).toFixed(4)}`;
+    const amount = Number(value || 0);
+    if (!(amount > 0)) return "";
+    return amount >= 0.01 ? `$${amount.toFixed(2)}` : `$${amount.toFixed(4)}`;
   }
 
-  function activityLabel(activity) {
-    if (typeof activity === "string") return activity;
-    if (!activity || typeof activity !== "object") return "activity";
-    const tool = String(activity.tool || activity.name || "activity");
-    if (tool.toLowerCase() === "edit" || tool.toLowerCase() === "write") {
-      return `${tool} ${activity.file_path || activity.path || "file"}`;
+  function turnFailed(turn) {
+    return Boolean(
+      turn?.terminal_reason && turn.terminal_reason !== "completed",
+    );
+  }
+
+  function activityParts(activity) {
+    if (typeof activity === "string") return { verb: activity, detail: "" };
+    if (!activity || typeof activity !== "object") {
+      return { verb: "step", detail: "" };
     }
-    if (tool.toLowerCase() === "bash" || tool.toLowerCase() === "shell") {
-      return `${tool} ${activity.command || activity.input || ""}`.trim();
+    const kind = String(
+      activity.type || activity.tool || activity.name || "",
+    ).toLowerCase();
+    if (kind === "edit" || kind === "write") {
+      return { verb: kind, detail: activity.file_path || activity.path || "" };
     }
-    return tool;
+    if (kind === "bash" || kind === "shell") {
+      return {
+        verb: "run",
+        detail: activity.command || compactInput(activity.input),
+      };
+    }
+    if (activity.name) {
+      return {
+        verb: String(activity.name),
+        detail: compactInput(activity.input),
+      };
+    }
+    return { verb: kind || "step", detail: compactInput(activity.input) };
+  }
+
+  function compactInput(input) {
+    if (input == null) return "";
+    const text = typeof input === "string" ? input : JSON.stringify(input);
+    return text.length > 110 ? `${text.slice(0, 110)}…` : text;
+  }
+
+  function activityLine(activity) {
+    const { verb, detail } = activityParts(activity);
+    return detail ? `${verb} ${detail}` : verb;
+  }
+
+  function liveStateLabel(entry, index) {
+    if (entry.claimed_by_replica) return "working";
+    return index === 0 ? "starting" : "waiting";
+  }
+
+  function autoScroll(force = false) {
+    if (!turnsEl) return;
+    const nearBottom =
+      turnsEl.scrollHeight - turnsEl.scrollTop - turnsEl.clientHeight < 200;
+    if (force || nearBottom) turnsEl.scrollTop = turnsEl.scrollHeight;
   }
 
   function syncPendingPartials(entries) {
@@ -184,6 +284,8 @@
               pending_queue: body.pending_queue,
             }
           : body;
+        const force = !incremental;
+        tick().then(() => autoScroll(force));
       }
     } catch (error) {
       if (sequence === requestSequence) errorMessage = error.message;
@@ -500,10 +602,10 @@
       <span class="sr-only">Search sessions</span>
       <input
         bind:value={searchQuery}
-        placeholder="search transcript"
+        placeholder="search transcripts"
         autocomplete="off"
       />
-      {#if searchLoading}<span class="search-pulse">...</span>{/if}
+      {#if searchLoading}<span class="search-pulse">…</span>{/if}
     </label>
 
     {#if searchResults !== null}
@@ -515,10 +617,6 @@
             type="button"
             onclick={() => selectSession(result.session_id)}
           >
-            <span class="result-id mono"
-              >{result.local_session_id ||
-                `${result.workspace}/${result.seq}`}</span
-            >
             <span class="snippet">{result.snippet}</span>
             <span class="result-meta mono"
               >turn {result.seq} · {relativeTime(result.created_at)}</span
@@ -527,96 +625,174 @@
         {:else}<div class="empty">No matching turns</div>{/each}
       </div>
     {:else}
-      <div class="group-title">Active <span>{activeSessions.length}</span></div>
+      {#if activeSessions.length}
+        <div class="group-title">
+          Active <span>{activeSessions.length}</span>
+        </div>
+        <div class="session-list">
+          {#each activeSessions as session (session.id)}
+            {@render sessionRow(session)}
+          {/each}
+        </div>
+      {/if}
+      <div class="group-title history-title">Recent</div>
       <div class="session-list">
-        {#each activeSessions as session (session.id)}
+        {#each visibleHistorySessions as session (session.id)}
           {@render sessionRow(session)}
-        {:else}<div class="empty">No active sessions</div>{/each}
+        {:else}<div class="empty">
+            {activeSessions.length ? "No recent sessions" : "No sessions yet"}
+          </div>{/each}
       </div>
-      <div class="group-title history-title">
-        History <span>{historySessions.length}</span>
-      </div>
-      <div class="session-list">
-        {#each historySessions as session (session.id)}
-          {@render sessionRow(session)}
-        {:else}<div class="empty">No history</div>{/each}
-      </div>
+      {#if historySessions.length > recentHistorySessions.length}
+        <button
+          class="history-toggle"
+          type="button"
+          onclick={() => (showAllHistory = !showAllHistory)}
+          >{showAllHistory
+            ? "show recent only"
+            : `show all (${historySessions.length})`}</button
+        >
+      {/if}
     {/if}
   </aside>
 
   <section class="transcript" aria-label="Agent transcript">
     {#if selectedSession}
       <header class="transcript-head">
-        <div>
-          <div class="eyebrow mono">{displayName(selectedSession)}</div>
+        <div class="head-main">
+          <h1 class="session-title" title={headerTitle}>{headerTitle}</h1>
           <div class="session-context mono">
-            {formatRepoContext(selectedSession)}
+            {formatRepoContext(selectedSession)} · {selectedSession.model ||
+              "luna"} · {shortId(selectedSession)}
           </div>
         </div>
         <div class="head-actions">
-          <span class={`session-state ${statusClass(selectedSession)}`}
-            >{statusLabel(selectedSession)}</span
-          >
+          {#if statusClass(selectedSession) !== "completed"}
+            <span class={`session-state ${statusClass(selectedSession)}`}
+              >{statusLabel(selectedSession)}</span
+            >
+          {/if}
           <button class="destroy-button" type="button" onclick={destroySession}
             >destroy</button
           >
         </div>
       </header>
-      <div class="turns">
-        {#each detail?.turns ?? [] as turn (turn.seq)}
-          <article class="turn">
-            <div class="turn-bar mono">
-              <span>#{turn.seq}</span><span
-                >{turn.model || selectedSession.model || "luna"}</span
-              ><span>{cost(turn.cost_usd)}</span><span
-                >{turn.stop_reason || turn.terminal_reason || "pending"}</span
-              >
-            </div>
-            <div class="prompt"><span class="role">you</span>{turn.prompt}</div>
-            {#if turn.usage?.activities?.length}
-              <div class="activities" aria-label="Tool activity">
-                {#each turn.usage.activities as activity}<code
-                    >{activityLabel(activity)}</code
-                  >{/each}
+      <div class="turns" bind:this={turnsEl}>
+        <div class="turns-inner">
+          {#each detail?.turns ?? [] as turn (turn.seq)}
+            <article class="turn">
+              <div class="prompt">
+                <span class="role">you</span>
+                <div class="prompt-text">{turn.prompt}</div>
               </div>
-            {/if}
-            {#if turn.result_text}<pre
-                class="result">{turn.result_text}</pre>{/if}
-          </article>
-        {:else}<div class="empty transcript-empty">
-            No completed turns
-          </div>{/each}
-
-        {#if detail?.pending_queue?.length}
-          <div class="queue-title">pending queue</div>
-          {#each detail.pending_queue as entry (entry.seq)}
-            <div class="queue-entry">
-              <span class="queue-seq mono">#{entry.seq}</span>
-              <span class="queue-prompt">{entry.prompt}</span>
-              <span class:claimed={entry.claimed_by_replica} class="claim"
-                >{entry.claimed_by_replica ? "claimed" : "waiting"}</span
-              >
-              <span class="muted mono">{relativeTime(entry.created_at)}</span>
-            </div>
-            {#if renderedPending[entry.seq]?.partial_activities}
-              <div class="activities" aria-label="Tool activity">
-                {#each renderedPending[entry.seq].partial_activities as activity}
-                  <div class="activity">{activityLabel(activity)}</div>
-                {/each}
+              {#if turn.usage?.activities?.length}
+                <details class="steps">
+                  <summary
+                    >{turn.usage.activities.length}
+                    {turn.usage.activities.length === 1
+                      ? "step"
+                      : "steps"}</summary
+                  >
+                  <ol class="step-list">
+                    {#each turn.usage.activities as activity}
+                      <li>
+                        <span class="step-verb"
+                          >{activityParts(activity).verb}</span
+                        >
+                        <span class="step-detail"
+                          >{activityParts(activity).detail}</span
+                        >
+                      </li>
+                    {/each}
+                  </ol>
+                </details>
+              {/if}
+              {#if turnFailed(turn)}
+                <pre class="turn-error">{turn.result_text ||
+                    "The turn failed without output."}</pre>
+              {:else if turn.result_text}
+                <div class="result-md">
+                  {@html renderAgentMarkdown(turn.result_text)}
+                </div>
+              {/if}
+              <div class="turn-meta mono">
+                <span>{turn.model || selectedSession.model || "luna"}</span>
+                <span>{relativeTime(turn.created_at)}</span>
+                {#if cost(turn.cost_usd)}<span>{cost(turn.cost_usd)}</span>{/if}
+                {#if turnFailed(turn)}<span class="badge-failed">failed</span
+                  >{/if}
               </div>
-            {/if}
-            {#if renderedPending[entry.seq]?.partial_text}<pre
-                class="result">{renderedPending[entry.seq]
-                  .partial_text}</pre>{/if}
+            </article>
           {/each}
-        {/if}
+
+          {#each detail?.pending_queue ?? [] as entry, index (entry.seq)}
+            {@const partial = renderedPending[entry.seq]}
+            {@const state = liveStateLabel(entry, index)}
+            <article class="turn live">
+              <div class="prompt">
+                <span class="role">you</span>
+                <div class="prompt-text">{entry.prompt}</div>
+              </div>
+              <div
+                class={`live-line ${state === "working" ? "" : "quiet"}`}
+                aria-live="polite"
+              >
+                <span class="live-dot" aria-hidden="true"></span>
+                {#if state === "working"}
+                  {#if partial?.partial_activities?.length}
+                    <span class="live-latest"
+                      >{activityLine(
+                        partial.partial_activities[
+                          partial.partial_activities.length - 1
+                        ],
+                      )}</span
+                    >
+                  {:else}
+                    <span class="live-latest">working…</span>
+                  {/if}
+                {:else if state === "starting"}
+                  <span class="live-latest">starting up…</span>
+                {:else}
+                  <span class="live-latest">waiting for the turn ahead…</span>
+                {/if}
+              </div>
+              {#if partial?.partial_activities?.length > 1}
+                <ol class="step-list live-steps" aria-label="Agent activity">
+                  {#if partial.partial_activities.length > 6}
+                    <li class="step-earlier">
+                      … {partial.partial_activities.length - 6} earlier steps
+                    </li>
+                  {/if}
+                  {#each partial.partial_activities.slice(-6) as activity}
+                    <li>
+                      <span class="step-verb"
+                        >{activityParts(activity).verb}</span
+                      >
+                      <span class="step-detail"
+                        >{activityParts(activity).detail}</span
+                      >
+                    </li>
+                  {/each}
+                </ol>
+              {/if}
+              {#if partial?.partial_text}
+                <div class="result-md">
+                  {@html renderAgentMarkdown(partial.partial_text)}
+                </div>
+              {/if}
+            </article>
+          {/each}
+
+          {#if !(detail?.turns ?? []).length && !(detail?.pending_queue ?? []).length}
+            <div class="empty transcript-empty">
+              {detail
+                ? "No turns yet. Send a prompt below."
+                : "Loading session…"}
+            </div>
+          {/if}
+        </div>
       </div>
 
-      {#if detail?.pending_queue?.length}<div class="working-line shimmer">
-          <span class="dot working"></span>
-          {#if detail.pending_queue.some((entry) => entry.claimed_by_replica)}running{:else}waking…{/if}
-          <span class="muted">{detail.pending_queue.length} queued</span>
-        </div>{/if}
       <form
         class="composer"
         onsubmit={(event) => {
@@ -624,33 +800,34 @@
           sendPrompt();
         }}
       >
-        <textarea
-          bind:value={prompt}
-          placeholder="send a prompt to this session"
-          rows="3"
-          onkeydown={(e) => {
-            if (
-              (e.metaKey || e.ctrlKey) &&
-              e.key === "Enter" &&
-              !e.isComposing &&
-              !sending &&
-              prompt.trim()
-            ) {
-              e.preventDefault();
-              sendPrompt();
-            }
-          }}></textarea>
-        <div class="composer-actions">
-          <select class="mono" bind:value={composerModel} aria-label="Model">
-            <option value="">session default</option>
-            {#each MODELS as model}<option value={model}>{model}</option>{/each}
-          </select>
-          <button
-            class="send-button"
-            type="submit"
-            disabled={sending || !prompt.trim()}
-            >{sending ? "sending..." : "send"}</button
-          >
+        <div class="composer-inner">
+          <textarea
+            bind:value={prompt}
+            placeholder="send a prompt to this session (⌘⏎ to send)"
+            rows="3"
+            onkeydown={(e) => {
+              if (
+                (e.metaKey || e.ctrlKey) &&
+                e.key === "Enter" &&
+                !e.isComposing &&
+                !sending &&
+                prompt.trim()
+              ) {
+                e.preventDefault();
+                sendPrompt();
+              }
+            }}></textarea>
+          <div class="composer-actions">
+            {@render modelPicker(composerModel, (model) => {
+              composerModel = model;
+            })}
+            <button
+              class="send-button"
+              type="submit"
+              disabled={sending || !prompt.trim()}
+              >{sending ? "sending…" : "send"}</button
+            >
+          </div>
         </div>
       </form>
     {:else}
@@ -685,13 +862,12 @@
               }
             }}></textarea></label
         >
-        <label
-          >model<select class="mono" bind:value={newSession.model}
-            ><option value="">session default</option
-            >{#each MODELS as model}<option value={model}>{model}</option
-              >{/each}</select
-          ></label
-        >
+        <div class="field">
+          <span class="field-label">model</span>
+          {@render modelPicker(newSession.model, (model) => {
+            newSession.model = model;
+          })}
+        </div>
         <label
           >repo<select
             class="mono"
@@ -705,7 +881,7 @@
             {#if repoLoading}
               <option value="">loading repos</option>
             {:else}
-              <option value="">none (bare workspace)</option>
+              <option value="">none (scratch workspace)</option>
               {#each repos as repo}
                 <option value={repo.id} title={repo.description || ""}>
                   {repo.id}
@@ -740,7 +916,7 @@
             class="send-button"
             type="submit"
             disabled={creating || !newSession.prompt.trim()}
-            >{creating ? "creating" : "create"}</button
+            >{creating ? "creating…" : "create"}</button
           >
         </div>
       </form>
@@ -757,26 +933,47 @@
     class:chosen={String(selectedId) === String(session.id)}
     class="session-row"
     type="button"
-    aria-label={`${displayName(session)}: ${statusLabel(session)}`}
+    aria-label={`${sessionTitle(session)}: ${statusLabel(session)}`}
     onclick={() => selectSession(session)}
   >
-    <span
-      class={`dot ${statusClass(session)}`}
-      title={`${displayName(session)}: ${statusLabel(session)}`}
+    <span class={`dot ${sidebarDot(session)}`} title={statusLabel(session)}
     ></span>
     <span class="row-main"
-      ><span class="session-name">{displayName(session)}</span><span
+      ><span class="session-name">{sessionTitle(session)}</span><span
         class="row-sub mono"
       >
-        {#if session.repo}{session.repo}@{session.branch || "main"} · {relativeTime(
-            session.last_turn_at || session.created_at,
-          )}{:else}{session.model || "luna"} · {relativeTime(
-            session.last_turn_at || session.created_at,
-          )}{/if}
+        {session.model || "luna"}
+        {#if session.repo}· {(session.repo.split("/")[1] || session.repo) +
+            "@" +
+            (session.branch || "main")}{/if}
+        · {relativeTime(session.last_turn_at || session.created_at)}
       </span></span
     >
-    <span class="row-cost mono">{cost(session.total_cost_usd)}</span>
+    {#if cost(session.total_cost_usd)}
+      <span class="row-cost mono">{cost(session.total_cost_usd)}</span>
+    {/if}
   </button>
+{/snippet}
+
+{#snippet modelPicker(current, choose)}
+  <div class="model-chips" role="group" aria-label="Model">
+    <button
+      type="button"
+      class="chip"
+      class:on={!current}
+      aria-pressed={!current}
+      onclick={() => choose("")}>default</button
+    >
+    {#each MODELS as model}
+      <button
+        type="button"
+        class="chip"
+        class:on={current === model}
+        aria-pressed={current === model}
+        onclick={() => choose(model)}>{model}</button
+      >
+    {/each}
+  </div>
 {/snippet}
 
 <style>
@@ -791,15 +988,9 @@
     --font-ui:
       system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
-    --size-meta: 11px;
+    --size-meta: 11.5px;
     --size-body-mono: 12.5px;
-    --size-body: 13.5px;
-    --page-bg: #f5f2ec;
-    --panel-bg: #fffdfa;
-    --text: #252521;
-    --muted: #827c72;
-    --line: #d8d2c7;
-    --line-strong: #c9c2b7;
+    --size-body: 14px;
     color-scheme: light;
     height: 100vh;
     display: grid;
@@ -808,7 +999,7 @@
     color: var(--text);
     font-family: var(--font-ui);
     font-size: var(--size-body);
-    line-height: 1.4;
+    line-height: 1.45;
   }
   .console * {
     font-family: var(--font-ui);
@@ -838,13 +1029,14 @@
   input,
   textarea,
   select {
-    border-radius: 3px;
+    border-radius: 6px;
   }
   button:focus-visible,
   input:focus-visible,
   textarea:focus-visible,
-  select:focus-visible {
-    outline: 2px solid #8aa9c2;
+  select:focus-visible,
+  .steps summary:focus-visible {
+    outline: 2px solid var(--info);
     outline-offset: 1px;
   }
   .sidebar {
@@ -870,8 +1062,8 @@
   }
   .eyebrow,
   .group-title,
-  .queue-title {
-    color: #77736b;
+  .field-label {
+    color: var(--muted);
     font-size: var(--size-meta);
     line-height: 1.2;
     letter-spacing: 0.13em;
@@ -883,9 +1075,8 @@
   .quiet-button,
   .send-button {
     height: 30px;
-    padding: 0 10px;
+    padding: 0 12px;
     border: 1px solid var(--line-strong);
-    border-radius: 3px;
     font-size: var(--size-meta);
     line-height: 1;
   }
@@ -893,26 +1084,34 @@
   .new-button,
   .destroy-button,
   .quiet-button {
-    color: #4e4a43;
-    background: transparent;
+    color: var(--text);
+    background: var(--panel-bg);
   }
   .collapse-button {
     width: 30px;
     padding: 0;
+    background: transparent;
+  }
+  .destroy-button:hover {
+    color: var(--err);
+    border-color: var(--err-line);
+    background: var(--err-bg);
   }
   .new-button:hover,
-  .destroy-button:hover,
   .quiet-button:hover,
   .collapse-button:hover,
   .session-row:hover,
-  .session-row.chosen,
   .search-result:hover {
-    background: #ebe7df;
+    background: var(--hover);
+  }
+  .session-row.chosen {
+    background: var(--panel-bg);
+    border-color: var(--line);
   }
   .search-label {
     position: relative;
     display: block;
-    margin: 16px 0;
+    margin: 16px 0 12px;
   }
   .search-label input,
   .new-panel input,
@@ -923,7 +1122,6 @@
     color: var(--text);
     background: var(--panel-bg);
     border: 1px solid var(--line-strong);
-    border-radius: 3px;
     padding: 0 9px;
     outline: none;
   }
@@ -934,16 +1132,16 @@
   }
   .new-panel textarea,
   .composer textarea {
-    padding: 7px 9px;
+    padding: 8px 10px;
   }
   input:focus,
   textarea:focus,
   select:focus {
-    border-color: #7794a8;
+    border-color: var(--info);
   }
   select {
     appearance: none;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='m2.5 4.5 3.5 3 3.5-3' fill='none' stroke='%236b665d' stroke-width='1.25'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='m2.5 4.5 3.5 3 3.5-3' fill='none' stroke='%2363605a' stroke-width='1.25'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: right 8px center;
     padding-right: 27px;
@@ -952,7 +1150,7 @@
     position: absolute;
     top: 5px;
     right: 9px;
-    color: #8b857b;
+    color: var(--muted);
   }
   .group-title {
     display: flex;
@@ -960,7 +1158,15 @@
     margin: 12px 4px 6px;
   }
   .history-title {
-    margin-top: 20px;
+    margin-top: 18px;
+  }
+  .history-toggle {
+    margin: 8px 4px;
+    padding: 2px 0;
+    border: 0;
+    background: none;
+    color: var(--info);
+    font-size: var(--size-meta);
   }
   .session-list {
     min-height: 0;
@@ -974,7 +1180,7 @@
     color: inherit;
     background: transparent;
     border: 1px solid transparent;
-    padding: 7px 6px;
+    padding: 7px 8px;
     display: flex;
     gap: 8px;
     align-items: flex-start;
@@ -985,21 +1191,18 @@
     width: 7px;
     height: 7px;
     border-radius: 50%;
-    background: #979188;
-    margin-top: 5px;
+    background: var(--dot-idle);
+    margin-top: 6px;
   }
-  .dot.running {
-    background: #4c9660;
-  }
+  .dot.running,
   .dot.working {
-    background: #4c9660;
-    animation: pulse 1.2s ease-in-out infinite;
+    background: var(--ok);
   }
   .dot.warn {
-    background: #b47b2c;
+    background: var(--attn);
   }
   .dot.needs_input {
-    background: #4a83ad;
+    background: var(--info);
   }
   .row-main {
     min-width: 0;
@@ -1007,32 +1210,31 @@
     display: grid;
     gap: 2px;
   }
-  .session-name,
-  .result-id {
+  .session-name {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    color: #302e29;
-    font-size: var(--size-body-mono);
+    color: var(--text);
+    font-size: 13px;
   }
   .row-sub,
   .row-cost,
   .result-meta,
-  .muted,
   .session-context {
     color: var(--muted);
     font-size: var(--size-meta);
   }
   .row-cost {
     white-space: nowrap;
+    margin-top: 1px;
   }
   .search-result {
     display: grid;
     gap: 4px;
   }
   .snippet {
-    color: #625e56;
-    font-size: var(--size-body);
+    color: var(--text-soft);
+    font-size: 13px;
     line-height: 1.35;
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -1044,161 +1246,292 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
+    background: var(--panel-bg);
   }
   .transcript-head {
-    padding: 16px 24px 12px;
+    padding: 14px 28px;
     border-bottom: 1px solid var(--line);
   }
+  .head-main {
+    min-width: 0;
+  }
+  .session-title {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   .session-context {
-    margin-top: 4px;
-    font-family: var(--font-mono);
+    margin-top: 3px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
   .session-state {
-    color: #625e56;
-    border: 1px solid var(--line-strong);
-    padding: 5px 8px;
+    border-radius: 999px;
+    padding: 4px 10px;
     font-size: var(--size-meta);
     text-transform: lowercase;
-  }
-  .session-state.completed {
-    color: #938d83;
+    white-space: nowrap;
   }
   .session-state.warn {
-    color: #c79f4a;
+    color: var(--attn);
+    background: var(--attn-soft);
   }
   .session-state.needs_input {
-    color: #4a8ec7;
+    color: var(--info);
+    background: var(--info-soft);
   }
   .session-state.running,
   .session-state.working {
-    color: #4a9f5c;
+    color: var(--ok);
+    background: var(--ok-soft);
   }
   .turns {
     flex: 1;
-    padding: 16px 24px;
+    padding: 8px 28px 20px;
     overflow: auto;
   }
+  .turns-inner {
+    max-width: 860px;
+    margin: 0 auto;
+  }
   .turn {
-    border: 1px solid var(--line);
-    margin-bottom: 12px;
-    background: var(--panel-bg);
+    padding: 18px 0 14px;
+    border-top: 1px solid var(--line);
   }
-  .turn-bar {
-    display: flex;
-    gap: 12px;
-    padding: 7px 10px;
-    border-bottom: 1px solid #e2ddd4;
-    color: var(--muted);
-    font-size: var(--size-meta);
-  }
-  .turn-bar span:nth-last-child(2) {
-    margin-left: auto;
+  .turn:first-child {
+    border-top: 0;
   }
   .prompt {
-    padding: 10px 12px 8px;
-    color: #302e29;
+    display: flex;
+    gap: 10px;
+    align-items: baseline;
+    background: var(--page-bg);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 10px 12px;
+  }
+  .prompt-text {
+    color: var(--text);
+    font-weight: 500;
     white-space: pre-wrap;
-    line-height: 1.45;
-    font-size: var(--size-body);
+    overflow-wrap: anywhere;
+    min-width: 0;
   }
   .role {
     color: var(--muted);
-    margin-right: 8px;
     font-size: var(--size-meta);
     text-transform: uppercase;
+    letter-spacing: 0.08em;
+    flex: 0 0 auto;
   }
-  .activities {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-    padding: 0 12px 10px;
+  .steps {
+    margin: 10px 0 0;
   }
-  code {
-    color: #625e56;
-    border: 1px solid var(--line);
-    background: var(--page-bg);
-    padding: 3px 5px;
-    white-space: pre-wrap;
+  .steps summary {
+    cursor: pointer;
+    user-select: none;
+    width: fit-content;
+    color: var(--muted);
+    font-size: var(--size-meta);
+    font-family: var(--font-mono);
+    border-radius: 4px;
   }
-  .activity {
-    color: #625e56;
-    border: 1px solid var(--line);
-    background: var(--page-bg);
-    padding: 3px 5px;
-    white-space: pre-wrap;
+  .steps summary:hover {
+    color: var(--text);
   }
-  .result {
-    margin: 0;
-    padding: 12px;
-    border-top: 1px solid #e2ddd4;
-    color: #4d4942;
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-    line-height: 1.5;
-  }
-  .queue-title {
-    margin: 20px 0 6px;
-  }
-  .queue-entry {
+  .step-list {
+    margin: 8px 0 0;
+    padding: 0 0 0 12px;
+    border-left: 2px solid var(--line);
+    list-style: none;
     display: grid;
-    grid-template-columns: 38px minmax(0, 1fr) auto auto;
+    gap: 4px;
+  }
+  .step-list li {
+    min-width: 0;
+  }
+  .step-verb {
+    color: var(--text);
+    font-weight: 600;
+    font-family: var(--font-mono);
+    font-size: var(--size-meta);
+  }
+  .step-detail {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: var(--size-meta);
+    overflow-wrap: anywhere;
+  }
+  .step-earlier {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: var(--size-meta);
+  }
+  .live-steps {
+    margin-top: 8px;
+  }
+  .live-line {
+    display: flex;
     align-items: center;
     gap: 8px;
-    border-top: 1px solid #e2ddd4;
-    padding: 8px 3px;
+    margin: 12px 0 0;
+    color: var(--ok);
+    font-family: var(--font-mono);
     font-size: var(--size-body-mono);
+    min-width: 0;
   }
-  .queue-prompt {
+  .live-line.quiet {
+    color: var(--muted);
+  }
+  .live-dot {
+    flex: 0 0 8px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+  }
+  .live-latest {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .queue-seq,
-  .claim {
+  .result-md {
+    margin-top: 10px;
+    color: var(--text-soft);
+    line-height: 1.6;
+    overflow-wrap: anywhere;
+  }
+  .result-md :global(p) {
+    margin: 0 0 10px;
+  }
+  .result-md :global(p:last-child) {
+    margin-bottom: 0;
+  }
+  .result-md :global(h2),
+  .result-md :global(h3) {
+    color: var(--text);
+    margin: 16px 0 6px;
+    font-size: 15px;
+  }
+  .result-md :global(h3) {
+    font-size: 14px;
+  }
+  .result-md :global(ul),
+  .result-md :global(ol) {
+    margin: 8px 0 10px;
+    padding-left: 22px;
+  }
+  .result-md :global(li) {
+    margin: 3px 0;
+  }
+  .result-md :global(code) {
+    font-family: var(--font-mono);
+    font-size: var(--size-body-mono);
+    background: var(--code-bg);
+    border-radius: 3px;
+    padding: 1px 4px;
+  }
+  .result-md :global(pre) {
+    background: var(--code-bg);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 10px 12px;
+    overflow-x: auto;
+    margin: 10px 0;
+  }
+  .result-md :global(pre code) {
+    background: none;
+    padding: 0;
+  }
+  .result-md :global(a) {
+    color: var(--info);
+  }
+  .result-md :global(blockquote) {
+    border-left: 3px solid var(--line-strong);
+    margin: 10px 0;
+    padding: 2px 12px;
     color: var(--muted);
   }
-  .claim.claimed {
-    color: #4c9660;
+  .result-md :global(table) {
+    border-collapse: collapse;
+    margin: 10px 0;
   }
-  .working-line {
-    border-top: 1px solid var(--line);
-    padding: 8px 24px;
-    color: #625e56;
+  .result-md :global(th),
+  .result-md :global(td) {
+    border: 1px solid var(--line);
+    padding: 5px 9px;
+    text-align: left;
+  }
+  .turn-error {
+    margin: 10px 0 0;
+    padding: 10px 12px;
+    background: var(--err-bg);
+    border: 1px solid var(--err-line);
+    border-radius: 8px;
+    color: var(--err);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    line-height: 1.5;
+  }
+  .turn-meta {
+    display: flex;
+    gap: 12px;
+    margin-top: 10px;
+    color: var(--muted);
     font-size: var(--size-meta);
   }
-  .working-line.shimmer {
-    background: linear-gradient(90deg, transparent, #ebe7df, transparent);
-    background-size: 200% 100%;
-    animation: shimmer 1.8s linear infinite;
-  }
-  .working-line .dot {
-    display: inline-block;
-    margin: 0 7px 1px 0;
-  }
-  .working-line .muted {
-    margin-left: 6px;
+  .badge-failed {
+    color: var(--err);
+    font-weight: 600;
   }
   .composer {
     border-top: 1px solid var(--line);
-    padding: 12px 24px 16px;
+    padding: 12px 28px 16px;
+  }
+  .composer-inner {
+    max-width: 860px;
+    margin: 0 auto;
     display: grid;
-    gap: 8px;
+    gap: 10px;
   }
   .composer textarea {
     resize: vertical;
     min-height: 70px;
   }
-  .composer select {
-    width: auto;
-    min-width: 110px;
+  .composer-actions {
+    align-items: flex-start;
+  }
+  .model-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .chip {
+    font-family: var(--font-mono);
+    font-size: var(--size-meta);
+    padding: 5px 10px;
+    border: 1px solid var(--line-strong);
+    border-radius: 999px;
+    background: var(--panel-bg);
+    color: var(--text);
+  }
+  .chip:hover {
+    background: var(--hover);
+  }
+  .chip.on {
+    background: var(--ink);
+    border-color: var(--ink);
+    color: var(--ink-text);
   }
   .send-button {
-    color: var(--panel-bg);
-    background: #4d6757;
-    border-color: #4d6757;
+    color: var(--ink-text);
+    background: var(--ink);
+    border-color: var(--ink);
+    font-weight: 600;
   }
   .send-button:disabled {
     cursor: not-allowed;
@@ -1209,28 +1542,34 @@
     z-index: 2;
     top: 0;
     right: 0;
-    width: min(350px, 100vw);
+    width: min(360px, 100vw);
     height: 100vh;
-    background: var(--page-bg);
+    overflow: auto;
+    background: var(--panel-bg);
     border-left: 1px solid var(--line-strong);
     padding: 20px;
-    box-shadow: -1px 0 2px #4b463d1a;
+    box-shadow: -2px 0 12px rgba(0, 0, 0, 0.07);
   }
   .new-panel form {
     display: grid;
-    gap: 12px;
+    gap: 14px;
     margin-top: 16px;
   }
-  .new-panel label {
+  .new-panel label,
+  .new-panel .field {
     display: grid;
-    gap: 5px;
-    color: #77736b;
+    gap: 6px;
+    color: var(--muted);
     font-size: var(--size-meta);
     text-transform: uppercase;
     letter-spacing: 0.08em;
   }
   .new-panel textarea {
     resize: vertical;
+    color: var(--text);
+    text-transform: none;
+    letter-spacing: normal;
+    font-size: var(--size-body);
   }
   .new-actions {
     justify-content: flex-end;
@@ -1238,25 +1577,32 @@
   }
   .empty {
     padding: 10px 4px;
-    color: #938d83;
-    font-size: var(--size-meta);
+    color: var(--muted);
+    font-size: 13px;
   }
   .blank-state {
     margin: auto;
   }
   .transcript-empty {
-    padding: 24px 0;
+    padding: 32px 0;
   }
   .error-banner {
     position: fixed;
     right: 16px;
     bottom: 16px;
     max-width: 420px;
-    padding: 9px 11px;
-    border: 1px solid #c58c88;
-    color: #874b46;
-    background: #fff1ef;
-    font-size: var(--size-meta);
+    padding: 10px 12px;
+    border: 1px solid var(--err-line);
+    border-radius: 6px;
+    color: var(--err);
+    background: var(--err-bg);
+    font-size: 13px;
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .dot.working,
+    .live-dot {
+      animation: pulse 1.2s ease-in-out infinite;
+    }
   }
   .sidebar-collapsed {
     grid-template-columns: 44px minmax(0, 1fr);
@@ -1280,6 +1626,7 @@
   .sidebar-collapsed .new-button,
   .sidebar-collapsed .search-label,
   .sidebar-collapsed .group-title,
+  .sidebar-collapsed .history-toggle,
   .sidebar-collapsed .row-main,
   .sidebar-collapsed .row-cost,
   .sidebar-collapsed .search-result,
@@ -1290,6 +1637,7 @@
   :global(html[data-agents-rail="collapsed"]) .console .new-button,
   :global(html[data-agents-rail="collapsed"]) .console .search-label,
   :global(html[data-agents-rail="collapsed"]) .console .group-title,
+  :global(html[data-agents-rail="collapsed"]) .console .history-toggle,
   :global(html[data-agents-rail="collapsed"]) .console .row-main,
   :global(html[data-agents-rail="collapsed"]) .console .row-cost,
   :global(html[data-agents-rail="collapsed"]) .console .search-result,
@@ -1318,14 +1666,6 @@
       opacity: 0.35;
     }
   }
-  @keyframes shimmer {
-    from {
-      background-position: 200% 0;
-    }
-    to {
-      background-position: -200% 0;
-    }
-  }
   @media (max-width: 760px) {
     .console {
       grid-template-columns: 1fr;
@@ -1344,8 +1684,7 @@
     }
     .transcript-head,
     .turns,
-    .composer,
-    .working-line {
+    .composer {
       padding-left: 16px;
       padding-right: 16px;
     }

--- a/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
+++ b/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
@@ -1,0 +1,38 @@
+/* Palette for the private /agents console.
+ *
+ * Colors live here, in a real CSS file, rather than in the component's
+ * <style> block: the component references var(--*) only, so the
+ * svelte-hardcoded-color-in-style rule stays clean by construction
+ * instead of by suppression.
+ *
+ * Direction: white working surfaces, near-black ink, and color reserved
+ * for state (running / attention / error). The previous grey-on-beige
+ * scheme was rejected for readability; secondary text stays secondary
+ * through size, never through washout (see .impeccable.md).
+ */
+.console {
+  --page-bg: #f4f3f0; /* chrome: sidebar, new-session drawer */
+  --panel-bg: #ffffff; /* working surfaces: transcript, inputs */
+  --text: #1b1a18;
+  --text-soft: #3a3835; /* response body */
+  --muted: #63605a; /* meta lines; 5.9:1 on white, AA for body text */
+  --line: #e3e1dc; /* hairline dividers */
+  --line-strong: #c7c3bb; /* control borders */
+  --hover: #edebe6;
+
+  --ink: #22211e; /* solid buttons + selected model chips */
+  --ink-text: #ffffff;
+
+  --ok: #2e6b41; /* running / working; 5.6:1 on white */
+  --ok-soft: #e7f0e9;
+  --attn: #8f6212; /* warn; text-safe amber */
+  --attn-soft: #f6eedd;
+  --info: #33608c; /* needs input + focus ring */
+  --info-soft: #e8eff7;
+  --err: #9d3a30;
+  --err-bg: #faf1ef;
+  --err-line: #e4c1bc;
+
+  --code-bg: #f2f1ee; /* inline code + fenced blocks in rendered markdown */
+  --dot-idle: #c2beb6; /* history sessions carry no status color */
+}

--- a/projects/monolith/frontend/src/routes/private/agents/markdown.js
+++ b/projects/monolith/frontend/src/routes/private/agents/markdown.js
@@ -3,12 +3,17 @@
 //
 // That renderer is the XSS control for public chat output (ADR 005
 // layer 8) and deliberately has no inline-link grammar, so this module
-// does NOT extend it. Instead it masks [text](https://...) links with
+// does NOT extend it. Instead it masks [text](http(s)://...) links with
 // NUL sentinels before rendering (NUL cannot appear in the input; it is
 // stripped first, the same trick the shared renderer uses for tag
 // spans), then swaps the sentinels for anchors built from fully escaped
 // parts. javascript:, data:, and every other scheme never match the
 // mask, so they stay inert escaped text exactly as before.
+//
+// The pre-render transforms (h1 downgrade, link masking) are applied
+// line by line OUTSIDE fenced code blocks only, so a `# comment` or a
+// literal [text](url) inside a fence renders exactly as the agent wrote
+// it. The fence open/close patterns mirror the shared renderer's.
 
 import { renderMarkdown } from "$lib/components/notes/markdown.js";
 
@@ -18,6 +23,8 @@ const EMPTY_TITLE_MAP = new Map();
 const LINK = /\[([^\]]+)\]\((https?:\/\/[^\s)<>"']+)\)/g;
 const SENTINEL = (index) => `\x00AGENTLINK${index}\x00`;
 const SENTINEL_RESTORE = /\x00AGENTLINK(\d+)\x00/g;
+const FENCE_OPEN = /^```\w*\s*$/;
+const FENCE_CLOSE = /^```\s*$/;
 
 const escapeHtml = (value) =>
   String(value).replace(
@@ -25,22 +32,46 @@ const escapeHtml = (value) =>
     (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c],
   );
 
+function mapOutsideFences(text, fn) {
+  const out = [];
+  let inFence = false;
+  for (const line of text.split("\n")) {
+    if (!inFence && FENCE_OPEN.test(line)) {
+      inFence = true;
+      out.push(line);
+    } else if (inFence && FENCE_CLOSE.test(line)) {
+      inFence = false;
+      out.push(line);
+    } else {
+      out.push(inFence ? line : fn(line));
+    }
+  }
+  return out.join("\n");
+}
+
 export function renderAgentMarkdown(text) {
   const cleaned = String(text ?? "")
     .replace(/\x00/g, "")
     // The agent's spoken summary duplicates the answer; it is surfaced
     // separately (turn.voice_summary) and is noise in the transcript.
+    // The second replace drops a still-streaming block whose closing
+    // tag has not arrived yet, so it never flashes in mid-stream.
     .replace(/<voice>[\s\S]*?<\/voice>/gi, "")
-    // The shared renderer suppresses h1 (note titles render elsewhere);
-    // agent output has no separate title, so keep its top heading.
-    .replace(/^# (?=\S)/gm, "## ")
+    .replace(/<voice>[\s\S]*$/i, "")
     .trim();
 
   const links = [];
-  const masked = cleaned.replace(LINK, (_, label, href) => {
-    links.push({ label, href });
-    return SENTINEL(links.length - 1);
-  });
+  const masked = mapOutsideFences(cleaned, (line) =>
+    line
+      // The shared renderer suppresses h1 (note titles render
+      // elsewhere); agent output has no separate title, so keep its
+      // top heading.
+      .replace(/^# (?=\S)/, "## ")
+      .replace(LINK, (_, label, href) => {
+        links.push({ label, href });
+        return SENTINEL(links.length - 1);
+      }),
+  );
   const html = renderMarkdown(masked, EMPTY_TITLE_MAP);
   return html.replace(SENTINEL_RESTORE, (match, index) => {
     const link = links[Number(index)];

--- a/projects/monolith/frontend/src/routes/private/agents/markdown.js
+++ b/projects/monolith/frontend/src/routes/private/agents/markdown.js
@@ -1,0 +1,50 @@
+// Markdown rendering for agent turn output, layered over the shared
+// escaping renderer in $lib/components/notes/markdown.js.
+//
+// That renderer is the XSS control for public chat output (ADR 005
+// layer 8) and deliberately has no inline-link grammar, so this module
+// does NOT extend it. Instead it masks [text](https://...) links with
+// NUL sentinels before rendering (NUL cannot appear in the input; it is
+// stripped first, the same trick the shared renderer uses for tag
+// spans), then swaps the sentinels for anchors built from fully escaped
+// parts. javascript:, data:, and every other scheme never match the
+// mask, so they stay inert escaped text exactly as before.
+
+import { renderMarkdown } from "$lib/components/notes/markdown.js";
+
+const EMPTY_TITLE_MAP = new Map();
+// href charset excludes whitespace, quotes, angle brackets, and `)` so
+// the attribute cannot be broken out of; escapeHtml is applied anyway.
+const LINK = /\[([^\]]+)\]\((https?:\/\/[^\s)<>"']+)\)/g;
+const SENTINEL = (index) => `\x00AGENTLINK${index}\x00`;
+const SENTINEL_RESTORE = /\x00AGENTLINK(\d+)\x00/g;
+
+const escapeHtml = (value) =>
+  String(value).replace(
+    /[&<>"]/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c],
+  );
+
+export function renderAgentMarkdown(text) {
+  const cleaned = String(text ?? "")
+    .replace(/\x00/g, "")
+    // The agent's spoken summary duplicates the answer; it is surfaced
+    // separately (turn.voice_summary) and is noise in the transcript.
+    .replace(/<voice>[\s\S]*?<\/voice>/gi, "")
+    // The shared renderer suppresses h1 (note titles render elsewhere);
+    // agent output has no separate title, so keep its top heading.
+    .replace(/^# (?=\S)/gm, "## ")
+    .trim();
+
+  const links = [];
+  const masked = cleaned.replace(LINK, (_, label, href) => {
+    links.push({ label, href });
+    return SENTINEL(links.length - 1);
+  });
+  const html = renderMarkdown(masked, EMPTY_TITLE_MAP);
+  return html.replace(SENTINEL_RESTORE, (match, index) => {
+    const link = links[Number(index)];
+    if (!link) return "";
+    return `<a href="${escapeHtml(link.href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(link.label)}</a>`;
+  });
+}

--- a/projects/monolith/frontend/src/routes/private/agents/markdown.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/markdown.test.js
@@ -66,4 +66,29 @@ describe("renderAgentMarkdown", () => {
     expect(html).toContain("<code>ci</code>");
     expect(html).toContain("<pre><code>plain block</code></pre>");
   });
+
+  it("renders http links as anchors too", () => {
+    const html = renderAgentMarkdown("[svc](http://monolith.svc:8080/x)");
+    expect(html).toContain('href="http://monolith.svc:8080/x"');
+  });
+
+  it("leaves shell comments inside fences untouched", () => {
+    const html = renderAgentMarkdown("```bash\n# install deps\nnpm i\n```");
+    expect(html).toContain("# install deps");
+    expect(html).not.toContain("<h2>");
+  });
+
+  it("leaves markdown links inside fences as literal text", () => {
+    const html = renderAgentMarkdown(
+      "```\nsee [docs](https://example.com/x)\n```",
+    );
+    expect(html).not.toContain("<a ");
+    expect(html).toContain("[docs](https://example.com/x)");
+  });
+
+  it("strips an unterminated voice block while streaming", () => {
+    const html = renderAgentMarkdown("The answer.\n\n<voice>Spoken so far");
+    expect(html).toContain("The answer.");
+    expect(html).not.toContain("Spoken so far");
+  });
 });

--- a/projects/monolith/frontend/src/routes/private/agents/markdown.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/markdown.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { renderAgentMarkdown } from "./markdown.js";
+
+describe("renderAgentMarkdown", () => {
+  it("renders https links as safe anchors", () => {
+    const html = renderAgentMarkdown(
+      "See [the listings](https://example.com/a?b=1&c=2) today",
+    );
+    expect(html).toContain(
+      '<a href="https://example.com/a?b=1&amp;c=2" target="_blank" rel="noopener noreferrer">the listings</a>',
+    );
+  });
+
+  it("renders links inside list items", () => {
+    const html = renderAgentMarkdown("- [x](https://example.com)");
+    expect(html).toMatch(/<li>.*<a href="https:\/\/example\.com".*<\/li>/);
+  });
+
+  it("leaves javascript: and data: links as inert text", () => {
+    for (const bad of [
+      "[click](javascript:alert(1))",
+      "[x](data:text/html,<script>alert(1)</script>)",
+    ]) {
+      const html = renderAgentMarkdown(bad);
+      expect(html).not.toContain("href");
+      expect(html).not.toMatch(/<a[\s>]/i);
+    }
+  });
+
+  it("escapes HTML in link labels", () => {
+    const html = renderAgentMarkdown("[<img onerror=x>](https://example.com)");
+    expect(html).not.toMatch(/<img/i);
+    expect(html).toContain("&lt;img");
+  });
+
+  it("cannot be forged with an injected sentinel", () => {
+    const html = renderAgentMarkdown("\x00AGENTLINK0\x00 and plain text");
+    expect(html).not.toContain("<a ");
+    expect(html).toContain("plain text");
+  });
+
+  it("still escapes injected HTML", () => {
+    const html = renderAgentMarkdown("<script>alert(1)</script>");
+    expect(html).not.toMatch(/<script>/i);
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("strips voice summaries", () => {
+    const html = renderAgentMarkdown(
+      "The answer.\n\n<voice>Spoken duplicate.</voice>",
+    );
+    expect(html).toContain("The answer.");
+    expect(html).not.toContain("Spoken duplicate");
+    expect(html).not.toContain("voice");
+  });
+
+  it("keeps a top-level heading by downgrading it to h2", () => {
+    expect(renderAgentMarkdown("# Plan")).toContain("<h2>Plan</h2>");
+  });
+
+  it("renders bold, code, and fences from agent output", () => {
+    const html = renderAgentMarkdown(
+      "**Saturday:** run `ci`\n\n```\nplain block\n```",
+    );
+    expect(html).toContain("<strong>Saturday:</strong>");
+    expect(html).toContain("<code>ci</code>");
+    expect(html).toContain("<pre><code>plain block</code></pre>");
+  });
+});

--- a/projects/monolith/frontend/vitest.config.js
+++ b/projects/monolith/frontend/vitest.config.js
@@ -4,6 +4,9 @@ import { fileURLToPath } from "node:url";
 export default defineConfig({
   resolve: {
     alias: {
+      // SvelteKit's `$lib` alias, for tests that exercise modules importing
+      // through it (the agents markdown wrapper does).
+      $lib: fileURLToPath(new URL("./src/lib", import.meta.url)),
       // The bare node test env has no SvelteKit plugin, so the `$app/environment`
       // virtual module does not resolve when a `+page.server.js` load (and, via
       // cache-headers.js, `versionedEtag`) is imported directly. Point it at a


### PR DESCRIPTION
Demo-readiness pass on the private /agents console, driven by direct UX feedback, plus Qwen-generated session names.

## UI redesign
- **Contrast and readability first**: white working surfaces, near-black ink, AA-passing secondary text. All colors are named tokens in a new `agents-theme.css`, so the hex-literal semgrep rule stays clean by construction.
- **Sidebar**: sessions listed by human title instead of UUID; history limited to the last 24h with a "show all" toggle; dots grey except running (green, pulsing while working) or needs-attention (blue needs-input; amber only for warnings under an hour old).
- **Turns**: seq numbers, $0.0000 costs, and "completed" labels removed. Results render as markdown; errors get a distinct error box; `<voice>` blocks are stripped.
- **Live view**: queue jargon (claimed/waiting/#seq) removed. A running turn shows a pulsing status line with the latest labeled step, a rolling feed of recent steps, and the streaming partial text as markdown with stick-to-bottom auto-scroll. Completed turns fold their steps into an expandable "N steps" disclosure.
- **Model picker**: chips replace the native select in the composer and new-session drawer.
- **Bug fix**: activity chips all rendered as the literal word "activity" because the guest shim emits `type`-keyed events (`{type: edit|bash|tool_use}`) while the renderer read only `.tool`/`.name`.

## Markdown rendering
Agent output renders through a new agents-local wrapper (`routes/private/agents/markdown.js`) over the shared escaping renderer. The shared renderer is the public-tier XSS control (ADR 005 layer 8) and is deliberately untouched: links are masked with NUL sentinels before rendering and re-injected as fully escaped anchors, `https?://` schemes only, so `javascript:`/`data:` stay inert text exactly as before.

## Qwen session names
- New `title` / `title_turn_seq` columns on `agent_sessions` (+ migration, atlas.sum regenerated with the pinned community v1.1.0 binary).
- A leader-owned refresh loop (`titles.py`) renames any session whose newest turn postdates its stored title, so names appear shortly after activity and refresh as work continues. Qwen is self-hosted, so the calls are free; failures just leave the session stale for the next tick.
- The router serves `title` with a first-prompt fallback until a name exists, so the UI never shows raw UUIDs.
- The extra leader singleton moves the lifespan task counts up by one (2→3 without Discord, 5→6 with); all ten assertions updated.

Chart bumps for monolith (0.285.459) and monolith-public (0.89.384, shared image) included.

`ci test`: Executed 59 out of 760 tests: 760 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)