### PR TITLE
fix(platform): run apko locks on amd64

### DIFF
--- a/projects/platform/renovate/templates/apko-lock-script.yaml
+++ b/projects/platform/renovate/templates/apko-lock-script.yaml
@@ -34,8 +34,18 @@ data:
     git checkout -B "$branch"
 
     while IFS= read -r -d '' config; do
+      lock="${config%.yaml}.lock.json"
+      if [[ ! -f "$lock" ]]; then
+        echo "Skipping ${config}: no committed ${lock}"
+        continue
+      fi
       echo "Refreshing ${config}"
-      bazel run @rules_apko//apko -- lock "$config"
+      # The repository registers an ARM64 execution platform for OCaml. Force
+      # the local AMD64 platform first so rules_apko selects an executable that
+      # matches this workflow pod.
+      bazel run \
+        --extra_execution_platforms=//bazel/tools/platforms:linux_x86_64 \
+        @rules_apko//apko -- lock "$config"
     done < <(
       find projects buck2 -type f \( -name apko.yaml -o -name 'apko-*.yaml' \) -print0
     )


### PR DESCRIPTION
## Summary

- skip YAML files that match the apko naming convention but have no committed lock file
- prioritize the repository AMD64 execution platform so rules_apko selects a binary compatible with the workflow pod

## Live validation

A disposable pod using the deployed Renovate image successfully regenerated `buck2/examples/wolfi-hello/apko.lock.json` with the proposed execution-platform flag on an AMD64 cluster node. The probe pod was deleted afterward.

This fixes the two failures observed in the first manual apko maintenance run.