### PR TITLE
chore(platform): arm longhorn automatic engine image upgrades

### DIFF
--- a/projects/platform/longhorn/values-prod.yaml
+++ b/projects/platform/longhorn/values-prod.yaml
@@ -17,6 +17,11 @@ cfIngress:
 
 longhorn:
   preUpgradeChecker:
+    # Upstream explicitly recommends disabling the pre-upgrade hook Job under
+    # ArgoCD, so this is deliberate and should stay false. The version guardrail
+    # itself is NOT disabled by this: upgradeVersionCheck stays at its upstream
+    # default of true, and longhorn-manager runs with --upgrade-version-check,
+    # performing the check after the DaemonSet pods start instead.
     jobEnabled: false
 
   defaultSettings:
@@ -32,3 +37,15 @@ longhorn:
 
     # Default to single replica for homelab workloads
     defaultReplicaCount: 1
+
+    # Migrate volume engine images automatically, one volume per node at a time.
+    # Upstream leaves this null, which means Longhorn's built-in default of 0
+    # applies, and 0 disables engine migration entirely. A chart bump moves only
+    # the longhorn-manager control plane; each volume keeps running its existing
+    # engine image until this reconciler moves it. Engine compatibility is a
+    # bounded window (the image advertises cliAPIVersion / cliAPIMinVersion), so
+    # leaving engines pinned across several manager upgrades eventually puts them
+    # outside the range a newer manager accepts, and those volumes stop
+    # attaching. Setting this before the staged 1.8.1 -> 1.9.2 -> 1.10.2 ->
+    # 1.11.3 upgrade means engines roll along with each step. See issue #4576.
+    concurrentAutomaticEngineUpgradePerNodeLimit: 1


### PR DESCRIPTION
Prep step for the staged Longhorn upgrade in #4576. No version changes here.

## Why

Longhorn splits its version into two independently-moving parts:

- the **manager** (control plane), which a chart bump moves
- the **engine image** (per-volume data plane), which migrates separately

`concurrentAutomaticEngineUpgradePerNodeLimit` is left null upstream, so
Longhorn's built-in default of `0` applies, and `0` disables engine migration
entirely. Verified against the cluster: all 13 live volumes (47 references) run
the single `ei-db6c2b6f` / `longhornio/longhorn-engine:v1.8.1` image, and no
other engine image exists.

Engine compatibility is a bounded window. The deployed image advertises:

```
cliAPIVersion: 10          cliAPIMinVersion: 8
controllerAPIVersion: 5    controllerAPIMinVersion: 4
```

Stepping the manager through several minors while engines stay pinned at v1.8.1
eventually puts them outside the range a newer manager accepts, at which point
those volumes stop attaching. This is also why #4576's between-step check
"confirm `engine-image-ei-*` has rolled" could never pass as configured: nothing
would have rolled them.

## Why land it separately

The change is inert today. The default engine image is already v1.8.1 and every
volume already runs it, so the reconciler has nothing to move until the first
manager bump. Landing it alone verifies the setting reconciles into
`longhorn-default-setting` while still on a supported version, before any
one-way version change.

## Correction to the issue

`preUpgradeChecker.jobEnabled: false` initially looked like a disabled guardrail.
It is not. Upstream's own comment recommends disabling that hook Job under
ArgoCD, and it does not disable the version check: `upgradeVersionCheck` keeps
its default of `true`, and the DaemonSet runs `longhorn-manager ... --upgrade-version-check`.
Left as-is, with a comment so it does not get "fixed" later.

Separately, Longhorn's own `stable-longhorn-versions` does not list 1.12.0 and
reports `latest-longhorn-version: v1.11.3`, so the comment targets a
stable-only ladder: `1.8.1 -> 1.9.2 -> 1.10.2 -> 1.11.3`.

## Verification

Rendered diff against origin/main is exactly one line, and no pre-upgrade Job
appears:

```
90a91
>     concurrent-automatic-engine-upgrade-per-node-limit: 1
```

The other five settings in the rendered ConfigMap are byte-identical to what is
live in the cluster.

`defaultSettings` edits are confirmed to reconcile into an already-installed
cluster, not just apply at install: Longhorn was installed 2025-09-22, and the
commit setting `replicaAutoBalance` / `nodeDrainPolicy` is dated 2025-11-04, six
weeks later, with the cluster showing those values today.

`ci test`: `Executed 2 out of 743 tests: 743 tests pass.`

## Post-merge

`projects/platform/*` pins `targetRevision: HEAD`, so this deploys on merge.
Confirm the setting actually took:

```
kubectl get settings.longhorn.io concurrent-automatic-engine-upgrade-per-node-limit -n longhorn
```

Expected `1`. No volume or engine churn should follow.

Refs #4576