### PR TITLE
test(embervm): barrier all parked requests before releasing activator health gates

### DIFF
--- a/projects/embervm/noded/server/activator_test.go
+++ b/projects/embervm/noded/server/activator_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
 )
@@ -53,6 +54,28 @@ func activatorRequest(t *testing.T, handler http.Handler, workload, path, body s
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	return rec
+}
+
+// waitForActivatorParked polls the activator's parked count under the mutex until
+// it reaches expected, or times out. This ensures the test does not release the
+// health handler before all concurrent requests have actually been admitted and
+// are parked waiting for that release, rather than being scheduled but not yet
+// in the activator's join() critical section.
+func waitForActivatorParked(t *testing.T, a *activator, expected int) {
+	t.Helper()
+	timeout := time.Now().Add(5 * time.Second)
+	for {
+		a.mu.Lock()
+		current := a.parked
+		a.mu.Unlock()
+		if current >= expected {
+			return
+		}
+		if time.Now().After(timeout) {
+			t.Fatalf("timeout waiting for %d parked requests, got %d", expected, current)
+		}
+		time.Sleep(time.Millisecond)
+	}
 }
 
 func TestActivatorStragglerProxiesLiveVM(t *testing.T) {
@@ -201,6 +224,11 @@ func TestActivatorSingleFlight(t *testing.T) {
 		}()
 	}
 	<-healthStarted
+	// Wait for all 8 requests to reach the activator and be parked. healthStarted
+	// only proves the FIRST request reached the health handler; stragglers may not
+	// yet have called join() and incremented a.parked. Do not release the health
+	// gate until all are actually admitted, so the single-flight assertion holds.
+	waitForActivatorParked(t, s.activator, requests)
 	close(releaseHealth)
 	for i := 0; i < requests; i++ {
 		rec := <-responses

--- a/projects/embervm/noded/server/group_activator_test.go
+++ b/projects/embervm/noded/server/group_activator_test.go
@@ -96,6 +96,28 @@ func enableGroupActivatorWorkload(s *Server, workload string, listenPort, guestP
 	}})
 }
 
