### PR TITLE
feat(monolith): deny token replay back to the Context Forge API

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.499
+version: 0.285.500
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.499
+      targetRevision: 0.285.500
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.499
+version: 0.285.500
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cilium-policy.yaml
+++ b/projects/monolith/chart/templates/cilium-policy.yaml
@@ -1,0 +1,58 @@
+{{- /*
+Token-replay containment for forwarded MCP identity tokens.
+
+Context Forge forwards the caller's authentik access token to this service so
+tools can scope their own results (mcp PR #4565), and authentik names the
+monolith as a second audience so the token can be validated here rather than
+merely believed. That pair is deliberately chosen over header-based identity,
+which would ask this service to trust anything able to reach it in-cluster.
+
+The residual weakness is inherent to multi-audience tokens: exchange (RFC 8693)
+would mint a SEPARATE token per audience so a backend could not reuse it
+elsewhere, but authentik does not advertise the token-exchange grant. One
+multi-audience token is a single bearer credential valid at BOTH Context Forge
+and here, so a compromised monolith could present it back to the gateway and act
+as the user.
+
+That is a network property, so it is closed on the network. This denies the
+monolith egress to the gateway's API, which it has no reason to call: federation
+runs the other way, gateway -> monolith.
+
+Uses `egressDeny`, NOT `egress`, and the distinction is load-bearing. A plain
+`egress` rule makes the selected endpoints default-deny for ALL other egress,
+which on the monolith would take out Postgres, the object store, and every
+outbound integration. `egressDeny` denies only what it names and leaves
+everything else alone, so this file cannot cause an outage by omission.
+
+Gated and default-false in chart/values.yaml, matching the monolith-public
+policy convention, so merging is inert until a deploy override opts in. Before
+flipping it, confirm there is genuinely no monolith -> mcp traffic:
+
+    hubble observe --from-namespace monolith --to-namespace mcp --last 200
+*/}}
+{{- if .Values.ciliumPolicy.tokenReplayDeny.enabled }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-no-token-replay
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  description: >-
+    Deny the monolith egress to the Context Forge API, so a forwarded
+    multi-audience identity token cannot be replayed back at the gateway.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: monolith
+  egressDeny:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: {{ .Values.ciliumPolicy.tokenReplayDeny.gatewayNamespace }}
+            app: {{ .Values.ciliumPolicy.tokenReplayDeny.gatewayPodLabel }}
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "4444"
+              protocol: TCP
+{{- end }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1191,3 +1191,17 @@ cfIngress:
     rateLimit:
       requests: 100
       unit: Minute
+
+# Cilium policies for this chart. See templates/cilium-policy.yaml.
+ciliumPolicy:
+  # Deny monolith -> Context Forge egress, so a forwarded multi-audience
+  # identity token cannot be replayed back at the gateway. Uses egressDeny, so
+  # it denies only what it names and cannot default-deny anything else.
+  #
+  # Default false: merging is inert, and a deploy override opts in after
+  # confirming there is no legitimate monolith -> mcp traffic with
+  # `hubble observe --from-namespace monolith --to-namespace mcp`.
+  tokenReplayDeny:
+    enabled: false
+    gatewayNamespace: mcp
+    gatewayPodLabel: context-forge-gateway-mcp-stack-mcpgateway

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.499
+      targetRevision: 0.285.500
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Pairs with #4566 (authentik multi-audience) and mcp #4565 (token forwarding).

## Why

Context Forge forwards the caller's authentik token here so tools can scope their own results, and authentik names the monolith as a second audience so the token can be **validated** rather than merely believed. That pair was chosen over header-based identity, which would ask this service to trust anything able to reach it in-cluster.

The residual weakness is inherent to multi-audience tokens. Exchange (RFC 8693) mints a separate token per audience so a backend cannot reuse it elsewhere, but authentik does not advertise that grant. One multi-audience token is a single bearer credential valid at **both** Context Forge and here, so a compromised monolith could present it back to the gateway and act as the user.

That is a network property, so it is closed on the network. The monolith is denied egress to the gateway API, which it has no reason to call: federation runs the other way, gateway → monolith.

## `egressDeny`, not `egress`

This distinction is load-bearing. A plain `egress` rule makes the selected endpoints **default-deny for all other egress**, which here would take out Postgres, the object store and every outbound integration. `egressDeny` denies only what it names and leaves everything else untouched, so this file cannot cause an outage by omission.

Verified in the rendered output:

```
selector:    {'app.kubernetes.io/name': 'monolith'}
egressDeny:  [{'toEndpoints': [{'matchLabels': {'io.kubernetes.pod.namespace': 'mcp',
              'app': 'context-forge-gateway-mcp-stack-mcpgateway'}}], 'toPorts': [80, 4444]}]
has plain egress key: False
```

Both `egressDeny` and `enableDefaultDeny` exist in the installed CRD, and Cilium already runs `enable-wireguard: true`, so this path is encrypted in transit regardless.

## Inert on merge

Default `false`, matching the `monolith-public` policy convention, so merging renders nothing (0 CiliumNetworkPolicy documents with default values). Flip it in a deploy override after confirming there is no legitimate traffic:

```
hubble observe --from-namespace monolith --to-namespace mcp --last 200
```

## Note

There is currently **no CiliumNetworkPolicy at all** for the private `monolith` namespace, while `monolith-public` and `embervm` both have them. This adds one narrow deny rather than closing that gap, which deserves its own pass.

Carries the chart bump; `bump-chart.sh` also bumped `monolith-public`, which shares the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39