### PR TITLE
feat(embervm): hydrate from GitHub over https, with full history

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.463
+version: 0.1.464

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.463
+      targetRevision: 0.1.464
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -3320,6 +3320,25 @@ class ProcessManager:
         if getattr(self.claude, "workspace", None):
             _ensure_cli_dir(self.claude.workspace)
         if repo is not None and branch is not None:
+            # Say what the guest is doing while it clones. Without this the UI
+            # falls through to "starting the agent..." for the whole hydration,
+            # because that is its label for "VM running, no partials yet", and a
+            # multi-second clone reads as dead time.
+            #
+            # A plain string is a valid activity (the console's activityParts
+            # takes `typeof activity === "string"` as {verb, detail:""}), and
+            # partial_activities is the FIRST branch of its live-line ladder, so
+            # this needs no schema, no migration and no console change. The
+            # adapter builds its own pusher immediately after and its real CLI
+            # activities replace this line.
+            #
+            # Only meaningful when hydration actually clones: a restored volume
+            # short-circuits on the rev-parse gate, so the pusher fires and is
+            # replaced almost at once, which is the honest signal either way.
+            if progress_token:
+                _ProgressPusher(progress_token).push(
+                    "", ["cloning %s@%s" % (repo, branch)]
+                )
             self._hydrate_workspace(repo, branch)
         adapter = self._adapter(model)
         try:

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -299,11 +299,13 @@ SANDBOX_PROMPT = (
     "interactive terminal: you cannot prompt mid-turn, so a question ends your "
     "turn and is read asynchronously.\n"
     "- When the session has a repo, the checkout is at /workspace/src. It is a "
-    "depth-1 single-branch clone, so history before the tip commit is absent. "
-    "git log beyond HEAD, git bisect and git blame on older lines will fail, "
-    "and unshallowing is not supported here.\n"
-    "- origin points at an internal read-only mirror, not at GitHub. The mirror "
-    "accepts pushes only under refs/agents/**.\n"
+    "single-branch blob:none partial clone, so the FULL history of that branch "
+    "is present and git log, git blame and git bisect all work. File contents "
+    "are fetched on demand, so an operation touching many old revisions pauses "
+    "while blobs download rather than failing.\n"
+    "- origin points at GitHub over https. Pushes go to the real repository, so "
+    "treat any push as publishing. The proxy attaches the credential on the way "
+    "out; you hold none.\n"
     "- Your git identity is already configured. Do not set user.name or "
     "user.email.\n"
     "- All network egress is proxied. The public internet is reachable and "
@@ -3103,6 +3105,39 @@ class ProcessManager:
             # A durable volume can contain a partial clone from a prior failure.
             shutil.rmtree(checkout_dir, ignore_errors=True)
         _ensure_cli_dir(self.workspace)
+        # Hydrate from GitHub over https, not from the git-mirror over git://.
+        #
+        # The mirror was chosen (ADR agents/050) because it needs no credential
+        # and is node-local. What disqualified it is the transport: #4389 stopped
+        # propagating half-close onto the vsock leg, and that suppression is
+        # scoped to the git-daemon port
+        # (shim.py: half_close_upstream = not host_port.endswith(":9418")), so a
+        # git:// tunnel never closes and a SECOND lane connection while it lingers
+        # wedges (#4417). That is what forced --depth=1: a blob filter defers
+        # blobs, and checkout then lazy-fetches them on exactly that second
+        # connection. Shallow-but-complete was the only single-connection shape.
+        #
+        # Over :443 the tunnel tears down normally, which is why sequential CLI
+        # HTTPS and gh both work today. So the filter becomes usable, and with it
+        # FULL HISTORY: --filter=blob:none keeps every commit and tree and defers
+        # only file contents, so git log, blame and bisect all work and blobs
+        # arrive on demand. --depth=1 is therefore gone, not merely relaxed.
+        #
+        # No credential enters the guest. github.com is a credentialed egressTo
+        # host (deploy/values.yaml): the sidecar terminates the guest's TLS with a
+        # leaf minted from the egress CA, sets Authorization itself using Basic
+        # (git-receive-pack 401s on Bearer), and originates fresh verified TLS. A
+        # guest already reaches github.com this way for gh and for push, so
+        # sourcing the clone here grants nothing it did not already hold. It also
+        # fixes private repos, which the mirror non-fatally SKIPS when it has no
+        # read token of its own.
+        #
+        # http.proxy rather than HTTPS_PROXY: apply_egress_ca_trust() runs before
+        # this and exports GIT_SSL_CAINFO into os.environ, but the proxy URL is
+        # only ever built inside the per-adapter CLI spawn envs, which this
+        # subprocess does not inherit. Passing it as git config keeps the setting
+        # on this one clone instead of leaking proxy env into every child.
+        egress_port = os.environ.get(EGRESS_PORT_ENV, str(DEFAULT_EGRESS_PORT))
         clone_command = [
             "git",
             "clone",
@@ -3110,20 +3145,10 @@ class ProcessManager:
             "--branch",
             branch,
             "--config",
-            "core.gitProxy=%s" % GIT_PROXY_PATH,
+            "http.proxy=http://%s:%s" % (EGRESS_LOCALHOST, egress_port),
             "--single-branch",
-            "--depth=1",
-            # --depth=1 shallow clone reduces transfer from 249.40 MiB (full) to
-            # ~11.2 MiB (working tree only), saving ~37s of hydration time. Shallow
-            # clones are single-connection because the tip commit's blobs ride in the
-            # same packfile as the objects, so checkout is satisfied entirely from
-            # one fetch with no lazy blob loads on a second connection.
-            # Not using --filter=blob:none (which would reopen #4417): blob filters
-            # defer blobs, making checkout lazy-fetch them on a second connection
-            # that wedges. History is available on demand via git fetch --unshallow
-            # or --deepen=N, though such fetches also open a second connection and
-            # remain subject to #4417 until that is fixed.
-            "git://git-mirror.monolith.svc.cluster.local:9418/%s" % repo,
+            "--filter=blob:none",
+            "https://github.com/%s.git" % repo,
             checkout_dir,
         ]
         try:

--- a/projects/embervm/runtimes/claude/shim_hydration_test.py
+++ b/projects/embervm/runtimes/claude/shim_hydration_test.py
@@ -459,3 +459,61 @@ def test_poisoned_directory_is_cleaned_and_recloned(manager, monkeypatch):
     monkeypatch.setattr(shim.subprocess, "run", fake_run)
     manager.turn("first", repo="owner/repo", branch="main")
     assert [command[1] for command in calls] == ["-C", "clone", "-C"]
+
+
+def test_cloning_progress_is_pushed_before_the_clone(manager, monkeypatch):
+    """The console shows the clone WHILE it runs, so the push must precede it.
+
+    Pushed after, it would only ever be visible once the thing it announces had
+    already finished, which is the failure this guards: the whole point is that
+    a multi-second hydration stops reading as dead time under the console's
+    "starting the agent..." fallback.
+    """
+    events = []
+
+    class _CapturingPusher:
+        def __init__(self, progress_token):
+            events.append(("pusher", progress_token))
+
+        def push(self, text, activities=None):
+            events.append(("push", text, activities))
+
+    monkeypatch.setattr(shim, "_ProgressPusher", _CapturingPusher)
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "clone":
+            events.append(("clone", command[-2]))
+        return _GitProcess()
+
+    monkeypatch.setattr(shim.subprocess, "run", fake_run)
+
+    manager.turn("first", repo="owner/repo", branch="main", progress_token="tok-1")
+
+    assert ("pusher", "tok-1") in events
+    push_index = next(i for i, e in enumerate(events) if e[0] == "push")
+    clone_index = next(i for i, e in enumerate(events) if e[0] == "clone")
+    assert push_index < clone_index, "progress must be pushed BEFORE the clone runs"
+
+    # A bare string is a valid activity to the console (activityParts treats
+    # `typeof activity === "string"` as {verb, detail: ""}), and naming the repo
+    # and branch is what distinguishes this from a generic spinner.
+    assert events[push_index][2] == ["cloning owner/repo@main"]
+
+
+def test_no_progress_push_without_a_token(manager, monkeypatch):
+    """No token means no ingest route, so pushing would be a wasted round trip."""
+    pushes = []
+
+    class _CapturingPusher:
+        def __init__(self, progress_token):
+            pushes.append(progress_token)
+
+        def push(self, *_args, **_kwargs):
+            pushes.append("pushed")
+
+    monkeypatch.setattr(shim, "_ProgressPusher", _CapturingPusher)
+    monkeypatch.setattr(shim.subprocess, "run", lambda *_a, **_k: _GitProcess())
+
+    manager.turn("first", repo="owner/repo", branch="main")
+
+    assert pushes == []

--- a/projects/embervm/runtimes/claude/shim_hydration_test.py
+++ b/projects/embervm/runtimes/claude/shim_hydration_test.py
@@ -220,10 +220,10 @@ def test_git_command_shape(manager, monkeypatch):
             "--branch",
             "main",
             "--config",
-            "core.gitProxy=/tmp/ember-git-proxy",
+            "http.proxy=http://127.0.0.1:1024",
             "--single-branch",
-            "--depth=1",
-            "git://git-mirror.monolith.svc.cluster.local:9418/owner/repo",
+            "--filter=blob:none",
+            "https://github.com/owner/repo.git",
             checkout_dir,
         ],
     ]
