### PR TITLE
fix(signoz): pin the gRPC OTLP exporter after k8s-infra 0.16.0 flipped it

### DIFF
--- a/projects/platform/signoz/Chart.yaml
+++ b/projects/platform/signoz/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: signoz
 description: A Helm chart wrapper for SigNoz
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.135.1"
 dependencies:
   - name: signoz

--- a/projects/platform/signoz/values.yaml
+++ b/projects/platform/signoz/values.yaml
@@ -8,3 +8,28 @@ k8s-infra:
   presets:
     prometheus:
       enabled: true
+    # Pin the gRPC OTLP exporter. k8s-infra 0.16.0 flipped BOTH of these
+    # defaults (otlpExporter true->false, otlphttpExporter false->true), which
+    # swaps every pipeline's exporter from "otlp" to "otlphttp". The two take
+    # different endpoint syntax: otlp takes a bare host:port, otlphttp needs a
+    # full URL with a scheme. otelCollectorEndpoint above is a bare host:port
+    # on 4317 (the gRPC port), so under otlphttp every export failed with
+    # `unsupported protocol scheme` and the agents silently dropped all logs
+    # and metrics while still reporting Ready. It also crashlooped the
+    # otel-deployment, because our metrics/scraper pipeline in values-prod.yaml
+    # names the otlp exporter and the chart prepends its own, leaving a
+    # reference to an exporter that was no longer defined.
+    #
+    # Set BOTH. The chart applies its exporter block only under
+    # `if or presets.otlpExporter.enabled presets.otlphttpExporter.enabled`,
+    # so pinning otlphttpExporter to false alone disables the block entirely
+    # and renders a collector with NO exporters and no logs pipeline.
+    #
+    # Moving to otlphttp requires changing otelCollectorEndpoint to
+    # http://signoz-otel-collector.signoz.svc.cluster.local:4318 in the same
+    # change, and dropping the hardcoded exporter name in values-prod.yaml.
+    # See #4536.
+    otlpExporter:
+      enabled: true
+    otlphttpExporter:
+      enabled: false


### PR DESCRIPTION
Fixes #4536. The signoz app has been Degraded since `02bb85fa3` merged at 08:06Z, and the damage is wider than that issue first recorded.

## Cause

k8s-infra 0.16.0 flipped **both** exporter preset defaults:

| preset | 0.15.0 | 0.16.0 |
|---|---|---|
| `presets.otlpExporter.enabled` | `true` | `false` |
| `presets.otlphttpExporter.enabled` | `false` | `true` |

That swaps every collector pipeline from the `otlp` exporter to `otlphttp`. The two take different endpoint syntax: `otlp` takes a bare `host:port`, `otlphttp` needs a full URL with a scheme. Our `otelCollectorEndpoint` is a bare `host:port` on 4317, the gRPC port.

## Two failures, one loud and one silent

**Silent, and the worse of the two.** All four otel-agents start cleanly, report Ready, and then fail every export:

```
failed to make an HTTP request: Post "signoz-otel-collector.signoz.svc.cluster.local:4317/v1/logs":
unsupported protocol scheme "signoz-otel-collector.signoz.svc.cluster.local"
```

Total telemetry loss for roughly 11 hours with no alert, because the pods stayed Ready the whole time.

**Loud.** The otel-deployment crashlooped 130+ times:

```
invalid configuration: service::pipelines::metrics/scraper: references exporter "otlp" which is not configured
```

Our `metrics/scraper` pipeline in `values-prod.yaml` names the `otlp` exporter, and the chart prepends its own, leaving a reference to an exporter that is no longer defined. The previous ReplicaSet kept serving, so the app read Degraded rather than down.

## Why both presets are set

The chart applies its exporter block only under:

```gotemplate
{{- if or .Values.presets.otlpExporter.enabled .Values.presets.otlphttpExporter.enabled }}
```

So pinning `otlphttpExporter: false` **alone** disables the block entirely and renders a collector with no exporters at all and no logs pipeline, which is worse than the bug. I caught that by rendering the first attempt rather than trusting the preset name, and the comment in `values.yaml` records it so the next person does not repeat it.

## Verification

The rendered `otel-agent` and `otel-deployment` collector configs are **byte-identical** to what k8s-infra 0.15.0 produced, so this restores the exact last-known-good configuration rather than approximating it:

```
$ diff <(render k8s-infra 0.15.0) <(render 0.16.0 + this fix)
IDENTICAL
```

Every pipeline exporter reference resolves:

```
signoz-k8s-infra-otel-agent       exporters: ['otlp']   logs/metrics/traces      ok
signoz-k8s-infra-otel-deployment  exporters: ['otlp']   logs/metrics/internal/metrics/scraper  ok
```

`Executed 1 out of 1 test: 1 test passes` with `--nocache_test_results` against `e6a386530`.

## Follow-up, not in this PR

Moving to `otlphttp` deliberately would mean changing `otelCollectorEndpoint` to `http://signoz-otel-collector.signoz.svc.cluster.local:4318` and dropping the hardcoded exporter name from `values-prod.yaml`. That is a real choice worth making on purpose, not by inheriting a flipped upstream default. Noted in the values comment.