+// waitForGroupActivatorParked polls the group activator's parked count for the
+// workload under the mutex until it reaches expected, or times out. This ensures
+// the test does not release the restore handler before all concurrent clients have
+// actually been admitted and are parked waiting for that release, rather than
+// being scheduled but not yet in the group activator's join() critical section.
+func waitForGroupActivatorParked(t *testing.T, a *groupActivator, workload string, expected int) {
+	t.Helper()
+	timeout := time.Now().Add(5 * time.Second)
+	for {
+		a.mu.Lock()
+		current := a.parked[workload]
+		a.mu.Unlock()
+		if current >= expected {
+			return
+		}
+		if time.Now().After(timeout) {
+			t.Fatalf("timeout waiting for %d parked clients on %q, got %d", expected, workload, current)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func addGroupActivatorBundle(s *Server, driver *fakeGroupMemberDriver, setID, groupInstanceID, memberName, pinnedIP string, port uint32) {
 	driver.mu.Lock()
 	driver.banked[setID+"/"+memberName] = true
@@ -264,6 +286,11 @@ func TestGroupActivatorSingleFlight(t *testing.T) {
 		conns = append(conns, groupActivatorConn(t, listenPort))
 	}
 	<-driver.restoreStarted
+	// Wait for all 8 clients to reach the group activator and be parked. restoreStarted
+	// only proves the FIRST restore started; stragglers may not yet have called join()
+	// and incremented a.parked[workload]. Do not release the restore gate until all
+	// are actually admitted, so the single-flight assertion holds.
+	waitForGroupActivatorParked(t, s.groupActivator, "scratch-k8s", clients)
 	close(driver.releaseRestore)
 	for _, conn := range conns {
 		groupActivatorRoundTrip(t, conn, "all group clients")

--- a/projects/embervm/noded/server/stateful_activator_test.go
+++ b/projects/embervm/noded/server/stateful_activator_test.go
@@ -103,6 +103,28 @@ func addStatefulActivatorBundle(t *testing.T, s *Server, driver *fakeStatefulDri
 	s.statefulBundles.add(statefulBundleEntry{snapshotRef: ref, workload: workload, generation: 0})
 }
 
+// waitForStatefulActivatorParked polls the stateful activator's parked count for
+// the workload under the mutex until it reaches expected, or times out. This ensures
+// the test does not release the restore handler before all concurrent clients have
+// actually been admitted and are parked waiting for that release, rather than
+// being scheduled but not yet in the stateful activator's join() critical section.
+func waitForStatefulActivatorParked(t *testing.T, a *statefulActivator, workload string, expected int) {
+	t.Helper()
+	timeout := time.Now().Add(5 * time.Second)
+	for {
+		a.mu.Lock()
+		current := a.parked[workload]
+		a.mu.Unlock()
+		if current >= expected {
+			return
+		}
+		if time.Now().After(timeout) {
+			t.Fatalf("timeout waiting for %d parked clients on %q, got %d", expected, workload, current)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func TestStatefulActivatorColdBootResolvesBaseLocally(t *testing.T) {
 	port := statefulActivatorEchoServer(t)
 	s, _, driver := newStatefulTestServer(t)
@@ -180,6 +202,11 @@ func TestStatefulActivatorSingleFlight(t *testing.T) {
 		conns <- statefulActivatorConn(t, listenPort)
 	}
 	<-driver.restoreStarted
+	// Wait for all 8 clients to reach the stateful activator and be parked. restoreStarted
+	// only proves the FIRST restore started; stragglers may not yet have called join()
+	// and incremented a.parked[workload]. Do not release the restore gate until all
+	// are actually admitted, so the single-flight assertion holds.
+	waitForStatefulActivatorParked(t, s.statefulActivator, "wl-state", clients)
 	close(driver.releaseRestore)
 	for i := 0; i < clients; i++ {
 		conn := <-conns


### PR DESCRIPTION
Fixes #4478.

## The defect

`TestActivatorSingleFlight` failed 3 separate times today during unrelated work:

```
--- FAIL: TestActivatorSingleFlight (0.00s)
    activator_test.go:212: ClaimServing calls = 2, want 1
```

This is a test synchronisation defect, not a product bug. The activator's single-flight logic is correct.

The test fires 8 concurrent requests, then:

```go
<-healthStarted
close(releaseHealth)
```

`healthStarted` fires when the **first** request reaches the guest health handler. It says nothing about the other 7. When the scheduler is slow with a straggler, the leader's flight completes and clears itself from `a.flights` before that straggler calls `join()`, so the straggler becomes a fresh leader, reserves a second boot, and `driver.claims` becomes 2.

## The fix

`join()` increments `a.parked` under `a.mu` for every admitted request, leader and follower alike, so that counter is exactly the missing signal. The tests now wait for all N requests to be parked before releasing the gate.

Two things deliberately preserved:

- **The counter is read only while holding `a.mu`.** Peeking at `a.parked` directly would be a reported data race under `-race`, which would be a worse bug than the flake.
- **`claims == 1` is unchanged.** The tempting fix for a flaky single-flight test is to accept `<= 2`, which would delete the only property the test exists to prove. The defect was in the precondition, not the assertion. `healthStarted` is kept as the initial ordering gate; it is simply no longer the only one.

## Same defect in two sibling tests

The "wait for one signal, assume all N arrived" shape was also present in the group and stateful activator single-flight tests, which gate on `restoreStarted`. Both are fixed with the same barrier, indexing the per-workload `parked` map rather than a scalar.

## Verification

A single green run proves nothing about a 1-in-many race, so:

```
ci test //projects/embervm/noded/server:server_test -- --nocache_test_results --runs_per_test=20
Executed 1 out of 1 test: 1 test passes.
```

20 runs, no `FLAKY` marker (the failing runs previously printed `FLAKY, failed in 1 out of 2`), and `29 processes: ... 27 remote` confirms the repeats actually executed rather than being served from cache.

Test-only change: no chart bump, nothing deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)