### PR TITLE
fix(monolith): the postgres console stops calling a mid-bank run a cold start

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.399
+version: 0.89.401
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.399
+      targetRevision: 0.89.401
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.474
+version: 0.285.476
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.474
+      targetRevision: 0.285.476
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
@@ -19,6 +19,12 @@
   // /api fetches: the public tier's rule 2 (public-tier-checklist.md).
   import { onMount } from "svelte";
   import { fade } from "svelte/transition";
+  import {
+    classifyTier,
+    includedSnapshotWait,
+    phaseLabel,
+    shouldRetry,
+  } from "./console-retry.js";
 
   /** @type {{ turnstileSiteKey?: string, initialStatus?: object|null, initialSavings?: object|null, status?: object|null, running?: boolean, stopwatchMs?: number }} */
   let {
@@ -38,6 +44,11 @@
   // transiently; retry the same request under the still-ticking stopwatch so
   // it reads as one longer wake, not repeated failures. Capped at 3s.
   const RETRY_DELAYS_MS = [500, 1000, 2000, 3000];
+  // Transient failures are sub-second (in-band busy, mid-transition refusals),
+  // so all retries happen within 6.5s of delays. A slow failure stops after
+  // one attempt, capping the worst case at about 90s instead of 375+s. A
+  // legitimate cold boot can take up to 60s, so in-flight attempts continue.
+  const RETRY_WINDOW_MS = 30_000;
 
   const ORDER_COLUMNS = [
     { key: "id", label: "id", type: "bigserial" },
@@ -195,6 +206,7 @@
   // return {ok: true, ...} on success or {ok: false, permanent, error} on a
   // failure worth surfacing; a thrown error is treated as transient.
   async function fetchWithBackoff(doAttempt) {
+    const startTime = performance.now();
     let lastResult = null;
     for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
       try {
@@ -205,6 +217,13 @@
         lastResult = { ok: false, error: String(err) };
       }
       if (attempt < RETRY_DELAYS_MS.length) {
+        if (!shouldRetry(performance.now() - startTime, RETRY_WINDOW_MS)) {
+          return {
+            ...lastResult,
+            error:
+              "the demo took too long to answer and may be waking from cold, try again in a moment",
+          };
+        }
         await sleep(RETRY_DELAYS_MS[attempt]);
       }
     }
@@ -436,16 +455,16 @@
         status = { ...(status ?? {}), state: "serving" };
       }
       view = mode === "aggregate" ? "summary" : "orders";
-      const tier =
-        body.classification === "relight" || body.classification === "warm"
-          ? body.classification
-          : "cold";
-      if (tiers[tier] == null || body.connect_ms < tiers[tier]) {
+      const tier = classifyTier(body.classification);
+      if (
+        tier !== null &&
+        (tiers[tier] == null || body.connect_ms < tiers[tier])
+      ) {
         tiers = { ...tiers, [tier]: body.connect_ms };
       }
       runHistory = [
         ...runHistory.slice(-(SPARK_MAX - 1)),
-        { connect_ms: body.connect_ms, tier },
+        { connect_ms: body.connect_ms, tier: tier ?? "unclear" },
       ];
     } finally {
       running = false;
@@ -696,9 +715,22 @@
               <span class="fade-swap" in:fade={{ duration: 220 }}>
                 {running ? ms(stopwatchMs) : ms(lastRun?.connect_ms)}
               </span>
+              {#if running && phaseLabel(status?.state)}
+                <span class="stat-phase">{phaseLabel(status?.state)}</span>
+              {/if}
             {/key}
           </span>
         </div>
+        <!-- The completed-run attribution gets its OWN line rather than sitting
+             beside the value: the left column is 340px and .stat-row is a
+             space-between flex, so a sentence next to the number wraps and
+             pushes the whole stats card taller. The live phaseLabel above is
+             two words and does fit inline. -->
+        {#if !running && lastRun && includedSnapshotWait(lastRun)}
+          <p class="stat-note">
+            this run waited for the snapshot to finish writing
+          </p>
+        {/if}
         <div class="stat-row">
           <span class="stat-name">query</span>
           <span class="stat-value">
@@ -726,7 +758,11 @@
           <div class="spark" aria-hidden="true">
             {#each runHistory as run, i (i)}
               <span
-                class="spark-bar spark-{run.tier}"
+                class:spark-unclear={run.tier === "unclear"}
+                class:spark-cold={run.tier === "cold"}
+                class:spark-warm={run.tier === "warm"}
+                class:spark-relight={run.tier === "relight"}
+                class="spark-bar"
                 style:height="{sparkHeight(run.connect_ms)}%"
               ></span>
             {/each}
@@ -1119,6 +1155,10 @@
     background: var(--em-amber);
   }
 
+  .spark-bar.spark-unclear {
+    background: var(--em-faint);
+  }
+
   .spark-caption {
     font-family: var(--em-mono);
     font-size: 10.5px;
@@ -1147,6 +1187,21 @@
 
   .stat-value.stat-live {
     color: var(--em-ember);
+  }
+
+  .stat-phase {
+    margin-left: 6px;
+    color: var(--em-muted);
+    font-family: var(--em-mono);
+    font-size: 11px;
+    font-weight: 400;
+  }
+
+  .stat-note {
+    margin: -4px 0 0;
+    color: var(--em-faint);
+    font-size: 11px;
+    line-height: 1.35;
   }
 
   .console-header {

--- a/projects/monolith/frontend/src/lib/public/ember/console-retry.js
+++ b/projects/monolith/frontend/src/lib/public/ember/console-retry.js
@@ -1,0 +1,65 @@
+/**
+ * Maps the backend classification string to a tier, or null when the result
+ * is unclear. Transitional and unknown values are real measurements, but not
+ * confident classifications, so they must never be written into best-times.
+ * For example, a measured 12.2ms transitional run with phase_before=banking
+ * was landing in "cold start" and destroying the comparison. These runs still
+ * belong in history and the sparkline.
+ */
+export function classifyTier(classification) {
+  if (
+    classification === "warm" ||
+    classification === "relight" ||
+    classification === "cold"
+  ) {
+    return classification;
+  }
+  return null;
+}
+
+/**
+ * Checks whether a measurement included VM snapshot write time. These runs
+ * are excluded from best-times by classifyTier, but when shown in the last-run
+ * row they need attribution so the visitor understands the time.
+ */
+export function includedSnapshotWait(body) {
+  return (
+    body?.phase_before === "banking" || body?.phase_before === "checkpointed"
+  );
+}
+
+/**
+ * Gates whether the next attempt starts, not the current attempt. Transient
+ * failures are sub-second, such as in-band busy responses and mid-transition
+ * refusals, so retries fit within the 6.5s delay window. A slow failure must
+ * not be retried, keeping the worst case near 90s instead of 375+s. Legitimate
+ * cold boots can take up to 60s (wakeTimeoutSeconds), so an in-flight attempt
+ * must not be cut off.
+ */
+export function shouldRetry(elapsedMs, retryWindow) {
+  return elapsedMs < retryWindow;
+}
+
+/**
+ * Returns an indicative live VM phase. Status is cached server-side for about
+ * 500ms and polled every 700ms, so this can lag reality by about 1s. It shows
+ * what the VM is doing, not a synchronised readout, and helps prevent the
+ * visitor from mistaking a wake for a hang. Unknown states stay silent rather
+ * than inventing precision we do not have.
+ */
+export function phaseLabel(state) {
+  switch (state) {
+    case "banking":
+    case "checkpointed":
+      return "writing snapshot";
+    case "relighting":
+    case "starting":
+      return "restoring";
+    case "cold_booting":
+      return "cold booting";
+    case "banked":
+      return "waking";
+    default:
+      return "";
+  }
+}

--- a/projects/monolith/frontend/src/lib/public/ember/console-retry.test.js
+++ b/projects/monolith/frontend/src/lib/public/ember/console-retry.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyTier,
+  includedSnapshotWait,
+  phaseLabel,
+  shouldRetry,
+} from "./console-retry.js";
+
+describe("classifyTier", () => {
+  it.each([
+    ["warm", "warm"],
+    ["relight", "relight"],
+    ["cold", "cold"],
+  ])("classifies %s", (classification, expected) => {
+    expect(classifyTier(classification)).toBe(expected);
+  });
+
+  it.each(["transitional", "unknown", "unrecognized", undefined, null])(
+    "leaves %s unclear",
+    (classification) => {
+      expect(classifyTier(classification)).toBeNull();
+    },
+  );
+});
+
+describe("shouldRetry", () => {
+  it("allows a retry well within the window", () => {
+    expect(shouldRetry(500, 30000)).toBe(true);
+  });
+
+  it("allows retries late in the attempt sequence while in the window", () => {
+    expect(shouldRetry(29000, 30000)).toBe(true);
+    expect(shouldRetry(15000, 30000)).toBe(true);
+  });
+
+  it("stops at and after the window boundary", () => {
+    expect(shouldRetry(30000, 30000)).toBe(false);
+    expect(shouldRetry(31000, 30000)).toBe(false);
+  });
+
+  it("allows all fast transient retries in a one-second sequence", () => {
+    const attempts = [0, 250, 500, 750, 1000];
+    expect(attempts.every((elapsed) => shouldRetry(elapsed, 30000))).toBe(true);
+  });
+
+  it("refuses a retry after a slow attempt has passed its retry window", () => {
+    expect(shouldRetry(20000, 15000)).toBe(false);
+  });
+});
+
+describe("includedSnapshotWait", () => {
+  it.each([
+    [{ phase_before: "banking" }, true],
+    [{ phase_before: "checkpointed" }, true],
+    [{ phase_before: "banked" }, false],
+    [{ phase_before: "serving" }, false],
+    [{ phase_before: "unknown" }, false],
+    [{}, false],
+    [null, false],
+    [undefined, false],
+  ])("returns %s for %s", (body, expected) => {
+    expect(includedSnapshotWait(body)).toBe(expected);
+  });
+});
+
+describe("phaseLabel", () => {
+  it.each([
+    ["banking", "writing snapshot"],
+    ["checkpointed", "writing snapshot"],
+    ["relighting", "restoring"],
+    ["starting", "restoring"],
+    ["cold_booting", "cold booting"],
+    ["banked", "waking"],
+  ])("labels %s", (state, expected) => {
+    expect(phaseLabel(state)).toBe(expected);
+  });
+
+  it.each(["serving", "failed", "unknown", "", null, undefined])(
+    "silences %s",
+    (state) => {
+      expect(phaseLabel(state)).toBe("");
+    },
+  );
+});


### PR DESCRIPTION
Closes the console half of #4477. The control-plane half shipped as #4479, and the memory reduction as #4480.

## 1. A mid-transition run was being filed as a cold start

`classify_wake` returns five values (`warm`, `relight`, `cold`, `transitional`, `unknown`). The console folded the last two into `"cold"` and then took the **minimum**:

```js
const tier = body.classification === "relight" || body.classification === "warm"
  ? body.classification : "cold";
if (tiers[tier] == null || body.connect_ms < tiers[tier]) { ... }
```

Measured on prod: a run with `total_ms: 12.2`, `classification: transitional`, `phase_before: banking` wrote **~12 ms into "cold start"**, destroying the cold-vs-snapshot-vs-warm comparison the whole page exists to make.

These are real measurements but not confident classifications, so they now keep their place in history and the sparkline (neutral colour) and never touch best-times.

## 2. Retries had no wall-clock budget

Five attempts, no total deadline, over a proxy that allows 90s each. I measured a 60s stall on prod; five of those is over five minutes of ticking stopwatch with no cancel.

The rule now is **retries are for fast failures**. A new attempt only starts inside a 30s window:

- a transient (in-band `busy`, a mid-transition refusal) fails in well under a second, so it still gets every retry inside the existing 6.5s of delays
- a slow failure stops after one attempt

In-flight attempts are never cut off, because a genuine cold boot legitimately takes up to 60s (`wakeTimeoutSeconds`), and truncating that would break the demo's own cold-start measurement.

## 3. A slow run looked like a hang

The console already polls the lifecycle state, so while a run is in flight it now says what the VM is actually doing: `writing snapshot`, `restoring`, `cold booting`, `waking`. Unknown states say **nothing** rather than inventing a phase.

And since `connect_ms` is measured around the whole connect, it includes time parked waiting for a checkpoint to finish writing. A completed run that waited is now attributed as such, rather than a bare 5.18 s reading as wake latency. Measuring the split properly needs the park duration out of noded, filed as #4481.

Honesty constraint, stated in the code: the status read is cached ~500ms server-side and polled at 700ms, so the live label can lag by about a second. It indicates what the VM is doing; it is not a synchronised readout.

## Why the caption instead of a number

The page promises "every number on this page is a real measurement". Subtracting an estimated park time to show a prettier "actual wake" would put a fabricated number on that page. Showing the honest total plus an honest attribution is correct; inventing the split is not.

## Verification

- `ci test`: `Executed 49 out of 756 tests: 756 tests pass`.
- Focused, cache disabled: `ci test //projects/monolith/frontend:test -- --nocache_test_results` passes.
- Bazel swallows stdout on a green target, so I also ran vitest directly to confirm the new file actually executes rather than being silently unglobbed: `Test Files 1 passed (1) / Tests 33 passed (33)`.
- `//projects/embervm/noded/server:server_test` flaked again (3rd sighting). Different language, different package, cannot be reached by this diff. Tracked as #4478.

## Field results from the three PRs together

| | worst case | mid-bank typical | activator dial failures |
|---|---|---|---|
| before | 60,080 ms | 60 s or connection closed | 5 per ~24 queries |
| after #4479 | 6,855 ms | 3,391-6,855 ms | 0 |
| after #4480 | **2,093 ms** | **832-925 ms** | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)