### PR TITLE
chore(renovate): open security PRs for vulnerability alerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,13 @@
   "prHourlyLimit": 2,
   "minimumReleaseAge": "3 days",
   "internalChecksFilter": "strict",
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["dependencies", "security"],
+    "schedule": ["at any time"],
+    "minimumReleaseAge": null,
+    "prCreation": "immediate"
+  },
   "enabledManagers": [
     "argocd",
     "bazel-module",


### PR DESCRIPTION
Follow-up to the Dependabot sweep (#4571, #4572, #4573, #4575). Those 32 alerts were cleared by hand because Renovate was never configured to act on advisories.

## The gap

`renovate.json` had no `vulnerabilityAlerts` block, so Renovate raised no remediation PRs at all. The dependency dashboard had no `## Vulnerabilities` section, which is the visible symptom.

## The change

```json
"vulnerabilityAlerts": {
  "enabled": true,
  "labels": ["dependencies", "security"],
  "schedule": ["at any time"],
  "minimumReleaseAge": null,
  "prCreation": "immediate"
}
```

Both bypasses are the point of the block:

| Repo default | Why it is wrong for an advisory |
|---|---|
| `schedule: before 6am on monday` | holds a security fix for up to a week |
| `minimumReleaseAge: 3 days` | a sensible soak for routine updates, the wrong tradeoff for a known CVE |

`automerge` is deliberately **not** set here, so the existing "minor/patch/pin/digest automerge after CI" rule applies unchanged rather than being widened for security PRs specifically.

## Verification

- Validated against the published `renovate-schema.json` (not just JSON syntax)
- `ci` green: `Executed 2 out of 738 tests: 738 tests pass.`
- Runner cadence confirmed: the `renovate` CronWorkflow in `monolith-workflows` fires daily at `0 4 * * *` America/Vancouver, so a new advisory should surface within a day

## Known limit, deliberate

`enabledManagers` does **not** include `pip_requirements`, so advisories against `bazel/requirements/*.txt` still cannot be auto-fixed. That is precisely the class that dominated this sweep. `aiohttp` is reachable via `pep621` (direct pyproject dependency), but `cryptography` and `mcp` live only in the compiled locks and stay manual. Adding `pip_requirements` would also pull the compiled locks into the routine weekly update stream, which is a separate call.

## Unverified

Whether `RENOVATE_TOKEN` (secret `renovate-github`) carries the scope needed to read Dependabot alerts. If it does not, Renovate logs that it cannot read vulnerability alerts and this config is inert. The next daily run's logs will show it; the workflow's TTL had already reaped the last run's pod, so I could not check retrospectively.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)