### PR TITLE
fix(authentik): configure external postgres connection

### DIFF
--- a/projects/platform/authentik/values.yaml
+++ b/projects/platform/authentik/values.yaml
@@ -11,7 +11,18 @@ authentik:
       user: authentik
       port: 5432
   global:
+    # authentik.existingSecret replaces the chart-generated configuration
+    # secret, so the PostgreSQL connection settings must be supplied here too.
+    # Without these values authentik falls back to localhost:5432.
     env:
+      - name: AUTHENTIK_POSTGRESQL__HOST
+        value: authentik-pg-rw
+      - name: AUTHENTIK_POSTGRESQL__NAME
+        value: authentik
+      - name: AUTHENTIK_POSTGRESQL__USER
+        value: authentik
+      - name: AUTHENTIK_POSTGRESQL__PORT
+        value: "5432"
       - name: AUTHENTIK_POSTGRESQL__PASSWORD
         valueFrom:
           secretKeyRef:
@@ -86,4 +97,3 @@ authentik:
           app.kubernetes.io/part-of: authentik
       spec:
         itemPath: vaults/k8s-homelab/items/authentik
-


### PR DESCRIPTION
## Summary

The initial authentik deployment used an existingSecret for AUTHENTIK_SECRET_KEY. The upstream chart ignores authentik.* values when an existing configuration Secret is selected, so server and worker fell back to localhost:5432.

This change explicitly supplies the PostgreSQL host, database, user, port, and generated CNPG password through AUTHENTIK_POSTGRESQL__ environment variables for both components.

## Validation

- helm lint projects/platform/authentik
- helm template with Kubernetes 1.33.0
- Confirmed all PostgreSQL environment variables render for server and worker
- git diff --check