### PR TITLE
feat(embervm): measure the wake net of the snapshot wait it was hiding

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.468
+version: 0.1.469

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -885,7 +885,15 @@ defmodule Embervm.NodeRegistry do
         # StatefulManager adopts it (the fenced-writer rule already trusts its
         # forward generation) instead of orphan-destroying it. Absent on a pre-018
         # daemon reads :INSTANCE_ORIGIN_UNSPECIFIED == the CP-issued default.
-        origin: v.origin
+        origin: v.origin,
+        # Activator park measurements (#4481). These live on StatefulVm ONLY, not
+        # on GroupMemberVm: the demo's wake timing is a stateful-workload fact and
+        # the group lane has no equivalent caller waiting on a checkpoint. The
+        # sequence is what makes attribution clock-free (compare it either side of
+        # a request); the duration is the value being attributed.
+        activator_park_seq: v.activator_park_seq,
+        last_activator_park_ms: v.last_activator_park_ms,
+        last_activator_park_at_unix_ms: v.last_activator_park_at_unix_ms
       }
     end
   end

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -1210,10 +1210,25 @@ defmodule Embervm.Router do
       generation: instance.generation,
       created_at: instance.created_at,
       last_active_at: instance.last_active_at,
+      # Activator park measurements (#4481). Map.get, NOT dot access: these are
+      # additive fields, so an instance recorded before this shipped (or by a
+      # pre-#4481 daemon) simply does not carry the keys, and dot access would
+      # raise KeyError on the whole status read rather than degrade to null.
+      # Zero means "never measured" on the wire (proto3 scalars have no
+      # presence), so it maps to nil rather than a misleading 0ms.
+      last_park_ms: positive_or_nil(Map.get(instance, :last_activator_park_ms)),
+      last_park_at: positive_or_nil(Map.get(instance, :last_activator_park_at_unix_ms)),
+      park_seq: positive_or_nil(Map.get(instance, :activator_park_seq)),
       updated_at: instance.updated_at,
       terminal_reason: instance.terminal_reason
     }
   end
+
+  # nil for an absent or non-positive measurement. proto3 scalars carry no
+  # presence, so a daemon that has never recorded a park reports 0, which must
+  # read as "no measurement" rather than as a real zero-millisecond wait.
+  defp positive_or_nil(value) when is_integer(value) and value > 0, do: value
+  defp positive_or_nil(_), do: nil
 
   # Whether `workload` is a STATEFUL-class workload in the catalog. Resolves the
   # catalog module + table from app-env so a request test can inject a fake without

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -2356,7 +2356,11 @@ defmodule Embervm.StatefulManager do
   end
 
   defp adopt_live(state, instance, node_id, vm) do
