### PR TITLE
feat(monolith): route the graph on a pushed branch, not a dead column

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.506
+version: 0.285.507
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.506
+      targetRevision: 0.285.507
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1571,6 +1571,7 @@ py_library(
         ":pkg_framework",
         "@pip//dbos",
         "@pip//fastapi",
+        "@pip//httpx",
         "@pip//pydantic",
         "@pip//sqlmodel",
     ],
@@ -4349,6 +4350,17 @@ py_test(
     imports = ["."],
     deps = [
         ":pkg_graph",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "graph_steps_test",
+    srcs = ["graph/steps_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_graph",
+        "@pip//httpx",
         "@pip//pytest",
     ],
 )

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.506
+version: 0.285.507
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.506
+      targetRevision: 0.285.507
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/graph/policy.py
+++ b/projects/monolith/graph/policy.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
 
+def work_branch(workflow_id: str) -> str:
+    """The scratch branch one graph run pushes its implementation to.
+
+    Lives under `claude/` because that is this repo's established agent branch
+    namespace (ADR 038 decision 6 has implementer runs pushing `claude/*`, and
+    origin already carries a dozen). A namespace agents are not expected to
+    write would make the oracle silently return "no push" forever, which is the
+    same class of dead signal that AgentTurn.commit_sha turned out to be.
+    """
+    return f"claude/graph-{workflow_id}"
+
+
 def next_action(attempt: int, max_attempts: int, commit_sha: str | None) -> str:
     """Decide what the graph does next, given one attempt's outcome.
 
@@ -15,8 +27,12 @@ def next_action(attempt: int, max_attempts: int, commit_sha: str | None) -> str:
     return "escalate"
 
 
-def implementer_prompt(task: str, previous_failure: str | None) -> str:
-    prompt = f"Implement this task: {task}"
+def implementer_prompt(task: str, branch: str, previous_failure: str | None) -> str:
+    prompt = (
+        f"Implement this task: {task}\n"
+        f"Create branch {branch} from the base branch, make the change, commit it, "
+        f"and push {branch} to GitHub. Do not open a pull request. Do not push to main."
+    )
     if previous_failure:
         prompt += f"\nPrevious attempt failed: {previous_failure}"
     return prompt
@@ -24,5 +40,6 @@ def implementer_prompt(task: str, previous_failure: str | None) -> str:
 
 def reviewer_prompt(task: str, branch: str, commit_sha: str) -> str:
     return (
-        f"Review the implementation of: {task}\nBranch: {branch}\nCommit: {commit_sha}"
+        f"Review the pushed branch {branch} for this task: {task}\n"
+        f"Branch: {branch}\nCommit: {commit_sha}"
     )

--- a/projects/monolith/graph/policy_test.py
+++ b/projects/monolith/graph/policy_test.py
@@ -1,6 +1,12 @@
 import pytest
 
-from graph.policy import implementer_prompt, next_action, reviewer_prompt
+from graph.policy import implementer_prompt, next_action, reviewer_prompt, work_branch
+
+
+def test_work_branch():
+    assert work_branch("wf-123") == "claude/graph-wf-123"
+    # Must live in the agent branch namespace agents can actually push to.
+    assert work_branch("wf-123").startswith("claude/")
 
 
 @pytest.mark.parametrize(
@@ -26,9 +32,12 @@ def test_next_action_is_exhaustive(attempt, maximum, commit, expected):
 
 
 def test_prompt_builders():
-    assert implementer_prompt("fix bug", None) == "Implement this task: fix bug"
+    prompt = implementer_prompt("fix bug", "claude/graph-wf-123", None)
+    assert "claude/graph-wf-123" in prompt
+    assert "Do not open a pull request" in prompt
+    assert "Do not push to main" in prompt
     assert "Previous attempt failed: tests failed" in implementer_prompt(
-        "fix bug", "tests failed"
+        "fix bug", "claude/graph-wf-123", "tests failed"
     )
     prompt = reviewer_prompt("fix bug", "feature", "abc123")
     assert "fix bug" in prompt

--- a/projects/monolith/graph/steps.py
+++ b/projects/monolith/graph/steps.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+
+import httpx
 from dbos import DBOS
 
 
@@ -44,7 +47,22 @@ def poll_turn(session_id: int, after_seq: int) -> dict | None:
         return {
             "seq": turn.seq,
             "result_text": turn.result_text,
-            "commit_sha": turn.commit_sha,
             "terminal_reason": turn.terminal_reason,
             "cost_usd": turn.cost_usd,
         }
+
+
+@DBOS.step(retries_allowed=True, max_attempts=3, backoff_rate=2.0)
+def read_branch_head(repo: str, branch: str) -> str | None:
+    """Read a pushed branch head from GitHub, independently of the agent claim."""
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_API_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    url = f"https://api.github.com/repos/{repo}/git/ref/heads/{branch}"
+    with httpx.Client(timeout=10.0) as client:
+        response = client.get(url, headers=headers)
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    return response.json()["object"]["sha"]

--- a/projects/monolith/graph/steps_test.py
+++ b/projects/monolith/graph/steps_test.py
@@ -1,0 +1,51 @@
+import httpx
+import pytest
+
+import graph.steps as steps
+
+
+class FakeClient:
+    response = None
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def get(self, url, headers):
+        self.url = url
+        self.headers = headers
+        return self.response
+
+
+@pytest.mark.parametrize(
+    ("status", "payload", "expected"),
+    [(200, {"object": {"sha": "deadbeef"}}, "deadbeef"), (404, {}, None)],
+)
+def test_read_branch_head(monkeypatch, status, payload, expected):
+    request = httpx.Request(
+        "GET", "https://api.github.com/repos/jomcgi/homelab/git/ref/heads/graph/wf-1"
+    )
+    response = httpx.Response(status, json=payload, request=request)
+    FakeClient.response = response
+    monkeypatch.setattr(steps.httpx, "Client", FakeClient)
+
+    assert (
+        steps.read_branch_head.__wrapped__("jomcgi/homelab", "graph/wf-1") == expected
+    )
+
+
+def test_read_branch_head_raises_on_server_error(monkeypatch):
+    request = httpx.Request(
+        "GET", "https://api.github.com/repos/jomcgi/homelab/git/ref/heads/graph/wf-1"
+    )
+    FakeClient.response = httpx.Response(500, json={"message": "boom"}, request=request)
+    monkeypatch.setattr(steps.httpx, "Client", FakeClient)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        steps.read_branch_head.__wrapped__("jomcgi/homelab", "graph/wf-1")

--- a/projects/monolith/graph/workflows.py
+++ b/projects/monolith/graph/workflows.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from dbos import DBOS
 
 from graph import config
-from graph.policy import implementer_prompt, next_action, reviewer_prompt
+from graph.policy import implementer_prompt, next_action, reviewer_prompt, work_branch
 from graph.queues import codex_queue
-from graph.steps import poll_turn, start_agent_session
+from graph.steps import poll_turn, read_branch_head, start_agent_session
 
 # How long to wait between polls for a session's next turn. Each sleep is a
 # durable checkpoint, so the interval also sets how much wait is re-done after a
@@ -59,12 +59,15 @@ def _await_turn(session_id: int, after_seq: int, timeout_s: int) -> dict | None:
     return None
 
 
-def _escalated(attempt: int, session_id: int | None, turn: dict | None) -> dict:
+def _escalated(
+    attempt: int, session_id: int | None, turn: dict | None, branch_name: str
+) -> dict:
     return {
         "status": "escalated",
         "attempts": attempt,
         "implementer_session_id": session_id,
         "commit_sha": None,
+        "work_branch": branch_name,
         "reviewer_session_id": None,
         "review_text": None,
         "cost_usd": _cost(turn),
@@ -73,6 +76,11 @@ def _escalated(attempt: int, session_id: int | None, turn: dict | None) -> dict:
 
 @DBOS.workflow()
 def implement_then_review(task: str, repo: str, branch: str) -> dict:
+    try:
+        workflow_id = DBOS.workflow_id
+    except Exception:  # noqa: BLE001 - no workflow context
+        workflow_id = None
+    branch_name = work_branch(workflow_id or "unknown")
     max_attempts = max(1, config.max_attempts())
     attempt = 0
     previous_failure = None
@@ -84,7 +92,7 @@ def implement_then_review(task: str, repo: str, branch: str) -> dict:
         attempt += 1
         implementer_session_id = _queued_session(
             session_key(f"implement-{attempt}"),
-            implementer_prompt(task, previous_failure),
+            implementer_prompt(task, branch_name, previous_failure),
             config.implementer_model(),
             repo,
             branch,
@@ -92,21 +100,26 @@ def implement_then_review(task: str, repo: str, branch: str) -> dict:
         implementer_turn = _await_turn(
             implementer_session_id, 0, config.turn_timeout_seconds()
         )
-        turn_commit = implementer_turn.get("commit_sha") if implementer_turn else None
-        action = next_action(attempt, max_attempts, turn_commit)
+        head_sha = read_branch_head(repo, branch_name)
+        action = next_action(attempt, max_attempts, head_sha)
         if action == "review":
-            commit_sha = turn_commit
+            commit_sha = head_sha
             break
         if action == "escalate":
-            return _escalated(attempt, implementer_session_id, implementer_turn)
+            return _escalated(
+                attempt, implementer_session_id, implementer_turn, branch_name
+            )
         previous_failure = (
-            "The implementer produced no commit before the turn completed."
+            f"The branch {branch_name} was not found on the remote after the "
+            "turn completed, so the work was not pushed. Push it this time."
         )
 
     if commit_sha is None:
         # Defensive: next_action should have escalated already. Never fall
         # through into the reviewer without a commit to review.
-        return _escalated(attempt, implementer_session_id, implementer_turn)
+        return _escalated(
+            attempt, implementer_session_id, implementer_turn, branch_name
+        )
 
     # The reviewer gets a FRESH session (ADR 038 decision 3). It is never
     # handed the implementer's lineage: a prompt-injected implementer could
@@ -115,7 +128,7 @@ def implement_then_review(task: str, repo: str, branch: str) -> dict:
     # prepare its auditor's room.
     reviewer_session_id = _queued_session(
         session_key("review"),
-        reviewer_prompt(task, branch, commit_sha),
+        reviewer_prompt(task, branch_name, commit_sha),
         config.reviewer_model(),
         repo,
         branch,
@@ -126,6 +139,7 @@ def implement_then_review(task: str, repo: str, branch: str) -> dict:
         "attempts": attempt,
         "implementer_session_id": implementer_session_id,
         "commit_sha": commit_sha,
+        "work_branch": branch_name,
         "reviewer_session_id": reviewer_session_id,
         "review_text": reviewer_turn.get("result_text") if reviewer_turn else None,
         "cost_usd": _cost(implementer_turn) + _cost(reviewer_turn),

--- a/projects/monolith/graph/workflows_test.py
+++ b/projects/monolith/graph/workflows_test.py
@@ -17,12 +17,20 @@ def workflow(*args):
     return workflows.implement_then_review.__wrapped__(*args)
 
 
-def run(monkeypatch, turns):
+def run(monkeypatch, turns, heads=None):
     sessions = iter(turns)
     calls = []
+    if heads is None:
+        heads = [
+            turns[session].get("commit_sha")
+            for session in sorted(turns)
+            if session < 200
+        ]
+    branch_heads = iter(heads)
     monkeypatch.setattr(workflows, "codex_queue", lambda: Queue())
     monkeypatch.setattr(workflows, "start_agent_session", lambda *args: 0)
     monkeypatch.setattr(workflows, "_await_turn", lambda session, *_: turns[session])
+    monkeypatch.setattr(workflows, "read_branch_head", lambda *_: next(branch_heads))
     monkeypatch.setattr(
         workflows,
         "_queued_session",
@@ -44,6 +52,8 @@ def test_commit_on_first_attempt_goes_to_review(monkeypatch):
     result = workflow("task", "jomcgi/homelab", "main")
     assert result["status"] == "review"
     assert result["attempts"] == 1
+    assert result["commit_sha"] == "abc"
+    assert result["work_branch"] == "claude/graph-unknown"
     assert len(calls) == 2
 
 
@@ -121,6 +131,27 @@ def test_reviewer_has_no_lineage_argument(monkeypatch):
     workflow("task", "jomcgi/homelab", "main")
     assert len(calls[1]) == 5
     assert all("lineage" not in str(value) for value in calls[1])
+
+
+def test_routes_on_github_head_not_turn_commit(monkeypatch):
+    """The turn CLAIMS a commit; GitHub says the branch was never pushed. The
+    graph must believe GitHub. Routing on the turn field is what made the
+    reviewer unreachable, because AgentTurn.commit_sha is never written."""
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": "abc", "result_text": "done", "cost_usd": 1},
+            102: {"commit_sha": "def", "result_text": "done", "cost_usd": 1},
+        },
+        heads=[None, None],
+    )
+    result = workflow("task", "jomcgi/homelab", "main")
+    assert result["status"] == "escalated"
+    assert result["reviewer_session_id"] is None
+    assert result["commit_sha"] is None
+    # Two implementer attempts, and never a reviewer, despite both turns
+    # self-reporting a commit sha.
+    assert len(calls) == 2
 
 
 def test_session_keys_are_deterministic_and_distinct(monkeypatch):


### PR DESCRIPTION
Makes the reviewer node reachable. Follow-up to #4579/#4580/#4581, tracked by
#4578.

## The bug the first live run exposed

The graph decided "did the implementer succeed?" by reading
`AgentTurn.commit_sha`. **That column is dead.** Its only references repo-wide:

- `agent_sessions/models.py:82` (declared, `index=True`)
- `agent_sessions/store.py:184,200` (a `create_turn` parameter)
- `agent_sessions/store.py:549` (hardcoded `commit_sha=None`)
- `agent_sessions/router.py:263` (serialized into the API response)

Nothing has ever written a real sha. Run `graph-demo-2` proved it: Luna
genuinely committed `2de38ed84 docs(monolith): document queue concurrency`, and
the column was null, so the run escalated after two attempts and no review ever
happened.

It is a dead seam that reads as live: indexed, typed, and returned by the API.
That is precisely why I picked it as the artifact-based oracle over the agent's
prose.

## Why not just parse the result text

ADR 038 decision 1 forbids it, and the reasoning holds here exactly: the agent
is the thing being graded, so letting it report its own commit sha is letting it
supply its own grade. The oracle must be an artifact a machine checks
independently.

## The fix

The implementer pushes a scratch branch; a deterministic step reads that
branch's head from the GitHub API.

- `policy.work_branch()` -> `claude/graph-<workflow_id>`.
- `steps.read_branch_head()` -> sha on 200, **None on 404**, raises otherwise.
  A missing branch is a normal outcome and must not trip the step's retry
  policy; a 500 is flakiness and should.
- The workflow routes `next_action` on that sha and no longer touches the turn's
  `commit_sha`.

**The `claude/` namespace is load-bearing, not cosmetic.** My first draft used
`graph/<id>`. ADR 038's security section cites ADR 041's confinement of guest
mirror pushes to `refs/agents/**`, which sent me to check where agents can
actually write: `claude/*` is the established namespace (ADR 038 decision 6, and
origin carries 13 such branches). Shipping `graph/*` would have produced an
oracle that silently answers "no" forever, which is the same class of bug as the
dead column.

For the record, this does not make the mirror authoritative. ADR 041 keeps
`refs/agents/**` a non-authoritative audit and replay namespace that "never
feeds CI, ArgoCD, or PRs", while authoritative writes go direct to GitHub, which
is what this reads.

## Verification

`ci test`: `Executed 3 out of 743 tests: 743 tests pass` (743, up from 742: the
new `graph_steps_test`). An earlier run in this branch legitimately caught two
failures I introduced, both fixed.

New regression test: the graph escalates when the turn self-reports a commit sha
but GitHub says the branch was never pushed.

Chart bumped to 0.285.507.

## Blast radius

Graph runs now create real remote branches under `claude/graph-*`. They are
never on main, never opened as PRs, and are deletable. The merge node still does
not exist (ADR 027 is Draft), so nothing autonomous can land.