### PR TITLE
fix(signoz): stop pinning the otlp exporter in the scraper pipeline

### DIFF
--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -206,8 +206,13 @@ k8s-infra:
               - k8sattributes
               - resourcedetection
               - batch
-            exporters:
-              - otlp
+            # No exporters key on purpose. The chart appends the exporter its
+            # presets render, so naming a transport here pins something upstream
+            # owns. k8s-infra 0.16.0 flipped presets.otlpExporter to false and
+            # otlphttpExporter to true, which left this list referencing an
+            # "otlp" exporter that no longer existed and crash-looped the
+            # collector. Omitting it follows whichever transport the chart
+            # enables.
 
 # signoz subchart configuration
 # NOTE: k8s-infra is a sibling subchart (not nested inside signoz). Configure


### PR DESCRIPTION
## What

The `k8s-infra` otel-deployment collector has been in `CrashLoopBackOff` since the
0.15.0 to 0.16.0 subchart bump landed: 138 restarts over 11 hours. Cluster infra
metrics (DCGM GPU, CNPG, Hubble, and both httpcheck synthetic probes) have been
dark that whole time.

```
Error: invalid configuration: service::pipelines::metrics/scraper:
       references exporter "otlp" which is not configured
```

## Why it broke

k8s-infra 0.16.0 flipped its exporter presets, moving the default transport from
OTLP gRPC to OTLP HTTP:

| preset | 0.15.0 | 0.16.0 |
|---|---|---|
| `presets.otlpExporter.enabled` | `true` | `false` |
| `presets.otlphttpExporter.enabled` | `false` | `true` |

We do not set either preset, so we inherit the new defaults and only `otlphttp`
gets rendered into the `exporters` block. But our `metrics/scraper` override
named `otlp` explicitly, and the chart **appends** the preset exporter rather
than replacing the list, so the pipeline rendered as `[otlphttp, otlp]` against
an exporters block defining only `otlphttp`. The collector refuses to start on a
pipeline referencing an undefined exporter.

The other two pipelines (`logs`, `metrics/internal`) never overrode `exporters`,
which is why only this one crashed.

## The fix

Drop the `exporters` key so the pipeline inherits whichever transport the
chart's presets enable, rather than pinning a transport name upstream owns.

## Verification

Rendered with `helm template` using both values files, as ArgoCD does:

```
exporters defined: ['otlphttp']
  logs:             exporters=['otlphttp']
  metrics/internal: exporters=['otlphttp']
  metrics/scraper:  exporters=['otlphttp']   <- was ['otlphttp', 'otlp']
RESULT: VALID - every pipeline exporter is defined, no duplicates
```

All six `metrics/scraper` receivers are preserved (`prometheus/dcgm`,
`prometheus/cnpg`, `prometheus/hubble`, `httpcheck/k8s-services`,
`httpcheck/cloudflare-pages`, `prometheus/scraper`).

## Why CI did not catch this

The `argocd_app` template test renders the collector config as an opaque string
inside a ConfigMap, and `helm_chart` sets `lint = False`. A change that is valid
YAML but an invalid collector config renders green. Worth a follow-up: run
`otelcol validate` over the rendered ConfigMap in the template test.

No chart bump: `projects/platform/signoz` is a `targetRevision: HEAD` git-path
source, so merge deploys directly and no image digests change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)