### PR TITLE
feat(authentik): declare MCP group, application gate and MFA as a blueprint

### DIFF
--- a/projects/platform/authentik/blueprints/mcp-auth.yaml
+++ b/projects/platform/authentik/blueprints/mcp-auth.yaml
@@ -1,0 +1,70 @@
+version: 1
+metadata:
+  name: homelab - MCP auth
+  labels:
+    blueprints.goauthentik.io/description: |
+      Group, application gate and MFA enforcement for the central MCP endpoint.
+      Context Forge maps the group name below onto one of its teams via the
+      sso_providers team_mapping, and filters the tool catalogue from team
+      membership, so this group is the thing that decides who sees which tools.
+entries:
+  # ── 1. The group entitlements hang off ──────────────────────────────────
+  # The name is load-bearing: it must match the key in Context Forge's
+  # sso_providers.team_mapping, because authentik emits group NAMES (not ids)
+  # in the `groups` claim of the default profile scope.
+  - model: authentik_core.group
+    id: homelab-admin
+    identifiers:
+      name: homelab-admin
+    attrs:
+      is_superuser: false
+
+  # ── 2. Membership ───────────────────────────────────────────────────────
+  # `attrs` REPLACES a many-to-many rather than merging into it, so the
+  # existing "authentik Admins" membership has to be restated here or applying
+  # this blueprint would silently strip it and lock the only human account out
+  # of the authentik admin interface.
+  - model: authentik_core.user
+    identifiers:
+      username: akadmin
+    attrs:
+      groups:
+        - !Find [authentik_core.group, [name, authentik Admins]]
+        - !KeyOf homelab-admin
+
+  # ── 3. Gate the MCP application ─────────────────────────────────────────
+  # Until this exists the application has ZERO policy bindings, which in
+  # authentik means every authenticated account may authorize it. That was
+  # tolerable while akadmin was the only human account and the virtual servers
+  # were empty; it is not once the catalogue is attached.
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !Find [authentik_core.application, [slug, mcp-friends]]
+      group: !KeyOf homelab-admin
+      order: 0
+    attrs:
+      enabled: true
+      negate: false
+      timeout: 30
+
+  # ── 4. Make the existing MFA stage actually enforce ─────────────────────
+  # authentik's own default-authentication-flow blueprint already creates and
+  # binds `default-authentication-mfa-validation`, but with no attrs at all, so
+  # it sits at the model default `not_configured_action: skip`. A user with no
+  # registered device passes straight through: the stage is present and
+  # enforces nothing.
+  #
+  # `configure` is deliberate over `deny`: it enrols a device inline on first
+  # login instead of locking out an account that has none yet. Recovery if
+  # WebAuthn enrolment misbehaves is `kubectl exec ... -- ak shell`, which is
+  # how the akadmin password was fixed earlier.
+  - model: authentik_stages_authenticator_validate.authenticatorvalidatestage
+    identifiers:
+      name: default-authentication-mfa-validation
+    attrs:
+      not_configured_action: configure
+      configuration_stages:
+        - !Find [
+            authentik_stages_authenticator_webauthn.authenticatorwebauthnstage,
+            [name, default-authenticator-webauthn-setup],
+          ]

--- a/projects/platform/authentik/templates/blueprints-configmap.yaml
+++ b/projects/platform/authentik/templates/blueprints-configmap.yaml
@@ -1,0 +1,24 @@
+{{- /*
+Custom authentik blueprints, mounted from a ConfigMap.
+
+The upstream chart discovers and applies every key ending in `.yaml` from each
+ConfigMap listed under `authentik.blueprints.configMaps`, so the files in
+../blueprints/ are the reviewable source of truth and authentik's worker
+reconciles them. That is the declarative alternative to clicking through the
+admin UI, and it survives a database rebuild the way clicked config does not.
+
+Blueprint entries match on `identifiers`, so re-application is idempotent and a
+re-applied entry updates in place rather than creating duplicates.
+*/}}
+{{- $files := .Files.Glob "blueprints/*.yaml" }}
+{{- if $files }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-mcp-blueprints
+  labels:
+    app.kubernetes.io/name: authentik
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{ ($files.AsConfig) | indent 2 }}
+{{- end }}

--- a/projects/platform/authentik/values.yaml
+++ b/projects/platform/authentik/values.yaml
@@ -2,6 +2,13 @@
 # requires Ember's object-authorization matrix to land before SSO is admitted.
 
 authentik:
+  # Custom blueprints from ../blueprints/, rendered into a ConfigMap by
+  # templates/blueprints-configmap.yaml. The chart discovers every key ending
+  # in `.yaml` and authentik's worker applies them, so groups, policy bindings
+  # and stage configuration are reviewable in Git rather than clicked.
+  blueprints:
+    configMaps:
+      - authentik-mcp-blueprints
   authentik:
     existingSecret:
       secretName: authentik-secrets


### PR DESCRIPTION
Companion to #4557. That PR makes the root MCP endpoint discoverable and trusts authentik as an issuer; this one creates the thing entitlements actually hang off, and closes two gaps that are live right now.

## Three problems, all currently true in production

**1. The `mcp-friends` application has zero policy bindings.**

```
RESULT_APPS [('mcp-friends', 0)]
```

In authentik that means *every* authenticated account may authorize it. Bounded today only by there being one human account:

```
RESULT_USERS [('AnonymousUser', True), ('ak-outpost-…', True), ('akadmin', True)]
```

Not acceptable once the 57-tool catalogue is attached.

**2. No group exists for entitlements.** Context Forge maps a group **name** onto one of its teams via `sso_providers.team_mapping`, and filters the tool catalogue from team membership. authentik emits group names (not ids) in the `groups` claim of the default `profile` scope, which Claude already requests. So the name here is load-bearing and must match the mapping key.

**3. MFA is present and enforces nothing.** authentik's own `flow-default-authentication-flow.yaml` creates and binds the stage with **no `attrs` at all**:

```yaml
- identifiers:
    name: default-authentication-mfa-validation
  model: authentik_stages_authenticator_validate.authenticatorvalidatestage
```

which leaves it at the model default:

```python
not_configured_action = models.TextField(choices=NotConfiguredAction.choices,
                                         default=NotConfiguredAction.SKIP)
```

An account with no registered device passes straight through a flow that looks MFA-protected. This sets it to `configure`, chosen over `deny` so a device is enrolled inline rather than locking out an account that has none yet.

## Why blueprints rather than a script

authentik applies them natively and the upstream chart mounts them from a ConfigMap, so these become Git state its own worker reconciles. Verified rendering: the ConfigMap is produced and the **worker** deployment mounts it as `blueprints-cm-authentik-mcp-blueprints`. Entries match on `identifiers`, so re-application updates in place and is safe to repeat.

## The sharp edge

`attrs` **replaces** a many-to-many rather than merging into it, so the `authentik Admins` membership is restated explicitly. Omitting it would strip the only human account's admin access on apply.

## Risk and recovery

The MFA change takes effect on next login and will prompt for WebAuthn enrolment. If that misbehaves, recovery is `kubectl exec -n authentik <pod> -- ak shell`, which is how the akadmin password was fixed earlier tonight. If you would rather land the group and the policy binding first and do MFA separately, drop the fourth entry from `blueprints/mcp-auth.yaml` before merging.

`projects/platform/*` is `targetRevision: HEAD`, so **merging applies this immediately**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39