### PR TITLE
fix(monolith): surface hikes map init failure instead of a blank map

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.528
+version: 0.285.529
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.528
+      targetRevision: 0.285.529
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.528
+version: 0.285.529
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.528
+      targetRevision: 0.285.529
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/hikes/HikesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/hikes/HikesMap.svelte
@@ -77,6 +77,12 @@
   // uuid -> walk row, so a marker click can recover the full record.
   const index = new Map();
 
+  // Map init failed: either the (~1 MB) maplibre chunk did not load or the
+  // browser refused a WebGL context. The map is the only view of the walks, so
+  // without this the page renders its controls over a blank rectangle and a
+  // dead map is indistinguishable from a slow one.
+  let mapError = $state(false);
+
   let selected = $state(null); // selected walk (light list row), or null
   // The light corpus omits summary + hourly windows; the card fetches them per
   // walk on selection from /app/hikes/walk/{uuid}. detail = {summary, windows}.
@@ -254,7 +260,6 @@
   });
 
   onMount(() => {
-    let cleanup = () => {};
     let destroyed = false;
 
     (async () => {
@@ -359,25 +364,38 @@
           }
         }
       });
+    })().catch((err) => {
+      // Rejects if the maplibre chunk failed to load or the Map constructor
+      // threw, which it does when the browser hands out no WebGL context.
+      // Unhandled, both leave the container blank forever with nothing logged.
+      // Errors raised later from map event callbacks are outside this chain.
+      if (destroyed) return;
+      console.error("hikes map failed to initialise", err);
+      mapError = true;
+    });
 
-      cleanup = () => {
-        index.clear();
-        map?.remove();
-        map = null;
-        layerReady = false;
-        lastFitKey = null;
-      };
-    })();
-
+    // Teardown runs whether or not init got far enough to build the map, so a
+    // throw partway through cannot strand a live map instance.
     return () => {
       destroyed = true;
-      cleanup();
+      index.clear();
+      map?.remove();
+      map = null;
+      layerReady = false;
+      lastFitKey = null;
     };
   });
 </script>
 
 <div class="map-wrap" class:panel-open={selected}>
   <div class="map" bind:this={mapContainer}></div>
