### PR TITLE
feat(mcp): serve RFC 9728 discovery for the root MCP endpoint

### DIFF
--- a/projects/mcp/context-forge-gateway/chart/templates/httproute.yaml
+++ b/projects/mcp/context-forge-gateway/chart/templates/httproute.yaml
@@ -1,4 +1,49 @@
 {{- if .Values.httpRoute.enabled }}
+{{- if .Values.httpRoute.rootMcp.enabled }}
+{{- /*
+RFC 9728 discovery for the ROOT /mcp endpoint, served by Envoy.
+
+Context Forge implements protected-resource metadata ONLY per virtual server:
+  /.well-known/oauth-protected-resource/mcp  -> 404 "Expected: .../servers/{id}/mcp"
+  /.well-known/oauth-protected-resource      -> 404 "deprecated"
+and the root /mcp 401 carries a bare `WWW-Authenticate: Bearer` with no
+`resource_metadata` parameter. An MCP client therefore has no way to discover
+the authorization server, and dead-ends on the 401 no matter how it is routed.
+
+So Envoy supplies the two missing pieces: this document, and the pointer to it
+(the ResponseHeaderModifier on the /mcp rule below). Context Forge still does
+the actual token validation, via an sso_providers row with
+trusted_for_api_auth=true, and still filters the tool list per caller from
+tools.visibility / tools.team_id. Nothing here grants access; it only tells the
+client where to go and get a token.
+
+`resource` MUST equal the URL clients actually connect to, because RFC 9728
+clients compare it against the endpoint they are talking to. That is why this
+is a static document rather than a rewrite onto a virtual-server path: under a
+rewrite Context Forge would publish /servers/<uuid>/mcp while the client
+connected to /mcp, and the two would disagree.
+*/}}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: {{ include "context-forge.fullname" . }}-root-resource-metadata
+  labels:
+    {{- include "context-forge.labels" . | nindent 4 }}
+spec:
+  directResponse:
+    contentType: application/json
+    statusCode: 200
+    body:
+      type: Inline
+      inline: |
+        {{- $meta := dict
+              "resource" (printf "https://%s/mcp" .Values.httpRoute.hostname)
+              "authorization_servers" (list .Values.httpRoute.rootMcp.authorizationServer)
+              "bearer_methods_supported" (list "header")
+              "scopes_supported" .Values.httpRoute.rootMcp.scopes }}
+        {{ toJson $meta }}
+---
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -12,6 +57,49 @@ spec:
   hostnames:
     - {{ .Values.httpRoute.hostname | quote }}
   rules:
+    {{- if .Values.httpRoute.rootMcp.enabled }}
+    # Discovery document for the root MCP endpoint. Exact match, so it wins over
+    # both the /mcp prefix and the catch-all regardless of rule ordering.
+    # Cloudflare Access must bypass this path or the client never reaches it.
+    - matches:
+        - path:
+            type: Exact
+            value: /.well-known/oauth-protected-resource/mcp
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.envoyproxy.io
+            kind: HTTPRouteFilter
+            name: {{ include "context-forge.fullname" . }}-root-resource-metadata
+
+    # The root MCP endpoint. The ResponseHeaderModifier replaces Context Forge's
+    # bare `WWW-Authenticate: Bearer` with one carrying the resource_metadata
+    # pointer, which is what makes discovery work without the client having to
+    # guess the well-known path. It is set on every response from this rule,
+    # including 200s; clients ignore the header on success.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mcp
+      filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Forwarded-Proto
+                value: https
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: WWW-Authenticate
+                value: >-
+                  Bearer resource_metadata="https://{{ .Values.httpRoute.hostname }}/.well-known/oauth-protected-resource/mcp"
+      backendRefs:
+        - name: context-forge-gateway-mcp-stack-mcpgateway
+          port: 80
+    {{- end }}
+
+    # Everything else: admin UI, REST API, static assets. Stays behind the
+    # hostname-wide Cloudflare Access application.
     - matches:
         - path:
             type: PathPrefix

--- a/projects/mcp/context-forge-gateway/chart/values.yaml
+++ b/projects/mcp/context-forge-gateway/chart/values.yaml
@@ -122,6 +122,30 @@ httpRoute:
   gatewayRef:
     name: cloudflare-ingress
     namespace: envoy-gateway-system
