### PR TITLE
feat(monolith): poll agent VM state at 100ms, harden the CP listing

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.385
+version: 0.89.386
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.385
+      targetRevision: 0.89.386
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -190,12 +190,24 @@ _VM_ASLEEP_STATES = {"banking", "banked", "parking", "parked"}
 @router.get("/vms")
 async def list_session_vms() -> dict:
     """Map ember session ids to a coarse VM state for the console UI."""
+    # The control plane retains terminal session rows for days, so the
+    # listing can exceed one page; a silently truncated page would render
+    # a parked-days-ago session as "off" (the opposite of the truth).
+    # Follow `total` across pages, bounded far above the workload cap.
+    items = []
+    offset = 0
     try:
-        page = await _transport.list_sessions(limit=500)
+        for _ in range(4):
+            page = await _transport.list_sessions(limit=500, offset=offset)
+            batch = page.get("items", [])
+            items.extend(batch)
+            offset += len(batch)
+            if not batch or offset >= int(page.get("total") or 0):
+                break
     except EmberVMTransportError as exc:
         return {"vms": {}, "error": str(exc)}
     vms = {}
-    for item in page.get("items", []):
+    for item in items:
         state = str(item.get("state", ""))
         if state in _VM_AWAKE_STATES:
             coarse = "awake"

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -172,6 +172,29 @@ def test_list_session_vms_maps_control_plane_states(client, monkeypatch):
     assert body["vms"]["s-park"]["cp_state"] == "parked"
 
 
+def test_list_session_vms_follows_pagination(client, monkeypatch):
+    calls = []
+
+    async def fake_list_sessions(limit=50, offset=0):
+        calls.append(offset)
+        if offset == 0:
+            return {
+                "total": 501,
+                "items": [
+                    {"session_id": f"s-{i}", "state": "parked"} for i in range(500)
+                ],
+            }
+        return {"total": 501, "items": [{"session_id": "s-tail", "state": "running"}]}
+
+    monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
+    body = client.get("/api/agents/vms").json()
+    # The CP retains terminal rows for days; the tail page must be
+    # fetched or an old parked session silently renders as "off".
+    assert calls == [0, 500]
+    assert len(body["vms"]) == 501
+    assert body["vms"]["s-tail"]["state"] == "awake"
+
+
 def test_list_session_vms_degrades_when_embervm_is_down(client, monkeypatch):
     async def broken_list_sessions(limit=50, offset=0):
         raise EmberVMTransportError("control plane unreachable")

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -26,6 +26,10 @@ from shared.k8s_auth import auth_headers
 
 logger = logging.getLogger(__name__)
 
+# Session listing is an in-memory control-plane read serving the console's
+# VM-state poll; it must never inherit the turn-sized read timeout.
+LIST_SESSIONS_READ_TIMEOUT = 5.0
+
 
 def _retryable_from_response(exc: httpx.HTTPStatusError) -> bool:
     try:
@@ -281,7 +285,13 @@ class EmberVmShimTransport:
 
         url = f"{EMBERVM_URL}/v1/workloads/{self.workload}/sessions"
         headers = auth_headers()
-        timeout = httpx.Timeout(self.read_timeout, connect=SUBMIT_CONNECT_TIMEOUT)
+        # NOT self.read_timeout: that 30-minute value is sized for a turn,
+        # and this listing now serves the console's fast VM-state poll. A
+        # wedged control plane must fail the poll's degrade path in
+        # seconds, not accumulate half-hour requests behind it.
+        timeout = httpx.Timeout(
+            LIST_SESSIONS_READ_TIMEOUT, connect=SUBMIT_CONNECT_TIMEOUT
+        )
 
         try:
             async with httpx.AsyncClient(timeout=timeout) as client:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.460
+version: 0.285.461
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.460
+      targetRevision: 0.285.461
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -175,10 +175,12 @@
     return amount >= 0.01 ? `$${amount.toFixed(2)}` : `$${amount.toFixed(4)}`;
   }
 
-  // Mirrors the backend's _CLEAN_TERMINAL_REASONS: "completed"/"end_turn"
-  // from the claude lane, "stop" from the pi lane's raw stopReason. A
-  // qwen turn is a normal success with terminal_reason "stop", and the
-  // old !== "completed" check painted every one of them as failed.
+  // Success allowlist shared with the backend's _CLEAN_TERMINAL_REASONS:
+  // "completed"/"end_turn" from the claude lane, "stop" from the pi
+  // lane's raw stopReason. One deliberate difference: a missing
+  // terminal_reason warns the SESSION server-side (transport died
+  // mid-turn) but does not paint the turn card failed here, since the
+  // card has no error text to show for it.
   const CLEAN_TERMINAL_REASONS = new Set(["completed", "end_turn", "stop"]);
 
   function turnFailed(turn) {
@@ -586,14 +588,30 @@
     }
   });
 
-  // Guest VM state polls on its own cadence: the control plane parks a VM
-  // idleBankSeconds (20s) after its last invoke without telling the
-  // monolith, so a fixed 5s poll keeps the chip honest even when the
-  // session list has dropped to its slow 15s interval.
+  // Guest VM state polls at the transcript ladder's 100ms cadence: this
+  // page has one private viewer, the control-plane listing is a cheap
+  // in-memory read, and the 20s idle-park should flip the chip the
+  // moment it happens. Self-scheduling (like the ladder) so a slow
+  // fetch never stacks requests; a hidden tab skips the fetch entirely
+  // because unlike the ladder this loop runs for the life of the page.
   $effect(() => {
-    loadVms();
-    const interval = setInterval(loadVms, 5000);
-    return () => clearInterval(interval);
+    let stopped = false;
+    let timeoutHandle;
+    const schedulePoll = async () => {
+      if (stopped) return;
+      const startTime = Date.now();
+      if (!document.hidden) await loadVms();
+      if (stopped) return;
+      timeoutHandle = setTimeout(
+        schedulePoll,
+        Math.max(0, 100 - (Date.now() - startTime)),
+      );
+    };
+    schedulePoll();
+    return () => {
+      stopped = true;
+      clearTimeout(timeoutHandle);
+    };
   });
 
   $effect(() => () => {


### PR DESCRIPTION
The vm chip poll drops from 5s to the transcript ladder's 100ms cadence: this page has one private viewer, the CP listing is an in-memory read, and the 20s idle-park should flip the chip the moment it happens. The loop self-schedules (a slow fetch never stacks requests) and a hidden tab skips fetching.

Both should-fix findings from the #4464 review ride along, since each matters more at this cadence:
- `list_sessions` gets its own 5s read timeout instead of inheriting the turn-sized 1800s value, so a wedged control plane fails the poll's degrade path in seconds instead of accumulating half-hour requests behind the poll.
- `/api/agents/vms` follows the CP's `total` across pages (bounded 4x500) instead of silently truncating at 500, where a session parked days ago would render as `vm off`.

Chart bumps: monolith 0.285.461, monolith-public 0.89.386.

`ci test`: Executed 61 out of 761 tests: 761 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)