### PR TITLE
fix(embervm): cut the git proxy idle deadline in the guest, not in values

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.461
+version: 0.1.463

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.461
+      targetRevision: 0.1.463
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -521,31 +521,27 @@ claudeRuntimeWorkload:
   # trigger the rebuild that arming requires. Scoped to claude-runtime because
   # only a restore that carries a volume needs the placeholder: task bases
   # restore volume-less and are unaffected either way.
+  # WARNING: every entry below is a base-SIGNATURE input and NOTHING here reaches
+  # the guest's environment. The control plane sends the map as
+  # BuildBaseRequest.init_env, noded never reads that field (the base-build claim
+  # is ClaimSpec{Arch, ThreadID} and ClaimSpec has no env member), and the guest's
+  # whole environment comes from guest-init setDefaultEnv plus the ember.env.*
+  # boot args that only ClaimStateful populates. So an entry here re-keys the base
+  # and rebuilds it, which looks exactly like a successful deploy, while changing
+  # nothing the guest can read. Use it as a rebuild epoch, never as a knob.
+  # Making it mean what it says is tracked in #4429.
   initEnv:
     EMBER_BASE_EPOCH: "warm-restore-3"
-    # initEnv participates in the base signature, so this re-keys and rebuilds
-    # only the claude-runtime base at the next chart bump. Prewarm failure fails
-    # the base build by design.
+    # INERT, kept only as documented intent: the shim reads EMBER_PREWARM_CLIS
+    # from its own environment, which never receives this, so _read_prewarm_clis
+    # returns () and prewarm silently no-ops. Live turn-timing confirms it: first
+    # turns log path=lazy_spawn, never a prewarmed CLI. #4423 (prewarm codex and
+    # pi too) has to fix the wiring above before it can build on this.
     EMBER_PREWARM_CLIS: "claude"
-    # Interim speed knob for #4429, pending protocol-aware completion.
-    #
-    # The git proxy helper cannot see the end of a response: #4412 stopped
-    # propagating half-close onto the vsock leg (Firecracker hybrid vsock has
-    # none, and propagating it killed in-flight responses), so the server-held
-    # connection never closes and git blocks until the helper exits. The helper
-    # therefore infers completion from silence, and its default deadline is 10s,
-    # which is charged to EVERY clone after the last byte arrives.
-    #
-    # Measured: fitting t = a + b*bytes across an 11.24 MiB shallow clone (11.5s)
-    # and a 249.40 MiB full clone (~37s) gives 9.3 MiB/s marginal throughput and
-    # a 10.3s fixed cost. The lane is fast; the constant is this timeout.
-    #
-    # 2s, not lower: the mirror serves this entire clone in 1.3s over loopback,
-    # so this leaves roughly 2x margin over the whole server-side operation
-    # rather than over one gap. If the deadline ever does fire early the pack
-    # fails git's own checksum, so hydration errors loudly and retries rather
-    # than leaving a silently truncated checkout.
-    EMBER_GIT_PROXY_IDLE_EXIT_SECONDS: "2"
+    # The git proxy idle deadline that dominates hydration (#4429) is deliberately
+    # NOT here: it was set here first, rebuilt the base, and left the guest on its
+    # 10s default anyway. It now lives in the guest at shim.py, which is the only
+    # place a guest-read value can live today.
   # ON. The ADR 027 memory:false/filesystem:true quadrant: sessions ride
   # per-lineage workspace volumes with park/rejoin instead of memory-snapshot
   # banking, and raw files in S3 replace multi-GiB snapshots.

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -541,14 +541,39 @@ def main():
             sys.stderr.write("ERROR: proxy handshake returned a non-200 response\n")
             return 1
         sock.settimeout(None)
