### PR TITLE
fix(mcp): make the provisioning script fail loudly instead of silently

### DIFF
--- a/projects/mcp/context-forge-gateway/scripts/provision-mcp-auth.sh
+++ b/projects/mcp/context-forge-gateway/scripts/provision-mcp-auth.sh
@@ -19,7 +19,15 @@
 # Idempotent: every step is create-or-update, so it is safe to run repeatedly
 # and safe to run after a database rebuild.
 #
-# Usage: ./provision-mcp-auth.sh
+# PREREQUISITE: the running pod must have SSO_ENABLED=true, which mounts the
+# /auth/sso router. Setting it in deploy/values.yaml is NOT enough on its own:
+# it lands in the gateway ConfigMap, the mcp-stack chart puts no checksum
+# annotation on the pod template, so nothing rolls the pod and the process keeps
+# the old value. `kubectl rollout status` still reports success, because the
+# deployment really is at its desired state. This script asserts the live value
+# rather than trusting the manifest.
+#
+# Usage: CLIENT_ID=<authentik client id> ./provision-mcp-auth.sh
 set -euo pipefail
 
 NS=mcp
@@ -34,46 +42,74 @@ AUTHENTIK_BASE=${AUTHENTIK_BASE:-https://auth.jomcgi.dev}
 CLIENT_ID=${CLIENT_ID:?set CLIENT_ID to the authentik OAuth2 provider client id}
 ADMIN_EMAIL=${ADMIN_EMAIL:-joe@jomcgi.dev}
 
-POD=$(kubectl get pod -n "$NS" -l app=context-forge-gateway-mcp-stack-mcpgateway \
-	-o jsonpath='{.items[0].metadata.name}')
-[ -n "$POD" ] || {
-	echo "no gateway pod found" >&2
+die() {
+	echo "ERROR: $*" >&2
 	exit 1
 }
+
+POD=$(kubectl get pod -n "$NS" -l app=context-forge-gateway-mcp-stack-mcpgateway \
+	--field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}')
+[ -n "$POD" ] || die "no running gateway pod found"
 echo "gateway pod: $POD"
 
-# Short-lived admin JWT, minted inside the pod so the signing key never leaves it.
 run() { kubectl exec -n "$NS" "$POD" -- sh -c "$1"; }
+
+# Assert the PROCESS env, not the manifest. A ConfigMap change without a pod
+# restart leaves these disagreeing, and every API call below would 404.
+live_sso=$(run 'printf %s "${SSO_ENABLED:-unset}"')
+[ "$live_sso" = "true" ] || die "pod has SSO_ENABLED=$live_sso, so /auth/sso is not mounted.
+The ConfigMap may already say true: a ConfigMap edit does not roll this
+deployment. Restart it and re-run:
+  kubectl rollout restart deploy/context-forge-gateway-mcp-stack-mcpgateway -n $NS"
+
+# Short-lived admin JWT, minted inside the pod so the signing key never leaves it.
 run "cd /app && python3 -m mcpgateway.utils.create_jwt_token -u '$ADMIN_EMAIL' --admin -e 10 2>/dev/null | tail -1 > /tmp/.pv_tok"
 trap 'kubectl exec -n "$NS" "$POD" -- rm -f /tmp/.pv_tok /tmp/.pv_body >/dev/null 2>&1 || true' EXIT
 
+# Writes the response body to stdout and the HTTP status to $API_STATUS, so
+# callers can fail on anything non-2xx instead of parsing an error page as data.
+API_STATUS=""
 api() { # api METHOD PATH [JSON]
-	local method=$1 path=$2 body=${3:-}
+	local method=$1 path=$2 body=${3:-} out
 	if [ -n "$body" ]; then
 		local b64
 		b64=$(printf '%s' "$body" | base64 | tr -d '\n')
-		run "echo '$b64' | base64 -d > /tmp/.pv_body && curl -sS -X $method \
+		out=$(run "echo '$b64' | base64 -d > /tmp/.pv_body && curl -sS -X $method \
       -H \"Authorization: Bearer \$(cat /tmp/.pv_tok)\" -H 'Content-Type: application/json' \
-      --data @/tmp/.pv_body http://localhost:4444$path"
+      --data @/tmp/.pv_body -w '\n%{http_code}' http://localhost:4444$path")
 	else
-		run "curl -sS -X $method -H \"Authorization: Bearer \$(cat /tmp/.pv_tok)\" http://localhost:4444$path"
+		out=$(run "curl -sS -X $method -H \"Authorization: Bearer \$(cat /tmp/.pv_tok)\" \
+      -w '\n%{http_code}' http://localhost:4444$path")
 	fi
+	API_STATUS=${out##*$'\n'}
+	printf '%s' "${out%$'\n'*}"
+}
+
+api_ok() { # api_ok METHOD PATH [JSON] -- dies unless 2xx
+	local resp
+	resp=$(api "$@")
+	case "$API_STATUS" in
+	2*) printf '%s' "$resp" ;;
+	*) die "$1 $2 returned HTTP $API_STATUS: $(printf '%s' "$resp" | head -c 300)" ;;
+	esac
 }
 
 # ── 1. Team ────────────────────────────────────────────────────────────────
-TEAM_ID=$(api GET /teams/ | python3 -c "
+TEAM_ID=$(api_ok GET /teams/ | python3 -c "
 import json,sys
 teams=json.load(sys.stdin)
 teams=teams.get('teams', teams) if isinstance(teams, dict) else teams
 print(next((t['id'] for t in teams if t.get('name')=='$TEAM_NAME'), ''))
 ")
 if [ -z "$TEAM_ID" ]; then
-	TEAM_ID=$(api POST /teams/ "{\"name\":\"$TEAM_NAME\",\"description\":\"Full monolith catalogue. Mapped from the authentik group of the same name.\",\"visibility\":\"private\"}" |
+	TEAM_ID=$(api_ok POST /teams/ \
+		"{\"name\":\"$TEAM_NAME\",\"description\":\"Full monolith catalogue. Mapped from the authentik group of the same name.\",\"visibility\":\"private\"}" |
 		python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
 	echo "created team $TEAM_NAME -> $TEAM_ID"
 else
 	echo "team $TEAM_NAME already exists -> $TEAM_ID"
 fi
+[ -n "$TEAM_ID" ] || die "team id came back empty"
 
 # ── 2. Trusted external IdP ────────────────────────────────────────────────
 # client_secret is required by the request schema but unused on the API-auth
@@ -100,16 +136,23 @@ read -r -d '' PROVIDER <<JSON || true
 }
 JSON
 
-if api GET /auth/sso/admin/providers/authentik | grep -q '"id"'; then
-	api PUT /auth/sso/admin/providers/authentik "$PROVIDER" >/dev/null
+api GET /auth/sso/admin/providers/authentik >/dev/null
+if [ "$API_STATUS" = "200" ]; then
+	api_ok PUT /auth/sso/admin/providers/authentik "$PROVIDER" >/dev/null
 	echo "updated sso provider 'authentik'"
 else
-	api POST /auth/sso/admin/providers "$PROVIDER" >/dev/null
+	api_ok POST /auth/sso/admin/providers "$PROVIDER" >/dev/null
 	echo "created sso provider 'authentik'"
 fi
+
+# ── 3. Verify from the database, not from the API's own say-so ─────────────
+rows=$(kubectl exec -n "$NS" context-forge-pg-1 -- psql -U postgres -d mcpgateway -t -A \
+	-c "select count(*) from sso_providers where issuer='$ISSUER' and trusted_for_api_auth;" 2>/dev/null |
+	tr -dc '0-9')
+[ "$rows" = "1" ] || die "expected exactly 1 trusted sso_providers row for $ISSUER, found ${rows:-0}"
 
 echo
 echo "── resulting sso_providers row ──"
 kubectl exec -n "$NS" context-forge-pg-1 -- psql -U postgres -d mcpgateway -x \
 	-c "select name, issuer, api_audience, trusted_for_api_auth, team_mapping from sso_providers;" 2>/dev/null |
-	grep -v '^Defaulted' || true
+	grep -v '^Defaulted'


### PR DESCRIPTION
Follow-up to #4557. The first real run of that script produced this:

```
created team homelab-admin -> ddfa9777454146908de4944d6786d002
created sso provider 'authentik'

── resulting sso_providers row ──
(0 rows)
```

It created nothing. Every API call 404'd, the responses went to `/dev/null`, and the success messages were unconditional. Self-inflicted false green.

## Root cause underneath it

`SSO_ENABLED` lands in the gateway ConfigMap, and `mcp-stack` puts **no checksum annotation on the pod template**, so a values change does not roll the deployment:

```
pod age:                  4h5m      ← never restarted
configmap SSO_ENABLED:    true
running pod env:          SSO_ENABLED=false
```

`kubectl rollout status` reported "successfully rolled out" the whole time, correctly: the deployment really was at its desired state. Nothing in the pod template had changed.

## Changes

**Status checking.** `api()` now returns the HTTP status alongside the body, and `api_ok()` dies on anything non-2xx, so an error page can no longer be parsed as data.

**Assert the live process env, not the manifest.** The script refuses to run unless the pod actually has `SSO_ENABLED=true`, and the error names the fix:

```
ERROR: pod has SSO_ENABLED=false, so /auth/sso is not mounted.
The ConfigMap may already say true: a ConfigMap edit does not roll this
deployment. Restart it and re-run:
  kubectl rollout restart deploy/context-forge-gateway-mcp-stack-mcpgateway -n mcp
```

**Verify from the database.** Final step asserts exactly one trusted `sso_providers` row for the issuer, rather than trusting the API's own report.

Verified by running it against the current un-restarted pod: exits 1 with the message above instead of claiming success.

## Known gap, not fixed here

`mcp-stack` exposes no `podAnnotations` for the mcpgateway deployment, so there is no values-level way to make config changes roll the pod. Worth a follow-up, either a checksum annotation upstream or a Kyverno mutation like the existing `inject-otel-env-vars`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39