### PR TITLE
fix(embervm): opt the hydration clone into egress credential injection

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.464
+version: 0.1.465

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.464
+      targetRevision: 0.1.465
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -345,6 +345,26 @@ def _cli_privilege_kwargs():
 
 GIT_PROXY_PATH = "/tmp/ember-git-proxy"
 
+# The guest env var holding gh's login-gate dummy. Named here rather than
+# inlined because it is the SAME switch two consumers flip: gh sends it as a
+# bearer, and hydration sends it as Basic, and both exist only so the egress
+# sidecar's presence-keyed injection fires.
+GH_TOKEN_ENV = "GH_TOKEN"
+
+
+def _github_basic_optin():
+    """Return base64 for a Basic Authorization that opts into injection.
+
+    The VALUE is inert and is discarded by the sidecar, which overwrites the
+    header with the real credential. Only its PRESENCE matters, so an absent
+    GH_TOKEN still yields a well-formed header rather than dropping the opt-in
+    and taking a 401: the failure that would cause is silent hydration loss, and
+    a header with an empty token costs nothing.
+    """
+    token = os.environ.get(GH_TOKEN_ENV, "")
+    return base64.b64encode(("x-access-token:%s" % token).encode()).decode()
+
+
 # The egress CA the sidecar mints MITM leaves from, and the reserved preamble
 # name it serves that certificate on. Fetched at spawn rather than baked into
 # the guest image so a CA rotation does not require a fleet base rebuild.
@@ -3146,6 +3166,39 @@ class ProcessManager:
             branch,
             "--config",
             "http.proxy=http://%s:%s" % (EGRESS_LOCALHOST, egress_port),
+            # The LOGIN GATE DUMMY that opts this clone into credential
+            # injection, derived from the same GH_TOKEN gh already presents
+            # rather than defined here.
+            #
+            # The sidecar's injection is PRESENCE-KEYED: it replaces an
+            # Authorization header the guest already sent and DISCARDS whatever
+            # value was in it (egress-proxy injectRequest: `requested :=
+            # len(req.Header.Values(sec.Header)) > 0 || sec.injectAlwaysPath(...)`
+            # then `if !requested { return false }`). The header is an opt-in
+            # switch, never a credential, which is what stops a prompt-injected
+            # guest from authenticating as anyone else.
+            #
+            # git sends no Authorization on its first request, so nothing was
+            # injected and github.com answered 401, which git surfaces as
+            # "could not read Username for 'https://github.com'" once it falls
+            # through to an interactive prompt. gh never hit this because it
+            # always sends its own dummy. Reusing GH_TOKEN keeps the value where
+            # guest env is defined (guest-init setDefaultEnv, alongside
+            # CLAUDE_CODE_OAUTH_TOKEN) instead of adding a second, credential
+            # shaped literal to this file.
+            #
+            # injectAlwaysPaths cannot cover this instead: it is an EXACT match
+            # on req.URL.Path, and git's paths are per repository
+            # (/owner/repo.git/info/refs, /owner/repo.git/git-upload-pack), so it
+            # would have to enumerate every repo anyone might ever select.
+            #
+            # x-access-token:<token> is the Basic shape GitHub's git endpoint
+            # expects. Scoped to github.com by URL so it is never presented
+            # anywhere else, and written into the clone's config so the lazy blob
+            # fetches --filter=blob:none defers carry it too.
+            "--config",
+            "http.https://github.com/.extraHeader=Authorization: Basic %s"
+            % _github_basic_optin(),
             "--single-branch",
             "--filter=blob:none",
             "https://github.com/%s.git" % repo,

--- a/projects/embervm/runtimes/claude/shim_hydration_test.py
+++ b/projects/embervm/runtimes/claude/shim_hydration_test.py
@@ -1,3 +1,4 @@
+import base64
 import io
 import json
 import os
@@ -221,6 +222,9 @@ def test_git_command_shape(manager, monkeypatch):
             "main",
             "--config",
             "http.proxy=http://127.0.0.1:1024",
+            "--config",
+            "http.https://github.com/.extraHeader=Authorization: Basic %s"
+            % shim._github_basic_optin(),
             "--single-branch",
             "--filter=blob:none",
             "https://github.com/owner/repo.git",
@@ -322,6 +326,9 @@ def test_hydration_works_for_non_default_branch(manager, monkeypatch):
         "develop",
         "--config",
         "http.proxy=http://127.0.0.1:1024",
+        "--config",
+        "http.https://github.com/.extraHeader=Authorization: Basic %s"
+        % shim._github_basic_optin(),
         "--single-branch",
         "--filter=blob:none",
         "https://github.com/owner/repo.git",
@@ -517,3 +524,61 @@ def test_no_progress_push_without_a_token(manager, monkeypatch):
     manager.turn("first", repo="owner/repo", branch="main")
 
     assert pushes == []
