### PR TITLE
feat(mcp): rewrite the root MCP endpoint onto a virtual server

### DIFF
--- a/projects/mcp/context-forge-gateway/chart/templates/httproute.yaml
+++ b/projects/mcp/context-forge-gateway/chart/templates/httproute.yaml
@@ -72,11 +72,30 @@ spec:
             kind: HTTPRouteFilter
             name: {{ include "context-forge.fullname" . }}-root-resource-metadata
 
-    # The root MCP endpoint. The ResponseHeaderModifier replaces Context Forge's
-    # bare `WWW-Authenticate: Bearer` with one carrying the resource_metadata
-    # pointer, which is what makes discovery work without the client having to
-    # guess the well-known path. It is set on every response from this rule,
-    # including 200s; clients ignore the header on success.
+    # The root MCP endpoint, rewritten onto a virtual server.
+    #
+    # Context Forge's ROOT /mcp cannot authenticate an external IdP token at
+    # all: auth_middleware -> get_current_user -> verify_jwt_token_cached, which
+    # only accepts internally-minted JWTs. The dispatcher that consults trusted
+    # SSO providers, verify_credentials_cached -> _maybe_verify_external, is
+    # never reached from this path, so SSO_API_TOKEN_AUTH_ENABLED and
+    # trusted_for_api_auth are both honoured by code nothing here calls. Same in
+    # upstream main as of v1.0.7.
+    #
+    # The per-virtual-server path is a different code path entirely:
+    # streamablehttp_transport calls verify_oauth_access_token itself against
+    # server.oauth_config, bypassing get_current_user. That one works, proven
+    # end to end. So rewrite onto it.
+    #
+    # The rewrite is only safe because Envoy owns both halves of discovery. A
+    # naive rewrite breaks RFC 9728: Context Forge would advertise
+    # /servers/<id>/mcp while the client connected to /mcp, and clients compare
+    # those. Here the directResponse above declares `resource` as the /mcp URL,
+    # and the ResponseHeaderModifier below overrides Context Forge's pointer, so
+    # the client only ever sees /mcp and the two agree.
+    #
+    # Audience still resolves: authentik mints aud = client_id, and the
+    # transport falls back to oauth_config.client_id when `resource` is unset.
     - matches:
         - path:
             type: PathPrefix
@@ -87,6 +106,11 @@ spec:
             set:
               - name: X-Forwarded-Proto
                 value: https
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /servers/{{ required "httpRoute.rootMcp.serverId is required when rootMcp is enabled" .Values.httpRoute.rootMcp.serverId }}/mcp
         - type: ResponseHeaderModifier
           responseHeaderModifier:
             set:

--- a/projects/mcp/context-forge-gateway/chart/values.yaml
+++ b/projects/mcp/context-forge-gateway/chart/values.yaml
@@ -142,6 +142,15 @@ httpRoute:
     enabled: false
     # OIDC issuer URL, with trailing slash, exactly as the token's `iss` claim.
     authorizationServer: ""
+    # Context Forge virtual server that /mcp is rewritten onto. Required, because
+    # the ROOT endpoint cannot authenticate an external IdP token (see
+    # templates/httproute.yaml for the call graph); only the per-virtual-server
+    # path can. Clients never see this id.
+    #
+    # It is a runtime object id, so a rebuilt gateway database regenerates it and
+    # this value goes stale. scripts/provision-mcp-auth.sh owns creating that
+    # server and prints the id, so the two are updated together.
+    serverId: ""
     scopes:
       - openid
       - profile

--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -144,6 +144,11 @@ httpRoute:
   rootMcp:
     enabled: true
     authorizationServer: https://auth.jomcgi.dev/application/o/mcp-friends/
+    # The "homelab-admin" virtual server, carrying the full monolith catalogue.
+    # One server is enough: list_server_tools filters per caller from
+    # tools.visibility and team membership, so entitlements are expressed as
+    # tags on tools rather than as a server (and a URL) per tier.
+    serverId: a9e472d2d61949169a5894ed37f067e1
 
 # friends.jomcgi.dev reaches exactly one virtual server, "friends-empty",
 # which is deliberately empty: tools/list returns [] so the hostname exposes


### PR DESCRIPTION
## Why the root endpoint cannot work

```
auth_middleware → get_current_user → verify_jwt_token_cached      ← internal JWTs only
                                     verify_credentials_cached    ← the dispatcher
                                       └→ _maybe_verify_external  ← single caller
```

`_maybe_verify_external` has exactly one caller, and `get_current_user` is not it. So `SSO_API_TOKEN_AUTH_ENABLED` (#4562) and the provider's `trusted_for_api_auth` are both correct, both live in the process, and both honoured by code nothing on this route calls. Upstream `main` has identical wiring as of v1.0.7, released four days ago, so there is nothing to wait for.

Everything else was verified good. The issued token, decoded from authentik's database:

```
iss     https://auth.jomcgi.dev/application/o/mcp-friends/   ← matches sso_providers.issuer
aud     3EWnvYhHHMBhodkwMDOlMoTfG30okOkkdwQFMjzd            ← matches api_audience
markers []                                                   ← not mistakable for an ID token
email   joe@jomcgi.dev                                        ← matches PLATFORM_ADMIN_EMAIL
groups  ['authentik Admins', 'homelab-admin']                 ← team_mapping resolves
```

## What this does instead

`streamablehttp_transport` calls `verify_oauth_access_token` itself against `server.oauth_config`, bypassing `get_current_user` entirely. That path authenticated an authentik token end to end earlier tonight. So `/mcp` is rewritten onto it:

```
client → mcp.jomcgi.dev/mcp → Envoy ReplaceFullPath → /servers/<uuid>/mcp
```

The client never sees the UUID.

## Why the rewrite is safe now and was not before

A naive rewrite breaks RFC 9728: Context Forge would advertise `/servers/<id>/mcp` while the client connected to `/mcp`, and clients compare those. Envoy now owns both halves of discovery, so they agree:

- the `directResponse` document declares `resource: https://mcp.jomcgi.dev/mcp`
- the `ResponseHeaderModifier` overrides Context Forge's `WWW-Authenticate` pointer

Audience still resolves via the `oauth_config.client_id` fallback, since authentik mints `aud = client_id`.

## One server, not one per tier

`list_server_tools(db, server_id, user_email=..., token_teams=...)` filters per caller, so entitlements stay tags on tools (`visibility`, `team_id`) rather than a server, and a URL, per tier.

## Why not fork

Apache-2.0, so it is permitted. But it is an auth path on an upstream shipping monthly releases, images here are apko-built so we would own a Python app image build, and the fix is not provably one line: the external payload carries `token_use: "session"` and `teams`, while `get_current_user` resolves identity via `user_email` then a UUID `sub`. Worth filing upstream, not worth carrying.

## Rendered

```
[('Exact', '/.well-known/oauth-protected-resource/mcp')]  ExtensionRef
[('PathPrefix', '/mcp')]  RequestHeaderModifier
    URLRewrite -> {'type': 'ReplaceFullPath', 'replaceFullPath': '/servers/a9e472d2.../mcp'}
    ResponseHeaderModifier
[('PathPrefix', '/')]  RequestHeaderModifier
```

`serverId` is `required` in the template: a rebuilt gateway database regenerates it, and a silently-empty value would route `/mcp` to `/servers//mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39