### PR TITLE
feat(monolith): show guest VM state in agents console, fix qwen turn status

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.384
+version: 0.89.385
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.384
+      targetRevision: 0.89.385
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -168,12 +168,21 @@ def _persist_session(
         )
 
 
+# Terminal reasons that mean the turn ended normally. The claude lane
+# reports "completed" or "end_turn"; the pi lane passes the model's raw
+# stopReason through, which is "stop" for a normal qwen turn (see
+# runtimes/claude/shim.py). Comparing against "completed" alone marked
+# every successful qwen turn warn. None (transport died mid-turn) and
+# unrecognized values stay warn.
+_CLEAN_TERMINAL_REASONS = {"completed", "end_turn", "stop"}
+
+
 def _turn_status(turn: Turn) -> str:
     # permission_denials is the signal for "agent blocked waiting on user";
     # stop_reason enum (end_turn, max_tokens, etc.) never indicates user input needed
     if turn.permission_denials:
         return "needs_input"
-    if turn.is_error or turn.terminal_reason != "completed":
+    if turn.is_error or turn.terminal_reason not in _CLEAN_TERMINAL_REASONS:
         return "warn"
     return "completed"
 

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -384,6 +384,22 @@ def _completed_turn(message: str) -> Turn:
     )
 
 
+@pytest.mark.parametrize(
+    ("terminal_reason", "expected"),
+    [
+        ("completed", "completed"),  # claude lane
+        ("end_turn", "completed"),  # claude lane, raw stream value
+        ("stop", "completed"),  # pi lane passes qwen's stopReason through
+        ("error", "warn"),
+        (None, "warn"),  # transport died mid-turn
+        ("max_tokens", "warn"),  # truncated turn deserves attention
+    ],
+)
+def test_turn_status_accepts_every_lane_clean_reason(terminal_reason, expected):
+    turn = _completed_turn("hello")._replace(terminal_reason=terminal_reason)
+    assert mcp._turn_status(turn) == expected
+
+
 def _completed_delivery(message: str) -> tuple[Turn, EmberSession]:
     return _completed_turn(message), EmberSession("ember-1", "token-1", None)
 

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -139,6 +139,7 @@ def _session_payload(
         "model": row.model,
         "status": row.status,
         "title": row.title or _fallback_title(first_turn_prompt, first_pending_prompt),
+        "ember_session_id": row.ember_session_id,
         "created_at": _iso(row.created_at),
         "last_turn_at": _iso(row.last_turn_at),
         "voice_summary": row.voice_summary,
@@ -176,6 +177,39 @@ def list_sessions(
     session: Session = Depends(get_session),
 ) -> list[dict]:
     return _rows(session, status, limit)
+
+
+# Control-plane session states collapsed to what the console renders. The
+# guest lifecycle is the control plane's truth, not the monolith's local
+# binding: a park (idleBankSeconds after the last invoke) happens without
+# the monolith noticing until the next send, so the UI polls this instead.
+_VM_AWAKE_STATES = {"creating", "running", "relighting"}
+_VM_ASLEEP_STATES = {"banking", "banked", "parking", "parked"}
+
+
+@router.get("/vms")
+async def list_session_vms() -> dict:
+    """Map ember session ids to a coarse VM state for the console UI."""
+    try:
+        page = await _transport.list_sessions(limit=500)
+    except EmberVMTransportError as exc:
+        return {"vms": {}, "error": str(exc)}
+    vms = {}
+    for item in page.get("items", []):
+        state = str(item.get("state", ""))
+        if state in _VM_AWAKE_STATES:
+            coarse = "awake"
+        elif state in _VM_ASLEEP_STATES:
+            coarse = "asleep"
+        else:
+            coarse = "off"
+        vms[item.get("session_id")] = {
+            "state": coarse,
+            "cp_state": state,
+            "last_invoke_at": item.get("last_invoke_at"),
+            "expires_at": item.get("expires_at"),
+        }
+    return {"vms": vms}
 
 
 @router.get("/sessions/{session_id}")

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -14,6 +14,7 @@ from agent_sessions import mcp
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.router import router
 from core.db import get_session
+from faas.embervm_client import EmberVMTransportError
 
 
 @pytest.fixture(name="session")
@@ -138,6 +139,47 @@ def test_list_sessions_title_falls_back_to_pending_prompt(client, session):
     assert titles["pending-only"] == "First line"
     assert titles["empty"] == ""
     assert titles["named"] == "Qwen picked this name"
+
+
+def test_list_sessions_exposes_ember_binding(client, session):
+    _session(session, "bound", ember_session_id="s-abc123")
+    _session(session, "unbound")
+
+    body = client.get("/api/agents/sessions").json()
+    bindings = {item["local_session_id"]: item["ember_session_id"] for item in body}
+    assert bindings["bound"] == "s-abc123"
+    assert bindings["unbound"] is None
+
+
+def test_list_session_vms_maps_control_plane_states(client, monkeypatch):
+    async def fake_list_sessions(limit=50, offset=0):
+        return {
+            "items": [
+                {"session_id": "s-run", "state": "running", "expires_at": 99},
+                {"session_id": "s-park", "state": "parked", "last_invoke_at": 5},
+                {"session_id": "s-bank", "state": "banked"},
+                {"session_id": "s-gone", "state": "destroying"},
+            ]
+        }
+
+    monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
+    body = client.get("/api/agents/vms").json()
+    assert body["vms"]["s-run"]["state"] == "awake"
+    assert body["vms"]["s-park"]["state"] == "asleep"
+    assert body["vms"]["s-bank"]["state"] == "asleep"
+    assert body["vms"]["s-gone"]["state"] == "off"
+    assert body["vms"]["s-run"]["expires_at"] == 99
+    assert body["vms"]["s-park"]["cp_state"] == "parked"
+
+
+def test_list_session_vms_degrades_when_embervm_is_down(client, monkeypatch):
+    async def broken_list_sessions(limit=50, offset=0):
+        raise EmberVMTransportError("control plane unreachable")
+
+    monkeypatch.setattr(mcp._transport, "list_sessions", broken_list_sessions)
+    body = client.get("/api/agents/vms").json()
+    assert body["vms"] == {}
+    assert "unreachable" in body["error"]
 
 
 def test_get_session_detail(client, session):

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.459
+version: 0.285.460
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.459
+      targetRevision: 0.285.460
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1,7 +1,7 @@
 <script>
   import { tick } from "svelte";
   import { renderAgentMarkdown } from "./markdown.js";
-  import { statusClass, statusLabel } from "./status.js";
+  import { statusClass, statusLabel, vmState } from "./status.js";
   import "./agents-theme.css";
 
   let { data } = $props();
@@ -50,6 +50,7 @@
   let searchController = null;
   let requestSequence = 0;
   let renderedPending = $state({});
+  let vms = $state({});
   let turnsEl = $state(null);
 
   const selectedSession = $derived(
@@ -174,9 +175,16 @@
     return amount >= 0.01 ? `$${amount.toFixed(2)}` : `$${amount.toFixed(4)}`;
   }
 
+  // Mirrors the backend's _CLEAN_TERMINAL_REASONS: "completed"/"end_turn"
+  // from the claude lane, "stop" from the pi lane's raw stopReason. A
+  // qwen turn is a normal success with terminal_reason "stop", and the
+  // old !== "completed" check painted every one of them as failed.
+  const CLEAN_TERMINAL_REASONS = new Set(["completed", "end_turn", "stop"]);
+
   function turnFailed(turn) {
     return Boolean(
-      turn?.terminal_reason && turn.terminal_reason !== "completed",
+      turn?.terminal_reason &&
+      !CLEAN_TERMINAL_REASONS.has(turn.terminal_reason),
     );
   }
 
@@ -308,6 +316,17 @@
       }
     } catch (error) {
       errorMessage = error.message;
+    }
+  }
+
+  async function loadVms() {
+    try {
+      const response = await fetch("/agents/vms");
+      if (!response.ok) return;
+      const body = await response.json();
+      vms = body.vms ?? {};
+    } catch {
+      // VM state is advisory; keep the last known map on transient failures.
     }
   }
 