+        # This default is the whole hydration budget, not a safety margin, and it
+        # has to live HERE rather than in chart values (#4429).
+        #
+        # The helper cannot see the end of a response: #4412 stopped propagating
+        # half-close onto the vsock leg (Firecracker hybrid vsock has none, and
+        # propagating it killed in-flight responses), so the server-held
+        # connection never closes and git blocks until this process exits. The
+        # deadline below is therefore charged to EVERY clone after its last byte.
+        # Measured live at the old 10s default: an 11.24 MiB shallow clone took
+        # 10.9s wall for ~1.2s of transfer.
+        #
+        # 2s, not lower: the mirror serves that entire clone in 1.3s over
+        # loopback, so this leaves roughly 2x margin over the whole server-side
+        # operation rather than over one gap. If it ever does fire early the pack
+        # fails git's own checksum, so hydration errors loudly and retries rather
+        # than leaving a silently truncated checkout.
+        #
+        # Not a chart knob: the workload CR's initEnv is a base-SIGNATURE input
+        # only. The control plane sends it as BuildBaseRequest.init_env, noded
+        # never reads that field (the base-build claim is ClaimSpec{Arch,
+        # ThreadID}, and ClaimSpec has no env member), and the guest's entire
+        # environment comes from guest-init setDefaultEnv plus ember.env.* boot
+        # args that only ClaimStateful populates. Setting this in values.yaml
+        # re-keys the base and rebuilds it while changing nothing in the guest,
+        # which is exactly how the 10s default survived a deploy that looked
+        # successful. The env override below stays for tests, which set it in
+        # their own process environment.
         try:
-            idle_exit = float(
-                os.environ.get("EMBER_GIT_PROXY_IDLE_EXIT_SECONDS", "10")
-            )
+            idle_exit = float(os.environ.get("EMBER_GIT_PROXY_IDLE_EXIT_SECONDS", "2"))
             if idle_exit <= 0:
-                idle_exit = 10
+                idle_exit = 2
         except ValueError:
-            idle_exit = 10
+            idle_exit = 2
         # Daemon threads: interpreter exit must never wait on a pump still
         # blocked in recv (the idle-exit path below leaves exactly that).
         stdin_pump = threading.Thread(

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -3285,6 +3285,59 @@ def test_git_proxy_helper_exits_when_response_goes_idle(tmp_path, monkeypatch):
     assert time.monotonic() - started < 6
 
 
+def test_git_proxy_helper_default_idle_deadline_is_seconds_not_tens(
+    tmp_path, monkeypatch
+):
+    # The DEFAULT is the one that runs in prod: the workload CR's initEnv is a
+    # base-signature input that never reaches the guest environment, so there is
+    # no chart override in play and this constant IS the hydration tail (#4429).
+    # It regressed silently once (a 10s default charged to every clone, measured
+    # at 10.9s wall for ~1.2s of transfer), so this asserts the default itself
+    # with the env var deliberately unset rather than trusting the override path.
+    helper_path = tmp_path / "ember-git-proxy"
+    monkeypatch.setattr(shim, "GIT_PROXY_PATH", str(helper_path))
+    shim._write_git_proxy_helper()
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind((shim.EGRESS_LOCALHOST, 0))
+    listener.listen()
+    accepted = []
+
+    def serve_connection():
+        connection, _ = listener.accept()
+        accepted.append(connection)
+        connection.recv(4096)
+        connection.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        connection.recv(4096)
+        connection.sendall(b"response payload")
+        time.sleep(9)
+
+    accept_thread = threading.Thread(target=serve_connection, daemon=True)
+    accept_thread.start()
+    environment = os.environ.copy()
+    environment[shim.EGRESS_PORT_ENV] = str(listener.getsockname()[1])
+    environment.pop("EMBER_GIT_PROXY_IDLE_EXIT_SECONDS", None)
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            [sys.executable, str(helper_path), "example.com", "9418"],
+            input=b"request",
+            env=environment,
+            capture_output=True,
+            timeout=8,
+        )
+    finally:
+        listener.close()
+        for connection in accepted:
+            connection.close()
+    assert result.returncode == 0
+    assert result.stdout == b"response payload"
+    # Comfortably under the old 10s default and over the 2s deadline plus the
+    # helper's 0.5s poll granularity, so this fails loudly on a regression to
+    # tens of seconds without being tight enough to flake on a slow runner.
+    assert time.monotonic() - started < 6
+
+
 def test_egress_forwarder_takes_absolute_uri_host_and_replays_the_request(monkeypatch):
     # HTTP_PROXY is set alongside HTTPS_PROXY, so a plain-HTTP request arrives as
     # an absolute-URI line rather than a CONNECT. The destination comes from Host,


