### PR TITLE
fix(stars): configure refresh S3 environment

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.493
+version: 0.285.494
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.493
+      targetRevision: 0.285.494
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.493
+version: 0.285.494
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -238,6 +238,7 @@ jobs:
       args: ["stars-refresh"]
       schedule: "0 */3 * * *" # every 3h (was 10800s)
       concurrencyPolicy: Forbid
+      s3: true # refresh also materializes the compact sites snapshot to S3
       # ~14k met.no fetches at the ~15 req/s courtesy rate is ~15-18 min; the
       # highest external fanout in the registry. 45 min gives headroom for a slow
       # met.no day without ever overlapping the next run (Forbid + 3h schedule).

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.493
+      targetRevision: 0.285.494
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Inject SeaweedFS S3 settings into the stars refresh CronWorkflow so the materializer can publish sites.json. Bump coupled charts.