### PR TITLE
chore(monolith): retire worldcup-sim and cut cron pod churn

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.401
+version: 0.89.402
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.401
+      targetRevision: 0.89.402
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.476
+version: 0.285.477
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -61,13 +61,23 @@ jobs:
   dbSecretName: monolith-pg-app
   dbSecretKey: uri
   cronWorkflows:
+    # worldcup.refresh cut over to Argo 2026-06-22, then the tournament it
+    # models resolved on 2026-06-28: all 72 group fixtures finished and
+    # qualification went final (16 eliminated / 32 qualified). The sim
+    # early-exits with nothing left to simulate, so every run since has been a
+    # no-op, confirmed live by fixtures.updated_at and qualification.computed_at
+    # both frozen at 2026-06-28T04:30Z (~1950 runs, zero writes). MANUAL-ONLY
+    # per the idiom below: suspended, not deleted, because the standings page
+    # still serves the stored rows and deleting the entry would tear down the
+    # CronWorkflow they are read through. Hand-submit it if fixtures are ever
+    # reloaded for the next tournament.
     - name: worldcup-sim
       replaces: worldcup.refresh
       args: ["worldcup-sim"]
-      schedule: "*/30 * * * *"
+      schedule: "0 0 1 1 *"
       concurrencyPolicy: Forbid
       activeDeadlineSeconds: 600
-      suspend: false # worldcup.refresh cut over to Argo 2026-06-22
+      suspend: true
       resources:
         requests:
           cpu: 250m
@@ -118,14 +128,19 @@ jobs:
     # stats_rollup counts cluster resources via the in-cluster K8s API, so it
     # runs under the dedicated least-privilege monolith-stats SA (defined in the
     # argo-workflows platform chart) instead of the shared executor SA. Also
-    # needs ClickHouse for GPU metrics. 2-min cadence (was 120s); per-run pod
-    # overhead ~10s is fine.
+    # needs ClickHouse for GPU metrics. 5-min cadence (was 2-min, originally
+    # 120s): a rollup of counters nobody reads sub-minute did not justify 720
+    # pods/day at ~10s per-run overhead. Deadline widened 120 -> 240s because
+    # the old 120 was only ~6-12x a normal 10-20s run, so a brief upstream
+    # stall tripped it: on 2026-08-07 05:36-05:55Z this job failed 5 times on
+    # "active longer than the specified deadline" while the work itself was
+    # fine. Kept under the 5-min interval so Forbid never perpetually skips.
     - name: observability-stats-rollup
       replaces: observability.stats_rollup
       args: ["observability-stats-rollup"]
-      schedule: "*/2 * * * *"
+      schedule: "*/5 * * * *"
       concurrencyPolicy: Forbid
-      activeDeadlineSeconds: 120
+      activeDeadlineSeconds: 240
       suspend: false
       serviceAccountName: monolith-stats
       env:
@@ -363,14 +378,29 @@ jobs:
     # private dashboard reads a single row instead of doing a live ~235-resource
     # scan on every request. Cluster reads run under the dedicated least-privilege
     # monolith-stats SA (same as observability-stats-rollup). SIGNOZ_API_KEY is the
-    # 1Password key cloned into monolith-workflows by Kyverno. Every minute, to
-    # match the frontend's 60s refresh.
+    # 1Password key cloned into monolith-workflows by Kyverno.
+    #
+    # 2-min cadence (was every minute). The binding constraint is NOT the
+    # frontend's 60s poll (private/+page.svelte) but cluster_snapshot.py's
+    # _STALE_FALLBACK_SECS = 600: past 10 minutes the reader abandons the row
+    # and does the live ~235-resource scan per request rather than serve a
+    # stale "all healthy". 2 min sits well inside that, so the dashboard shows
+    # at most 2-min-old data and the fallback never trips. Do NOT stretch this
+    # past ~5 min: crossing the 600s floor makes every dashboard request a full
+    # live scan, which is far worse than the cron it would be saving.
+    # Halving the cadence drops 1440 -> 720 pods/day, the single biggest source
+    # of workflow pod churn in this registry. Deadline widened 120 -> 240s for
+    # the same reason as observability-stats-rollup: this job failed 5 times in
+    # the 2026-08-07 05:36-05:55Z stall purely on the deadline. That deadline
+    # deliberately exceeds the 2-min interval, so under Forbid a slow run skips
+    # the next window: at a 600s staleness budget, one skipped window (4-min-old
+    # data) beats a run killed at 120s that writes nothing at all.
     - name: home-cluster-snapshot-refresh
       replaces: home.cluster_snapshot_refresh
       args: ["home-cluster-snapshot-refresh"]
