### PR TITLE
feat(monolith): let MCP agent sessions pick a repo, defaulting to homelab

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.388
+version: 0.89.390
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.388
+      targetRevision: 0.89.390
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -27,6 +27,19 @@ from agent_sessions.transport import (
 )
 from core.db import get_engine
 from core.mcp_app import mcp
+from goosecracker.api import REPO_CATALOG
+
+# Voice and MCP sessions hydrate this repo unless the caller names another. The
+# /agents console makes the choice explicit in a dropdown; there is no dropdown
+# here, and a session with no checkout cannot do the work these calls ask for
+# (read the code, open a PR), so an empty workspace is the wrong default for
+# this surface even though it is the cheaper one.
+#
+# Cost is real and per SESSION, not per repo: volumes are per lineage, so every
+# new session clones again. Issue #4473 moves the clone back to a node-local
+# mirror over http, which is what makes this default cheap rather than merely
+# convenient.
+DEFAULT_AGENT_REPO = "jomcgi/homelab"
 from faas.embervm_client import EmberVMTransportError
 from framework import log_task_exception
 
@@ -615,7 +628,12 @@ def _activity_values(turns: list[AgentTurn]) -> tuple[list[str], list[str]]:
 
 
 @mcp.tool
-async def monolith_agent_session_start(prompt: str, model: str | None = None) -> dict:
+async def monolith_agent_session_start(
+    prompt: str,
+    model: str | None = None,
+    repo: str = DEFAULT_AGENT_REPO,
+    branch: str = "main",
+) -> dict:
     """Start a voice-drivable coding agent session and queue its first turn.
 
     Args:
@@ -624,20 +642,35 @@ async def monolith_agent_session_start(prompt: str, model: str | None = None) ->
             Claude family: opus, sonnet, fable. Codex family: luna, terra,
             sol. Pi family: qwen. Omit for the claude CLI default. Later
             sends may only name models within the pinned family.
+        repo: owner/repo to check out into the guest workspace, defaulting to
+            jomcgi/homelab. Must be in the catalog. Pass an empty string for a
+            session with NO checkout, which starts faster and suits a session
+            that only talks.
+        branch: Branch to check out. Defaults to main.
     """
     try:
         model_family(model)
     except ValueError as exc:
         return {"accepted": False, "error": str(exc)}
+    # Catalog-gated on the same rule the /agents route uses, and for a stronger
+    # reason here: this value reaches the guest and is interpolated into a clone
+    # URL on a credentialed egress path, so an arbitrary string would be a
+    # fetch-anything primitive carrying a real GitHub token.
+    selected_repo = repo.strip() or None
+    if selected_repo is not None and selected_repo not in REPO_CATALOG:
+        return {
+            "accepted": False,
+            "error": f"unknown repo {selected_repo}; catalog: {', '.join(REPO_CATALOG)}",
+        }
     local_session_id = str(uuid4())
     workspace = "<guest>"  # Workspace is in the guest, not the pod
     row = await asyncio.to_thread(
         _persist_session,
         local_session_id,
         workspace,
-        "main",
+        branch,
         model,
-        None,
+        selected_repo,
         discord_thread=None,
         system_prompt=voice.VOICE_INSTRUCTION,
     )

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -1400,3 +1400,68 @@ def test_ui_mark_store_is_bounded():
     assert mcp._consume_ui_originated(1, 0) is False
     assert mcp._consume_ui_originated(1, mcp._UI_ORIGINATED_CAP + 49) is True
     mcp._ui_originated.clear()
