### PR TITLE
fix(mcp): allow cluster CIDRs through Context Forge SSRF protection

### DIFF
--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -6,6 +6,12 @@ mcp-stack:
       MCPGATEWAY_CATALOG_ENABLED: "true"
       MCPGATEWAY_TOOL_CANCELLATION_ENABLED: "true"
     secret:
+      # 1.0.x enables SSRF protection by default and blocks RFC 1918
+      # destinations, which rejects gateway registration for any in-cluster
+      # MCP server with `loc=('body','url') type=value_error`. Allow only the
+      # k3s pod and service CIDRs rather than flipping
+      # SSRF_ALLOW_PRIVATE_NETWORKS, so RFC 1918 stays blocked everywhere else.
+      SSRF_ALLOWED_NETWORKS: '["10.42.0.0/16", "10.43.0.0/16"]'
       # Enforce OAuth on the MCP endpoint itself. Until now the JSON-RPC
       # endpoint authenticated nobody: an unauthenticated tools/list returned
       # all 57 tools, including monolith-agent-session-destroy, and tools/call


### PR DESCRIPTION
## Problem

After the 1.0.7 rebuild, the `monolith` gateway could not be re-registered, leaving `mcp.jomcgi.dev` with no backend.

The API returns a masked `422 {"detail":"An error occurred, please try again."}`. The real cause is only in the gateway log:

```
Request validation error on /gateways: 1 error(s): [loc=('body','url') type=value_error]
```

1.0.x ships SSRF protection enabled with `ssrf_allow_private_networks: false`, so RFC 1918 destinations are rejected. The monolith service is `10.43.x.x`, so every in-cluster registration fails.

## Fix

Allowlist the k3s pod and service CIDRs only, rather than flipping `SSRF_ALLOW_PRIVATE_NETWORKS`. RFC 1918 stays blocked everywhere else, so the protection keeps its value against tool URLs pointing at the rest of the LAN.

## Validation

`helm template` renders the key; `ci lint` clean. Post-merge: restart, register the gateway, confirm the catalogue repopulates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)