### PR TITLE
feat(stars): materialize map snapshot

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.495
+version: 0.285.496
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -363,6 +363,8 @@ web:
       value: "sites.json"
     - name: STARS_MAP_S3_KEY
       value: "map.json"
+    - name: STARS_HISTORY_MAP_S3_KEY
+      value: "history-map.json"
     - name: ARTIFACTS_S3_BUCKET
       value: "artifacts"
   # CPU request is sized so the HPA's per-container CPU utilization is a

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -361,6 +361,8 @@ web:
       value: "stars"
     - name: STARS_SITES_S3_KEY
       value: "sites.json"
+    - name: STARS_MAP_S3_KEY
+      value: "map.json"
     - name: ARTIFACTS_S3_BUCKET
       value: "artifacts"
   # CPU request is sized so the HPA's per-container CPU utilization is a

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.495
+      targetRevision: 0.285.496
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.495
+version: 0.285.496
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -104,6 +104,8 @@ spec:
               value: {{ $.Values.stars.climatologyKey | quote }}
             - name: STARS_SITES_S3_KEY
               value: {{ $.Values.stars.sitesKey | quote }}
+            - name: STARS_MAP_S3_KEY
+              value: {{ $.Values.stars.mapKey | quote }}
             {{- end }}
             {{- if .changelog }}
             # chat.changelog needs the full config list (to look up the named

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -106,6 +106,8 @@ spec:
               value: {{ $.Values.stars.sitesKey | quote }}
             - name: STARS_MAP_S3_KEY
               value: {{ $.Values.stars.mapKey | quote }}
+            - name: STARS_HISTORY_MAP_S3_KEY
+              value: {{ $.Values.stars.historyMapKey | quote }}
             {{- end }}
             {{- if .changelog }}
             # chat.changelog needs the full config list (to look up the named

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1142,6 +1142,7 @@ stars:
   gridKey: "grid.json"
   climatologyKey: "climatology.json"
   sitesKey: "sites.json"
+  mapKey: "map.json"
   s3AccessKeyId: "duckdb"
   s3SecretAccessKey: "duckdb"
 

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1143,6 +1143,7 @@ stars:
   climatologyKey: "climatology.json"
   sitesKey: "sites.json"
   mapKey: "map.json"
