### PR TITLE
feat(monolith): compose agent sessions into a durable DBOS graph

### DIFF
--- a/bazel/requirements/all.txt
+++ b/bazel/requirements/all.txt
@@ -747,6 +747,7 @@ click==8.3.1 \
     #   click-default-group
     #   click-option-group
     #   cligj
+    #   dbos
     #   rasterio
     #   semgrep
     #   sqlite-utils
@@ -903,6 +904,12 @@ dateparser==1.4.0 \
     #   -c bazel/requirements/runtime.txt
     #   -r bazel/requirements/runtime.txt
     #   htmldate
+dbos==2.29.0 \
+    --hash=sha256:49104b64b8917dc3d321704f1d20058486c86129420b96b910f1e725fbdebca6 \
+    --hash=sha256:ae6015bba43b5842a4a99abcc7826ca00c758af767ebaf79e6304c0b4f58ec46
+    # via
+    #   -c bazel/requirements/runtime.txt
+    #   -r bazel/requirements/runtime.txt
 dbus-fast==2.46.4 \
     --hash=sha256:018c7d878857599e3478c56575aa2ed9ff52eb7a88c5118685db8e033b3916e9 \
     --hash=sha256:0cc59b9d6ee59ab58d8cdc58f19a4e5ad6451392d215933eedd4482925e8ecf1 \
@@ -1280,7 +1287,7 @@ googleapis-common-protos==1.72.0 \
     #   -r bazel/requirements/runtime.txt
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-greenlet==3.3.2 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' \
+greenlet==3.3.2 \
     --hash=sha256:02b0a8682aecd4d3c6c18edf52bc8e51eacdd75c8eac52a790a210b06aa295fd \
     --hash=sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082 \
     --hash=sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b \
@@ -3198,6 +3205,7 @@ psycopg[binary]==3.3.3 \
     # via
     #   -c bazel/requirements/runtime.txt
     #   -r bazel/requirements/runtime.txt
+    #   dbos
 psycopg-binary==3.3.3 ; implementation_name != 'pypy' \
     --hash=sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d \
     --hash=sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12 \
@@ -3784,6 +3792,7 @@ python-dateutil==2.9.0.post0 \
     #   -r bazel/requirements/runtime.txt
     #   botocore
     #   dateparser
+    #   dbos
     #   htmldate
     #   icalendar
     #   jsii
@@ -3927,6 +3936,7 @@ pyyaml==6.0.3 \
     #   -c bazel/requirements/runtime.txt
     #   -r bazel/requirements/runtime.txt
     #   copier
+    #   dbos
     #   fastmcp
     #   huggingface-hub
     #   jinja2-ansible-filters
@@ -4470,7 +4480,7 @@ soupsieve==2.8.4 \
     #   --override bazel/requirements/overrides.txt
     #   -r bazel/requirements/runtime.txt
     #   beautifulsoup4
-sqlalchemy==2.0.48 \
+sqlalchemy[asyncio]==2.0.48 \
     --hash=sha256:01f6bbd4308b23240cf7d3ef117557c8fd097ec9549d5d8a52977544e35b40ad \
     --hash=sha256:07edba08061bc277bfdc772dd2a1a43978f5a45994dd3ede26391b405c15221e \
     --hash=sha256:10853a53a4a00417a00913d270dddda75815fcb80675874285f41051c094d7dd \
@@ -4537,6 +4547,7 @@ sqlalchemy==2.0.48 \
     # via
     #   -c bazel/requirements/runtime.txt
     #   -r bazel/requirements/runtime.txt
+    #   dbos
     #   sqlmodel
 sqlite-fts4==1.0.3 \
     --hash=sha256:0359edd8dea6fd73c848989e1e2b1f31a50fe5f9d7272299ff0e8dbaa62d035f \
@@ -5142,6 +5153,7 @@ websockets==16.0 \
     # via
     #   -c bazel/requirements/runtime.txt
     #   -r bazel/requirements/runtime.txt
+    #   dbos
     #   fastmcp
     #   google-genai
     #   uvicorn

--- a/bazel/requirements/runtime.txt
+++ b/bazel/requirements/runtime.txt
@@ -656,6 +656,7 @@ click==8.3.1 \
     #   --override bazel/requirements/overrides.txt
     #   click-default-group
     #   cligj
+    #   dbos
     #   rasterio
     #   sqlite-utils
     #   typer
@@ -776,6 +777,10 @@ dateparser==1.4.0 \
     --hash=sha256:7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378 \
     --hash=sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4
     # via htmldate
+dbos==2.29.0 \
+    --hash=sha256:49104b64b8917dc3d321704f1d20058486c86129420b96b910f1e725fbdebca6 \
+    --hash=sha256:ae6015bba43b5842a4a99abcc7826ca00c758af767ebaf79e6304c0b4f58ec46
+    # via homelab (pyproject.toml)
 dbus-fast==2.46.4 \
     --hash=sha256:018c7d878857599e3478c56575aa2ed9ff52eb7a88c5118685db8e033b3916e9 \
     --hash=sha256:0cc59b9d6ee59ab58d8cdc58f19a4e5ad6451392d215933eedd4482925e8ecf1 \
@@ -1087,7 +1092,7 @@ googleapis-common-protos==1.72.0 \
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-greenlet==3.3.2 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' \
+greenlet==3.3.2 \
     --hash=sha256:02b0a8682aecd4d3c6c18edf52bc8e51eacdd75c8eac52a790a210b06aa295fd \
     --hash=sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082 \
     --hash=sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b \
@@ -2746,7 +2751,9 @@ protobuf==6.33.5 \
 psycopg[binary]==3.3.3 \
     --hash=sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9 \
     --hash=sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698