+
+  {#if mapError}
+    <p class="map-error" role="status">
+      The map could not be loaded. It needs WebGL, which some browsers restrict.
+      Try reloading, or open this page in another browser.
+    </p>
+  {/if}
 
   {#if selected}
     <aside class="card">
@@ -461,13 +479,16 @@
     </aside>
   {/if}
 
-  <!-- Effort legend: the colour ramp that tints the markers. -->
-  <div class="legend">
-    <span class="legend-title">Effort</span>
-    <span class="legend-bar" aria-hidden="true"></span>
-    <span class="legend-ends"><span>Gentle</span><span>Strenuous</span></span>
-    <span class="legend-note">distance + ascent + time</span>
-  </div>
+  <!-- Effort legend: the colour ramp that tints the markers. Pointless next to
+       a map that never came up, so it goes with it. -->
+  {#if !mapError}
+    <div class="legend">
+      <span class="legend-title">Effort</span>
+      <span class="legend-bar" aria-hidden="true"></span>
+      <span class="legend-ends"><span>Gentle</span><span>Strenuous</span></span>
+      <span class="legend-note">distance + ascent + time</span>
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -547,6 +568,25 @@
   .map :global(.maplibregl-ctrl-attrib-inner) {
     font-family: var(--mono);
     font-size: 10px;
+  }
+
+  /* Map-failed notice: centred in the dead map area, same paper/ink treatment
+     as the legend and card so it reads as part of the page, not a crash. */
+  .map-error {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 3;
+    max-width: min(320px, calc(100% - 32px));
+    padding: 14px 16px;
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    font-family: var(--mono);
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--ink);
+    text-align: center;
   }
 
   /* Walk detail card: a hard-shadow paper card (neobrutalist), top-right and


### PR DESCRIPTION
## What

`HikesMap` initialised maplibre in an unguarded async IIFE inside `onMount`:

```js
(async () => {
  maplibregl = (await import("maplibre-gl")).default;
  map = new maplibregl.Map({ ... });
})();
```

Nothing catches that chain. A rejected `import("maplibre-gl")` (the chunk is ~1 MB) or a throw from the `Map` constructor (which is what happens when the browser hands out no WebGL context) became an unhandled rejection. `map.on("load")` never fired, `layerReady` stayed false, and since the map is the only view of the walks, the page rendered its controls and stats over a blank rectangle with nothing logged. A dead map was indistinguishable from a slow one.

This PR catches the init chain, logs the error, and renders a fallback notice in the dead map area. The effort legend is dropped when there is no map for it to explain. Teardown moves out of the deferred `cleanup` binding into the returned destructor, so a throw partway through init can no longer strand a live map instance.

## Why this, and what it is not

This came out of the Firefox on iOS report. It is **not** a confirmed root-cause fix, and it is worth being explicit about that.

What the investigation did establish, by computing the module closures of the shipped bundle from jomcgi.dev:

- The eager `/app/*` shell is 15 modules; the `/app/hikes` route including the lazy maplibre chunk is 23. The highest feature floor in either is **Safari 15.4** (`Object.hasOwn`, `.at(n)`).
- The Safari 16.4 features present in the build (class static blocks, regex lookbehind) are all inside Mermaid, on a different route's lazy chunk. Not in the shell, not on the hikes path.

So any device new enough to run a current Firefox for iOS is already well past the floor, and the `es2022` build target is **not** the cause. That rules out downlevelling the build, which was the leading hypothesis and would have been a plausible but wrong fix to ship.

That leaves browser policy or a runtime failure, and WebGL context acquisition under Firefox iOS's WKWebView is the most likely candidate. This PR does not fix that. It makes it visible: the next report comes with a message on screen and a `console.error` instead of a blank rectangle.

Live reproduction was not possible from the session that wrote this. Chromium could not reach the network through the agent proxy (`ERR_CONNECTION_RESET` at the origin TLS handshake), and spoofing a Firefox iOS UA in Chromium would not have exercised WebKit anyway.

## Scope note

The same unprotected init pattern exists in all six map components (`TripMap`, `DayMap`, `HikesMap`, `CampsitesMap`, `StarsMap`, `ShipsMap`). Only `HikesMap` is changed here, since that is the page under investigation. Whether to fix the other five one by one or extract a shared init helper is a design call worth making deliberately rather than folding into this PR.

## Public tier checklist

`/app/hikes` is served by the public origin, so `docs/runbooks/public-tier-checklist.md` applies.

- public_reader grants: N/A, no schema or query changes
- No `/api` on the public origin: N/A, no fetch added. The existing per-walk fetch already goes through the same-origin `+server.js` proxy route
- gazelle-exclude vs the public binary: N/A, no new imports
- is_global / visibility filtering: N/A, no queries
- **Both charts bumped**: yes, `monolith` and `monolith-public` to **0.285.529** via `bump-chart.sh`, against main at 0.285.528
- Post-deploy verification: still to do, `curl -sS -o /dev/null -w '%{http_code}\n' https://jomcgi.dev/app/hikes` once merged and rolled out, plus confirming the deployed chart version actually moved

## Verification

`ci` was unavailable in the authoring session (no `codex`, `bazel`, or `ci` on PATH), so this leans on PR CI. Checked locally against pinned versions after every rebase:

- Svelte 5 compile of the edited component: clean, 0 warnings, including no unused-CSS warning for the new rule
- Prettier: clean, and the only reformat it ever wanted was one blank line inside the new code, which confirms no unrelated churn

Copy for the fallback notice is a first draft and yours to finalise.

## Chart bump history, and a warning

The bump on this PR has been silently dropped and restored **five times** (0.285.492 → 495 → 496 → 497 → 529). Each time the mechanism is identical: main lands its own monolith chart bump while this PR is open, and the next branch update discards this PR's bump as `patch contents already upstream`.

It is silent, not loud. At `ae27ce2` this PR was carrying **only** the `.svelte` file with auto-merge armed, which would have merged green and never deployed. The `pr-workflow` skill already names the hazard: "two PRs claiming the same chart version means the loser's bump is silently dropped."

**Before merging, confirm `git diff origin/main...HEAD` still lists 5 files, not 1.**

The durable fix would be a CI guard asserting that any PR touching `projects/<svc>/` carries a chart version strictly greater than main's, turning a silent non-deploy into a red check.