### PR TITLE
feat(mcp): forward the caller's token so tools can scope their own results

### DIFF
--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -67,6 +67,47 @@ mcp-stack:
       # sufficient.
       - name: SSO_API_TOKEN_AUTH_ENABLED
         value: "true"
+      # Forward the caller's authentik token to upstream gateways, so the
+      # monolith can learn WHO is calling and scope its own results.
+      #
+      # Context Forge's ACL is tool-granular: it decides whether you may call
+      # search_knowledge, never what search_knowledge returns. Without this the
+      # monolith sees every invocation as "the gateway" and cannot distinguish
+      # an admin from a friend, so per-caller data scoping is impossible and
+      # tiers would have to be built from separate tools per audience.
+      #
+      # Deliberately a TOKEN and not a header. Context Forge also supports
+      # PROXY_USER_HEADER-style identity injection, but that asks the monolith
+      # to believe a header, so anything able to reach the monolith in-cluster
+      # could claim to be anyone. A forwarded RS256 token is verifiable: the
+      # monolith checks it against authentik's JWKS and trusts authentik, not
+      # us. A compromised gateway cannot forge a signature.
+      #
+      # The forwarding happens because the monolith gateway has no gateway-level
+      # auth (gateways.auth_type is empty), which selects this branch in
+      # passthrough_headers.py:
+      #
+      #   # When gateway has no auth, pass through client's Authorization
+      #   client_auth = request_headers_lower.get("authorization")
+      #
+      # DEFAULT_PASSTHROUGH_HEADERS stays empty, so Authorization is the only
+      # thing forwarded, via that branch rather than an allowlist.
+      #
+      # INERT until the monolith validates the token. Enabling it alone changes
+      # no behaviour; it is the prerequisite for the monolith-side work.
+      #
+      # Two properties to keep in mind:
+      #  - the token's `aud` is the MCP client id, not the monolith, so the
+      #    monolith must validate `iss` strictly and knowingly accept that
+      #    audience. RFC 8693 token exchange is the correct fix and Context
+      #    Forge implements it (services/token_exchange_cache.py, keyed by
+      #    gateway+user+audience), but authentik does not advertise the
+      #    token-exchange grant, so it is unavailable here.
+      #  - this setting is global, not per gateway. Every gateway registered
+      #    later also receives the caller's token, and a token you hand a
+      #    backend is a token that backend can replay.
+      - name: ENABLE_HEADER_PASSTHROUGH
+        value: "true"
       # Enforce OAuth on the MCP endpoint itself. Until now the JSON-RPC
       # endpoint authenticated nobody: an unauthenticated tools/list returned
       # all 57 tools, including monolith-agent-session-destroy, and tools/call


### PR DESCRIPTION
## Token exchange: checked, and unavailable

You asked whether RFC 8693 is implemented. Split answer:

**Context Forge implements it**, and in the right direction. `services/token_exchange_cache.py` stores exchanged tokens *"keyed by gateway+user+audience"*, referenced from `oauth_manager`, `gateway_service` and `tool_service`. That is downstream identity propagation with proper audience scoping, exactly what this problem wants.

**authentik does not.** Its discovery advertises:

```
grant_types_supported: [authorization_code, refresh_token, implicit,
                        client_credentials, password, device_code]
```

No `urn:ietf:params:oauth:grant-type:token-exchange`, and its provider form offers no such option. Same shape as the DCR finding: the gateway implements the correct mechanism and the IdP is the blocker.

So this PR takes the pragmatic path and documents why.

## The problem

Context Forge's ACL is **tool-granular**: it decides whether you may call `search_knowledge`, never what `search_knowledge` returns. The monolith sees every invocation as "the gateway":

```
ENABLE_HEADER_PASSTHROUGH=false
```

so it cannot distinguish an admin from a friend, and tiers would have to be built from duplicate tools per audience rather than one auth-aware tool.

## Why a token and not a header

Context Forge also supports `PROXY_USER_HEADER`-style identity injection. That asks the monolith to *believe* a header, so anything able to reach it in-cluster could claim to be anyone. It is the same bargain we rejected for `TRUST_PROXY_AUTH_DANGEROUSLY`, one layer further in.

A forwarded RS256 token is verifiable. The monolith checks it against authentik's JWKS and trusts **authentik**, not this gateway. A compromised or misconfigured gateway cannot forge a signature.

## Why it works without per-gateway config

```
name       | monolith
auth_type  | (empty)      ← no gateway-level auth
```

which selects this branch:

```python
# When gateway has no auth, pass through client's Authorization if present
client_auth = request_headers_lower.get("authorization")
```

`DEFAULT_PASSTHROUGH_HEADERS` stays empty, so `Authorization` is the only header forwarded, via that branch rather than an allowlist.

## Sequencing

**This is inert on its own.** The monolith does not yet validate the token, so merging changes no behaviour; it only starts sending a token that is currently ignored. It is a prerequisite for the monolith-side work, not a feature.

Merge now as a prerequisite, or hold it to land alongside the monolith validator. Your call, and worth an ADR either way, since "the monolith validates authentik tokens directly" is a trust-boundary decision.

## Two properties to keep in mind

- The token's `aud` is the MCP client id, not the monolith, so the monolith must validate `iss` strictly and knowingly accept that audience. Token exchange would fix it if authentik ever supports the grant.
- `ENABLE_HEADER_PASSTHROUGH` is **global**, not per gateway. Every gateway registered later also receives the caller's token, and a token you hand a backend is a token that backend can replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39