### PR DESCRIPTION
## Problem

Agent session workspace hydration takes ~11s for a clone that transfers ~11 MiB. Measured live on the 16gi brick, minutes before this PR:

```
ember-claude-shim: turn-timing phase=hydration_clone ms=10865
```

Almost none of that is transfer. The git proxy helper cannot see the end of a response, because #4412 stopped propagating half-close onto the vsock leg (Firecracker hybrid vsock has none, and propagating it killed in-flight responses). The server-held connection never closes, so git blocks until the helper process exits, and the helper infers completion from silence. That deadline is charged to every clone after its last byte arrives.

`0d4a11488` set `EMBER_GIT_PROXY_IDLE_EXIT_SECONDS: "2"` in `claudeRuntimeWorkload.initEnv` yesterday to fix exactly this. It never took effect.

## Why the override did nothing

`initEnv` is a base-**signature** input only. Nothing in it reaches the guest:

1. Helm renders it into the Workload CR correctly.
2. The control plane sends it as `BuildBaseRequest.init_env` (`node.proto:571`) and hashes it into `signature/1`.
3. **noded never reads that field.** There is no `InitEnv` reference in checked-in Go, and the base-build claim is `substrate.ClaimSpec{Arch, ThreadID}` (`noded/server/server.go:802`). `ClaimSpec` has no env member.
4. The guest's whole environment comes from `setDefaultEnv`, a hardcoded Go map (`guest-init/cmd/main.go:146`), plus `setMmdsEnv` reading `ember.env.*` boot args, which noded populates only from `ClaimStateful`'s first-boot secrets.

Because it feeds the signature, the edit *did* re-key the base, rebuild it (4.3 GB, visible in the 15:22 retention sweep) and roll the VMs. Every visible symptom of a successful deploy was present while the guest kept its 10s default.

## Changes

- **`shim.py`**: default idle deadline 10s to 2s, with the reasoning recorded at the point of truth, including why it cannot be a chart knob.
- **`deploy/values.yaml`**: removed the dead `EMBER_GIT_PROXY_IDLE_EXIT_SECONDS`, and put a warning on the `initEnv` block that nothing in it reaches the guest. Use it as a rebuild epoch, never as a knob.
- **`EMBER_PREWARM_CLIS` marked inert**: same root cause. `_read_prewarm_clis()` returns `()` on an unset value and silently no-ops, and live turns log `path=lazy_spawn`, never a prewarmed CLI, so prewarm has never run in prod. Value left in place as documented intent; #4423 has to fix the wiring before it can build on it.
- **New test** asserting the *default* with the env var explicitly popped. The existing test only covered the override path, which is why a 10s default could sit in prod unnoticed.
- **Chart bumped** 0.1.461 to 0.1.463. Load-bearing here: the base signature keys on the resolved image digest, so the shim change is what re-keys and rebuilds the base that picks it up.

## Expected effect

Hydration from ~10.9s to roughly 3.5s: about 1.2s of real transfer at the lane's 9.3 MiB/s, plus the 2s deadline and the helper's 0.5s poll granularity. Getting under that needs the protocol-aware completion work in #4429.

## Testing

`ci lint` clean. `ci test` green, 761 tests pass, with the new guard passing. The target reported `FLAKY` on an unrelated pre-existing test (#4425); root cause captured and a fix is following separately.

Refs #4429

🤖 Generated with [Claude Code](https://claude.com/claude-code)