### PR TITLE
fix(embervm): the activator waits out a bank instead of splicing into it

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.466
+version: 0.1.467

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.466
+      targetRevision: 0.1.467
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/activator.go
+++ b/projects/embervm/noded/server/activator.go
@@ -24,7 +24,21 @@ const (
 	activatorWakeMax    = 30
 	activatorWakeWindow = time.Minute
 	activatorBodyMax    = 8 << 20
+	// The transition wait is short enough to notice a checkpoint resolve
+	// promptly, while the deadline prevents a stuck VM from pinning a client.
+	activatorInFlightPollInterval = 25 * time.Millisecond
+	activatorInFlightTimeout      = 10 * time.Second
 )
+
+// A guest that is paused can leave its tap reachable while swallowing SYNs, so
+// an unbounded dial sits on kernel SYN retransmit (~127s) and the caller reads
+// it as a hang. Bound only the dial so an unreachable guest fails fast; once
+// connected, a splice is a long-lived connection and must not be capped by this
+// timeout. A var rather than a const purely so the test can shrink it: proving
+// the bound requires a context with NO deadline of its own (a context that
+// already carries one would be honoured by the unbounded dial too, and the test
+// would pass against the very regression it exists to catch).
+var activatorDialTimeout = 10 * time.Second
 
 var activatorDeniedHeaders = map[string]struct{}{
 	"content-length":      {},
@@ -299,7 +313,9 @@ func allowedHeaders(headers http.Header) http.Header {
 }
 
 func spliceTCP(ctx context.Context, client net.Conn, address string) error {
-	guest, err := (&net.Dialer{}).DialContext(ctx, "tcp", address)
+	dialCtx, cancel := context.WithTimeout(ctx, activatorDialTimeout)
+	defer cancel()
+	guest, err := (&net.Dialer{}).DialContext(dialCtx, "tcp", address)
 	if err != nil {
 		return err
 	}

--- a/projects/embervm/noded/server/stateful_activator.go
+++ b/projects/embervm/noded/server/stateful_activator.go
@@ -18,6 +18,22 @@ type statefulActivatorFlight struct {
 	err   error
 }
 
+type statefulInFlightWaitResult uint8
+
+const (
+	statefulInFlightSplice statefulInFlightWaitResult = iota
+	statefulInFlightWake
+	statefulInFlightTimeout
+	statefulInFlightCanceled
+	// statefulInFlightPending is the poll loop's internal "not decided yet"
+	// sentinel and is never returned to a caller. It is deliberately distinct
+	// from statefulInFlightWake: folding the two together makes a resolved
+	// transition (the token appeared, or the entry was removed) look identical
+	// to a transition still in progress, so the wait spins to its deadline
+	// instead of handing straight over to the wake path.
+	statefulInFlightPending
+)
+
 // statefulActivator is noded's node-local opaque-L4 wake path. The accepted
 // port identifies the workload, so each eligible workload has exactly one
 // in-flight relight and its parked connections independently splice once the
@@ -102,9 +118,23 @@ func (a *statefulActivator) handle(ctx context.Context, conn net.Conn, listenPor
 		return
 	}
 
-	if live, token, ok := a.server.statefulVMs.byWorkloadCheckpoint(reg.Workload); ok && token == "" {
-		a.splice(ctx, conn, live)
-		return
+	if live, token, inFlight, ok := a.server.statefulVMs.byWorkloadCheckpoint(reg.Workload); ok && token == "" {
+		if !inFlight {
+			a.splice(ctx, conn, live)
+			return
+		}
+		live, result := a.waitForInFlight(ctx, reg.Workload)
+		switch result {
+		case statefulInFlightSplice:
+			a.splice(ctx, conn, live)
+			return
+		case statefulInFlightTimeout:
+			a.forwardToControlPlane(ctx, conn, listenPort)
+			return
+		case statefulInFlightCanceled:
+			_ = conn.Close()
+			return
+		}
 	}
 
 	flight, leader, ok := a.join(reg.Workload)
@@ -197,14 +227,67 @@ func (a *statefulActivator) complete(workload string, flight *statefulActivatorF
 	a.mu.Unlock()
 }
 
+// waitForInFlight waits for a stop transition to expose a safe decision. A
+// checkpoint token means wake must claim and abort the paused VM, a removed
+// entry means wake must relight or cold-boot, and a cleared guard permits the
+// existing live VM to be spliced. The bounded fallback preserves the
+// node-local activator's escape hatch when a transition gets stuck.
+func (a *statefulActivator) waitForInFlight(ctx context.Context, workload string) (*statefulEntry, statefulInFlightWaitResult) {
+	deadline := time.NewTimer(activatorInFlightTimeout)
+	defer deadline.Stop()
+	poll := time.NewTicker(activatorInFlightPollInterval)
+	defer poll.Stop()
+	check := func() (*statefulEntry, statefulInFlightWaitResult) {
+		entry, token, inFlight, ok := a.server.statefulVMs.byWorkloadCheckpoint(workload)
+		if !ok || token != "" {
+			return nil, statefulInFlightWake
+		}
+		if !inFlight {
+			return entry, statefulInFlightSplice
+		}
+		return nil, statefulInFlightPending
+	}
+	if entry, result := check(); result != statefulInFlightPending {
+		return entry, result
+	}
+	for {
+		select {
+		case <-poll.C:
+			if entry, result := check(); result != statefulInFlightPending {
+				return entry, result
+			}
+		case <-deadline.C:
+			return nil, statefulInFlightTimeout
+		case <-ctx.Done():
+			return nil, statefulInFlightCanceled
+		}
+	}
+}
+
 func (a *statefulActivator) wake(ctx context.Context, reg workloadEntry) (*statefulEntry, error) {
-	if live, token, ok := a.server.statefulVMs.byWorkloadCheckpoint(reg.Workload); ok {
+	for {
+		live, token, inFlight, ok := a.server.statefulVMs.byWorkloadCheckpoint(reg.Workload)
+		if !ok {
+			break
+		}
 		if token == "" {
-			return live, nil
+			if !inFlight {
+				return live, nil
+			}
+			resumed, result := a.waitForInFlight(ctx, reg.Workload)
+			switch result {
+			case statefulInFlightSplice:
+				return resumed, nil
+			case statefulInFlightTimeout:
+				return nil, fmt.Errorf("noded: stateful workload %q remained in transition", reg.Workload)
+			case statefulInFlightCanceled:
+				return nil, ctx.Err()
+			}
+			continue
 		}
 		e, claimed := a.server.statefulVMs.claimResolve(live.vmID, token)
 		if !claimed {
-			if resumed, resumedToken, found := a.server.statefulVMs.byWorkloadCheckpoint(reg.Workload); found && resumedToken == "" {
+			if resumed, resumedToken, resumedInFlight, found := a.server.statefulVMs.byWorkloadCheckpoint(reg.Workload); found && resumedToken == "" && !resumedInFlight {
 				return resumed, nil
 			}
 			return nil, fmt.Errorf("noded: checkpoint resolve raced for stateful workload %q", reg.Workload)
@@ -212,8 +295,8 @@ func (a *statefulActivator) wake(ctx context.Context, reg workloadEntry) (*state
 		if _, err := a.server.abortCheckpoint(ctx, e, token, 0); err != nil {
 			return nil, err
 		}
-		resumed, resumedToken, ok := a.server.statefulVMs.byWorkloadCheckpoint(reg.Workload)
-		if !ok || resumedToken != "" {
+		resumed, resumedToken, resumedInFlight, ok := a.server.statefulVMs.byWorkloadCheckpoint(reg.Workload)
+		if !ok || resumedToken != "" || resumedInFlight {
 			return nil, fmt.Errorf("noded: checkpoint abort for stateful workload %q did not restore a live VM", reg.Workload)
 		}
 		return resumed, nil

--- a/projects/embervm/noded/server/stateful_activator_test.go
+++ b/projects/embervm/noded/server/stateful_activator_test.go
@@ -283,3 +283,84 @@ func TestStatefulActivatorWakeFailureForwardsToControlPlane(t *testing.T) {
 		t.Errorf("stateful wake calls = claims:%d restores:%d, want 0:0", driver.claims, driver.restores)
 	}
 }
+
+func TestStatefulActivatorWaitsForInFlightDecision(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*statefulRegistry, *statefulEntry)
+	}{
+		{
+			name: "token appears and wakes",
+			mutate: func(reg *statefulRegistry, entry *statefulEntry) {
+				reg.markCheckpointed(entry.vmID, "checkpoint-token")
+			},
+		},
+		{
+			name: "entry disappears and wakes",
+			mutate: func(reg *statefulRegistry, entry *statefulEntry) {
+				reg.remove(entry.vmID)
+			},
+		},
+		{
+			name: "guard clears and splices",
+			mutate: func(reg *statefulRegistry, entry *statefulEntry) {
+				reg.clearInFlight(entry.vmID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _, _ := newStatefulTestServer(t)
+			entry := &statefulEntry{vmID: "vm-in-flight", workload: "wl-state"}
+			s.statefulVMs.add(entry)
+			if _, ok := s.statefulVMs.beginStop(entry.vmID); !ok {
+				t.Fatal("beginStop failed")
+			}
+			a := newStatefulActivator(s)
+			go func() {
+				time.Sleep(2 * activatorInFlightPollInterval)
+				tt.mutate(s.statefulVMs, entry)
+			}()
+
+			got, result := a.waitForInFlight(context.Background(), entry.workload)
+			want := statefulInFlightWake
+			if tt.name == "guard clears and splices" {
+				want = statefulInFlightSplice
+				if got != entry {
+					t.Fatalf("wait entry = %p, want %p", got, entry)
+				}
+			}
+			if result != want {
+				t.Fatalf("wait result = %v, want %v", result, want)
+			}
+		})
+	}
+}
+
+func TestSpliceTCPBoundsGuestDial(t *testing.T) {
+	client, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = peer.Close()
+	})
+
+	// context.Background() deliberately carries NO deadline, so the only thing
+	// that can bound this dial is activatorDialTimeout itself. Passing a context
+	// that already had a deadline would be honoured by an unbounded dial too, so
+	// the test would pass against the regression it exists to catch. 192.0.2.1
+	// is TEST-NET-1: it black-holes the SYN rather than refusing it, which is
+	// what a paused guest does.
+	restore := activatorDialTimeout
+	activatorDialTimeout = 150 * time.Millisecond
+	t.Cleanup(func() { activatorDialTimeout = restore })
+
+	started := time.Now()
+	err := spliceTCP(context.Background(), client, "192.0.2.1:5432")
+	if err == nil {
+		t.Fatal("spliceTCP succeeded against a black-hole address")
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("spliceTCP dial took %s, want it bounded by activatorDialTimeout", elapsed)
+	}
+}

--- a/projects/embervm/noded/server/stateful_registry.go
+++ b/projects/embervm/noded/server/stateful_registry.go
@@ -271,18 +271,22 @@ func (r *statefulRegistry) byWorkload(workload string) (*statefulEntry, bool) {
 	return nil, false
 }
 
-// byWorkloadCheckpoint returns the workload's live entry and its checkpoint
-// token under the registry lock, so the activator can decide whether it must
-// claim and abort a paused checkpoint before splicing.
-func (r *statefulRegistry) byWorkloadCheckpoint(workload string) (*statefulEntry, string, bool) {
+// byWorkloadCheckpoint returns the workload's live entry, checkpoint token, and
+// stop-in-flight guard under the registry lock, so the activator can decide
+// whether it must claim and abort a paused checkpoint before splicing. The
+// entry guard is read while holding e.mu, with r.mu held first.
+func (r *statefulRegistry) byWorkloadCheckpoint(workload string) (e *statefulEntry, token string, inFlight bool, ok bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for _, e := range r.vms {
-		if e.workload == workload {
-			return e, e.checkpointToken, true
+	for _, entry := range r.vms {
+		if entry.workload == workload {
+			entry.mu.Lock()
+			inFlight = entry.inFlight
+			entry.mu.Unlock()
+			return entry, entry.checkpointToken, inFlight, true
 		}
 	}
-	return nil, "", false
+	return nil, "", false, false
 }
 
 // snapshotRefInUse reports whether any LIVE stateful VM was relit from the given


### PR DESCRIPTION
Closes #4477.

## What was wrong

The node-local activator decided "this VM is serving" from the checkpoint token alone:

```go
if live, token, ok := statefulVMs.byWorkloadCheckpoint(reg.Workload); ok && token == "" {
    a.splice(ctx, conn, live)
```

An empty token also means "mid-transition". Both `stopStatefulCheckpoint` and `stopStatefulBank` set the entry's `inFlight` guard via `beginStop` and only stamp a token later (a bank never stamps one at all), so for the whole pause-and-snapshot window the entry sits in the registry with an empty token. `byWorkloadCheckpoint` never read `inFlight`, and `inFlight` appeared nowhere in `stateful_activator.go`.

## Evidence from prod

Both halves of the failure, on the live `/ember/postgres` exhibit:

- Tap already released: `stateful activator: guest dial failed ... dial tcp 172.31.0.2:5432: connect: no route to host`. `splice()` then closes the client socket and returns **without ever attempting a wake**. 19 occurrences in 6h, 5 of them inside ~80s of active probing, so the rate is traffic-correlated.
- Guest merely paused: the tap still routes, the SYN is swallowed, and the unbounded dial sits on kernel retransmit. A query fired 2.2s after the previous one (the demo's idle-bank window, `idleBankSeconds: 1` against a 1s sweeper tick) **stalled for 60s**.

## The fix

- `byWorkloadCheckpoint` reports the in-flight guard, read under `e.mu` while holding `r.mu`.
- The fast-path splice requires entry-exists **and** empty token **and** not in flight.
- When a transition is in progress the activator waits for it to resolve rather than guessing: a token means claim and abort the paused VM, a removed entry means relight or cold-boot, a cleared guard means splice, and a stuck transition falls back to the control plane, which already parks these callers correctly in `park_during_checkpoint`.
- `wake()` takes the same guard, since it would otherwise hand back the entry the fast path just refused.
- `spliceTCP` bounds its dial (the splice itself stays uncapped, it is long-lived by design).

Deliberately not cold-booting behind a transition: that would race a second live VM against the singleton volume attach.

## Verification

- `ci test`: `Executed 7 out of 761 tests: 761 tests pass` (warm cache).
- Focused, cache disabled, since a warm-cache summary proves nothing about the change (#4118): `ci test //projects/embervm/noded/server:server_test -- --nocache_test_results --runs_per_test=6` passes 6/6.
- One run surfaced a pre-existing flake in `TestActivatorSingleFlight`, unreachable from this diff (`spliceTCP` has four call sites, none in the serving HTTP path). Baseline `origin/main` and this branch both pass 6/6. Filed as #4478.

## Follow-ups (not in this PR)

- The console retries 5x with no total deadline, turning a 60s stall into ~5 minutes; and `classify_wake`'s `transitional` is folded into `"cold"`, so a measured 12.2ms run wrote ~12ms into "cold start". That is the next PR.
- `commitCheckpoint` still has a remove-VM-to-add-bundle window where a wake sees neither, and picks a cold boot. Left until this soaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)