### PR TITLE
fix(stars): bound materializer memory

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.491
+version: 0.285.492
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.491
+      targetRevision: 0.285.492
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.491
+version: 0.285.492
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -243,15 +243,15 @@ jobs:
       # met.no day without ever overlapping the next run (Forbid + 3h schedule).
       activeDeadlineSeconds: 2700
       suspend: false
-      # 512Mi is comfortable now that the refresh fetches + persists in batches
-      # (stars/jobs.py REFRESH_BATCH_SIZE) instead of holding the whole ~14k-site
-      # grid in memory at once, which OOMed this pod.
+      # Refresh fetches + persists in batches, while materialization uses scalar
+      # columns instead of ORM hydration. Keep a 1GiB ceiling as headroom for
+      # the full ~14k-site snapshot and JSON serialization.
       resources:
         requests:
           cpu: 250m
-          memory: 512Mi
+          memory: 1Gi
         limits:
-          memory: 512Mi
+          memory: 1Gi
     - name: knowledge-repo-docs-reconcile
       replaces: knowledge.repo_docs_reconcile
       args: ["knowledge-repo-docs-reconcile"]

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.491
+      targetRevision: 0.285.492
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/stars/router.py
+++ b/projects/monolith/stars/router.py
@@ -156,21 +156,37 @@ def _build_sites_from_db(
 
     # Static site metadata, keyed by site id, joined into each row group at read
     # time. Sourced from the stars.sites table (light-pollution grid, ADR 006).
-    by_id = {site.id: site for site in session.exec(select(Site)).all()}
+    by_id = {
+        site.id: site
+        for site in session.exec(
+            select(
+                Site.id, Site.name, Site.lat, Site.lon, Site.altitude_m, Site.lp_zone
+            )
+        ).all()
+    }
 
     # Read-time correctness filter: only hours at or after the current clock
     # hour. The prune job is best-effort housekeeping; the endpoint must not
     # trust the table to be already pruned.
-    rows = session.exec(select(SiteHour).where(SiteHour.hour_time >= cutoff)).all()
+    rows = session.exec(
+        select(
+            SiteHour.site_id,
+            SiteHour.hour_time,
+            SiteHour.cloud_area_fraction,
+            SiteHour.sun_elevation_deg,
+            SiteHour.fetched_at,
+        ).where(SiteHour.hour_time >= cutoff)
+    ).all()
 
-    by_site: dict[str, list[SiteHour]] = {}
+    # Keep only the five scalar fields needed by the response. The previous
+    # implementation hydrated ~340k SQLModel objects, which OOM-killed both the
+    # web pod and the 512 MiB materializer job.
+    by_site: dict[str, list[tuple[datetime, float, float]]] = {}
     max_fetched: datetime | None = None
-    for row in rows:
-        if row.fetched_at is not None and (
-            max_fetched is None or row.fetched_at > max_fetched
-        ):
-            max_fetched = row.fetched_at
-        by_site.setdefault(row.site_id, []).append(row)
+    for site_id, hour_time, cloud, sun, fetched_at in rows:
+        if fetched_at is not None and (max_fetched is None or fetched_at > max_fetched):
+            max_fetched = fetched_at
+        by_site.setdefault(site_id, []).append((hour_time, cloud, sun))
 
     # Track, across all sites, whether any site has a true-dark hour (sun < -12,
     # cloud-independent) and whether any kept hour exists at all (< -10). These
@@ -198,12 +214,9 @@ def _build_sites_from_db(
         # always >= the dark count. In a normal (dark) night they are equal; only
         # in the midsummer no-true-dark window does twilight exceed dark.
         clear_twilight = [
-            h
-            for h in hours
-            if is_twilight_hour(h.sun_elevation_deg)
-            and h.cloud_area_fraction < CLEAR_CLOUD_MAX_PCT
+            h for h in hours if is_twilight_hour(h[2]) and h[1] < CLEAR_CLOUD_MAX_PCT
         ]
-        clear_hours = [h for h in clear_twilight if is_dark_hour(h.sun_elevation_deg)]
+        clear_hours = [h for h in clear_twilight if is_dark_hour(h[2])]
         clear_dark_hours = len(clear_hours)
         clear_twilight_hours = len(clear_twilight)
 
@@ -212,9 +225,9 @@ def _build_sites_from_db(
         # twilight) at all tonight" is a sky-geometry question, not a cloud one.
         # Every kept row is already below the -10 floor, but check explicitly so
         # the mode stays correct even against unexpected rows.
-        if any(is_dark_hour(h.sun_elevation_deg) for h in hours):
+        if any(is_dark_hour(h[2]) for h in hours):
             any_dark_hour = True
-        if any(is_twilight_hour(h.sun_elevation_deg) for h in hours):
+        if any(is_twilight_hour(h[2]) for h in hours):
             any_twilight_hour = True
 
         # The site's upcoming clear windows in chronological order, capped at
@@ -228,11 +241,11 @@ def _build_sites_from_db(
         # headlines above carry the magnitudes.
         best_hours = [
             {
-                "time": _iso(h.hour_time),
-                "cloud_area_fraction": h.cloud_area_fraction,
-                "dark": is_dark_hour(h.sun_elevation_deg),
+                "time": _iso(h[0]),
+                "cloud_area_fraction": h[1],
+                "dark": is_dark_hour(h[2]),
             }
-            for h in sorted(clear_twilight, key=lambda h: h.hour_time)[:_DISPLAY_HOURS]
+            for h in sorted(clear_twilight, key=lambda h: h[0])[:_DISPLAY_HOURS]
         ]
         sites.append(
             {


### PR DESCRIPTION
## Summary
- replace SiteHour ORM hydration with scalar forecast columns for materialization
- raise the stars refresh/materialization workflow memory ceiling to 1GiB

## Validation
- `pytest -q projects/monolith/stars/router_test.py projects/monolith/stars/health_test.py`
- repository lint hooks pass

This follows the materializer OOM after the initial stars deployment.