+  # RFC 9728 discovery for the ROOT /mcp endpoint, so one central endpoint can
+  # serve every caller and Context Forge filters the tool list per identity
+  # (tools.visibility + tools.team_id) instead of per URL. Context Forge only
+  # publishes protected-resource metadata for virtual servers, so Envoy serves
+  # the document and injects the pointer. See templates/httproute.yaml.
+  #
+  # Requires, and is useless without, all three of:
+  #   1. a Cloudflare Access application over `<hostname>/mcp` and
+  #      `<hostname>/.well-known/oauth-protected-resource` with a Bypass policy,
+  #      or the client is challenged at the edge and never reaches Envoy;
+  #   2. an sso_providers row in Context Forge with trusted_for_api_auth=true,
+  #      issuer matching authorizationServer, and api_audience set to the
+  #      authentik client_id (authentik mints `aud` = client_id, ignoring
+  #      RFC 8707 `resource`);
+  #   3. tools carrying visibility=team and a team_id, otherwise every
+  #      authenticated caller sees the whole catalogue.
+  rootMcp:
+    enabled: false
+    # OIDC issuer URL, with trailing slash, exactly as the token's `iss` claim.
+    authorizationServer: ""
+    scopes:
+      - openid
+      - profile
+      - email
 
 # Per-tier hostnames, each scoped to exactly one virtual server. See
 # templates/httproute-scoped.yaml for why these must never route "/".

--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -79,6 +79,15 @@ secret:
 httpRoute:
   enabled: true
   hostname: mcp.jomcgi.dev
+  # One central MCP endpoint at mcp.jomcgi.dev/mcp, authenticated by authentik
+  # and filtered per identity by Context Forge, rather than a virtual server
+  # (and therefore a UUID) per trust tier. A Cloudflare Access application with
+  # a Bypass policy covers /mcp and /.well-known/oauth-protected-resource; the
+  # hostname-wide application still guards /admin, /tools and /gateways, so the
+  # control plane keeps its edge layer while the data plane uses OAuth.
+  rootMcp:
+    enabled: true
+    authorizationServer: https://auth.jomcgi.dev/application/o/mcp-friends/
 
 # friends.jomcgi.dev reaches exactly one virtual server, "friends-empty",
 # which is deliberately empty: tools/list returns [] so the hostname exposes

--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -16,6 +16,16 @@ mcp-stack:
       # envFrom order is [secret, configMap, secret], so a value set only in
       # the first secret is shadowed by the ConfigMap default of "[]".
       SSRF_ALLOWED_NETWORKS: '["10.42.0.0/16", "10.43.0.0/16"]'
+      # Mounts the /auth/sso router, which is the only way to manage the
+      # sso_providers row that makes authentik a trusted issuer for the root
+      # /mcp endpoint. Defaults to false, and while false the admin API 404s.
+      #
+      # This does NOT gate the auth path itself: verify_credentials.py resolves
+      # the trusted provider straight from the table, so tokens would validate
+      # either way. It gates router mounting (main.py) and the browser SSO flow
+      # only. Those endpoints live outside the Cloudflare Access bypass, so they
+      # stay behind Access on mcp.jomcgi.dev.
+      SSO_ENABLED: "true"
     secret:
       # Enforce OAuth on the MCP endpoint itself. Until now the JSON-RPC
       # endpoint authenticated nobody: an unauthenticated tools/list returned

