### PR TITLE
feat(mcp): enforce OAuth on the MCP endpoint

### DIFF
--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -5,6 +5,23 @@ mcp-stack:
       MCPGATEWAY_UI_ENABLED: "true"
       MCPGATEWAY_CATALOG_ENABLED: "true"
       MCPGATEWAY_TOOL_CANCELLATION_ENABLED: "true"
+    secret:
+      # Enforce OAuth on the MCP endpoint itself. Until now the JSON-RPC
+      # endpoint authenticated nobody: an unauthenticated tools/list returned
+      # all 57 tools, including monolith-agent-session-destroy, and tools/call
+      # reached dispatch. Only Cloudflare Access stood in front of it, so the
+      # protection was a property of one ingress path rather than of the
+      # gateway. The REST endpoints (/admin, /tools) already returned 401.
+      #
+      # This is also what makes a virtual server's oauth_enabled meaningful:
+      # that flag only PUBLISHES protected-resource metadata. Without
+      # enforcement the endpoint answers 200 with no WWW-Authenticate, so no
+      # client ever begins an OAuth flow.
+      #
+      # Note this is gateway-wide, not per server. mcp.jomcgi.dev tokens are
+      # issued by jomcgi.cloudflareaccess.com and DCR_ALLOWED_ISSUERS is empty,
+      # so that path may need its issuer trusted once validation is enforced.
+      MCP_REQUIRE_AUTH: "true"
     probes:
       startup:
         type: exec


### PR DESCRIPTION
## What

Sets `MCP_REQUIRE_AUTH: "true"` on the Context Forge gateway.

## Why

The MCP JSON-RPC endpoint authenticated nobody. Verified from inside the cluster with no credentials:

- `tools/list` returned **all 57 tools**, including `monolith-agent-session-destroy`
- `tools/call` reached dispatch (a nonexistent tool answers "Tool not found", not "unauthorized")
- `/admin` and `/tools` already returned 401, so the gap was specific to `/mcp`

Cloudflare Access was its only guard, which made the protection a property of one ingress path rather than of the gateway.

It also blocks the friends experiment. A virtual server's `oauth_enabled` only **publishes** protected-resource metadata; without enforcement the endpoint answers 200 with no `WWW-Authenticate`, so no client ever begins an OAuth flow. `friends.jomcgi.dev` currently advertises authentik as its authorization server and is still reachable anonymously.

## Risk, accepted deliberately

The setting is gateway-wide. `mcp.jomcgi.dev` presents tokens issued by `jomcgi.cloudflareaccess.com` and `DCR_ALLOWED_ISSUERS` is `[]`, so that connector may break once tokens are actually validated. Revert is a values change on a `HEAD` chart, so seconds. If enforcement works, the intent is to cut the existing path over to the same model.

## Deploy note

The gateway pod template has **no secret checksum annotation**, and the config arrives via `envFrom`. So syncing this does not restart anything: a manual rollout is required before the setting takes effect.

## Validation

- `helm template`: rendered secret carries `MCP_REQUIRE_AUTH: "true"`
- `ci lint`, `ci test` green (values-only; no bazel target reads these)

🤖 Generated with [Claude Code](https://claude.com/claude-code)