### PR TITLE
fix(monolith): refuse graph submissions on a follower replica

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.504
+version: 0.285.505
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.504
+      targetRevision: 0.285.505
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.504
+version: 0.285.505
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.504
+      targetRevision: 0.285.505
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/graph/router.py
+++ b/projects/monolith/graph/router.py
@@ -22,13 +22,18 @@ def _dbos():
     instance = runtime.init_dbos()
     if instance is None:
         raise HTTPException(status_code=503, detail="Graph DBOS is not configured")
+    if not runtime.is_launched():
+        # A follower replica: the router is mounted everywhere but DBOS only
+        # launches on the leader. Submitting here would target an unlaunched
+        # runtime, so say so rather than failing obscurely downstream.
+        raise HTTPException(
+            status_code=503, detail="Graph DBOS is not launched on this replica"
+        )
     return instance
 
 
 @router.post("/runs")
 def start_run(request: RunRequest) -> dict:
-    if not config.enabled():
-        raise HTTPException(status_code=503, detail="Graph workflows are disabled")
     if request.repo not in REPO_CATALOG:
         raise HTTPException(status_code=400, detail=f"unknown repo {request.repo}")
     from graph.workflows import implement_then_review
@@ -68,9 +73,15 @@ def list_runs() -> list[dict]:
 @router.post("/runs/{workflow_id}/cancel")
 def cancel_run(workflow_id: str) -> dict:
     _dbos().cancel_workflow(workflow_id)
-    # Guest-session cleanup is a follow-up, and an issue should be filed. Cancel
-    # does not silently pretend that the guest session has been reaped.
-    return {"workflow_id": workflow_id, "cancelled": True}
+    # Cancelling the workflow does NOT reap the guest session it started, and
+    # parked sessions count against the live capacity cap, so a cancelled graph
+    # can still deny creates cluster-wide. The compensating control-plane delete
+    # is tracked in #4578. Reported honestly rather than claiming a clean stop.
+    return {
+        "workflow_id": workflow_id,
+        "cancelled": True,
+        "guest_session_reaped": False,
+    }
 
 
 def _status_payload(status) -> dict:

--- a/projects/monolith/graph/router_test.py
+++ b/projects/monolith/graph/router_test.py
@@ -41,6 +41,7 @@ def test_start_run(monkeypatch):
             return Handle()
 
     monkeypatch.setattr(graph_router.runtime, "init_dbos", lambda: FakeDBOS())
+    monkeypatch.setattr(graph_router.runtime, "is_launched", lambda: True)
     response = client().post(
         "/api/graph/runs",
         json={
@@ -52,3 +53,22 @@ def test_start_run(monkeypatch):
     )
     assert response.status_code == 200
     assert response.json() == {"workflow_id": "wf-1"}
+
+
+def test_follower_replica_returns_503(monkeypatch):
+    """DBOS launches on the leader only, but every replica serves the router.
+    A follower must refuse rather than submit against an unlaunched runtime."""
+    monkeypatch.setenv("GRAPH_ENABLED", "true")
+
+    class FakeDBOS:
+        def start_workflow(self, *args):  # pragma: no cover - must not be reached
+            raise AssertionError("a follower replica must not submit a workflow")
+
+    monkeypatch.setattr(graph_router.runtime, "init_dbos", lambda: FakeDBOS())
+    monkeypatch.setattr(graph_router.runtime, "is_launched", lambda: False)
+    response = client().post(
+        "/api/graph/runs",
+        json={"task": "fix", "repo": "jomcgi/homelab", "branch": "main"},
+    )
+    assert response.status_code == 503
+    assert "not launched" in response.json()["detail"]

--- a/projects/monolith/graph/runtime.py
+++ b/projects/monolith/graph/runtime.py
@@ -27,6 +27,17 @@ def init_dbos():
     return _dbos
 
 
+def is_launched() -> bool:
+    """True only on a replica that actually launched DBOS.
+
+    DBOS launches on the LEADER only, but every replica serves the router, so a
+    request can land on a follower. Constructing a DBOS instance there and
+    calling start_workflow on it would submit against an unlaunched runtime, so
+    callers gate on this instead of on init_dbos() returning non-None.
+    """
+    return _launched
+
+
 def launch() -> None:
     global _launched
     instance = init_dbos()


### PR DESCRIPTION
Follow-up to #4579, which merged while I was still writing this fix.

## The bug

DBOS launches on the **leader** replica only, but every replica mounts the
graph router, and the monolith runs two replicas. A request landing on a
follower would call `runtime.init_dbos()`, receive a constructed-but-never-
launched instance, and submit a workflow against it.

`_dbos()` now gates on `runtime.is_launched()` and returns 503 on a follower
instead of failing obscurely downstream. There is a regression test whose fake
DBOS raises if `start_workflow` is reached at all.

The `GRAPH_ENABLED` check moves entirely into `_dbos()` so one place decides
whether this replica can serve a run. Unknown-repo validation deliberately
stays ahead of it, so a bad repo is still a 400 rather than a 503.

## Also: cancel no longer overstates what it did

Cancelling the workflow does **not** reap the guest session it started, and
parked sessions count against the live capacity cap, so a cancelled graph can
still deny creates cluster-wide with a 429. The response now returns
`guest_session_reaped: false` and the comment points at #4578 for the
compensating control-plane delete, rather than implying a clean stop.

## Verification

`ci test`: `Executed 54 out of 742 tests: 742 tests pass`
([invocation](https://app.buildbuddy.io/invocation/07f10f89-c3a5-4522-a148-52ddade34c8e)).
The re-run on this branch is a pure cache hit (`Executed 0 out of 742`) because
the content is byte-identical to that run: the fix was written before it and
only re-applied onto a fresh branch after #4579 merged.

Chart bumped to 0.285.505 since this deploys.