@@ -246,19 +246,32 @@ def test_git_clone_regression_guards(manager, monkeypatch):
     assert len(commands) == 1
     command = commands[0]
 
-    # Regression guard: --depth=1 must be present (shallow clone)
-    assert "--depth=1" in command, "clone command missing --depth=1"
+    # Regression guard: --depth=1 must be ABSENT. It was the workaround for
+    # #4417 while hydration ran over git:// (:9418, the one port whose tunnels
+    # deliberately never close). Over https the tunnel closes normally, and the
+    # whole point of the move is that history is present.
+    assert "--depth=1" not in command, "clone command must not be shallow"
 
-    # Regression guard: --filter must NOT be present (no blob filter)
-    # A blob filter causes second connection on checkout, wedging vsock (#4417)
-    assert not any("--filter" in arg for arg in command), (
-        "clone command must not contain --filter argument"
+    # Regression guard: the blob filter is what makes full history affordable.
+    # Dropping it turns hydration into a full-content clone of all history.
+    assert "--filter=blob:none" in command, "clone command missing --filter=blob:none"
+
+    # Regression guard: https to GitHub, never git://. A git:// URL would put
+    # hydration back on the port whose lingering tunnels wedge connection #2,
+    # and would also lose the sidecar's credential injection (it can only set a
+    # header on bytes it can read, which requires the TLS-MITM lane).
+    url = command[-2]
+    assert url.startswith("https://github.com/"), "clone must use https to GitHub"
+    assert not any(arg.startswith("git://") for arg in command), (
+        "clone command must not use the git:// transport"
     )
 
-    # Verify load-bearing flags remain
+    # Verify load-bearing flags remain. http.proxy, not core.gitProxy: the
+    # helper is a git:// proxy and does nothing for an https remote, and this
+    # subprocess does not inherit the CLI spawn env that carries HTTPS_PROXY.
     assert "--single-branch" in command, "clone command missing --single-branch"
-    assert any("core.gitProxy=" in arg for arg in command), (
-        "clone command missing core.gitProxy config"
+    assert any(arg.startswith("http.proxy=") for arg in command), (
+        "clone command missing http.proxy config"
     )
 
 
@@ -285,7 +298,7 @@ def test_no_hydration_when_repo_absent(manager, monkeypatch):
 
 
 def test_hydration_works_for_non_default_branch(manager, monkeypatch):
-    """Verify clone works for branches other than the mirror default."""
+    """Verify clone works for branches other than the repository default."""
     processes = [_GitProcess(), _GitProcess()]
     commands = []
 
@@ -308,10 +321,10 @@ def test_hydration_works_for_non_default_branch(manager, monkeypatch):
         "--branch",
         "develop",
         "--config",
-        "core.gitProxy=/tmp/ember-git-proxy",
+        "http.proxy=http://127.0.0.1:1024",
         "--single-branch",
-        "--depth=1",
-        "git://git-mirror.monolith.svc.cluster.local:9418/owner/repo",
+        "--filter=blob:none",
+        "https://github.com/owner/repo.git",
         checkout_dir,
     ]
     assert manager._checkout_dir == checkout_dir


### PR DESCRIPTION
Workspace hydration moves from the git-mirror over `git://` to GitHub over `https`, and from `--depth=1` to `--filter=blob:none`.

**The checkout now carries the full history of its branch**, so `git log`, `git blame` and `git bisect` work in a session for the first time. Only file contents are deferred, arriving on demand.

## The mirror was never the problem

ADR agents/050 chose it because it needs no credential and is node-local, and both are still true. What disqualified it is the transport. #4389 stopped propagating half-close onto the vsock leg, and that suppression is scoped to one port:

```python
GIT_DAEMON_PORT = "9418"
half_close_upstream = not host_port.endswith(":" + GIT_DAEMON_PORT)
```

A `git://` tunnel therefore never closes, and a second lane connection opened while it lingers wedges (#4417). That is what forced `--depth=1`: a blob filter defers blobs, checkout then lazy-fetches them on exactly that second connection, so shallow-but-complete was the only single-connection shape available.

Over `:443` the tunnel tears down normally. That is why sequential CLI HTTPS and `gh` both work today, and it is what makes the filter usable, with history coming along for free.

## No new credential exposure

`github.com` is already a credentialed `egressTo` host. The sidecar terminates the guest's TLS with a leaf minted from the egress CA, sets `Authorization` itself using Basic (`git-receive-pack` 401s on Bearer and 200s on Basic, per the values comment), and originates fresh verified TLS. A guest already reaches `github.com` that way for `gh` and for `push`, so sourcing the clone there grants it nothing it did not already hold. No credential enters the guest in either case.

## Why `http.proxy` and not `HTTPS_PROXY`

Ordering already works out: `apply_egress_ca_trust()` runs before `_hydrate_workspace` in `turn()` and exports `GIT_SSL_CAINFO` into `os.environ`, which the clone subprocess inherits. The proxy URL does **not** come along, because it is only ever built inside the per-adapter CLI spawn envs. Passing it as git config scopes it to this one clone instead of leaking proxy env into every child.

## Private repos: a narrower benefit than first claimed

Corrected after testing. The mirror clones a private repo only if its own token has read access, and otherwise "non-fatally skips", so a session could hydrate nothing at all. That failure mode is real, but it is **not** currently hit by `weave-hand/loom`: a live session cloned loom successfully through the mirror, so the mirror evidently holds it.

So this helps only where the mirror's token lacks access to a repo, and it removes the mirror's 60s refresh lag. It is not the headline benefit the first draft of this description implied.

## Progress signal

Second commit. Hydration sits in the console's `starting the agent...` bucket (its label for "guest running, no partials yet"), so a multi-second clone reads as dead time. The guest now pushes `cloning <repo>@<branch>` before the clone starts.

No schema change, no migration, no console change: `partial_activities` is the first branch of the live-line ladder and `activityParts` already accepts a bare string activity. The adapter's own pusher replaces the line with real CLI activity immediately after.

Naming the repo and branch rather than a generic spinner is deliberate, so a wrong repo or branch selection is visible while it clones instead of after the agent answers about the wrong tree. A test asserts the push happens BEFORE the clone, since pushed after it could only ever surface once the thing it announces had finished.

## System prompt

It asserted three things that are now false: a depth-1 clone with absent history, `origin` pointing at a read-only mirror, and pushes confined to `refs/agents/**`. Pushes now reach the real repository, so it says to treat any push as publishing.

## Testing

`ci lint` clean. `ci test` green, 761 tests pass. Locally, all 18 `shim_hydration_test` tests pass and the 5 system-prompt tests in `shim_test` pass.

Regression guards inverted with their reasoning, plus a new assertion that the URL is never `git://` again, since reverting that transport is what would silently reintroduce the wedge.

**Not yet proven:** the tests verify argv, not the wire. This needs a real session against a private repo to exercise the credential injection end to end.

## Follow-ups, deliberately not here

- The `git://` proxy helper is now unused by hydration. Left in place as the only route to the still-allowlisted mirror.
- **ADR agents/050 now contradicts the code** on both clone source and clone shape, and should be superseded.

Refs #4417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
