### PR TITLE
feat(mcp): scoped friends route to a single empty virtual server

### DIFF
--- a/projects/mcp/context-forge-gateway/chart/templates/httproute-scoped.yaml
+++ b/projects/mcp/context-forge-gateway/chart/templates/httproute-scoped.yaml
@@ -1,0 +1,75 @@
+{{- /*
+Scoped HTTPRoutes: one hostname per trust tier, each reaching exactly ONE
+virtual server.
+
+The gateway's own /mcp endpoint serves the FULL tool catalogue and does not
+authenticate (MCP_REQUIRE_AUTH is false; only Cloudflare Access guards it at
+the edge). So a tier hostname must never route PathPrefix "/", or it inherits
+that endpoint. Each route below is an allowlist: two rules, nothing else, and
+every other path on the hostname finds no route and 404s at the gateway.
+
+This is deliberately scaffolding. Routing is a poor authorization mechanism:
+it cannot express "this principal gets servers A and B", it needs one route
+per server, and it bakes a runtime UUID into the chart. The durable shape is
+a single path-transparent route per tier with MCP_REQUIRE_AUTH on and
+Context Forge teams doing the scoping. Until then, an empty virtual server
+plus a one-path allowlist is safe by construction.
+*/}}
+{{- range .Values.scopedRoutes }}
+{{- if .enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "context-forge.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "context-forge.labels" $ | nindent 4 }}
+    ingress-tier: {{ .tier | default "public" }}
+spec:
+  parentRefs:
+    - name: {{ $.Values.httpRoute.gatewayRef.name }}
+      namespace: {{ $.Values.httpRoute.gatewayRef.namespace }}
+  hostnames:
+    - {{ .hostname | quote }}
+  rules:
+    # OAuth discovery. MCP clients fetch the protected-resource document to
+    # find the authorization server, so it must resolve on THIS hostname or
+    # the client cannot start the flow. Served unrewritten; these documents
+    # are public by design.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /.well-known/
+      filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Forwarded-Proto
+                value: https
+      backendRefs:
+        - name: {{ $.Release.Name }}-mcp-stack-mcpgateway
+          port: 80
+
+    # The tier's MCP endpoint, rewritten onto its single virtual server.
+    # ReplacePrefixMatch (not ReplaceFullPath) so any suffix the transport
+    # appends survives the rewrite.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mcp
+      filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Forwarded-Proto
+                value: https
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /servers/{{ .serverId }}/mcp
+      backendRefs:
+        - name: {{ $.Release.Name }}-mcp-stack-mcpgateway
+          port: 80
+{{- end }}
+{{- end }}

--- a/projects/mcp/context-forge-gateway/chart/values.yaml
+++ b/projects/mcp/context-forge-gateway/chart/values.yaml
@@ -101,6 +101,18 @@ httpRoute:
     name: cloudflare-ingress
     namespace: envoy-gateway-system
 
+# Per-tier hostnames, each scoped to exactly one virtual server. See
+# templates/httproute-scoped.yaml for why these must never route "/".
+# serverId is a Context Forge runtime object id, so a recreated virtual
+# server needs this value updated. That coupling is one of the reasons this
+# pattern does not scale past the experiment it was added for.
+scopedRoutes: []
+#  - name: friends
+#    enabled: true
+#    hostname: friends.jomcgi.dev
+#    tier: public
+#    serverId: "<virtual server uuid>"
+
 # Periodic tool-catalog refresh. CF does not auto-discover new monolith MCP
 # tools (its health-gated auto-refresh never fires for the SSE monolith gateway,
 # whose last_seen never advances under the streamablehttp health tick), so a

--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -43,3 +43,18 @@ secret:
 httpRoute:
   enabled: true
   hostname: mcp.jomcgi.dev
+
+# friends.jomcgi.dev reaches exactly one virtual server, "friends-empty",
+# which is deliberately empty: tools/list returns [] so the hostname exposes
+# nothing even though MCP_REQUIRE_AUTH is off and no Cloudflare Access
+# application covers it. It exists to test whether a Claude connector can
+# complete an OAuth flow against authentik, via the virtual server's own
+# oauth_enabled / oauth_config, without spending Zero Trust seats.
+#
+# Do not add tools to that virtual server while it is unauthenticated.
+scopedRoutes:
+  - name: friends
+    enabled: true
+    hostname: friends.jomcgi.dev
+    tier: public
+    serverId: "5853c9310afc49699c96be8608a99cb7"


### PR DESCRIPTION
## Summary

Adds `friends.jomcgi.dev` reaching exactly one Context Forge virtual server, so a Claude connector can be tested against authentik OAuth without consuming Cloudflare Zero Trust seats.

The virtual server `friends-empty` (`5853c931...`) already exists and is deliberately empty: `tools/list` returns `[]`.

## Why the route is an allowlist

The gateway's own `/mcp` endpoint serves all 57 tools and **does not authenticate**. `MCP_REQUIRE_AUTH` is `false`, so Cloudflare Access at the edge is its only guard. Verified from inside the cluster: an unauthenticated `tools/list` returns the full catalogue including `monolith-agent-session-destroy`, and `tools/call` reaches dispatch.

So a tier hostname must never route `PathPrefix: /`. This route has two rules and nothing else:

| Path | Behaviour |
|---|---|
| `/.well-known/` | passthrough, so the client can fetch protected-resource metadata |
| `/mcp` | `ReplacePrefixMatch` onto `/servers/<id>/mcp` |

Every other path on the hostname finds no route and 404s at the gateway.

## Validation

- `helm template` with both values files: both HTTPRoutes render, rewrite target correct
- `ci lint`, `ci test` green (`Executed 3 out of 738 tests: 738 tests pass`)
- `friends.jomcgi.dev` already resolves to Cloudflare; the tunnel catch-all already delivers it to the gateway, so no DNS or tunnel change is needed
- Empty virtual server confirmed to return `{"tools":[]}` unauthenticated

## Deploy note

`targetRevision: HEAD`, so this goes live on merge. That is safe here only because the target virtual server is empty. **Do not add tools to it while `MCP_REQUIRE_AUTH` is off.**

## Known limitation

Routing is a poor authorization mechanism: one route per server, a runtime UUID baked into the chart, and no way to express "this principal gets servers A and B". The durable shape is one path-transparent route per tier with `MCP_REQUIRE_AUTH` on and Context Forge teams scoping access. This is scaffolding for the experiment, and the template says so.

## Follow-ups (not in this PR)

- Root `/mcp` unauthenticated behind Cloudflare Access only
- Orphaned `mcp-oauth-proxy` Service and Secret, plus its dead NetworkPolicy allow rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)