### PR TITLE
fix(monolith): make graph session-start idempotent and non-blocking

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.505
+version: 0.285.506
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.505
+      targetRevision: 0.285.506
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -23,14 +23,35 @@ from goosecracker.api import REPO_CATALOG
 def start_session_for_graph(
     local_session_id: str, prompt: str, model: str, repo: str, branch: str
 ) -> int:
-    """Create and schedule a graph-owned session through the normal session path."""
+    """Create and schedule a graph-owned session through the normal session path.
+
+    ``local_session_id`` is the caller's IDEMPOTENCY KEY, not a fresh uuid. DBOS
+    steps are at-least-once, so a retried step that minted a new id each time
+    would leave one live agent session per attempt, each burning a Codex slot.
+    A repeat call with the same key returns the existing session untouched.
+
+    Safe to call from a non-async thread. DBOS executes sync steps on a worker
+    thread with no running event loop, where ``_schedule_next_message`` cannot
+    ``asyncio.create_task``; the leader's orphan sweep (every 5s) picks the
+    pending message up instead, so scheduling here is an optimisation rather
+    than the liveness mechanism.
+    """
     if repo not in REPO_CATALOG:
         raise ValueError(f"unknown repo {repo}; catalog: {', '.join(REPO_CATALOG)}")
     model_family(model)
+    with Session(get_engine()) as session:
+        existing = store.get_session_by_local_id(session, local_session_id)
+    if existing is not None and existing.id is not None:
+        return existing.id
     row = _persist_session(local_session_id, "<guest>", branch, model, repo)
-    _persist_pending_message(row.id, prompt, model)
-    _schedule_next_message(row.id)
     assert row.id is not None
+    _persist_pending_message(row.id, prompt, model)
+    try:
+        _schedule_next_message(row.id)
+    except RuntimeError:
+        # No running event loop: this is a DBOS worker thread. The orphan sweep
+        # will claim and execute the pending message within ~5s.
+        pass
     return row.id
 
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.505
+version: 0.285.506
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.505
+      targetRevision: 0.285.506
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/graph/router.py
+++ b/projects/monolith/graph/router.py
@@ -85,9 +85,13 @@ def cancel_run(workflow_id: str) -> dict:
 
 
 def _status_payload(status) -> dict:
+    # `error` is a live exception object (e.g. DBOSMaxStepRetriesExceeded), which
+    # pydantic cannot serialize: returning it raw turned every failed run's
+    # status into a 500, hiding the very failure the caller was asking about.
+    error = getattr(status, "error", None)
     return {
         "workflow_id": status.workflow_id,
         "status": status.status,
         "result": getattr(status, "output", None),
-        "error": getattr(status, "error", None),
+        "error": None if error is None else f"{type(error).__name__}: {error}",
     }

--- a/projects/monolith/graph/steps.py
+++ b/projects/monolith/graph/steps.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
-from uuid import uuid4
-
 from dbos import DBOS
 
 
 @DBOS.step(retries_allowed=True, max_attempts=3, backoff_rate=2.0)
-def start_agent_session(prompt, model, repo, branch) -> int:
+def start_agent_session(session_key, prompt, model, repo, branch) -> int:
+    """Start (or re-attach to) one agent session.
+
+    ``session_key`` must be DETERMINISTIC for a given workflow and node. Steps
+    are at-least-once, so minting a uuid here meant every retry created another
+    live session holding another Codex slot, which is exactly the
+    externally-visible-step hazard ADR 038 decision 2 calls out.
+    """
     from agent_sessions.api import start_session_for_graph
 
-    return start_session_for_graph(str(uuid4()), prompt, model, repo, branch)
+    return start_session_for_graph(session_key, prompt, model, repo, branch)
 
 
 @DBOS.step()

--- a/projects/monolith/graph/workflows.py
+++ b/projects/monolith/graph/workflows.py
@@ -14,18 +14,36 @@ POLL_INTERVAL_SECONDS = 5
 
 
 @DBOS.workflow()
-def start_session_workflow(prompt: str, model: str, repo: str, branch: str) -> int:
+def start_session_workflow(
+    key: str, prompt: str, model: str, repo: str, branch: str
+) -> int:
     """Queue-able wrapper around the session-start step.
 
     DBOS queues enqueue WORKFLOWS, not steps, so the concurrency cap only
     applies if what we enqueue is a workflow. Enqueuing the step directly would
     not be gated by the queue at all.
     """
-    return start_agent_session(prompt, model, repo, branch)
+    return start_agent_session(key, prompt, model, repo, branch)
 
 
-def _queued_session(prompt: str, model: str, repo: str, branch: str) -> int:
-    handle = codex_queue().enqueue(start_session_workflow, prompt, model, repo, branch)
+def session_key(suffix: str) -> str:
+    """Deterministic idempotency key for one node of the current workflow.
+
+    Reading DBOS.workflow_id raises outside a workflow context, so this degrades
+    to a stable placeholder rather than exploding: the key only has to be
+    consistent across retries OF THE SAME RUN.
+    """
+    try:
+        workflow_id = DBOS.workflow_id
+    except Exception:  # noqa: BLE001 - no workflow context
+        workflow_id = None
+    return f"{workflow_id}-{suffix}"
+
+
+def _queued_session(key: str, prompt: str, model: str, repo: str, branch: str) -> int:
+    handle = codex_queue().enqueue(
+        start_session_workflow, key, prompt, model, repo, branch
+    )
     return handle.get_result()
 
 
