### PR TITLE
chore(deps): update actions/checkout digest

### DIFF
--- a/.github/workflows/update-semgrep-pro.yaml
+++ b/.github/workflows/update-semgrep-pro.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4


### PR DESCRIPTION
## Summary

Updates the pinned actions/checkout v4 digest to the current official v4 commit. This replaces the dashboard update Renovate could not push because its token cannot modify workflow files.

## Verification

- Repository lint hooks pass
- Remote Linux pre-push test passes