### PR TITLE
feat(monolith): stage the vm wake phases in the agents live line

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.386
+version: 0.89.387
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.386
+      targetRevision: 0.89.387
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.461
+version: 0.285.462
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.461
+      targetRevision: 0.285.462
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1,7 +1,7 @@
 <script>
   import { tick } from "svelte";
   import { renderAgentMarkdown } from "./markdown.js";
-  import { statusClass, statusLabel, vmState } from "./status.js";
+  import { statusClass, statusLabel, vmRunning, vmState } from "./status.js";
   import "./agents-theme.css";
 
   let { data } = $props();
@@ -804,8 +804,16 @@
                         ],
                       )}</span
                     >
-                  {:else}
+                  {:else if partial?.partial_text}
                     <span class="live-latest">working…</span>
+                  {:else if vmRunning(selectedSession, vms)}
+                    <!-- Claimed, VM confirmed running, no output yet: the
+                         CLI is spinning up / the model has the prompt. -->
+                    <span class="live-latest">starting the agent…</span>
+                  {:else}
+                    <!-- Claimed but the control plane does not report the
+                         guest running yet: park rejoin or cold boot. -->
+                    <span class="live-latest">waking vm…</span>
                   {/if}
                 {:else if state === "starting"}
                   <span class="live-latest">starting up…</span>
@@ -1331,22 +1339,24 @@
     text-transform: lowercase;
     white-space: nowrap;
   }
+  /* Soft tinted fills matching the session-state pills: state reads from
+     color, not from a hard outline. */
   .vm-chip {
     border-radius: 999px;
-    border: 1px solid var(--line-strong);
-    padding: 3px 10px;
+    padding: 4px 10px;
     font-family: var(--font-mono);
     font-size: var(--size-meta);
     color: var(--muted);
+    background: var(--hover);
     white-space: nowrap;
   }
   .vm-chip.vm-awake {
     color: var(--ok);
-    border-color: var(--ok);
+    background: var(--ok-soft);
   }
   .vm-chip.vm-asleep {
     color: var(--info);
-    border-color: var(--info);
+    background: var(--info-soft);
   }
   .session-state.warn {
     color: var(--attn);

--- a/projects/monolith/frontend/src/routes/private/agents/status.js
+++ b/projects/monolith/frontend/src/routes/private/agents/status.js
@@ -26,3 +26,10 @@ export function vmState(session, vms) {
   if (vm?.state === "awake" || vm?.state === "asleep") return vm.state;
   return "off";
 }
+
+// True only once the control plane reports the guest fully running (not
+// creating/relighting). Distinguishes "waking vm" from "vm is up but the
+// CLI has not produced output yet" for a claimed turn with no partials.
+export function vmRunning(session, vms) {
+  return vms?.[session?.ember_session_id]?.cp_state === "running";
+}

--- a/projects/monolith/frontend/src/routes/private/agents/status.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/status.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { statusClass, statusLabel, vmState } from "./status.js";
+import { statusClass, statusLabel, vmRunning, vmState } from "./status.js";
 
 test.each([
   [{ status: "running" }, "running", "running"],
@@ -41,5 +41,23 @@ describe("vmState", () => {
 
   test("is off when the vm map is missing", () => {
     expect(vmState({ ember_session_id: "s-awake" }, null)).toBe("off");
+  });
+});
+
+describe("vmRunning", () => {
+  test.each([
+    [{ cp_state: "running" }, true],
+    [{ cp_state: "relighting" }, false],
+    [{ cp_state: "creating" }, false],
+    [{ cp_state: "parked" }, false],
+  ])("cp_state %j running=%s", (vm, expected) => {
+    expect(vmRunning({ ember_session_id: "s-1" }, { "s-1": vm })).toBe(
+      expected,
+    );
+  });
+
+  test("is false with no binding or no map", () => {
+    expect(vmRunning({ ember_session_id: null }, {})).toBe(false);
+    expect(vmRunning(null, null)).toBe(false);
   });
 });


### PR DESCRIPTION
A claimed turn with no output yet now shows what is actually happening, driven by the control plane state the 100ms VM poll already carries: `waking vm…` while the guest is parked/relighting/creating (park rejoin ~250ms, cold boot seconds), then `starting the agent…` once the VM is confirmed `running` but the CLI has not streamed anything, then the usual latest-activity line. Previously all three phases read as a flat "working".

The vm chip also swaps its hard outlines for the session pills' soft tinted fills (green wash awake, frost asleep, neutral off).

Chart bumps: monolith 0.285.462, monolith-public 0.89.387.

`ci test`: Executed 2 out of 761 tests: 761 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)