-    # via homelab (pyproject.toml)
+    # via
+    #   homelab (pyproject.toml)
+    #   dbos
 psycopg-binary==3.3.3 ; implementation_name != 'pypy' \
     --hash=sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d \
     --hash=sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12 \
@@ -3262,6 +3269,7 @@ python-dateutil==2.9.0.post0 \
     #   homelab (pyproject.toml)
     #   botocore
     #   dateparser
+    #   dbos
     #   htmldate
     #   icalendar
     #   jsii
@@ -3391,6 +3399,7 @@ pyyaml==6.0.3 \
     --hash=sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0
     # via
     #   homelab (pyproject.toml)
+    #   dbos
     #   fastmcp
     #   huggingface-hub
     #   jsonschema-path
@@ -3808,7 +3817,7 @@ soupsieve==2.8.4 \
     # via
     #   --override bazel/requirements/overrides.txt
     #   beautifulsoup4
-sqlalchemy==2.0.48 \
+sqlalchemy[asyncio]==2.0.48 \
     --hash=sha256:01f6bbd4308b23240cf7d3ef117557c8fd097ec9549d5d8a52977544e35b40ad \
     --hash=sha256:07edba08061bc277bfdc772dd2a1a43978f5a45994dd3ede26391b405c15221e \
     --hash=sha256:10853a53a4a00417a00913d270dddda75815fcb80675874285f41051c094d7dd \
@@ -3872,7 +3881,9 @@ sqlalchemy==2.0.48 \
     --hash=sha256:f8649a14caa5f8a243628b1d61cf530ad9ae4578814ba726816adb1121fc493e \
     --hash=sha256:fac0fa4e4f55f118fd87177dacb1c6522fe39c28d498d259014020fec9164c29 \
     --hash=sha256:fd08b90d211c086181caed76931ecfa2bdfc83eea3cfccdb0f82abc6c4b876cb
-    # via sqlmodel
+    # via
+    #   dbos
+    #   sqlmodel
 sqlite-fts4==1.0.3 \
     --hash=sha256:0359edd8dea6fd73c848989e1e2b1f31a50fe5f9d7272299ff0e8dbaa62d035f \
     --hash=sha256:78b05eeaf6680e9dbed8986bde011e9c086a06cb0c931b3cf7da94c214e8930c
@@ -4350,6 +4361,7 @@ websockets==16.0 \
     --hash=sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4
     # via
     #   homelab (pyproject.toml)