-    StatefulStore.adopt_state(state.store, instance.instance_id, :serving)
+    StatefulStore.adopt_state(state.store, instance.instance_id, :serving, %{
+      last_activator_park_ms: Map.get(vm, :last_activator_park_ms, 0),
+      last_activator_park_at_unix_ms: Map.get(vm, :last_activator_park_at_unix_ms, 0),
+      last_activator_park_seq: Map.get(vm, :activator_park_seq, 0)
+    })
 
     StatefulStore.adopt_endpoint(state.store, instance.instance_id, node_id, vm.vm_id, %{
       ip: Map.get(vm, :ip),

--- a/projects/embervm/control/lib/embervm/stateful_store.ex
+++ b/projects/embervm/control/lib/embervm/stateful_store.ex
@@ -725,6 +725,9 @@ defmodule Embervm.StatefulStore do
       snapshot_size_bytes: row.snapshot_size_bytes,
       created_at: row.created_at,
       last_active_at: row.last_active_at,
+      last_activator_park_ms: 0,
+      last_activator_park_at_unix_ms: 0,
+      last_activator_park_seq: 0,
       updated_at: row.updated_at,
       terminal_reason: row.terminal_reason
     }

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.468
+      targetRevision: 0.1.469
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/activator.go
+++ b/projects/embervm/noded/server/activator.go
@@ -27,8 +27,12 @@ const (
 	// The transition wait is short enough to notice a checkpoint resolve
 	// promptly, while the deadline prevents a stuck VM from pinning a client.
 	activatorInFlightPollInterval = 25 * time.Millisecond
-	activatorInFlightTimeout      = 10 * time.Second
 )
+
+// A var rather than a const for the same reason as activatorDialTimeout below:
+// the timeout branch is only reachable by waiting the whole deadline out, so a
+// test that proves it either shrinks this or costs ten seconds on every run.
+var activatorInFlightTimeout = 10 * time.Second
 
 // A guest that is paused can leave its tap reachable while swallowing SYNs, so
 // an unbounded dial sits on kernel SYN retransmit (~127s) and the caller reads

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -2086,22 +2086,31 @@ func (s *Server) statefulVMsStatus() []*nodev1.StatefulVm {
 	}
 	live := s.statefulVMs.snapshot()
 	out := make([]*nodev1.StatefulVm, 0, len(live))
+	var lastParkMs map[string]uint64
+	var lastParkAtMs map[string]int64
+	var lastParkSeq map[string]uint64
+	if s.statefulActivator != nil {
+		lastParkMs, lastParkAtMs, lastParkSeq = s.statefulActivator.parkMeasurements()
+	}
 	for _, e := range live {
 		ip, port := e.ip, e.port
 		if s.servingNet != nil {
 			ip, port = s.servingNet.Endpoint(net.ParseIP(e.ip), e.port)
 		}
 		out = append(out, &nodev1.StatefulVm{
-			VmId:              e.vmID,
-			Workload:          e.workload,
-			Ip:                ip,
-			Port:              port,
-			Healthy:           e.healthy,
-			Generation:        e.generation,
-			LastProbeUnixMs:   e.lastProbeUnixMs,
-			CheckpointPending: e.checkpointPending,
-			CheckpointToken:   e.checkpointToken,
-			Origin:            e.origin,
+			VmId:                      e.vmID,
+			Workload:                  e.workload,
+			Ip:                        ip,
+			Port:                      port,
+			Healthy:                   e.healthy,
+			Generation:                e.generation,
+			LastProbeUnixMs:           e.lastProbeUnixMs,
+			CheckpointPending:         e.checkpointPending,
+			CheckpointToken:           e.checkpointToken,
+			Origin:                    e.origin,
+			LastActivatorParkMs:       lastParkMs[e.workload],
+			LastActivatorParkAtUnixMs: lastParkAtMs[e.workload],
+			ActivatorParkSeq:          lastParkSeq[e.workload],
 		})
 	}
 	return out

--- a/projects/embervm/noded/server/stateful_activator.go
+++ b/projects/embervm/noded/server/stateful_activator.go
@@ -41,18 +41,24 @@ const (
 type statefulActivator struct {
 	server *Server
 
-	mu      sync.Mutex
-	flights map[string]*statefulActivatorFlight
-	boots   int
-	parked  map[string]int
-	wakes   []time.Time
+	mu           sync.Mutex
+	flights      map[string]*statefulActivatorFlight
+	boots        int
+	parked       map[string]int
+	wakes        []time.Time
+	lastParkMs   map[string]uint64
+	lastParkAtMs map[string]int64
+	lastParkSeq  map[string]uint64
 }
 
 func newStatefulActivator(s *Server) *statefulActivator {
 	return &statefulActivator{
-		server:  s,
-		flights: make(map[string]*statefulActivatorFlight),
-		parked:  make(map[string]int),
+		server:       s,
+		flights:      make(map[string]*statefulActivatorFlight),
+		parked:       make(map[string]int),
+		lastParkMs:   make(map[string]uint64),
+		lastParkAtMs: make(map[string]int64),
+		lastParkSeq:  make(map[string]uint64),
 	}
 }
 
@@ -227,12 +233,41 @@ func (a *statefulActivator) complete(workload string, flight *statefulActivatorF
 	a.mu.Unlock()
 }
 
+// These bounded maps (one entry per workload) are never pruned because the
+// workload set is static and small, so memory growth is bounded by workload
+// count, not request volume.
+func (a *statefulActivator) parkMeasurements() (map[string]uint64, map[string]int64, map[string]uint64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	lastParkMs := make(map[string]uint64, len(a.lastParkMs))
+	lastParkAtMs := make(map[string]int64, len(a.lastParkAtMs))
+	lastParkSeq := make(map[string]uint64, len(a.lastParkSeq))
+	for workload, duration := range a.lastParkMs {
+		lastParkMs[workload] = duration
+	}
+	for workload, endedAt := range a.lastParkAtMs {
+		lastParkAtMs[workload] = endedAt
+	}
+	for workload, seq := range a.lastParkSeq {
+		lastParkSeq[workload] = seq
+	}
+	return lastParkMs, lastParkAtMs, lastParkSeq
+}
+
 // waitForInFlight waits for a stop transition to expose a safe decision. A
 // checkpoint token means wake must claim and abort the paused VM, a removed
 // entry means wake must relight or cold-boot, and a cleared guard permits the
 // existing live VM to be spliced. The bounded fallback preserves the
 // node-local activator's escape hatch when a transition gets stuck.
 func (a *statefulActivator) waitForInFlight(ctx context.Context, workload string) (*statefulEntry, statefulInFlightWaitResult) {
+	started := time.Now()
+	recordPark := func() {
+		a.mu.Lock()
+		a.lastParkMs[workload] = uint64(time.Since(started) / time.Millisecond)
+		a.lastParkAtMs[workload] = time.Now().UnixMilli()
+		a.lastParkSeq[workload]++
+		a.mu.Unlock()
+	}
 	deadline := time.NewTimer(activatorInFlightTimeout)
 	defer deadline.Stop()
 	poll := time.NewTicker(activatorInFlightPollInterval)
@@ -248,12 +283,18 @@ func (a *statefulActivator) waitForInFlight(ctx context.Context, workload string
 		return nil, statefulInFlightPending
 	}
 	if entry, result := check(); result != statefulInFlightPending {
+		if result == statefulInFlightSplice || result == statefulInFlightWake {
+			recordPark()
+		}
 		return entry, result
 	}
 	for {
 		select {
 		case <-poll.C:
 			if entry, result := check(); result != statefulInFlightPending {
+				if result == statefulInFlightSplice || result == statefulInFlightWake {
+					recordPark()
+				}
 				return entry, result
 			}
 		case <-deadline.C:

--- a/projects/embervm/noded/server/stateful_activator_test.go
+++ b/projects/embervm/noded/server/stateful_activator_test.go
@@ -361,6 +361,67 @@ func TestStatefulActivatorWaitsForInFlightDecision(t *testing.T) {
 			if result != want {
 				t.Fatalf("wait result = %v, want %v", result, want)
 			}
+			if got := a.lastParkMs[entry.workload]; got == 0 {
+				t.Errorf("last park duration = %d, want a completed park", got)
+			}
+			if got := a.lastParkAtMs[entry.workload]; got == 0 {
+				t.Errorf("last park end time = %d, want a completed park", got)
+			}
+		})
+	}
+}
+
+func TestStatefulActivatorDoesNotRecordUnservedInFlightOutcomes(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  func() (context.Context, context.CancelFunc)
+	}{
+		{
+			name: "timeout",
+			ctx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+		},
+		{
+			name: "canceled",
+			ctx: func() (context.Context, context.CancelFunc) {
+				return context.WithCancel(context.Background())
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _, _ := newStatefulTestServer(t)
+			entry := &statefulEntry{vmID: "vm-in-flight", workload: "wl-state"}
+			s.statefulVMs.add(entry)
+			if _, ok := s.statefulVMs.beginStop(entry.vmID); !ok {
+				t.Fatal("beginStop failed")
+			}
+			a := newStatefulActivator(s)
+			ctx, cancel := tt.ctx()
+			defer cancel()
+			if tt.name == "timeout" {
+				old := activatorInFlightTimeout
+				activatorInFlightTimeout = time.Millisecond
+				t.Cleanup(func() { activatorInFlightTimeout = old })
+			} else {
+				go func() {
+					time.Sleep(2 * activatorInFlightPollInterval)
+					cancel()
+				}()
+			}
+
+			_, result := a.waitForInFlight(ctx, entry.workload)
+			if (tt.name == "timeout" && result != statefulInFlightTimeout) ||
+				(tt.name == "canceled" && result != statefulInFlightCanceled) {
+				t.Fatalf("wait result = %v", result)
+			}
+			if _, ok := a.lastParkMs[entry.workload]; ok {
+				t.Errorf("last park duration was recorded for %s", tt.name)
+			}
+			if _, ok := a.lastParkAtMs[entry.workload]; ok {
+				t.Errorf("last park end time was recorded for %s", tt.name)
+			}
 		})
 	}
 }

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1644,6 +1644,31 @@ message StatefulVm {
   // (empty in Fork A). generation is already carried above (field 6, the volume
   // generation), so it is not duplicated here.
   string grant_id = 11;
+  // last_activator_park_ms is the duration in milliseconds of the most recent
+  // activator park for this workload that ended in the connection being served
+  // (splice or wake outcomes), or 0 if no such park has been recorded. This is
+  // a best-effort measurement per workload; multiple connections in flight could
+  // potentially record parks, so this is the most recent park, not provably
+  // the one that belongs to any particular caller. Include in NodeStatus so the
+  // control plane can correlate it with POST /query requests that fell within
+  // the park window.
+  uint64 last_activator_park_ms = 12;
+
+  // last_activator_park_at_unix_ms is the unix millisecond timestamp when the
+  // most recent park ended (i.e., when the decision was made to splice or wake).
+  // Zero if no park has been recorded. Diagnostic detail only. Correlation uses
+  // activator_park_seq instead, without relying on cross-host clock agreement.
+  int64 last_activator_park_at_unix_ms = 13;
+
+  // activator_park_seq is a per-workload counter that increments each time a
+  // park completes on a served outcome (splice or wake). Used to detect whether
+  // a park completed during a request window without relying on cross-host clock
+  // agreement. A sequence increase between two status reads proves a park
+  // happened in that window. This is a best-effort attribution (two visitors
+  // on the same bank both see the increment) so the UI must not present it as
+  // exact; the observation proves a park occurred, not that this specific
+  // request caused it.
+  uint64 activator_park_seq = 14;
 }
 
 // StatefulBundle is the ONE banked stateful bundle for a workload on node disk,

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.402
+version: 0.89.403
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.402
+      targetRevision: 0.89.403
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.477
+version: 0.285.478
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.477
+      targetRevision: 0.285.478
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/ember_public/core.py
+++ b/projects/monolith/ember_public/core.py
@@ -257,6 +257,9 @@ def shape_pg_status(status: dict) -> dict:
         "volume_bytes": status.get("volume_bytes"),
         "healthy": instance.get("healthy"),
         "last_active_at": instance.get("last_active_at"),
+        "last_park_ms": instance.get("last_park_ms"),
+        "last_park_at": instance.get("last_park_at"),
+        "park_seq": instance.get("park_seq"),
         "created_at": instance.get("created_at"),
     }
 

