### PR TITLE
perf(embervm): size demo-postgres for what it holds, 512 MiB to 150

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.467
+version: 0.1.468

--- a/projects/embervm/chart/templates/workload-demo-postgres.yaml
+++ b/projects/embervm/chart/templates/workload-demo-postgres.yaml
@@ -39,10 +39,26 @@ spec:
       initEnv:
         EMBER_HYPERVISOR_EPOCH: {{ .Values.hypervisorEpoch | quote }}
   resources:
-    # Same warm-peak sizing as scratch-postgres (the fc-base sizing coupling
-    # keys memMib to the shared base image, D-R3.11.1).
     vcpus: 1
-    memMib: 512
+    # Sized for what this guest actually holds, not the scratch-postgres warm
+    # peak it used to copy. The memfile is the one thing here that is FULLY
+    # allocated (the volume is a sparse cap: 2 GiB declared, ~144 MiB of real
+    # blocks), so memMib is written and read in full on every bank and every
+    # relight. It is therefore the demo's headline latency AND its per-bundle
+    # cost on the bricks' scratch.
+    #
+    # 150 MiB budget: ~25 MiB kernel, 32 MiB shared_buffers (see the matching
+    # -c flags in runtimes/postgres/guest-init/cmd/postgres_linux.go, which
+    # MUST come down with this number or Postgres cannot start), ~25 MiB of
+    # postmaster and backends, leaving ~65 MiB of page cache for a 144 MiB
+    # volume holding one small table.
+    #
+    # memMib is part of the base signature (control/lib/embervm/base_builder.ex
+    # signature/1), so moving it rebuilds this workload's base. Nothing shares
+    # that base any more: scratchPostgres.enabled is false in both the chart
+    # defaults and deploy/values.yaml (decommission tracked in #4198), so the
+    # old "keyed to the shared base image" coupling no longer binds.
+    memMib: 150
   stateful:
     # The port Postgres listens on inside the VM. Health is a TCP connect here.
     port: 5432

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.467
+      targetRevision: 0.1.468
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/postgres/guest-init/cmd/postgres_linux.go
+++ b/projects/embervm/runtimes/postgres/guest-init/cmd/postgres_linux.go
@@ -137,7 +137,19 @@ func postgresCommand(ctx context.Context, pgdata string) *exec.Cmd {
 		// the bootstrap createdb connects on.
 		"-c", "unix_socket_directories=/tmp",
 		"-c", "fsync=on",
-		"-c", "shared_buffers=128MB",
+		// MEMORY COUPLING: these are sized against the workload's memMib (150 MiB
+		// for demo-postgres, see chart/templates/workload-demo-postgres.yaml). The
+		// old 128MB shared_buffers was Postgres's own default and would consume
+		// almost the entire guest on its own, so it must not drift back up without
+		// memMib moving with it. Passed as -c so they apply at every start
+		// regardless of what initdb wrote into an existing volume's
+		// postgresql.conf; there is no reinit needed to pick them up.
+		//
+		// 32MB of shared buffers is ample for the demo's single small table, and
+		// maintenance_work_mem is pulled off its 64MB default so an autovacuum
+		// worker cannot claim a third of the guest.
+		"-c", "shared_buffers=32MB",
+		"-c", "maintenance_work_mem=16MB",
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.398
+version: 0.89.399
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.398
+      targetRevision: 0.89.399
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.473
+version: 0.285.474
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.473
+      targetRevision: 0.285.474
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/ember_public/core.py
+++ b/projects/monolith/ember_public/core.py
@@ -265,10 +265,18 @@ def shape_pg_status(status: dict) -> dict:
 # session). Accrual is lazy on the status poll: the demo VM can only wake when
 # something connects, so two consecutive samples that are both state ==
 # "banked" with the SAME generation prove the VM slept the entire gap between
-# the samples, and that whole gap is credited at 512 MiB per second. Any other
-# transition (a generation change, or either sample not banked) credits
-# nothing, so the counter is a conservative undercount, never an overcount.
-_DEMO_PG_SAVINGS_MIB_PER_S = 512.0
+# the samples, and that whole gap is credited at the guest's full footprint.
+# Any other transition (a generation change, or either sample not banked)
+# credits nothing, so the counter is a conservative undercount, never an
+# overcount.
+#
+# COUPLING: this MUST equal the demo workload's memMib, which is the size of
+# the memory the guest is actually not holding while it sleeps. It is declared
+# in projects/embervm/chart/templates/workload-demo-postgres.yaml (resources.
+# memMib). Changing one without the other silently mis-scales every future
+# credit; the historical total was accrued at whatever the rate was then, so
+# only new accrual moves.
+_DEMO_PG_SAVINGS_MIB_PER_S = 150.0
 # Below this gap, skip the write entirely: the status endpoint is polled
 # sub-second, and a banked VM's state/generation do not change between polls,
 # so without a throttle every poll would issue an UPDATE for zero new credit.

--- a/projects/monolith/ember_public/router_test.py
+++ b/projects/monolith/ember_public/router_test.py
@@ -519,7 +519,10 @@ def test_savings_banked_to_banked_same_generation_credits_elapsed(_savings_db):
     total = core.record_demo_pg_savings_core(
         _savings_db, state="banked", generation=7, now=t1
     )
-    assert total == 10 * 512.0
+    # Reads the rate off the constant rather than restating it: this test is
+    # about the elapsed-gap arithmetic, not the guest's footprint (which moves
+    # with the workload's memMib, see the coupling note on the constant).
+    assert total == 10 * core._DEMO_PG_SAVINGS_MIB_PER_S
 
 
 def test_savings_banked_to_banked_generation_change_credits_nothing(_savings_db):
@@ -568,7 +571,7 @@ def test_savings_sub_throttle_unchanged_sample_does_not_move_last_sample_at(
     total = core.record_demo_pg_savings_core(
         _savings_db, state="banked", generation=7, now=t2
     )
-    assert total == 6 * 512.0
+    assert total == 6 * core._DEMO_PG_SAVINGS_MIB_PER_S
 
 
 def test_postgres_status_includes_total_saved_mib_s(monkeypatch):


### PR DESCRIPTION
Follow-on to #4479 / #4477. Cuts the demo VM's guest memory from 512 MiB to 150 MiB.

## Why memory and not disk

I measured where the bytes actually are on node-3:

| file | declared | **real blocks** |
|---|---|---|
| `memfile` (per banked bundle) | 536,870,912 | **536,875,008 (fully allocated)** |
| `vol.img` | 2,147,483,648 | **151,027,712 (sparse)** |

The volume is a sparse **cap**, and the CRD says so in its own field description ("Sparse size cap … IMMUTABLE in v1"), which is why the status API returns `volume.allocated_bytes` (`router.ex:1182`) rather than the declared size. It was byte-identical at 01:47 and 03:00 under an hour of load, so nothing accumulates and there is nothing to reclaim. Shrinking it frees zero bytes, cannot express anything under 1 GiB, and would be rejected as an immutable-field edit anyway.

The memfile is the opposite: fully allocated, written on every bank and read on every relight. So `memMib` is at once the demo's headline latency and its per-bundle cost on the bricks' scratch, which #4290 keeps filling (it recurred today).

## The two numbers move together

`postgres_linux.go` was starting Postgres with `-c shared_buffers=128MB`, Postgres's own default. That alone would consume most of a 150 MiB guest, so it drops to 32MB, with `maintenance_work_mem` pulled off its 64MB default so an autovacuum worker cannot claim a third of the guest. Both are `-c` flags, so they apply at every start without reinitialising the existing volume.

Budget: ~25 MiB kernel, 32 MiB shared_buffers, ~25 MiB postmaster and backends, ~65 MiB page cache for one small table.

`_DEMO_PG_SAVINGS_MIB_PER_S` moves with it or every future credit is mis-scaled by 3.4x. Its two assertions now read the constant rather than restating the number, since they test the elapsed-gap arithmetic, not the footprint.

## The stale comment this removes

The manifest justified 512 as "keyed to the shared base image" with scratch-postgres. `scratchPostgres.enabled` is `false` in both the chart defaults and `deploy/values.yaml`, and it is being decommissioned (#4198), so nothing shares that base. `mem_mib` **is** in the base signature (`base_builder.ex:1421`), so this does rebuild the base, but leaves no duplicate behind.

## ROLLOUT: a manual step is required, do not merge and walk away

The existing banked bundle is a 512 MiB memfile and **Firecracker cannot restore it into a 150 MiB VM**. Per open issue #4408 an unrestorable stateful bundle *retry-loops in `banked`* instead of classifying a cold fallback, and that issue names this exact workload. The bundle is deliberately never auto-deleted.

So once the bricks carry this, the banked bundle must be evicted by hand (`DELETE /v1/stateful/demo-postgres/instance`, which destroys the VM and evicts the bundle). **The volume survives**, so the ledger is retained and the next connect cold-boots at the new size. I will do this and verify Postgres actually starts in 150 MiB before calling it done.

## Forward-looking note

ADR embervm/021 (**Draft**) proposes deriving CPU entitlement as `memMib / pivot` at a provisional 1,024 MiB/vCPU. Under that model this workload would derive ~0.15 vCPU, and the ADR already worries about "starving the 512 MiB datastores" at a higher pivot. Not a blocker today (the model is draft and `vcpus: 1` is still explicit), and this guest's work is trivially CPU-light (12 to 22 ms of query per wake, with relight I/O bound). Flagging it so whoever lands 021 gives this workload an explicit floor.

## Verification

- `ci test`: `Executed 233 out of 756 tests: 756 tests pass`.
- `//projects/embervm/noded/server:server_test` reported FLAKY once. Re-ran focused with `--nocache_test_results --runs_per_test=10`: 10/10 clean. That target is a different Go package from the one this PR touches, and the flake is the pre-existing `TestActivatorSingleFlight` race filed as #4478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)