@@ -567,6 +586,16 @@
     }
   });
 
+  // Guest VM state polls on its own cadence: the control plane parks a VM
+  // idleBankSeconds (20s) after its last invoke without telling the
+  // monolith, so a fixed 5s poll keeps the chip honest even when the
+  // session list has dropped to its slow 15s interval.
+  $effect(() => {
+    loadVms();
+    const interval = setInterval(loadVms, 5000);
+    return () => clearInterval(interval);
+  });
+
   $effect(() => () => {
     clearTimeout(searchTimer);
     searchController?.abort();
@@ -670,6 +699,13 @@
           </div>
         </div>
         <div class="head-actions">
+          <span
+            class={`vm-chip vm-${vmState(selectedSession, vms)}`}
+            title={vms[selectedSession.ember_session_id]?.cp_state
+              ? `control plane: ${vms[selectedSession.ember_session_id].cp_state}`
+              : "no live microVM; the next prompt boots fresh"}
+            >vm {vmState(selectedSession, vms)}</span
+          >
           {#if statusClass(selectedSession) !== "completed"}
             <span class={`session-state ${statusClass(selectedSession)}`}
               >{statusLabel(selectedSession)}</span
@@ -1276,6 +1312,23 @@
     font-size: var(--size-meta);
     text-transform: lowercase;
     white-space: nowrap;
+  }
+  .vm-chip {
+    border-radius: 999px;
+    border: 1px solid var(--line-strong);
+    padding: 3px 10px;
+    font-family: var(--font-mono);
+    font-size: var(--size-meta);
+    color: var(--muted);
+    white-space: nowrap;
+  }
+  .vm-chip.vm-awake {
+    color: var(--ok);
+    border-color: var(--ok);
+  }
+  .vm-chip.vm-asleep {
+    color: var(--info);
+    border-color: var(--info);
   }
   .session-state.warn {
     color: var(--attn);

--- a/projects/monolith/frontend/src/routes/private/agents/status.js
+++ b/projects/monolith/frontend/src/routes/private/agents/status.js
@@ -16,3 +16,13 @@ export function statusLabel(session) {
   if (session?.status === "warn") return "warn";
   return "completed";
 }
+
+// Coarse EmberVM guest state for a session, joined against the /agents/vms
+// control-plane listing. "off" covers no binding, a binding the control
+// plane no longer knows, and terminal states alike: in every case the next
+// prompt boots fresh.
+export function vmState(session, vms) {
+  const vm = vms?.[session?.ember_session_id];
+  if (vm?.state === "awake" || vm?.state === "asleep") return vm.state;
+  return "off";
+}

--- a/projects/monolith/frontend/src/routes/private/agents/status.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/status.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { statusClass, statusLabel } from "./status.js";
+import { statusClass, statusLabel, vmState } from "./status.js";
 
 test.each([
   [{ status: "running" }, "running", "running"],
@@ -18,5 +18,28 @@ describe("agent status", () => {
   test("exports the status mapping helpers", () => {
     expect(statusClass).toBeTypeOf("function");
     expect(statusLabel).toBeTypeOf("function");
+  });
+});
+
+describe("vmState", () => {
+  const vms = {
+    "s-awake": { state: "awake" },
+    "s-asleep": { state: "asleep" },
+    "s-weird": { state: "destroying" },
+  };
+
+  test.each([
+    [{ ember_session_id: "s-awake" }, "awake"],
+    [{ ember_session_id: "s-asleep" }, "asleep"],
+    [{ ember_session_id: "s-weird" }, "off"],
+    [{ ember_session_id: "s-unknown" }, "off"],
+    [{ ember_session_id: null }, "off"],
+    [null, "off"],
+  ])("maps %j to %s", (session, expected) => {
+    expect(vmState(session, vms)).toBe(expected);
+  });
+
+  test("is off when the vm map is missing", () => {
+    expect(vmState({ ember_session_id: "s-awake" }, null)).toBe("off");
   });
 });

--- a/projects/monolith/frontend/src/routes/private/agents/vms/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/vms/+server.js
@@ -1,0 +1,18 @@
+const API_BASE = process.env.API_BASE;
+
+export async function GET() {
+  try {
+    const res = await fetch(`${API_BASE}/api/agents/vms`, {
+      signal: AbortSignal.timeout(10000),
+    });
+    return new Response(res.body, {
+      status: res.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return new Response(JSON.stringify({ error: "vm state unavailable" }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}


### PR DESCRIPTION
Follow-up to #4463, demo-driven.

## Guest VM state chip
The transcript header now shows `vm awake` / `vm asleep` / `vm off`, joined against the EmberVM control plane's own session listing via a new `/api/agents/vms` endpoint (`transport.list_sessions`, management auth), polled every 5s by the console. The control plane parks a session VM 20s (`idleBankSeconds`) after its last invoke without telling the monolith, so the local binding cannot be trusted for liveness; the chip reflects CP truth and degrades to "off"/last-known when the CP is unreachable. Session payloads expose `ember_session_id` for the join.

CP state collapse: `creating/running/relighting` → awake, `banking/banked/parking/parked` → asleep, everything else (incl. absent) → off.

## Qwen turns no longer render as failed
The pi lane passes the model's raw `stopReason` through as `terminal_reason` — `"stop"` for a normal qwen turn — and both the turn card (red box + failed badge) and the backend `_turn_status` (session `warn` pill, amber dots) treated anything but `"completed"` as failure. Both now compare against a clean-reason allowlist (`completed`, `end_turn`, `stop`). `None` still warns: it means the transport died mid-turn (existing test pins this).

Chart bumps: monolith 0.285.460, monolith-public 0.89.385 (shared image).

`ci test`: Executed 61 out of 761 tests: 761 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)