--- a/projects/monolith/ember_public/router.py
+++ b/projects/monolith/ember_public/router.py
@@ -169,12 +169,58 @@ async def postgres_query(body: PostgresQueryRequest, request: Request) -> dict:
     finally:
         core.release_query_slot()
 
+    parked_ms = None
+    wake_ms = None
+    if core.EMBERVM_URL:
+        try:
+            # The post-roundtrip read uses the uncached fetch_demo_pg_status()
+            # to ensure a fresh sequence value; the 500ms pre-roundtrip cache
+            # cannot be relied on for coherency since the roundtrip takes ~900ms.
+            after = core.shape_pg_status(await core.fetch_demo_pg_status())
+            # `before` is the RAW control-plane payload (park_seq is nested under
+            # its instance map); `after` has been through shape_pg_status, which
+            # lifts those to the top level. Shape both or the comparison silently
+            # reads None on one side and never attributes anything.
+            before_seq = core.shape_pg_status(before or {}).get("park_seq")
+            after_seq = after.get("park_seq")
+            park_ms = after.get("last_park_ms")
+            # The sequence counter proves a park completed inside this request's
+            # window, but it does NOT prove that park belonged to this request:
+            # two visitors colliding on the same bank both see the same sequence
+            # increment. So this is best-effort attribution and the UI must not
+            # present it as exact.
+            #
+            # One known bias: before_seq comes from the CACHED pre-query read (up
+            # to _STATUS_CACHE_TTL_S stale), so the comparison window can start up
+            # to that much earlier than the request actually did, and a park that
+            # ended just before we arrived can be attributed to us. Reading it
+            # uncached would tighten the window but would put an unbounded
+            # control-plane read in front of the query semaphore, which is exactly
+            # what the cache exists to prevent. The bias is toward over-attributing
+            # a wait we did not pay, never toward hiding one we did; with the
+            # ~150 MiB memfile a bank now completes in well under a second, so the
+            # overlap is small and the UI labels the split as approximate anyway.
+            if (
+                isinstance(before_seq, int)
+                and before_seq > 0
+                and isinstance(after_seq, int)
+                and after_seq > before_seq
+                and isinstance(park_ms, (int, float))
+                and park_ms > 0
+            ):
+                parked_ms = park_ms
+                wake_ms = max(0, result["connect_ms"] - park_ms)
+        except Exception as exc:  # noqa: BLE001 - attribution is fail-soft
+            logger.warning("demo-postgres park attribution failed: %s", exc)
+
     return {
         **result,
         "total_ms": (perf_counter() - started) * 1000,
         "classification": core.classify_wake(before),
         "phase_before": (before or {}).get("state"),
         "generation": (before or {}).get("generation"),
+        "parked_ms": parked_ms,
+        **({"wake_ms": wake_ms} if wake_ms is not None else {}),
         "error": None,
     }
 