-      schedule: "* * * * *"
+      schedule: "*/2 * * * *"
       concurrencyPolicy: Forbid
-      activeDeadlineSeconds: 120
+      activeDeadlineSeconds: 240
       suspend: false
       serviceAccountName: monolith-stats
       env:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.476
+      targetRevision: 0.285.477
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Why

Investigating "why do we have failing cron workflows" turned up two things.

**The failures were stale.** All 13 `Failed` workflows sat in one 20-minute
window, `2026-08-07 05:36Z - 05:55Z`, and everything since has succeeded. The
13-failed / 34-succeeded ratio in a `kubectl get workflows` listing is a
retention artifact, not a failure rate: `cronworkflows.yaml` keeps failures for
`86400s` but successes for only `3600s`, so any snapshot over-represents failure
by ~24x. Those records expire on their own.

**But the burst was not random.** 10 of the 13 failures were
`home-cluster-snapshot-refresh` (5) and `observability-stats-rollup` (5), which
are the two highest-frequency, shortest-deadline jobs in the registry. Both had
`activeDeadlineSeconds: 120` against a normal 10-20s run, so a brief upstream
stall killed them on the deadline rather than on any fault in the work itself.

An audit of all 34 jobs also found exactly one that is genuinely dead.

## What changed

**`worldcup-sim` retired.** No-op since `2026-06-28`: all 72 group fixtures are
finished and qualification is final (16 eliminated / 32 qualified), so the sim
early-exits. Verified live, `fixtures.updated_at` and
`qualification.computed_at` are both frozen at `2026-06-28T04:30Z`, so it has
run ~1950 times since and written nothing.

Suspended via the file's existing manual-only idiom (`suspend: true` plus the
inert `0 0 1 1 *`) rather than deleted, for two reasons: the standings page
still serves the stored rows, and `ARGO_JOBS` membership is driven by
`replaces` **alone, not `suspend`** (`deployment.yaml:46-52`), so keeping the
entry is what holds the in-process `worldcup.refresh` disabled. It stays
hand-submittable if fixtures are ever reloaded.

**Cadence cut on the two churn jobs**, which also widens their deadline headroom:

| Job | Schedule | Deadline | Pods/day |
|---|---|---|---|
| `home-cluster-snapshot-refresh` | `* * * * *` -> `*/2 * * * *` | 120 -> 240 | 1440 -> 720 |
| `observability-stats-rollup` | `*/2 * * * *` -> `*/5 * * * *` | 120 -> 240 | 720 -> 288 |
| `worldcup-sim` | `*/30 * * * *` -> suspended | unchanged | 48 -> 0 |

Registry total: **4164 -> 2964 pods/day (-1200, -29%)**.

The cluster-snapshot comment claimed every-minute matched "the frontend's 60s
refresh", but the frontend poll is not a correctness bound. The real one is
`cluster_snapshot.py:32`'s `_STALE_FALLBACK_SECS = 600`: past 10 minutes the
reader abandons the row and does a live ~235-resource scan per request. 2 min
sits well inside that. I wrote the resulting cliff into the comment, since
cutting further is nearly free until ~5 min and then sharply negative.

`chat-drain-reminders` was deliberately left alone: its 120s deadline equals its
2-min interval, and widening it would make a slow run block the next reminder
window under `Forbid`.

## Verification

- `helm template` (with a stub image pin, since the template is guarded on the
  build-time `jobs.image`) renders all 34 CronWorkflows, the three changed specs
  correct, 5 now suspended, and `ARGO_JOBS` still containing `worldcup.refresh`.
- `ci lint` clean, `ci test` green: `Executed 2 out of 756 tests: 756 tests pass`.
- **Note:** no test actually covers this change. The only consumers of
  `//projects/monolith/chart` are `:migrations` and `chart.push`, and nothing
  reads `chart/values.yaml`. The green run shows nothing else broke, not that
  this is correct, so the real check is the post-merge live one below.

## Post-merge check

Confirm the CronWorkflows actually carry the new schedules:

```
kubectl get cronworkflows -n monolith-workflows \
  worldcup-sim home-cluster-snapshot-refresh observability-stats-rollup \
  -o custom-columns='NAME:.metadata.name,SUSPEND:.spec.suspend,SCHED:.spec.schedules'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QMcj7QnV7bvZo6vhWCHAj