+  historyMapKey: "history-map.json"
   s3AccessKeyId: "duckdb"
   s3SecretAccessKey: "duckdb"
 

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.495
+      targetRevision: 0.285.496
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -145,7 +145,7 @@
     historyLoading = true;
     historyError = false;
     try {
-      const res = await fetch(`/app/stars/history`);
+      const res = await fetch(`/app/stars/history-map`);
       if (!res.ok) throw new Error(`history ${res.status}`);
       const payload = await res.json();
       historyAllSites = payload.sites ?? [];
@@ -220,6 +220,13 @@
   let agoLabel = $derived(formatAgo(data.snapshot?.fetched_at, nowMs));
 
   onMount(() => {
+    // Warm the tiny historical visual payload after the live page has mounted.
+    // Historical mode then swaps instantly for most visitors without putting
+    // its request on the critical path.
+    const warmHistory = () => loadHistory();
+    const idle = window.requestIdleCallback
+      ? window.requestIdleCallback(warmHistory, { timeout: 2000 })
+      : window.setTimeout(warmHistory, 1000);
     // Live updates: re-run the SSR load every 30 min (the refresh job runs
     // 3-hourly). Same pattern as /app/hikes.
     const refresh = setInterval(() => {
@@ -231,6 +238,11 @@
     // sub-minute resolution.
     const clockTick = setInterval(() => (nowMs = Date.now()), 5 * 60_000);
     return () => {
+      if (window.cancelIdleCallback && typeof idle === "number") {
+        window.cancelIdleCallback(idle);
+      } else {
+        window.clearTimeout(idle);
+      }
       clearInterval(refresh);
       clearInterval(clockTick);
     };

--- a/projects/monolith/frontend/src/routes/public/app/stars/history-map/+server.js
+++ b/projects/monolith/frontend/src/routes/public/app/stars/history-map/+server.js
@@ -1,0 +1,14 @@
+import { error, json } from "@sveltejs/kit";
+import { STARS_HISTORY_CACHE_CONTROL } from "$lib/cache-headers.js";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+export async function GET({ fetch }) {
+  const res = await fetch(`${API_BASE}/api/stars/history-map`, {
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw error(503, "stars history map unavailable");
+  return json(await res.json(), {
+    headers: { "cache-control": STARS_HISTORY_CACHE_CONTROL },
+  });
+}

--- a/projects/monolith/frontend/src/routes/public/app/stars/map/+server.js
+++ b/projects/monolith/frontend/src/routes/public/app/stars/map/+server.js
@@ -1,0 +1,17 @@
+import { error, json } from "@sveltejs/kit";
+import { STARS_SITES_CACHE_CONTROL } from "$lib/cache-headers.js";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// Same-origin proxy for the map-only snapshot. The refresh job publishes this
+// separately from the detail payload so the map can start with coordinates and
+// headline scores instead of parsing every forecast window.
+export async function GET({ fetch }) {
+  const res = await fetch(`${API_BASE}/api/stars/map`, {
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw error(503, "stars map unavailable");
+  return json(await res.json(), {
+    headers: { "cache-control": STARS_SITES_CACHE_CONTROL },
+  });
+}

--- a/projects/monolith/stars/materialize.py
+++ b/projects/monolith/stars/materialize.py
@@ -22,6 +22,7 @@ def _materialize_sync() -> int:
     """Build and atomically replace the compact S3 payload."""
     bucket = os.environ.get("STARS_GRID_S3_BUCKET", "stars")
     key = os.environ.get("STARS_SITES_S3_KEY", "sites.json")
+    map_key = os.environ.get("STARS_MAP_S3_KEY", "map.json")
     request = SimpleNamespace(headers={})
     response = Response()
     with Session(get_engine()) as session:
@@ -29,10 +30,34 @@ def _materialize_sync() -> int:
     if not isinstance(payload, dict):
         raise RuntimeError("stars site builder returned a conditional response")
     body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    map_payload = {
+        "count": payload.get("count", 0),
+        "darkness": payload.get("darkness", "astronomical"),
+        "fetched_at": payload.get("fetched_at"),
+        "sites": [
+            {
+                "id": site["id"],
+                "name": site["name"],
+                "lat": site["lat"],
+                "lon": site["lon"],
+                "clear_dark_hours": site["clear_dark_hours"],
+                "clear_twilight_hours": site["clear_twilight_hours"],
+            }
+            for site in payload.get("sites", [])
+        ],
+    }
+    map_body = json.dumps(map_payload, separators=(",", ":")).encode("utf-8")
     _s3_client().put_object(
         Bucket=bucket,
         Key=key,
         Body=body,
+        ContentType="application/json",
+        CacheControl="public, max-age=0, s-maxage=1800, stale-if-error=86400",
+    )
+    _s3_client().put_object(
+        Bucket=bucket,
+        Key=map_key,
+        Body=map_body,
         ContentType="application/json",
         CacheControl="public, max-age=0, s-maxage=1800, stale-if-error=86400",
     )
@@ -42,6 +67,9 @@ def _materialize_sync() -> int:
         len(body),
         bucket,
         key,
+    )
+    logger.info(
+        "stars map materialized: %d bytes, s3://%s/%s", len(map_body), bucket, map_key
     )
     return len(body)
 

--- a/projects/monolith/stars/materialize.py
+++ b/projects/monolith/stars/materialize.py
@@ -13,7 +13,7 @@ from sqlmodel import Session
 
 from core.db import get_engine
 from stars.grid import _s3_client
-from stars.router import _build_sites_from_db
+from stars.router import _build_sites_from_db, get_history
 
 logger = logging.getLogger("monolith.stars.materialize")
 
@@ -27,6 +27,7 @@ def _materialize_sync() -> int:
     response = Response()
     with Session(get_engine()) as session:
         payload = _build_sites_from_db(request, response, session)
+        history_payload = get_history(request, response, session)
     if not isinstance(payload, dict):
         raise RuntimeError("stars site builder returned a conditional response")
     body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
@@ -47,12 +48,35 @@ def _materialize_sync() -> int:
         ],
     }
     map_body = json.dumps(map_payload, separators=(",", ":")).encode("utf-8")
+    history_map_payload = {
+        "sites": [
+            {
+                "id": site["id"],
+                "name": site["name"],
+                "lat": site["lat"],
+                "lon": site["lon"],
+                "clear": site["clear"],
+                "dark": site["dark"],
+            }
+            for site in history_payload.get("sites", [])
+        ]
+    }
+    history_map_body = json.dumps(history_map_payload, separators=(",", ":")).encode(
+        "utf-8"
+    )
     _s3_client().put_object(
         Bucket=bucket,
         Key=key,
         Body=body,
         ContentType="application/json",
         CacheControl="public, max-age=0, s-maxage=1800, stale-if-error=86400",
+    )
+    _s3_client().put_object(
+        Bucket=bucket,
+        Key=os.environ.get("STARS_HISTORY_MAP_S3_KEY", "history-map.json"),
+        Body=history_map_body,
+        ContentType="application/json",
+        CacheControl="public, max-age=0, s-maxage=31536000, stale-if-error=604800",
     )
     _s3_client().put_object(
         Bucket=bucket,
@@ -71,6 +95,7 @@ def _materialize_sync() -> int:
     logger.info(
         "stars map materialized: %d bytes, s3://%s/%s", len(map_body), bucket, map_key
     )
+    logger.info("stars history map materialized: %d bytes", len(history_map_body))
     return len(body)
 
 

--- a/projects/monolith/stars/router.py
+++ b/projects/monolith/stars/router.py
@@ -117,8 +117,27 @@ def get_sites(
     return Response(content=body, media_type="application/json", headers=headers)
 
 
+@router.get("/map")
+def get_map(request: Request):
+    """Serve the small map-only snapshot produced by the refresh job."""
+    try:
+        body, etag = _read_materialized_object("STARS_MAP_S3_KEY", "map.json")
+    except Exception as exc:  # noqa: BLE001 - turn storage failure into 503
+        logger.exception("stars map materialized payload unavailable")
+        raise HTTPException(status_code=503, detail="stars map unavailable") from exc
+    headers = {"Cache-Control": _SITES_CACHE_CONTROL, "ETag": etag}
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+    return Response(content=body, media_type="application/json", headers=headers)
+
+
 def _read_materialized_sites() -> tuple[bytes, str]:
     """Read the precomputed sites payload from SeaweedFS."""
+    return _read_materialized_object("STARS_SITES_S3_KEY", "sites.json")
+
+
+def _read_materialized_object(key_env: str, default_key: str) -> tuple[bytes, str]:
+    """Read one bounded materialized object from SeaweedFS."""
     endpoint = os.environ.get("SEAWEEDFS_S3_ENDPOINT", "").strip()
     if not endpoint:
         raise RuntimeError("SEAWEEDFS_S3_ENDPOINT is not configured")
@@ -127,7 +146,7 @@ def _read_materialized_sites() -> tuple[bytes, str]:
     from stars.grid import _s3_client
 
     bucket = os.environ.get("STARS_GRID_S3_BUCKET", "stars")
-    key = os.environ.get("STARS_SITES_S3_KEY", "sites.json")
+    key = os.environ.get(key_env, default_key)
     try:
         obj = _s3_client().get_object(Bucket=bucket, Key=key)
     except ClientError as exc:

--- a/projects/monolith/stars/router.py
+++ b/projects/monolith/stars/router.py
@@ -131,6 +131,24 @@ def get_map(request: Request):
     return Response(content=body, media_type="application/json", headers=headers)
 
 
+@router.get("/history-map")
+def get_history_map(request: Request):
+    """Serve the compact historical map snapshot produced by the refresh job."""
+    try:
+        body, etag = _read_materialized_object(
+            "STARS_HISTORY_MAP_S3_KEY", "history-map.json"
+        )
+    except Exception as exc:  # noqa: BLE001 - turn storage failure into 503
+        logger.exception("stars history map materialized payload unavailable")
+        raise HTTPException(
+            status_code=503, detail="stars history map unavailable"
+        ) from exc
+    headers = {"Cache-Control": _HISTORY_CACHE_CONTROL, "ETag": etag}
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+    return Response(content=body, media_type="application/json", headers=headers)
+
+
 def _read_materialized_sites() -> tuple[bytes, str]:
     """Read the precomputed sites payload from SeaweedFS."""
     return _read_materialized_object("STARS_SITES_S3_KEY", "sites.json")


### PR DESCRIPTION
Materialize a small map-only stars snapshot from the Argo refresh job, publish it beside sites.json, and expose a cacheable same-origin proxy. This establishes the separate critical-path artifact; frontend first-paint wiring can consume it independently from detail payloads.