--- a/projects/monolith/ember_public/router_test.py
+++ b/projects/monolith/ember_public/router_test.py
@@ -11,6 +11,7 @@ demos/firecracker_api_test.py.
 from __future__ import annotations
 
 import re
+import time
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -100,6 +101,90 @@ def test_postgres_status_shapes_control_plane_payload(monkeypatch):
     assert body["pair_valid"] is True
     assert body["healthy"] is True
     assert body["last_active_at"] == "2026-07-17T10:00:00Z"
+
+
+def test_shape_pg_status_includes_park_fields():
+    shaped = core.shape_pg_status(
+        _pg_status_payload(
+            instance={
+                "healthy": True,
+                "last_active_at": None,
+                "last_park_ms": 321,
+                "last_park_at": 1_728_000_000_123,
+                "park_seq": 4,
+            }
+        )
+    )
+    assert shaped["last_park_ms"] == 321
+    assert shaped["last_park_at"] == 1_728_000_000_123
+    assert shaped["park_seq"] == 4
+
+
+def _query_result(connect_ms=850.0):
+    return {
+        "connect_ms": connect_ms,
+        "query_ms": 12.0,
+        "mode": "aggregate",
+        "statements": [],
+        "inserted": None,
+        "rows": [],
+        "breakdown": [],
+        "total_orders": 0,
+        "total_revenue": 0.0,
+        "postmaster_start": "2026-07-17T08:00:00+00:00",
+    }
+
+
+def _patch_query_roundtrip(monkeypatch, statuses):
+    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
+    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
+    status_iter = iter(statuses)
+
+    async def fake_status():
+        return next(status_iter)
+
+    monkeypatch.setattr(core, "cached_demo_pg_status", fake_status)
+    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
+    monkeypatch.setattr(core, "demo_pg_orders_roundtrip", lambda *_: _query_result())
+
+
+def test_postgres_query_correlates_park_when_sequence_increases(monkeypatch):
+    _patch_query_roundtrip(
+        monkeypatch,
+        [
+            _pg_status_payload(state="banked", instance={"park_seq": 1}),
+            _pg_status_payload(instance={"last_park_ms": 300, "park_seq": 2}),
+        ],
+    )
+
+    body = _client().post("/api/ember/postgres/query", json={}).json()
+    assert body["parked_ms"] == 300
+    assert body["wake_ms"] == 550.0
+
+
+def test_postgres_query_skips_park_when_sequence_unchanged(monkeypatch):
+    _patch_query_roundtrip(
+        monkeypatch,
+        [
+            _pg_status_payload(state="banked"),
+            _pg_status_payload(instance={"last_park_ms": 300, "park_seq": 1}),
+        ],
+    )
+
+    body = _client().post("/api/ember/postgres/query", json={}).json()
+    assert body["parked_ms"] is None
+    assert "wake_ms" not in body
+
+
+def test_postgres_query_handles_missing_sequence(monkeypatch):
+    _patch_query_roundtrip(
+        monkeypatch,
+        [_pg_status_payload(state="banked"), _pg_status_payload(state="serving")],
+    )
+
+    body = _client().post("/api/ember/postgres/query", json={}).json()
+    assert body["parked_ms"] is None
+    assert "wake_ms" not in body
 
 
 def test_postgres_status_reports_live_presence(monkeypatch):