@@ -65,6 +83,7 @@ def implement_then_review(task: str, repo: str, branch: str) -> dict:
     while attempt < max_attempts:
         attempt += 1
         implementer_session_id = _queued_session(
+            session_key(f"implement-{attempt}"),
             implementer_prompt(task, previous_failure),
             config.implementer_model(),
             repo,
@@ -95,6 +114,7 @@ def implement_then_review(task: str, repo: str, branch: str) -> dict:
     # read as instructions, so an inherited workspace would let the auditee
     # prepare its auditor's room.
     reviewer_session_id = _queued_session(
+        session_key("review"),
         reviewer_prompt(task, branch, commit_sha),
         config.reviewer_model(),
         repo,

--- a/projects/monolith/graph/workflows_test.py
+++ b/projects/monolith/graph/workflows_test.py
@@ -26,8 +26,8 @@ def run(monkeypatch, turns):
     monkeypatch.setattr(
         workflows,
         "_queued_session",
-        lambda prompt, model, repo, branch: (
-            calls.append((prompt, model, repo, branch)) or next(sessions)
+        lambda key, prompt, model, repo, branch: (
+            calls.append((key, prompt, model, repo, branch)) or next(sessions)
         ),
     )
     return calls
@@ -92,7 +92,7 @@ def test_queue_receives_a_workflow_not_a_step(monkeypatch):
             return Handle()
 
     monkeypatch.setattr(workflows, "codex_queue", lambda: RecordingQueue())
-    workflows._queued_session("p", "luna", "jomcgi/homelab", "main")
+    workflows._queued_session("k-1", "p", "luna", "jomcgi/homelab", "main")
     assert enqueued == [workflows.start_session_workflow]
     assert enqueued[0] is not workflows.start_agent_session
 
@@ -119,5 +119,29 @@ def test_reviewer_has_no_lineage_argument(monkeypatch):
         },
     )
     workflow("task", "jomcgi/homelab", "main")
-    assert len(calls[1]) == 4
+    assert len(calls[1]) == 5
     assert all("lineage" not in str(value) for value in calls[1])
+
+
+def test_session_keys_are_deterministic_and_distinct(monkeypatch):
+    """Steps are at-least-once, so the session key is the idempotency key. A
+    retried step that minted a fresh uuid left one live agent session per
+    attempt, each holding a Codex slot."""
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": None, "result_text": "no", "cost_usd": 0},
+            102: {"commit_sha": "abc", "result_text": "done", "cost_usd": 0},
+            201: {"commit_sha": None, "result_text": "review", "cost_usd": 0},
+        },
+    )
+    workflow("task", "jomcgi/homelab", "main")
+    keys = [call[0] for call in calls]
+    # One key per node, stable across a re-run of the same workflow, and the
+    # reviewer never shares a key with an implementer attempt.
+    assert keys == [
+        workflows.session_key("implement-1"),
+        workflows.session_key("implement-2"),
+        workflows.session_key("review"),
+    ]
+    assert len(set(keys)) == 3


### PR DESCRIPTION
Found by **running the graph in the cluster**, not by testing it. The first live
run created three duplicate agent sessions and then returned HTTP 500 when asked
for its status. Three defects, all of which ADR 038 predicted in the abstract
and none of which the unit tests caught.

## 1. `RuntimeError: no running event loop`

DBOS executes sync steps on a **worker thread**. `_schedule_next_message` calls
`asyncio.create_task`, which needs the FastAPI event loop, so `start_agent_session`
threw on every invocation.

The leader's orphan sweep already claims unscheduled pending messages every 5
seconds, so scheduling is now an optimisation and its absence is tolerated
rather than fatal. Liveness comes from the sweep, which is the durable path
anyway.

## 2. The retry then created duplicate live sessions

That exception tripped the step's own `max_attempts=3` policy, and because the
step minted a fresh `uuid4()` per attempt, **each retry created another live
agent session holding another Codex slot**. Observed: sessions 162, 163, and 164
for a single run.

The session id is now a deterministic idempotency key derived from the workflow
id and the node (`<workflow>-implement-<n>`, `<workflow>-review`), and
`start_session_for_graph` returns the existing session for a repeat key.

This is ADR 038 decision 2's "every externally-visible step carries an
idempotency key" made concrete. Worth noting the hazard appeared on the *first*
run rather than in some later edge case, which is a decent argument for the ADR
having called it out as a named risk rather than a footnote.

## 3. Status endpoint 500'd on exactly the runs you would want to inspect

`_status_payload` returned the workflow's `error` field raw, and that is a live
exception object (`DBOSMaxStepRetriesExceeded`) which pydantic cannot serialize.
So any *failed* workflow's status became a 500, hiding the failure being asked
about. Now rendered as `"TypeName: message"`.

## Verification

`ci test`: `Executed 62 out of 742 tests: 742 tests pass`.

New regression tests: session keys are deterministic, distinct per node, and
stable across retries of the same run.

Chart bumped to 0.285.506. Follow-up to #4579 and #4580; tracked by #4578.