### PR TITLE
fix(agents): resume Codex sessions after device login

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.494
+version: 0.285.495
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.494
+      targetRevision: 0.285.495
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from sqlmodel import Session
 
 from agent_sessions import model_family, store
-from agent_sessions.codex_login import codex_login_gate
+from agent_sessions.codex_login import codex_login_gate, watch_for_login
 from agent_sessions.mcp import (
     _load_session_row,
     _persist_pending_message,
@@ -34,9 +34,6 @@ async def start_session_for_thread(
     if repo is not None and repo not in REPO_CATALOG:
         raise ValueError(f"unknown repo {repo}; catalog: {', '.join(REPO_CATALOG)}")
     model_family(model)
-    login = await codex_login_gate(model)
-    if login is not None:
-        return login
     row = await asyncio.to_thread(
         _persist_session,
         str(uuid4()),
@@ -47,6 +44,17 @@ async def start_session_for_thread(
         discord_thread=thread_id,
     )
     await asyncio.to_thread(_persist_pending_message, row.id, prompt, model)
+    login = await codex_login_gate(model)
+    if login is not None:
+        # Keep the thread binding and original prompt durable while the owner
+        # approves the device code. The watcher starts this exact pending turn
+        # once the broker reports granted.
+        async def resume() -> None:
+            await asyncio.to_thread(_set_session_status, row.id, "running")
+            _schedule_next_message(row.id)
+
+        watch_for_login(login.get("grant", "codex-cluster"), resume)
+        return login
     _schedule_next_message(row.id)
     return row.id
 

--- a/projects/monolith/agent_sessions/codex_login.py
+++ b/projects/monolith/agent_sessions/codex_login.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 
 import httpx
 
@@ -11,6 +13,10 @@ from agent_sessions import mcp
 
 _DEFAULT_GRANT = mcp._DEFAULT_GRANT
 logger = logging.getLogger(__name__)
+
+_LOGIN_POLL_INTERVAL = 5
+_LOGIN_TIMEOUT = 15 * 60
+_login_watch_tasks: set[asyncio.Task] = set()
 
 
 async def codex_login_gate(
@@ -67,3 +73,38 @@ async def codex_login_gate(
         "grant": grant,
         "message": "Approve the Codex login in your browser within about 15 minutes.",
     }
+
+
+def watch_for_login(grant: str, on_granted: Callable[[], Awaitable[None]]) -> None:
+    """Run a single approval watcher and invoke ``on_granted`` once.
+
+    The device flow belongs to the broker, so callers that had to pause a
+    session need a small bridge from the broker's eventual state change back to
+    their pending work. Keep the task strongly referenced until it finishes.
+    """
+
+    async def wait() -> None:
+        deadline = asyncio.get_running_loop().time() + _LOGIN_TIMEOUT
+        while asyncio.get_running_loop().time() < deadline:
+            try:
+                status = await mcp._broker_request(
+                    "GET", f"/grants/{grant}/login/status"
+                )
+            except Exception as exc:
+                logger.warning("Could not poll Codex login status: %s", exc)
+            else:
+                state = status.get("state")
+                if state == "granted":
+                    await on_granted()
+                    return
+                if state == "failed":
+                    logger.error("Codex broker login failed: %s", status.get("detail"))
+                    return
+            await asyncio.sleep(_LOGIN_POLL_INTERVAL)
+
+    task = asyncio.create_task(wait())
+    _login_watch_tasks.add(task)
+    task.add_done_callback(_login_watch_tasks.discard)
+    task.add_done_callback(
+        lambda done: done.exception() if not done.cancelled() else None
+    )

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from sqlmodel import Session, func, select
 
 from agent_sessions import model_family, store
-from agent_sessions.codex_login import codex_login_gate
+from agent_sessions.codex_login import codex_login_gate, watch_for_login
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.mcp import (
     _clear_ember_bindings_for,
@@ -295,9 +295,6 @@ async def start_session(request: StartRequest) -> dict:
         model_family(request.model)
     except ValueError as exc:
         return {"accepted": False, "error": str(exc)}
-    login = await codex_login_gate(request.model)
-    if login is not None:
-        return {"accepted": False, **login}
     row = await asyncio.to_thread(
         _persist_session,
         str(uuid4()),
@@ -311,6 +308,15 @@ async def start_session(request: StartRequest) -> dict:
     )
     # Queued from the UI, so its result does not get echoed to Discord.
     _mark_ui_originated(row.id, turn)
+    login = await codex_login_gate(request.model)
+    if login is not None:
+
+        async def resume() -> None:
+            await asyncio.to_thread(_set_session_status, row.id, "running")
+            _schedule_next_message(row.id)
+
+        watch_for_login(login.get("grant", "codex-cluster"), resume)
+        return {"accepted": False, **login, "session_id": row.id, "turn": turn}
     _schedule_next_message(row.id)
     return {"accepted": True, "session_id": row.id, "turn": turn}
 

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -644,8 +644,11 @@ def test_router_start_non_codex_models_enqueue_without_broker(
     assert calls == []
 
 
-def test_router_start_codex_login_required_does_not_enqueue(client, monkeypatch):
+def test_router_start_codex_login_required_preserves_session_and_watches(
+    client, session, monkeypatch
+):
     calls = []
+    watched = []
 
     async def broker_request(method, path):
         calls.append((method, path))
@@ -656,7 +659,19 @@ def test_router_start_codex_login_required_does_not_enqueue(client, monkeypatch)
     monkeypatch.setattr(mcp, "_broker_request", broker_request)
     monkeypatch.setattr(
         "agent_sessions.router._persist_session",
-        lambda *args, **kwargs: pytest.fail("login-required session was persisted"),
+        lambda local, workspace, branch, model, repo: store.create_session(
+            session, local, workspace, branch, model, repo
+        ),
+    )
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_pending_message",
+        lambda session_id, prompt, model: (
+            store.create_pending_message(session, session_id, prompt, model).seq
+        ),
+    )
+    monkeypatch.setattr(
+        "agent_sessions.router.watch_for_login",
+        lambda grant, callback: watched.append((grant, callback)),
     )
 
     body = client.post(
@@ -667,6 +682,11 @@ def test_router_start_codex_login_required_does_not_enqueue(client, monkeypatch)
     assert body["login_required"] is True
     assert body["verification_url"] == "https://example.test"
     assert body["user_code"] == "CODE"
+    assert body["session_id"]
+    assert body["turn"] == 1
+    row = store.get_session(session, body["session_id"])
+    assert row.discord_thread is None
+    assert watched and watched[0][0] == "codex-cluster"
     assert calls == [
         ("GET", "/grants/codex-cluster/login/status"),
         ("POST", "/grants/codex-cluster/login/start"),

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.494
+version: 0.285.495
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.494
+      targetRevision: 0.285.495
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Persist the agent session and original prompt before Codex device login completes.
- Poll broker login status and resume the pending turn after approval.
- Apply the same behavior to the /agents API path.
- Add regression coverage for login-required session preservation.

## Validation

- Repository commit hooks passed, including changed-file lint and remote CI pre-push checks.
- Focused pytest collection was blocked locally because `pydantic_ai` is not installed.