--- a/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
@@ -22,6 +22,7 @@
   import {
     classifyTier,
     includedSnapshotWait,
+    parkedMsBreakdown,
     phaseLabel,
     shouldRetry,
   } from "./console-retry.js";
@@ -726,10 +727,24 @@
              space-between flex, so a sentence next to the number wraps and
              pushes the whole stats card taller. The live phaseLabel above is
              two words and does fit inline. -->
-        {#if !running && lastRun && includedSnapshotWait(lastRun)}
-          <p class="stat-note">
-            this run waited for the snapshot to finish writing
-          </p>
+        <!-- {#if ... as x} is NOT Svelte: `as` bindings exist only on {#each}
+             and {#await}. Bind the breakdown with {@const} inside the block
+             instead, and fall back to the bare attribution when the backend
+             could not attribute a park to this request (see the correlation
+             note in ember_public/router.py: no attribution is far better than
+             a fabricated split). -->
+        {#if !running && lastRun}
+          {@const breakdown = parkedMsBreakdown(lastRun)}
+          {#if breakdown}
+            <p class="stat-note">
+              {ms(breakdown.total)} total: {ms(breakdown.parked)} waiting for the
+              snapshot, {ms(breakdown.wake)} actually waking
+            </p>
+          {:else if includedSnapshotWait(lastRun)}
+            <p class="stat-note">
+              this run waited for the snapshot to finish writing
+            </p>
+          {/if}
         {/if}
         <div class="stat-row">
           <span class="stat-name">query</span>

--- a/projects/monolith/frontend/src/lib/public/ember/console-retry.js
+++ b/projects/monolith/frontend/src/lib/public/ember/console-retry.js
@@ -29,6 +29,29 @@ export function includedSnapshotWait(body) {
 }
 
 /**
+ * Formats a parked_ms breakdown when it is present, or returns null.
+ * Returns an object { total, parked, wake } with millisecond values.
+ * Used when a measurement includes activator park time (snapshot wait).
+ * @param {object} body - the response body from POST /query
+ * @returns {object|null} - { total, parked, wake } or null if parked_ms absent
+ */
+export function parkedMsBreakdown(body) {
+  if (
+    !body ||
+    typeof body.parked_ms !== "number" ||
+    body.parked_ms === 0 ||
+    typeof body.wake_ms !== "number"
+  ) {
+    return null;
+  }
+  return {
+    total: body.parked_ms + body.wake_ms,
+    parked: body.parked_ms,
+    wake: body.wake_ms,
+  };
+}
+
+/**
  * Gates whether the next attempt starts, not the current attempt. Transient
  * failures are sub-second, such as in-band busy responses and mid-transition
  * refusals, so retries fit within the 6.5s delay window. A slow failure must

--- a/projects/monolith/frontend/src/lib/public/ember/console-retry.test.js
+++ b/projects/monolith/frontend/src/lib/public/ember/console-retry.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   classifyTier,
   includedSnapshotWait,
+  parkedMsBreakdown,
   phaseLabel,
   shouldRetry,
 } from "./console-retry.js";
@@ -60,6 +61,29 @@ describe("includedSnapshotWait", () => {
     [undefined, false],
   ])("returns %s for %s", (body, expected) => {
     expect(includedSnapshotWait(body)).toBe(expected);
+  });
+});
+
+describe("parkedMsBreakdown", () => {
+  it("returns a breakdown for valid data", () => {
+    expect(parkedMsBreakdown({ parked_ms: 300, wake_ms: 550 })).toEqual({
+      total: 850,
+      parked: 300,
+      wake: 550,
+    });
+  });
+
+  it.each([
+    [null, "missing body"],
+    [{}, "missing parked_ms"],
+    [{ parked_ms: 0, wake_ms: 10 }, "zero parked_ms"],
+    [{ parked_ms: 10 }, "missing wake_ms"],
+  ])("returns null for %s", (body) => {
+    expect(parkedMsBreakdown(body)).toBeNull();
+  });
+
+  it("calculates total as parked plus wake", () => {
+    expect(parkedMsBreakdown({ parked_ms: 125, wake_ms: 375 }).total).toBe(500);
   });
 });
 


### PR DESCRIPTION
Closes #4481. Follows #4479 (activator waits out a bank), #4480 (memfile 512 -> 150 MiB) and #4484 (console attribution).

## The problem

`connect_ms` is timed around the whole `psycopg.connect()`, so it includes time the connection sat parked in the activator waiting for an in-flight checkpoint to finish writing its memfile.

Measured on prod: `connect_ms: 5179.9`, `classification: transitional`, `phase_before: banking`. The wake was roughly **80 ms** (the abort/resume is ~107 microseconds per the Firecracker API log); the remaining ~5,100 ms was waiting for a 512 MiB write. #4484 made the console **attribute** that. This makes it **measurable**.

## How

- noded records the duration of each park that ended in the connection being **served** (splice/wake outcomes only, never timeouts or cancellations), plus a per-workload sequence that increments with it.
- Both ride NodeStatus on `StatefulVm` as additive fields (12, 13, 14).
- The control plane exposes them on `GET /v1/stateful/:name`.
- `POST /query` compares the sequence either side of the roundtrip and returns `parked_ms` plus a derived `wake_ms`.
- The console renders total / snapshot wait / actual wake, falling back to the plain attribution when unavailable.

## Why a sequence rather than timestamps

The first draft compared `time.Now()` on the **brick** against `time() * 1000` in the **monolith pod**, reconciled with 200 ms of slop on each side of a window often only ~900 ms wide. That makes the number a function of NTP skew between two hosts, and silently produces either missed or fabricated attributions.

Comparing a monotonic counter either side of the roundtrip proves a park completed inside our window **without either host agreeing about the time**, and the magic constant disappears rather than being tuned.

It still does not prove the park was *ours*: two visitors colliding on the same bank both observe one increment. So it stays best-effort, says so in the code, and the UI never presents it as exact. There is also a documented residual bias (the pre-query read is cached up to 500 ms, so the window can start slightly early), which biases toward over-attributing a wait we did not pay rather than hiding one we did.

## Reading discipline for the new fields

`Map.get` with a `positive_or_nil` guard, never dot access. proto3 scalars carry no presence, so a pre-#4481 daemon reports `0`, which must read as "never measured" rather than a real 0 ms, and an instance recorded before this shipped must degrade to null rather than raising `KeyError` on the entire status read. That last one was a genuine bug caught by CI, not a hypothetical.

## Verification

- `ci test`: `Executed 8 out of 756 tests: 756 tests pass`, and the Elixir suite `1201 tests, 0 failures, 6 skipped`.
- Warm-cache summaries prove nothing about a change (#4118), so all three changed targets were forced uncached: `ci test //projects/embervm/noded/server:server_test //projects/monolith:ember_public_router_test //projects/monolith/frontend:test -- --nocache_test_results` gives `Executed 3 out of 3 tests: 3 tests pass`.

## Note on timing

With #4480 shipped, a 10-gap collision sweep on prod now returns **10/10 clean relights at 8.4 to 18.9 ms with zero mid-bank hits**, so there is often no park to attribute at all. This is correctness for the case where a visitor does catch a bank, not a hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)