--- a/projects/mcp/context-forge-gateway/scripts/provision-mcp-auth.sh
+++ b/projects/mcp/context-forge-gateway/scripts/provision-mcp-auth.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Provision the runtime half of root-endpoint MCP auth.
+#
+# The chart gives Envoy the RFC 9728 discovery document. This gives Context
+# Forge the three database objects that make the resulting token mean something:
+#
+#   1. a team, which is what tool entitlements hang off;
+#   2. an sso_providers row with trusted_for_api_auth=true, so a bearer token
+#      from authentik is accepted at the ROOT /mcp endpoint rather than only on
+#      a virtual server;
+#   3. team_mapping, so an authentik group name becomes membership of that team
+#      at provisioning time. Membership is then read from the database, never
+#      from token claims (see verify_credentials: token_use="session" resolves
+#      via resolve_session_teams, not normalize_token_teams).
+#
+# None of this is in Git otherwise: Context Forge keeps it in Postgres, and that
+# database was rebuilt from scratch once already. Re-running this restores it.
+#
+# Idempotent: every step is create-or-update, so it is safe to run repeatedly
+# and safe to run after a database rebuild.
+#
+# Usage: ./provision-mcp-auth.sh
+set -euo pipefail
+
+NS=mcp
+TEAM_NAME=${TEAM_NAME:-homelab-admin}
+# The authentik group whose members should land in TEAM_NAME. Created by the
+# authentik blueprint, not by this script.
+AUTHENTIK_GROUP=${AUTHENTIK_GROUP:-homelab-admin}
+ISSUER=${ISSUER:-https://auth.jomcgi.dev/application/o/mcp-friends/}
+AUTHENTIK_BASE=${AUTHENTIK_BASE:-https://auth.jomcgi.dev}
+# authentik mints `aud` = client_id and ignores the RFC 8707 `resource`
+# parameter, so the audience Context Forge must expect IS the client id.
+CLIENT_ID=${CLIENT_ID:?set CLIENT_ID to the authentik OAuth2 provider client id}
+ADMIN_EMAIL=${ADMIN_EMAIL:-joe@jomcgi.dev}
+
+POD=$(kubectl get pod -n "$NS" -l app=context-forge-gateway-mcp-stack-mcpgateway \
+  -o jsonpath='{.items[0].metadata.name}')
+[ -n "$POD" ] || { echo "no gateway pod found" >&2; exit 1; }
+echo "gateway pod: $POD"
+
+# Short-lived admin JWT, minted inside the pod so the signing key never leaves it.
+run() { kubectl exec -n "$NS" "$POD" -- sh -c "$1"; }
+run "cd /app && python3 -m mcpgateway.utils.create_jwt_token -u '$ADMIN_EMAIL' --admin -e 10 2>/dev/null | tail -1 > /tmp/.pv_tok"
+trap 'kubectl exec -n "$NS" "$POD" -- rm -f /tmp/.pv_tok /tmp/.pv_body >/dev/null 2>&1 || true' EXIT
+
+api() { # api METHOD PATH [JSON]
+  local method=$1 path=$2 body=${3:-}
+  if [ -n "$body" ]; then
+    local b64
+    b64=$(printf '%s' "$body" | base64 | tr -d '\n')
+    run "echo '$b64' | base64 -d > /tmp/.pv_body && curl -sS -X $method \
+      -H \"Authorization: Bearer \$(cat /tmp/.pv_tok)\" -H 'Content-Type: application/json' \
+      --data @/tmp/.pv_body http://localhost:4444$path"
+  else
+    run "curl -sS -X $method -H \"Authorization: Bearer \$(cat /tmp/.pv_tok)\" http://localhost:4444$path"
+  fi
+}
+
+# ── 1. Team ────────────────────────────────────────────────────────────────
+TEAM_ID=$(api GET /teams/ | python3 -c "
+import json,sys
+teams=json.load(sys.stdin)
+teams=teams.get('teams', teams) if isinstance(teams, dict) else teams
+print(next((t['id'] for t in teams if t.get('name')=='$TEAM_NAME'), ''))
+")
+if [ -z "$TEAM_ID" ]; then
+  TEAM_ID=$(api POST /teams/ "{\"name\":\"$TEAM_NAME\",\"description\":\"Full monolith catalogue. Mapped from the authentik group of the same name.\",\"visibility\":\"private\"}" \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+  echo "created team $TEAM_NAME -> $TEAM_ID"
+else
+  echo "team $TEAM_NAME already exists -> $TEAM_ID"
+fi
+
+# ── 2. Trusted external IdP ────────────────────────────────────────────────
+# client_secret is required by the request schema but unused on the API-auth
+# path: the provider is a PUBLIC client (PKCE, no secret), and this row exists
+# so Context Forge can verify signatures via jwks_uri, not to start a flow.
+read -r -d '' PROVIDER <<JSON || true
+{
+  "id": "authentik",
+  "name": "authentik",
+  "display_name": "authentik",
+  "provider_type": "oidc",
+  "client_id": "$CLIENT_ID",
+  "client_secret": "",
+  "authorization_url": "$AUTHENTIK_BASE/application/o/authorize/",
+  "token_url": "$AUTHENTIK_BASE/application/o/token/",
+  "userinfo_url": "$AUTHENTIK_BASE/application/o/userinfo/",
+  "issuer": "$ISSUER",
+  "jwks_uri": "${ISSUER}jwks/",
+  "scope": "openid profile email",
+  "auto_create_users": true,
+  "trusted_for_api_auth": true,
+  "api_audience": "$CLIENT_ID",
+  "team_mapping": {"$AUTHENTIK_GROUP": "$TEAM_ID"}
+}
+JSON
+
+if api GET /auth/sso/admin/providers/authentik | grep -q '"id"'; then
+  api PUT /auth/sso/admin/providers/authentik "$PROVIDER" >/dev/null
+  echo "updated sso provider 'authentik'"
+else
+  api POST /auth/sso/admin/providers "$PROVIDER" >/dev/null
+  echo "created sso provider 'authentik'"
+fi
+
+echo
+echo "── resulting sso_providers row ──"
+kubectl exec -n "$NS" context-forge-pg-1 -- psql -U postgres -d mcpgateway -x \
+  -c "select name, issuer, api_audience, trusted_for_api_auth, team_mapping from sso_providers;" 2>/dev/null \
+  | grep -v '^Defaulted' || true

--- a/projects/mcp/context-forge-gateway/scripts/provision-mcp-auth.sh
+++ b/projects/mcp/context-forge-gateway/scripts/provision-mcp-auth.sh
@@ -35,8 +35,11 @@ CLIENT_ID=${CLIENT_ID:?set CLIENT_ID to the authentik OAuth2 provider client id}
 ADMIN_EMAIL=${ADMIN_EMAIL:-joe@jomcgi.dev}
 
 POD=$(kubectl get pod -n "$NS" -l app=context-forge-gateway-mcp-stack-mcpgateway \
-  -o jsonpath='{.items[0].metadata.name}')
-[ -n "$POD" ] || { echo "no gateway pod found" >&2; exit 1; }
+	-o jsonpath='{.items[0].metadata.name}')
+[ -n "$POD" ] || {
+	echo "no gateway pod found" >&2
+	exit 1
+}
 echo "gateway pod: $POD"
 
 # Short-lived admin JWT, minted inside the pod so the signing key never leaves it.
@@ -45,16 +48,16 @@ run "cd /app && python3 -m mcpgateway.utils.create_jwt_token -u '$ADMIN_EMAIL' -
 trap 'kubectl exec -n "$NS" "$POD" -- rm -f /tmp/.pv_tok /tmp/.pv_body >/dev/null 2>&1 || true' EXIT
 
 api() { # api METHOD PATH [JSON]
-  local method=$1 path=$2 body=${3:-}
-  if [ -n "$body" ]; then
-    local b64
-    b64=$(printf '%s' "$body" | base64 | tr -d '\n')
-    run "echo '$b64' | base64 -d > /tmp/.pv_body && curl -sS -X $method \
+	local method=$1 path=$2 body=${3:-}
+	if [ -n "$body" ]; then
+		local b64
+		b64=$(printf '%s' "$body" | base64 | tr -d '\n')
+		run "echo '$b64' | base64 -d > /tmp/.pv_body && curl -sS -X $method \
       -H \"Authorization: Bearer \$(cat /tmp/.pv_tok)\" -H 'Content-Type: application/json' \
       --data @/tmp/.pv_body http://localhost:4444$path"
-  else
-    run "curl -sS -X $method -H \"Authorization: Bearer \$(cat /tmp/.pv_tok)\" http://localhost:4444$path"
-  fi
+	else
+		run "curl -sS -X $method -H \"Authorization: Bearer \$(cat /tmp/.pv_tok)\" http://localhost:4444$path"
+	fi
 }
 
 # ── 1. Team ────────────────────────────────────────────────────────────────
@@ -65,11 +68,11 @@ teams=teams.get('teams', teams) if isinstance(teams, dict) else teams
 print(next((t['id'] for t in teams if t.get('name')=='$TEAM_NAME'), ''))
 ")
 if [ -z "$TEAM_ID" ]; then
-  TEAM_ID=$(api POST /teams/ "{\"name\":\"$TEAM_NAME\",\"description\":\"Full monolith catalogue. Mapped from the authentik group of the same name.\",\"visibility\":\"private\"}" \
-    | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
-  echo "created team $TEAM_NAME -> $TEAM_ID"
+	TEAM_ID=$(api POST /teams/ "{\"name\":\"$TEAM_NAME\",\"description\":\"Full monolith catalogue. Mapped from the authentik group of the same name.\",\"visibility\":\"private\"}" |
+		python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+	echo "created team $TEAM_NAME -> $TEAM_ID"
 else
-  echo "team $TEAM_NAME already exists -> $TEAM_ID"
+	echo "team $TEAM_NAME already exists -> $TEAM_ID"
 fi
 
 # ── 2. Trusted external IdP ────────────────────────────────────────────────
@@ -98,15 +101,15 @@ read -r -d '' PROVIDER <<JSON || true
 JSON
 
 if api GET /auth/sso/admin/providers/authentik | grep -q '"id"'; then
-  api PUT /auth/sso/admin/providers/authentik "$PROVIDER" >/dev/null
-  echo "updated sso provider 'authentik'"
+	api PUT /auth/sso/admin/providers/authentik "$PROVIDER" >/dev/null
+	echo "updated sso provider 'authentik'"
 else
-  api POST /auth/sso/admin/providers "$PROVIDER" >/dev/null
-  echo "created sso provider 'authentik'"
+	api POST /auth/sso/admin/providers "$PROVIDER" >/dev/null
+	echo "created sso provider 'authentik'"
 fi
 
 echo
 echo "── resulting sso_providers row ──"
 kubectl exec -n "$NS" context-forge-pg-1 -- psql -U postgres -d mcpgateway -x \
-  -c "select name, issuer, api_audience, trusted_for_api_auth, team_mapping from sso_providers;" 2>/dev/null \
-  | grep -v '^Defaulted' || true
+	-c "select name, issuer, api_audience, trusted_for_api_auth, team_mapping from sso_providers;" 2>/dev/null |
+	grep -v '^Defaulted' || true


### PR DESCRIPTION
## Why

Context Forge publishes protected-resource metadata **only per virtual server**. Verified against the running gateway:

```
/.well-known/oauth-protected-resource/mcp  -> 404 "Expected: .../servers/{server_id}/mcp"
/.well-known/oauth-protected-resource      -> 404 "deprecated and non-compliant with RFC 9728"
/.well-known/oauth-authorization-server    -> 404 Not found
POST /mcp/                                 -> 401, WWW-Authenticate: Bearer   (bare, no pointer)
```

So a client pointed at `mcp.jomcgi.dev/mcp` has no way to learn where to authenticate, and dead-ends on the 401. The only working shape was a virtual-server URL, which forces a UUID per trust tier into the chart and couples a Git-managed route to a regenerated database id.

## What

Envoy supplies the two pieces Context Forge will not:

- an `HTTPRouteFilter` direct response serving the metadata document at `/.well-known/oauth-protected-resource/mcp`
- a `ResponseHeaderModifier` on the `/mcp` rule putting `resource_metadata` into `WWW-Authenticate`

Context Forge still validates the token and still filters the tool list per caller, so this grants nothing. It only tells clients where to get a token.

The payoff is that entitlements become `tools.visibility` + `tools.team_id` on one central endpoint, rather than a separate URL per tier.

## Verification

Rendered and parsed:

```json
{"resource": "https://mcp.jomcgi.dev/mcp",
 "authorization_servers": ["https://auth.jomcgi.dev/application/o/mcp-friends/"],
 "bearer_methods_supported": ["header"],
 "scopes_supported": ["openid", "profile", "email"]}
```

Rule precedence renders as Exact `/.well-known/oauth-protected-resource/mcp` -> PathPrefix `/mcp` -> PathPrefix `/`, and the direct-response rule correctly carries zero `backendRefs`.

`resource` deliberately equals the URL clients connect to. A rewrite onto a virtual-server path would make Context Forge publish `/servers/<uuid>/mcp` while the client connected to `/mcp`, and RFC 9728 clients compare those.

## Not included, required before this does anything

1. Cloudflare Access Bypass application over `mcp.jomcgi.dev/mcp` and `/.well-known/oauth-protected-resource` (**already created**, verified: those paths now return Context Forge's own 401/404 while `/admin` and `/tools` still return `server: cloudflare`).
2. An `sso_providers` row with `trusted_for_api_auth=true`, `issuer` matching `authorizationServer`, and `api_audience` set to the authentik `client_id` (authentik mints `aud` = client_id and ignores RFC 8707 `resource`).
3. Tools tagged `visibility=team` with a `team_id`. Until then every authenticated caller sees the whole catalogue.

## Deploy note

`projects/mcp/context-forge-gateway` is `targetRevision: HEAD` on a git path, so **merging deploys immediately** and no chart version bump is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39