### PR TITLE
fix(authentik): set X-Forwarded-Proto on the public route

### DIFF
--- a/projects/platform/authentik/values.yaml
+++ b/projects/platform/authentik/values.yaml
@@ -44,6 +44,20 @@ authentik:
         # Public login and OIDC discovery endpoint. Admin access remains an
         # authentik policy concern and friend applications are separate routes.
         enabled: true
+        # Cloudflare terminates TLS and the tunnel forwards plain HTTP to the
+        # gateway, whose listener is HTTP:80. Without this header authentik
+        # believes it is serving over HTTP and generates http:// URLs, so the
+        # browser blocks its own API calls from the https:// page as mixed
+        # content. The login page renders and then fails with "The request
+        # failed and the interceptors did not return an alternative response",
+        # and nothing reaches the pod, because the request is never sent.
+        # cf-ingress-library routes carry the same header for the same reason.
+        filters:
+          - type: RequestHeaderModifier
+            requestHeaderModifier:
+              set:
+                - name: X-Forwarded-Proto
+                  value: https
         hostnames:
           - auth.jomcgi.dev
         parentRefs:


### PR DESCRIPTION
## Symptom

`https://auth.jomcgi.dev` renders the login page and then fails with "The request failed and the interceptors did not return an alternative response".

## Cause

Cloudflare terminates TLS and the tunnel forwards plain HTTP to the gateway, whose listener is `HTTP:80`. The route added in #4548 sets no `X-Forwarded-Proto`, so authentik believes it is serving over HTTP and generates `http://` URLs. The page is on `https://`, so the browser blocks authentik's own API calls as mixed content.

Confirmed from the access log rather than inferred:

```
23:17:18  302  GET /                                        scheme=http  host=auth.jomcgi.dev
23:17:18  302  GET /flows/-/default/authentication/?next=/  scheme=http  host=auth.jomcgi.dev
23:17:18  200  GET /if/flow/default-authentication-flow/    scheme=http  host=auth.jomcgi.dev
                (no executor call follows, from any client)
```

The page loads, and the follow-up `/api/v3/flows/executor/...` never reaches the pod, because the browser refuses to send it. `scheme=http` on a request that arrived over HTTPS is the tell.

## Fix

Add the same `RequestHeaderModifier` the cf-ingress routes already carry. The upstream chart's `server.route.main` supports `filters`, so this is values-only.

## Validation

- `helm template`: route renders with the filter, backend and hostname unchanged
- `ci lint`, `ci test` green (`Executed 2 out of 738 tests: 738 tests pass`)

`targetRevision: HEAD`, so this deploys on merge.

## Note

`/ws/client/` also appears in the log with no status. Envoy should upgrade it transparently; worth re-checking after this lands, since a broken websocket only degrades live updates rather than blocking login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)