### PR TITLE
feat(mcp): enable external-IdP bearer auth so authentik tokens are accepted

### DIFF
--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -52,6 +52,21 @@ mcp-stack:
       # stay behind Access on mcp.jomcgi.dev.
       - name: SSO_ENABLED
         value: "true"
+      # The other half of external-IdP bearer auth, and the one that actually
+      # gates it. SSO_ENABLED only mounts the /auth/sso router; this is what
+      # lets a token minted by a trusted provider authenticate an MCP request:
+      #
+      #   if not getattr(settings, "sso_api_token_auth_enabled", False):
+      #       return None
+      #
+      # runs before the token is even decoded, so with it false the whole
+      # external path is dead and every authentik token 401s as "Invalid token"
+      # with no verify_credentials log line to explain why. Its own description
+      # says each provider must ALSO set trusted_for_api_auth, which the
+      # provisioning script does: both halves are required, neither is
+      # sufficient.
+      - name: SSO_API_TOKEN_AUTH_ENABLED
+        value: "true"
       # Enforce OAuth on the MCP endpoint itself. Until now the JSON-RPC
       # endpoint authenticated nobody: an unauthenticated tools/list returned
       # all 57 tools, including monolith-agent-session-destroy, and tools/call


### PR DESCRIPTION
The OAuth flow now completes and Claude sends a token, but the gateway rejects it:

```
05:09:41 INFO    ✗ Auth context extraction failed (continuing as anonymous): 401: Invalid token
05:09:41 WARNING 401 POST /mcp/
```

with **zero** `verify_credentials` or `external-idp` log lines, which is the tell: the validator was never reached.

## Cause

```python
if not getattr(settings, "sso_api_token_auth_enabled", False):
    return None
```

That runs before the token is even decoded. `SSO_API_TOKEN_AUTH_ENABLED` is a **separate** setting from `SSO_ENABLED` and defaults to `false`.

Its own description spells out that both halves are required:

> "Accept access tokens issued by trusted external SSO providers as Bearer credentials on API/MCP endpoints, in addition to internally-minted JWTs. Each provider must **ALSO** be opted in via `SSOProvider.trusted_for_api_auth`. Default false preserves internal-JWT-only behavior."

We set the per-provider half (the provisioning script writes `trusted_for_api_auth = t`, verified in Postgres). The global half was never set, so the whole external path was dead.

`SSO_ENABLED` does **not** cover this. It only mounts the `/auth/sso` router and the browser SSO flow.

## Why this was hard to see

Same shape as `MCP_CLIENT_AUTH_ENABLED` silently disabling `TRUST_PROXY_AUTH` earlier in this series: the feature reads as configured from every angle, and a third setting decides whether any of it runs. The short-circuit returning `None` before decoding is also why there is no diagnostic in the log, just a generic "Invalid token" from the fallback internal-JWT path.

## After merge

`extraEnv` means merging rolls the pod, so this applies immediately with no manual restart.

Expected next: `verify_credentials` lines appear, the token validates against authentik's JWKS, `build_external_identity` provisions `joe@jomcgi.dev` onto the platform admin, and `tools/list` returns the catalogue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39