+    #   dbos
     #   fastmcp
     #   google-genai
     #   uvicorn

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.503
+version: 0.285.504
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.503
+      targetRevision: 0.285.504
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1557,7 +1557,11 @@ py_library(
     name = "pkg_graph",
     srcs = glob(
         ["graph/**/*.py"],
-        exclude = ["**/*_test.py", "**/test_*.py", "*/tests/**/*.py"],
+        exclude = [
+            "**/*_test.py",
+            "**/test_*.py",
+            "*/tests/**/*.py",
+        ],
     ),
     imports = ["."],
     visibility = ["//:__subpackages__"],
@@ -4311,28 +4315,42 @@ py_test(
     name = "graph_config_test",
     srcs = ["graph/config_test.py"],
     imports = ["."],
-    deps = [":pkg_graph", "@pip//pytest"],
+    deps = [
+        ":pkg_graph",
+        "@pip//pytest",
+    ],
 )
 
 py_test(
     name = "graph_policy_test",
     srcs = ["graph/policy_test.py"],
     imports = ["."],
-    deps = [":pkg_graph", "@pip//pytest"],
+    deps = [
+        ":pkg_graph",
+        "@pip//pytest",
+    ],
 )
 
 py_test(
     name = "graph_router_test",
     srcs = ["graph/router_test.py"],
     imports = ["."],
-    deps = [":pkg_graph", "@pip//fastapi", "@pip//httpx", "@pip//pytest"],
+    deps = [
+        ":pkg_graph",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+    ],
 )
 
 py_test(
     name = "graph_workflows_test",
     srcs = ["graph/workflows_test.py"],
     imports = ["."],
-    deps = [":pkg_graph", "@pip//pytest"],
+    deps = [
+        ":pkg_graph",
+        "@pip//pytest",
+    ],
 )
 
 py_test(

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -10,6 +10,7 @@
 # gazelle:exclude ember_public
 # gazelle:exclude e2e
 # gazelle:exclude framework
+# gazelle:exclude graph
 # gazelle:exclude knowledge
 # gazelle:exclude notes
 # gazelle:exclude scripts
@@ -96,6 +97,7 @@ _BACKEND_SRCS = glob(
         "grimoire/**/*.py",
         "grimoire_chat/**/*.py",
         "faas/**/*.py",
+        "graph/**/*.py",
     ],
     exclude = [
         # pytest discovers both *_test.py (sibling convention) and
@@ -1552,6 +1554,25 @@ py_library(
 )
 
 py_library(
+    name = "pkg_graph",
+    srcs = glob(
+        ["graph/**/*.py"],
+        exclude = ["**/*_test.py", "**/test_*.py", "*/tests/**/*.py"],
+    ),
+    imports = ["."],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":pkg_agent_sessions",
+        ":pkg_core",
+        ":pkg_framework",
+        "@pip//dbos",
+        "@pip//fastapi",
+        "@pip//pydantic",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_library(
     name = "pkg_dr_jobs",
     srcs = glob(
         [
@@ -1705,6 +1726,7 @@ py_library(
             "grimoire/**/*.py",
             "grimoire_chat/**/*.py",
             "faas/**/*.py",
+            "graph/**/*.py",
         ],
         exclude = [
             # pytest discovers both *_test.py (sibling convention) and
@@ -1727,6 +1749,7 @@ py_library(
     ),  # keep
     visibility = ["//:__subpackages__"],
     deps = [
+        "@pip//dbos",
         "@pip//astral",
         "@pip//beautifulsoup4",
         "@pip//boto3",
@@ -4282,6 +4305,34 @@ py_test(
         "@pip//pytest",
         "@pip//sqlmodel",
     ],
+)
+
+py_test(
+    name = "graph_config_test",
+    srcs = ["graph/config_test.py"],
+    imports = ["."],
+    deps = [":pkg_graph", "@pip//pytest"],
+)
+
+py_test(
+    name = "graph_policy_test",
+    srcs = ["graph/policy_test.py"],
+    imports = ["."],
+    deps = [":pkg_graph", "@pip//pytest"],
+)
+
+py_test(
+    name = "graph_router_test",
+    srcs = ["graph/router_test.py"],
+    imports = ["."],
+    deps = [":pkg_graph", "@pip//fastapi", "@pip//httpx", "@pip//pytest"],
+)
+
+py_test(
+    name = "graph_workflows_test",
+    srcs = ["graph/workflows_test.py"],
+    imports = ["."],
+    deps = [":pkg_graph", "@pip//pytest"],
 )
 
 py_test(

--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -20,6 +20,20 @@ from core.db import get_engine
 from goosecracker.api import REPO_CATALOG
 
 
+def start_session_for_graph(
+    local_session_id: str, prompt: str, model: str, repo: str, branch: str
+) -> int:
+    """Create and schedule a graph-owned session through the normal session path."""
+    if repo not in REPO_CATALOG:
+        raise ValueError(f"unknown repo {repo}; catalog: {', '.join(REPO_CATALOG)}")
+    model_family(model)
+    row = _persist_session(local_session_id, "<guest>", branch, model, repo)
+    _persist_pending_message(row.id, prompt, model)
+    _schedule_next_message(row.id)
+    assert row.id is not None
+    return row.id
+
+
 async def start_session_for_thread(
     thread_id: str, prompt: str, repo: str | None, model: str = "luna"
 ) -> int | dict:

--- a/projects/monolith/app/modules_private.py
+++ b/projects/monolith/app/modules_private.py
@@ -22,6 +22,7 @@ import demos.module
 import dr_jobs.module
 import ember_public.module
 import faas.module
+import graph.module
 import grimoire.module
 import hikes.module
 import home.module
@@ -52,6 +53,7 @@ ALL_MODULES: tuple[Module, ...] = (
     worldcup.module.MODULE,
     artifact.module.MODULE,
     faas.module.MODULE,
+    graph.module.MODULE,
     demos.module.MODULE,
     ember_public.module.MODULE,
     # MCP-only domains (no HTTP routes of their own). Placed here, before

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.503
+version: 0.285.504
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -123,6 +123,24 @@ spec:
             - name: SANDBOX_SESSION_WORKLOAD
               value: {{ .Values.sandbox.sessionWorkload | quote }}
             {{- end }}
+            {{- if .Values.graph.enabled }}
+            # DBOS graph layer (ADR agents/038). GRAPH_ENABLED is the master
+            # switch the module reads: with it false the router still mounts but
+            # every run endpoint 503s and DBOS is never launched, so the import
+            # stays inert on the public tier and in unit tests.
+            - name: GRAPH_ENABLED
+              value: "true"
+            - name: GRAPH_IMPLEMENTER_MODEL
+              value: {{ .Values.graph.implementerModel | quote }}
+            - name: GRAPH_REVIEWER_MODEL
+              value: {{ .Values.graph.reviewerModel | quote }}
+            - name: GRAPH_MAX_ATTEMPTS
+              value: {{ .Values.graph.maxAttempts | quote }}
+            - name: GRAPH_TURN_TIMEOUT_SECONDS
+              value: {{ .Values.graph.turnTimeoutSeconds | quote }}
+            - name: GRAPH_CODEX_CONCURRENCY
+              value: {{ .Values.graph.codexConcurrency | quote }}
+            {{- end }}
             {{- if and .Values.scratchPostgres.onepassword.itemPath (or .Values.scratchPostgres.enabled .Values.scratchPostgres.demoListenPort) }}
             # Shared postgres password for the EmberVM stateful DSNs below. Comes
             # from the monolith-namespace Secret the OnePasswordItem syncs (the

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -987,6 +987,30 @@ goosecracker:
   onepassword:
     itemPath: ""
 
+# Graph: DBOS-backed composition of agent sessions into deterministic workflows
+# (ADR agents/038). DBOS is an in-process library, not a service, and stores its
+# workflow state in a `dbos` schema inside the existing monolith database, so
+# enabling this adds no new deployment and no second database.
+#
+# Launched on the LEADER replica only in this first version, so two replicas do
+# not both run the recovery loop. Private tier only: the module is registered in
+# modules_private and never in modules_public.
+graph:
+  enabled: false
+  # The cheap implementer lane and the reviewer that gates it. The reviewer is
+  # never below Opus: ADR 038 decision 5 floors anything assessable only by
+  # reading, and a review is exactly that.
+  implementerModel: "luna"
+  reviewerModel: "opus"
+  # Hard bound on retry. The adjudicator (a later slice) may choose WITHIN this
+  # budget but can never extend it, which is what keeps "retry N times" a
+  # budget rather than a suggestion.
+  maxAttempts: 2
+  turnTimeoutSeconds: 1800
+  # Concurrent Codex dispatches. Three concurrent dispatches have been killed
+  # before, so this stays at 2 until there is evidence it can go higher.
+  codexConcurrency: 2
+
 # Knowledge gardener: LLM-driven decomposition of raw vault notes into
 # typed knowledge artifacts via the claude Code CLI. Uses CLAUDE_CODE_OAUTH_TOKEN
 # from the litellm-claude-auth 1Password item (same token as goose agents).

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.503
+      targetRevision: 0.285.504
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -200,6 +200,18 @@ goosecracker:
   onepassword:
     itemPath: "vaults/k8s-homelab/items/embervm-agent-secrets"
 
+# Graph layer (ADR agents/038): the first working example of composing agent
+# sessions into a durable DBOS workflow (implement, then review, across two
+# sessions). Enabled here because the chart default is false and a chart default
+# never arms anything in prod.
+#
+# Deliberately stops short of merging. ADR 027's implementer/reviewer gate is
+# still Draft and `agent-review/gate` does not exist in code, so nothing
+# autonomous may land on main yet; the merge queue is declared at concurrency 1
+# and left unused until it does.
+graph:
+  enabled: true
+
 # Taken offline 2026-06-14 for the ADR 006 Phase 4 transition: with the
 # gardener paused, the raw export / file moves can be done as a controlled
 # one-off, and the gardener stays down until the CLI-based version (Phase 4a-ii)

--- a/projects/monolith/domain_images.bzl
+++ b/projects/monolith/domain_images.bzl
@@ -54,6 +54,7 @@ MONOLITH_DOMAINS = [
     "worldcup",
     "artifact",
     "faas",
+    "graph",
     "demos",
     "ember_public",
     "agent",

--- a/projects/monolith/graph/__init__.py
+++ b/projects/monolith/graph/__init__.py
@@ -1,0 +1,1 @@
+"""Durable composition of agent sessions."""

--- a/projects/monolith/graph/config.py
+++ b/projects/monolith/graph/config.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+
+
+def enabled() -> bool:
+    return os.environ.get("GRAPH_ENABLED", "false").lower() == "true"
+
+
+def implementer_model() -> str:
+    return os.environ.get("GRAPH_IMPLEMENTER_MODEL", "luna")
+
+
+def reviewer_model() -> str:
+    return os.environ.get("GRAPH_REVIEWER_MODEL", "opus")
+
+
+def max_attempts() -> int:
+    return int(os.environ.get("GRAPH_MAX_ATTEMPTS", "2"))
+
+
+def turn_timeout_seconds() -> int:
+    return int(os.environ.get("GRAPH_TURN_TIMEOUT_SECONDS", "1800"))
+
+
+def codex_concurrency() -> int:
+    return int(os.environ.get("GRAPH_CODEX_CONCURRENCY", "2"))

--- a/projects/monolith/graph/config_test.py
+++ b/projects/monolith/graph/config_test.py
@@ -1,0 +1,34 @@
+import graph.config as config
+
+
+def test_defaults(monkeypatch):
+    for name in (
+        "GRAPH_ENABLED",
+        "GRAPH_IMPLEMENTER_MODEL",
+        "GRAPH_REVIEWER_MODEL",
+        "GRAPH_MAX_ATTEMPTS",
+        "GRAPH_TURN_TIMEOUT_SECONDS",
+        "GRAPH_CODEX_CONCURRENCY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    assert config.enabled() is False
+    assert config.implementer_model() == "luna"
+    assert config.reviewer_model() == "opus"
+    assert config.max_attempts() == 2
+    assert config.turn_timeout_seconds() == 1800
+    assert config.codex_concurrency() == 2
+
+
+def test_environment_overrides(monkeypatch):
+    monkeypatch.setenv("GRAPH_ENABLED", "true")
+    monkeypatch.setenv("GRAPH_IMPLEMENTER_MODEL", "cheap")
+    monkeypatch.setenv("GRAPH_REVIEWER_MODEL", "careful")
+    monkeypatch.setenv("GRAPH_MAX_ATTEMPTS", "4")
+    monkeypatch.setenv("GRAPH_TURN_TIMEOUT_SECONDS", "12")
+    monkeypatch.setenv("GRAPH_CODEX_CONCURRENCY", "7")
+    assert config.enabled() is True
+    assert config.implementer_model() == "cheap"
+    assert config.reviewer_model() == "careful"
+    assert config.max_attempts() == 4
+    assert config.turn_timeout_seconds() == 12
+    assert config.codex_concurrency() == 7

--- a/projects/monolith/graph/module.py
+++ b/projects/monolith/graph/module.py
@@ -1,0 +1,17 @@
+from framework import Module as _Module
+
+
+def register(app) -> None:
+    from graph.router import router
+
+    app.include_router(router)
+
+
+async def _leader_start(app):
+    from graph import runtime
+
+    runtime.launch()
+    return []
+
+
+MODULE = _Module(name="graph", register=register, leader_start=_leader_start)

--- a/projects/monolith/graph/policy.py
+++ b/projects/monolith/graph/policy.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+
+def next_action(attempt: int, max_attempts: int, commit_sha: str | None) -> str:
+    """Decide what the graph does next, given one attempt's outcome.
+
+    Success is "a commit exists", never a reading of the agent's prose. Per ADR
+    038 decision 1 the session's own account of itself is a claim, so routing
+    keys off an artifact instead. An empty string is not a commit.
+    """
+    if commit_sha:
+        return "review"
+    if attempt < max_attempts:
+        return "retry"
+    return "escalate"
+
+
+def implementer_prompt(task: str, previous_failure: str | None) -> str:
+    prompt = f"Implement this task: {task}"
+    if previous_failure:
+        prompt += f"\nPrevious attempt failed: {previous_failure}"
+    return prompt
+
+
+def reviewer_prompt(task: str, branch: str, commit_sha: str) -> str:
+    return (
+        f"Review the implementation of: {task}\nBranch: {branch}\nCommit: {commit_sha}"
+    )

--- a/projects/monolith/graph/policy_test.py
+++ b/projects/monolith/graph/policy_test.py
@@ -1,0 +1,36 @@
+import pytest
+
+from graph.policy import implementer_prompt, next_action, reviewer_prompt
+
+
+@pytest.mark.parametrize(
+    ("attempt", "maximum", "commit", "expected"),
+    [
+        (
+            attempt,
+            maximum,
+            commit,
+            "review"
+            if commit is not None
+            else "retry"
+            if attempt < maximum
+            else "escalate",
+        )
+        for maximum in (1, 2, 3)
+        for attempt in (0, 1, 2, 3, 4)
+        for commit in (None, "abc")
+    ],
+)
+def test_next_action_is_exhaustive(attempt, maximum, commit, expected):
+    assert next_action(attempt, maximum, commit) == expected
+
+
+def test_prompt_builders():
+    assert implementer_prompt("fix bug", None) == "Implement this task: fix bug"
+    assert "Previous attempt failed: tests failed" in implementer_prompt(
+        "fix bug", "tests failed"
+    )
+    prompt = reviewer_prompt("fix bug", "feature", "abc123")
+    assert "fix bug" in prompt
+    assert "feature" in prompt
+    assert "abc123" in prompt

--- a/projects/monolith/graph/queues.py
+++ b/projects/monolith/graph/queues.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from graph import config
+
+_queues = None
+
+
+def get_queues():
+    global _queues
+    if _queues is None:
+        from dbos import Queue
+
+        _queues = (
+            Queue("codex", concurrency=config.codex_concurrency()),
+            Queue("merge", concurrency=1),
+        )
+    return _queues
+
+
+def codex_queue():
+    return get_queues()[0]
+
+
+def merge_queue():
+    return get_queues()[1]
+
+
+# The merge queue is declared but not used yet: ADR 027's merge gate does not
+# exist in code, so this example stops at review.

--- a/projects/monolith/graph/router.py
+++ b/projects/monolith/graph/router.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from graph import config, runtime
+from goosecracker.api import REPO_CATALOG
+
+router = APIRouter(prefix="/api/graph", tags=["graph"])
+
+
+class RunRequest(BaseModel):
+    task: str
+    repo: str
+    branch: str
+    idempotency_key: str | None = None
+
+
+def _dbos():
+    if not config.enabled():
+        raise HTTPException(status_code=503, detail="Graph workflows are disabled")
+    instance = runtime.init_dbos()
+    if instance is None:
+        raise HTTPException(status_code=503, detail="Graph DBOS is not configured")
+    return instance
+
+
+@router.post("/runs")
+def start_run(request: RunRequest) -> dict:
+    if not config.enabled():
+        raise HTTPException(status_code=503, detail="Graph workflows are disabled")
+    if request.repo not in REPO_CATALOG:
+        raise HTTPException(status_code=400, detail=f"unknown repo {request.repo}")
+    from graph.workflows import implement_then_review
+
+    dbos = _dbos()
+    from dbos import SetWorkflowID
+
+    context = (
+        SetWorkflowID(request.idempotency_key) if request.idempotency_key else None
+    )
+    if context:
+        with context:
+            handle = dbos.start_workflow(
+                implement_then_review, request.task, request.repo, request.branch
+            )
+    else:
+        handle = dbos.start_workflow(
+            implement_then_review, request.task, request.repo, request.branch
+        )
+    return {"workflow_id": handle.workflow_id}
+
+
+@router.get("/runs/{workflow_id}")
+def get_run(workflow_id: str) -> dict:
+    status = _dbos().retrieve_workflow(workflow_id).get_status()
+    return _status_payload(status)
+
+
+@router.get("/runs")
+def list_runs() -> list[dict]:
+    return [
+        _status_payload(status)
+        for status in _dbos().list_workflows(limit=50, sort_desc=True)
+    ]
+
+
+@router.post("/runs/{workflow_id}/cancel")
+def cancel_run(workflow_id: str) -> dict:
+    _dbos().cancel_workflow(workflow_id)
+    # Guest-session cleanup is a follow-up, and an issue should be filed. Cancel
+    # does not silently pretend that the guest session has been reaped.
+    return {"workflow_id": workflow_id, "cancelled": True}
+
+
+def _status_payload(status) -> dict:
+    return {
+        "workflow_id": status.workflow_id,
+        "status": status.status,
+        "result": getattr(status, "output", None),
+        "error": getattr(status, "error", None),
+    }

--- a/projects/monolith/graph/router_test.py
+++ b/projects/monolith/graph/router_test.py
@@ -1,0 +1,54 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import graph.router as graph_router
+
+
+def client():
+    app = FastAPI()
+    app.include_router(graph_router.router)
+    return TestClient(app)
+
+
+def test_disabled_returns_503(monkeypatch):
+    monkeypatch.setenv("GRAPH_ENABLED", "false")
+    response = client().post(
+        "/api/graph/runs",
+        json={"task": "fix", "repo": "jomcgi/homelab", "branch": "main"},
+    )
+    assert response.status_code == 503
+    assert "disabled" in response.json()["detail"]
+
+
+def test_unknown_repo_rejected(monkeypatch):
+    monkeypatch.setenv("GRAPH_ENABLED", "true")
+    response = client().post(
+        "/api/graph/runs",
+        json={"task": "fix", "repo": "not/a-repo", "branch": "main"},
+    )
+    assert response.status_code == 400
+    assert "unknown repo" in response.json()["detail"]
+
+
+def test_start_run(monkeypatch):
+    monkeypatch.setenv("GRAPH_ENABLED", "true")
+
+    class Handle:
+        workflow_id = "wf-1"
+
+    class FakeDBOS:
+        def start_workflow(self, *args):
+            return Handle()
+
+    monkeypatch.setattr(graph_router.runtime, "init_dbos", lambda: FakeDBOS())
+    response = client().post(
+        "/api/graph/runs",
+        json={
+            "task": "fix",
+            "repo": "jomcgi/homelab",
+            "branch": "main",
+            "idempotency_key": "request-1",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"workflow_id": "wf-1"}

--- a/projects/monolith/graph/runtime.py
+++ b/projects/monolith/graph/runtime.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+
+from graph import config
+
+_dbos = None
+_launched = False
+
+
+def init_dbos():
+    global _dbos
+    if _dbos is not None or not config.enabled():
+        return _dbos
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        return None
+    from dbos import DBOS, DBOSConfig
+
+    _dbos = DBOS(
+        config=DBOSConfig(
+            name="monolith",
+            system_database_url=database_url,
+            dbos_system_schema="dbos",
+        )
+    )
+    return _dbos
+
+
+def launch() -> None:
+    global _launched
+    instance = init_dbos()
+    if instance is not None and not _launched:
+        instance.launch()
+        _launched = True
+
+
+def shutdown() -> None:
+    global _dbos, _launched
+    if _dbos is not None and config.enabled() and os.environ.get("DATABASE_URL"):
+        _dbos.destroy()
+        _dbos = None
+        _launched = False

--- a/projects/monolith/graph/steps.py
+++ b/projects/monolith/graph/steps.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from dbos import DBOS
+
+
+@DBOS.step(retries_allowed=True, max_attempts=3, backoff_rate=2.0)
+def start_agent_session(prompt, model, repo, branch) -> int:
+    from agent_sessions.api import start_session_for_graph
+
+    return start_session_for_graph(str(uuid4()), prompt, model, repo, branch)
+
+
+@DBOS.step()
+def poll_turn(session_id: int, after_seq: int) -> dict | None:
+    """One non-blocking look for the next turn of a session.
+
+    Deliberately does NOT sleep or block. The waiting is done by the caller at
+    workflow level with DBOS.sleep, so each wait is checkpointed and a process
+    restart resumes the wait instead of losing it. A step that blocked for the
+    full turn timeout would hold a worker thread for up to 30 minutes and would
+    restart its wait from zero on recovery, which is the fragile-edge shape ADR
+    038 decision 1 exists to remove.
+    """
+    from sqlmodel import Session, select
+
+    from agent_sessions.models import AgentTurn
+    from core.db import get_engine
+
+    with Session(get_engine()) as session:
+        turn = session.exec(
+            select(AgentTurn)
+            .where(AgentTurn.session_id == session_id, AgentTurn.seq > after_seq)
+            .order_by(AgentTurn.seq)
+        ).first()
+        if turn is None:
+            return None
+        return {
+            "seq": turn.seq,
+            "result_text": turn.result_text,
+            "commit_sha": turn.commit_sha,
+            "terminal_reason": turn.terminal_reason,
+            "cost_usd": turn.cost_usd,
+        }

--- a/projects/monolith/graph/workflows.py
+++ b/projects/monolith/graph/workflows.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dbos import DBOS
+
+from graph import config
+from graph.policy import implementer_prompt, next_action, reviewer_prompt
+from graph.queues import codex_queue
+from graph.steps import poll_turn, start_agent_session
+
+# How long to wait between polls for a session's next turn. Each sleep is a
+# durable checkpoint, so the interval also sets how much wait is re-done after a
+# process restart.
+POLL_INTERVAL_SECONDS = 5
+
+
+@DBOS.workflow()
+def start_session_workflow(prompt: str, model: str, repo: str, branch: str) -> int:
+    """Queue-able wrapper around the session-start step.
+
+    DBOS queues enqueue WORKFLOWS, not steps, so the concurrency cap only
+    applies if what we enqueue is a workflow. Enqueuing the step directly would
+    not be gated by the queue at all.
+    """
+    return start_agent_session(prompt, model, repo, branch)
+
+
+def _queued_session(prompt: str, model: str, repo: str, branch: str) -> int:
+    handle = codex_queue().enqueue(start_session_workflow, prompt, model, repo, branch)
+    return handle.get_result()
+
+
+def _await_turn(session_id: int, after_seq: int, timeout_s: int) -> dict | None:
+    """Wait for a session's next turn, checkpointing between polls."""
+    waited = 0
+    while waited < timeout_s:
+        turn = poll_turn(session_id, after_seq)
+        if turn is not None:
+            return turn
+        DBOS.sleep(POLL_INTERVAL_SECONDS)
+        waited += POLL_INTERVAL_SECONDS
+    return None
+
+
+def _escalated(attempt: int, session_id: int | None, turn: dict | None) -> dict:
+    return {
+        "status": "escalated",
+        "attempts": attempt,
+        "implementer_session_id": session_id,
+        "commit_sha": None,
+        "reviewer_session_id": None,
+        "review_text": None,
+        "cost_usd": _cost(turn),
+    }
+
+
+@DBOS.workflow()
+def implement_then_review(task: str, repo: str, branch: str) -> dict:
+    max_attempts = max(1, config.max_attempts())
+    attempt = 0
+    previous_failure = None
+    implementer_session_id = None
+    implementer_turn = None
+    commit_sha = None
+
+    while attempt < max_attempts:
+        attempt += 1
+        implementer_session_id = _queued_session(
+            implementer_prompt(task, previous_failure),
+            config.implementer_model(),
+            repo,
+            branch,
+        )
+        implementer_turn = _await_turn(
+            implementer_session_id, 0, config.turn_timeout_seconds()
+        )
+        turn_commit = implementer_turn.get("commit_sha") if implementer_turn else None
+        action = next_action(attempt, max_attempts, turn_commit)
+        if action == "review":
+            commit_sha = turn_commit
+            break
+        if action == "escalate":
+            return _escalated(attempt, implementer_session_id, implementer_turn)
+        previous_failure = (
+            "The implementer produced no commit before the turn completed."
+        )
+
+    if commit_sha is None:
+        # Defensive: next_action should have escalated already. Never fall
+        # through into the reviewer without a commit to review.
+        return _escalated(attempt, implementer_session_id, implementer_turn)
+
+    # The reviewer gets a FRESH session (ADR 038 decision 3). It is never
+    # handed the implementer's lineage: a prompt-injected implementer could
+    # plant CLAUDE.md, AGENTS.md, or a git hook that the reviewer's CLI would
+    # read as instructions, so an inherited workspace would let the auditee
+    # prepare its auditor's room.
+    reviewer_session_id = _queued_session(
+        reviewer_prompt(task, branch, commit_sha),
+        config.reviewer_model(),
+        repo,
+        branch,
+    )
+    reviewer_turn = _await_turn(reviewer_session_id, 0, config.turn_timeout_seconds())
+    return {
+        "status": "review",
+        "attempts": attempt,
+        "implementer_session_id": implementer_session_id,
+        "commit_sha": commit_sha,
+        "reviewer_session_id": reviewer_session_id,
+        "review_text": reviewer_turn.get("result_text") if reviewer_turn else None,
+        "cost_usd": _cost(implementer_turn) + _cost(reviewer_turn),
+    }
+
+
+def _cost(turn: dict | None) -> float:
+    return float((turn or {}).get("cost_usd") or 0)

--- a/projects/monolith/graph/workflows_test.py
+++ b/projects/monolith/graph/workflows_test.py
@@ -1,0 +1,123 @@
+import graph.workflows as workflows
+
+
+class Queue:
+    def enqueue(self, function, *args):
+        class Handle:
+            def get_result(self):
+                return function(*args)
+
+        return Handle()
+
+
+def workflow(*args):
+    # DBOS requires an initialized runtime to invoke the decorated entrypoint.
+    # The wrapped function is the deterministic control flow under test, while
+    # the decorator remains on the production entrypoint.
+    return workflows.implement_then_review.__wrapped__(*args)
+
+
+def run(monkeypatch, turns):
+    sessions = iter(turns)
+    calls = []
+    monkeypatch.setattr(workflows, "codex_queue", lambda: Queue())
+    monkeypatch.setattr(workflows, "start_agent_session", lambda *args: 0)
+    monkeypatch.setattr(workflows, "_await_turn", lambda session, *_: turns[session])
+    monkeypatch.setattr(
+        workflows,
+        "_queued_session",
+        lambda prompt, model, repo, branch: (
+            calls.append((prompt, model, repo, branch)) or next(sessions)
+        ),
+    )
+    return calls
+
+
+def test_commit_on_first_attempt_goes_to_review(monkeypatch):
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": "abc", "result_text": "done", "cost_usd": 1},
+            201: {"commit_sha": None, "result_text": "review", "cost_usd": 2},
+        },
+    )
+    result = workflow("task", "jomcgi/homelab", "main")
+    assert result["status"] == "review"
+    assert result["attempts"] == 1
+    assert len(calls) == 2
+
+
+def test_no_commit_retries(monkeypatch):
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": None, "result_text": "no", "cost_usd": 1},
+            102: {"commit_sha": "abc", "result_text": "done", "cost_usd": 1},
+            201: {"commit_sha": None, "result_text": "review", "cost_usd": 1},
+        },
+    )
+    result = workflow("task", "jomcgi/homelab", "main")
+    assert result["attempts"] == 2
+    assert len(calls) == 3
+
+
+def test_exhausted_attempts_escalate_without_reviewer(monkeypatch):
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": None, "result_text": "no", "cost_usd": 1},
+            102: {"commit_sha": None, "result_text": "no", "cost_usd": 1},
+        },
+    )
+    result = workflow("task", "jomcgi/homelab", "main")
+    assert result["status"] == "escalated"
+    assert result["reviewer_session_id"] is None
+    assert len(calls) == 2
+
+
+def test_queue_receives_a_workflow_not_a_step(monkeypatch):
+    """Regression: DBOS queues enqueue workflows, so the concurrency cap only
+    binds if what is enqueued is a workflow. Enqueuing the step directly left
+    the codex cap unenforced."""
+    enqueued = []
+
+    class RecordingQueue:
+        def enqueue(self, function, *args):
+            enqueued.append(function)
+
+            class Handle:
+                def get_result(self):
+                    return 101
+
+            return Handle()
+
+    monkeypatch.setattr(workflows, "codex_queue", lambda: RecordingQueue())
+    workflows._queued_session("p", "luna", "jomcgi/homelab", "main")
+    assert enqueued == [workflows.start_session_workflow]
+    assert enqueued[0] is not workflows.start_agent_session
+
+
+def test_empty_commit_sha_is_not_success(monkeypatch):
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": "", "result_text": "no", "cost_usd": 1},
+            102: {"commit_sha": "", "result_text": "no", "cost_usd": 1},
+        },
+    )
+    result = workflow("task", "jomcgi/homelab", "main")
+    assert result["status"] == "escalated"
+    assert len(calls) == 2
+
+
+def test_reviewer_has_no_lineage_argument(monkeypatch):
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": "abc", "result_text": "done", "cost_usd": 1},
+            201: {"commit_sha": None, "result_text": "review", "cost_usd": 1},
+        },
+    )
+    workflow("task", "jomcgi/homelab", "main")
+    assert len(calls[1]) == 4
+    assert all("lineage" not in str(value) for value in calls[1])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ dependencies = [
     # Argo Workflows Python SDK: build Workflow specs to submit batch jobs to
     # the monolith-workflows Argo controller (off-pod job execution).
     "hera",
+    # DBOS Transact: durable, Postgres-checkpointed workflows used to compose
+    # agent sessions into deterministic graphs (ADR agents/038). In-process
+    # library, not a service; its system tables live in the `dbos` schema of the
+    # existing monolith database.
+    "dbos",
     "jinja2~=3.1",
     "python-multipart>=0.0.31",
     "apscheduler~=3.10",


### PR DESCRIPTION
First working example of the composition layer decided in
[ADR agents/038](https://github.com/jomcgi/homelab/blob/main/docs/decisions/agents/038-autonomous-work-queue-tiered-gating.md).
Tracked by #4578.

## The chain

```
implement (Luna)  ->  commit?  ->  retry up to N  ->  review (Opus)
   codex queue,          |                              fresh session,
   concurrency 2         +--> no commit, attempts       no lineage
                              exhausted -> escalate
```

Two agent sessions, deterministic control flow between them, checkpointed to
the existing monolith Postgres so a pod roll resumes the graph rather than
losing it.

## What is deliberate here

**Control flow is in the engine, not in a model.** Retry is a counter, routing
is a Python branch, and the Codex cap is a queue at concurrency 2 (three
concurrent dispatches have been killed before). ADR 038 decision 8 explains why
a model never gets the edges: reproducibility, cost bounding, and the fact that
an orchestrator reading CI logs while holding routing authority is an injection
path.

**Success is an artifact, not a self-report.** `next_action` keys off
`commit_sha`, never off the agent's prose. Per ADR 038 decision 1 the session's
account of itself is a claim, and the guest is simultaneously the least-trusted
component and the one being graded.

**The reviewer gets a fresh session.** It is never handed the implementer's
lineage. Inheriting that workspace would let a prompt-injected implementer
plant `CLAUDE.md`, `AGENTS.md`, or a git hook that the reviewer's CLI reads as
instructions, which is the auditee preparing its auditor's room. There is a
regression test asserting the reviewer is started with no lineage argument.

**It stops short of merging.** ADR 027's gate is still Draft and
`agent-review/gate` does not exist in code, so nothing autonomous may land on
main. The merge queue is declared at concurrency 1 and left unused until it does.

## Review fixes applied before this PR

Luna's first pass had a real defect I caught on review: it enqueued
`start_agent_session` (a `@DBOS.step`) onto the queue, but **DBOS queues enqueue
workflows, not steps**, so the concurrency cap would not have bound at all. Now
wrapped in `start_session_workflow`, with a regression test asserting the queue
receives the workflow and not the step.

Also changed: the turn wait was a single step blocking up to 1800s with
`DBOS.sleep` inside it, which holds a worker thread for 30 minutes and restarts
its wait from zero on recovery. It is now a workflow-level poll of short steps
with durable sleeps between them, so each wait is checkpointed. And
`next_action` no longer treats an empty-string commit as success.

## Known limitation

The session verdict contract (ADR 038 decision 1) does not exist yet, so a node
polls `agent_turns` rather than waiting on a guest-pushed verdict. That is the
first checkbox on #4578, and it needs a guest-side change, so it is not
in scope here.

## Verification

- `ci test`: `Executed 52 out of 742 tests: 742 tests pass`
  ([invocation](https://app.buildbuddy.io/invocation/889d8eda-842a-49a5-85dc-d26d4c0aa224))
- The four graph test targets verified by label (cache-hit confirms they
  executed and passed in the run above)
- `helm template` renders the `GRAPH_*` env only on the private tier; the
  public tier render contains zero `GRAPH_` vars
- Chart bumped to 0.285.504 (monolith + monolith-public) since this deploys