+
+
+def test_clone_sends_an_authorization_header_to_opt_into_injection(
+    manager, monkeypatch
+):
+    """Regression for a live 401: the clone MUST present Authorization.
+
+    The egress sidecar's injection is presence-keyed. It replaces a header the
+    guest already sent and discards the value (injectRequest: `requested :=
+    len(req.Header.Values(sec.Header)) > 0 || injectAlwaysPath(...)` then
+    `if !requested { return false }`). Sending nothing injects nothing, so
+    github.com answered 401 and git reported "could not read Username for
+    'https://github.com'". Seen in prod as
+    `"egress injected" injected=false status=401`.
+
+    injectAlwaysPaths cannot substitute: it is an exact match on req.URL.Path and
+    git's paths are per repository, so it would have to enumerate every repo.
+    """
+    monkeypatch.setenv("GH_TOKEN", "dummy-from-guest-env")
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "clone":
+            commands.append(command)
+        return _GitProcess()
+
+    monkeypatch.setattr(shim.subprocess, "run", fake_run)
+    manager.turn("first", repo="owner/repo", branch="main")
+
+    configs = [
+        arg for arg in commands[0] if arg.startswith("http.") and "extraHeader" in arg
+    ]
+    assert len(configs) == 1, "clone must set exactly one extraHeader"
+    config = configs[0]
+
+    # Scoped by URL, so the opt-in is never presented to any other host.
+    assert config.startswith("http.https://github.com/.extraHeader="), (
+        "the Authorization opt-in must be scoped to github.com"
+    )
+
+    # Derived from guest env, NOT a literal in shim.py. A checked-in base64 blob
+    # reads as a credential and would drift from the dummy gh actually presents.
+    encoded = config.split("Authorization: Basic ", 1)[1]
+    assert base64.b64decode(encoded).decode() == (
+        "x-access-token:dummy-from-guest-env"
+    ), "the opt-in must be built from GH_TOKEN in the guest environment"
+
+
+def test_github_optin_is_well_formed_even_without_gh_token(monkeypatch):
+    """An absent GH_TOKEN must still yield a header, because presence is all.
+
+    Dropping the header on a missing env var would trade a loud config problem
+    for a silent 401 and an empty workspace, which is the failure mode this
+    whole path already proved is easy to miss.
+    """
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    encoded = shim._github_basic_optin()
+    assert base64.b64decode(encoded).decode() == "x-access-token:"


### PR DESCRIPTION
Hotfix for a live outage introduced by #4470. Every repo-bearing session 503s:

```
{"error":"workspace does not exist: /workspace/src"}
```

## What actually happened

Guest side:

```
turn-timing phase=hydration_clone ms=410
workspace hydration failed for weave-hand/loom@main: git command failed with exit code 128:
fatal: could not read Username for 'https://github.com': No such device or address
```

Sidecar side, the smoking gun:

```json
{"msg":"egress allowed (inject, tls)","dest":"github.com:443","dial":"140.82.113.3:443"}
{"msg":"egress injected","dest":"github.com","header":"Authorization",
 "injected":false,"path":"/weave-hand/loom.git/info/refs","status":401}
```

`injected: false`. The request was allowed and MITM'd, but no credential was attached.

## Root cause: injection is presence-keyed, not host-keyed

```go
requested := len(req.Header.Values(sec.Header)) > 0 || sec.injectAlwaysPath(req.URL.Path)
if !requested { return false }
```

The guest must **send** an `Authorization` header to opt in. Its value is discarded and replaced with the real credential, and that indirection is the security property: it's what stops a prompt-injected guest authenticating as anyone else.

`gh` works because it always sends its dummy `GH_TOKEN`. **Git sends no `Authorization` on its first request**, so nothing was injected, GitHub 401'd, and git fell through to an interactive prompt it cannot service inside a VM.

## Fix

The clone presents the same login-gate dummy `gh` does, as the Basic shape GitHub's git endpoint expects (`x-access-token:<token>`), **derived from `GH_TOKEN` in the guest environment** rather than defined in `shim.py`. Guest env belongs in `guest-init` `setDefaultEnv` next to `CLAUDE_CODE_OAUTH_TOKEN`, and a base64 literal in the shim would read as a checked-in credential and could drift from what `gh` actually presents.

`injectAlwaysPaths` cannot be used instead: it is an **exact** match on `req.URL.Path`, and git's paths are per repository (`/owner/repo.git/info/refs`, `/owner/repo.git/git-upload-pack`), so it would have to enumerate every repo anyone might ever select.

Scoped to `github.com` by URL so the opt-in is never presented elsewhere, and written into the clone's config so the lazy blob fetches `--filter=blob:none` defers carry it too.

An absent `GH_TOKEN` still yields a well-formed header. Dropping it would trade a loud config problem for a silent 401 and an empty workspace, which is the failure mode this path just proved is easy to miss.

## Testing

`ci lint` clean, pre-push `ci test` green, 22/22 hydration tests pass locally. New guards assert the header is scoped to github.com, is a Basic credential, and is **derived from env rather than a literal**, decoding to the dummy rather than anything real.

**Still unproven on the wire.** This fixes the specific 401 the sidecar logged; a real session is what confirms it.

Refs #4470

🤖 Generated with [Claude Code](https://claude.com/claude-code)