+
+
+def test_session_start_defaults_to_the_homelab_repo(monkeypatch, session):
+    """A voice session with no repo argument still gets a checkout.
+
+    Before this, mcp.py passed repo=None unconditionally, so an MCP-started
+    session hydrated nothing and the agent could not read the code or open a PR.
+    The console's dropdown has no equivalent here, so the default carries it.
+    """
+    monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
+
+    result = asyncio.run(mcp.monolith_agent_session_start("hello"))
+
+    row = store.get_session(session, result["session_id"])
+    assert row.repo == "jomcgi/homelab"
+    assert row.branch == "main"
+
+
+def test_session_start_accepts_an_explicit_repo_and_branch(monkeypatch, session):
+    monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
+
+    result = asyncio.run(
+        mcp.monolith_agent_session_start(
+            "hello", repo="weave-hand/loom", branch="develop"
+        )
+    )
+
+    row = store.get_session(session, result["session_id"])
+    assert row.repo == "weave-hand/loom"
+    assert row.branch == "develop"
+
+
+def test_session_start_empty_repo_opts_out_of_hydration(monkeypatch, session):
+    """An empty repo keeps the cheap, checkout-less session available.
+
+    Hydration is per SESSION (volumes are per lineage), so a talking-only
+    session should not pay a clone it will never read.
+    """
+    monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
+
+    result = asyncio.run(mcp.monolith_agent_session_start("hello", repo=""))
+
+    row = store.get_session(session, result["session_id"])
+    assert row.repo is None
+
+
+def test_session_start_rejects_a_repo_outside_the_catalog(monkeypatch, session):
+    """Fail closed: this value is interpolated into a clone URL in the guest.
+
+    The clone runs on a credentialed egress path, so an unvalidated repo would
+    be a fetch-anything primitive carrying a real GitHub token. Rejected BEFORE
+    any session row exists, so a bad argument costs nothing.
+    """
+    monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
+
+    result = asyncio.run(
+        mcp.monolith_agent_session_start("hello", repo="attacker/exfil")
+    )
+
+    assert result["accepted"] is False
+    assert "unknown repo attacker/exfil" in result["error"]
+    # No session id handed back, and nothing persisted under it: the gate runs
+    # before _persist_session, so a rejected repo leaves no row to clean up.
+    assert "session_id" not in result
+    assert session.exec(select(AgentSession)).all() == []

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.463
+version: 0.285.465
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.463
+      targetRevision: 0.285.465
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
`monolith_agent_session_start` passed `repo=None` unconditionally, so an MCP-started session hydrated nothing. The guest booted into an empty `/workspace` and the agent could not read the code or open a PR.

The `/agents` console has had a repo dropdown since ADR agents/050. This surface had no equivalent, and the hardcoded `workspace = "<guest>"` was the only reason.

## Almost everything already existed

`_persist_session` already takes `repo`, the store already has the column, and `mcp.py`'s resume path already forwards it (`:462`). The change is to stop passing `None`:

```python
repo: str = DEFAULT_AGENT_REPO,   # "jomcgi/homelab"
branch: str = "main",
...
selected_repo = repo.strip() or None
if selected_repo is not None and selected_repo not in REPO_CATALOG:
    return {"accepted": False, "error": f"unknown repo ...; catalog: ..."}
```

## Why it defaults to homelab rather than staying empty

There is no dropdown to put in front of a voice call, and a session with no checkout cannot do the work these calls ask for. An empty `repo` argument still opts out, because hydration is per **session** (volumes are per lineage), so a talking-only session should not pay a clone it will never read.

## Catalog-gated, and the reason is stronger here

Same rule the `/agents` route uses, but this value reaches the guest and is interpolated into `https://github.com/<repo>.git` on an egress path that attaches a real GitHub token. An arbitrary string would be a fetch-anything primitive with credentials. The console had a dropdown in front of it; a tool argument has nothing. Rejection happens **before** `_persist_session`, so a bad argument leaves no row behind.

## Cost this makes routine

Every new session now clones ~23 MB of full history from GitHub, with no cache between sessions and rate limits that scale with session count. **#4473** moves that back to a node-local mirror over http, which is what turns this default from convenient into cheap. That change is invisible here: same `repo` argument, different clone URL.

## Testing

`ci lint` clean. `ci test` green: `Executed 4 out of 761 tests: 761 tests pass`.

Four new tests: the default lands `jomcgi/homelab@main`; an explicit repo and branch are honoured; `repo=""` opts out; an off-catalog repo is rejected with no session row persisted.

An earlier run of this branch failed on a bad assertion in my own test (`store.list_sessions` does not exist); it now queries `AgentSession` directly, which is both real and a stronger check.

## After merge

Context Forge caches tool schemas for ~10 minutes and an open session keeps its snapshot, so `repo` and `branch` will not appear as arguments until the cache refreshes **and** a fresh session starts.

Refs #4473

🤖 Generated with [Claude Code](https://claude.com/claude-code)