### PR TITLE
perf(ci): stop pushing images from PR branches

### DIFF
--- a/bazel/helm/check-missed-bump.sh
+++ b/bazel/helm/check-missed-bump.sh
@@ -10,10 +10,12 @@
 #
 # This is the same digest-content check push.sh.tpl runs post-merge on main,
 # factored out so it can also run pre-merge on a PR branch and be unit tested
-# with stubbed helm/crane. It is deliberately content-stable (compares manifest
-# digests, not the build-timestamped tags). An unresolved digest fails OPEN (a
-# transient registry error must not wedge a PR), but an unpublished version is
-# only "nothing to assert" when this PR itself carries the bump. When
+# with a stubbed helm. It is content-stable (compares manifest digests, not the
+# build-timestamped tags) and reads those digests straight from the chart
+# values, so it needs no registry access and does not require the fresh images
+# to have been pushed. A chart with no pinned digest fails OPEN, but an
+# unpublished version is only "nothing to assert" when this PR itself carries
+# the bump. When
 # origin/main's Chart.yaml claims the SAME unpublished version, main's publish
 # is either still in flight or has failed; that is the state a rebase-merge
 # version collision leaves behind (two PRs claimed the same version, the
@@ -22,12 +24,11 @@
 # fails CLOSED rather than let another unverifiable PR merge on top.
 #
 # Usage:
-#   HELM=/path/helm CRANE=/path/crane REPOSITORY=oci://ghcr.io/... \
+#   HELM=/path/helm REPOSITORY=oci://ghcr.io/... \
 #     check-missed-bump.sh <chart_name> <chart_version> <fresh_chart_tgz> <project_dir>
 #
 # Env:
 #   HELM                path to the helm binary (required)
-#   CRANE               path to the crane binary (required)
 #   REPOSITORY          OCI chart repository (required), e.g. oci://ghcr.io/jomcgi/homelab/charts
 #   MAIN_CHART_VERSION  the chart version origin/main's Chart.yaml claims
 #                       (optional; empty disables the fail-closed collision path)
@@ -41,37 +42,37 @@ CHART_TGZ="${3:?fresh chart .tgz required}"
 PROJECT_DIR="${4:?project_dir required}"
 
 HELM="${HELM:?HELM env required}"
-CRANE="${CRANE:?CRANE env required}"
 REPOSITORY="${REPOSITORY:?REPOSITORY env required}"
-
-# Resolve one repo:tag to its manifest digest, retrying to absorb ghcr
-# propagation lag / transient rate limits. A genuinely gone tag ends UNRESOLVED,
-# which the caller treats as "skip", not "fail".
-_crane_digest() {
-	local ref="$1" i d
-	for i in 1 2 3; do
-		if d=$("$CRANE" digest "$ref" 2>/dev/null) && [[ -n "$d" ]]; then
-			printf '%s' "$d"
-			return 0
-		fi
-		if [[ $i -lt 3 ]]; then sleep 3; fi
-	done
-	printf 'UNRESOLVED'
-}
 
 # Emit sorted "repo=digest" lines for each ghcr.io/jomcgi image pinned in a
 # chart. Args pass straight to `helm show values` (a .tgz path, or
-# "REPO/NAME --version X"). The pinned tag embeds a build timestamp so it
-# changes every build even for identical content; resolving it to the manifest
-# digest gives a content-stable identity to compare.
+# "REPO/NAME --version X").
+#
+# The digest is read straight out of the chart values, where helm_images_values
+# (bazel/helm/images.bzl) pins it next to repository and tag, and where the
+# templates read it: charts deploy `repository@digest`. It used to be obtained
+# by resolving the pinned `tag:` through `crane digest`, which was equivalent
+# but required the fresh build's images to ALREADY BE IN THE REGISTRY. That
+# coupled the guard to PR image pushes: with those gone (buildbuddy.yaml builds
+# images on PRs instead of pushing them), the fresh tag no longer exists in ghcr
+# and every lookup would have failed to UNRESOLVED, silently fail-opening the
+# guard on every PR. Reading the pinned digest needs no registry at all.
+#
+# A ghcr image whose values carry no `digest:` (a chart published before digest
+# pinning) yields UNRESOLVED, which the caller treats as "skip", not "fail".
 _image_digests() {
 	"$HELM" show values "$@" 2>/dev/null | awk '
-    /^[[:space:]]*repository:[[:space:]]*/ { repo=$2 }
-    /^[[:space:]]*tag:[[:space:]]*/ && repo!="" { print repo"\t"$2; repo="" }' |
-		while IFS="$(printf '\t')" read -r repo tag; do
+    function flush() {
+      if (repo != "") { print repo "\t" (digest == "" ? "UNRESOLVED" : digest) }
+      repo = ""; digest = ""
+    }
+    /^[[:space:]]*repository:[[:space:]]*/ { flush(); repo=$2 }
+    /^[[:space:]]*digest:[[:space:]]*/ && repo!="" { digest=$2 }
+    END { flush() }' |
+		while IFS="$(printf '\t')" read -r repo digest; do
 			case "$repo" in
 			ghcr.io/jomcgi/*)
-				printf '%s=%s\n' "$repo" "$(_crane_digest "${repo}:${tag}")"
+				printf '%s=%s\n' "$repo" "$digest"
 				;;
 			esac
 		done | sort
@@ -124,8 +125,9 @@ fi
 FRESH_DIGESTS=$(_image_digests "$CHART_TGZ") || FRESH_DIGESTS=""
 PUB_DIGESTS=$(_image_digests "${REPOSITORY}/${CHART_NAME}" --version "${CHART_VERSION}") || PUB_DIGESTS=""
 
-# Fail open on any unresolved or empty digest set: a registry hiccup must not
-# block a PR. The version-scoped detector on main is the backstop for these.
+# Fail open on any unresolved or empty digest set: a chart that predates digest
+# pinning must not wedge a PR. The version-scoped detector on main is the
+# backstop for these.
 if [[ "$FRESH_DIGESTS" == *UNRESOLVED* ]] || [[ "$PUB_DIGESTS" == *UNRESOLVED* ]]; then
 	echo "check-missed-bump: WARNING: could not resolve all image digests for ${CHART_NAME}; skipping (fail open)." >&2
 	exit 0

--- a/bazel/helm/check-missed-bump.sh
+++ b/bazel/helm/check-missed-bump.sh
@@ -13,7 +13,7 @@
 # with a stubbed helm. It is content-stable (compares manifest digests, not the
 # build-timestamped tags) and reads those digests straight from the chart
 # values, so it needs no registry access and does not require the fresh images
-# to have been pushed. A chart with no pinned digest fails OPEN, but an
+# to have been pushed. A chart with nothing digest-pinned fails OPEN, but an
 # unpublished version is only "nothing to assert" when this PR itself carries
 # the bump. When
 # origin/main's Chart.yaml claims the SAME unpublished version, main's publish
@@ -58,12 +58,18 @@ REPOSITORY="${REPOSITORY:?REPOSITORY env required}"
 # and every lookup would have failed to UNRESOLVED, silently fail-opening the
 # guard on every PR. Reading the pinned digest needs no registry at all.
 #
-# A ghcr image whose values carry no `digest:` (a chart published before digest
-# pinning) yields UNRESOLVED, which the caller treats as "skip", not "fail".
+# A ghcr image with no `digest:` is pinned by tag only (e.g. a floating
+# `tag: main` that helm_images_values does not inject into). Those are SKIPPED
+# rather than failing the whole chart open. They were never comparable: the old
+# crane-based check resolved the identical `repo:tag` ref on both the fresh and
+# the published side, so it always got the same answer and could not detect
+# drift. Letting one of them suppress the chart would lose the real check on
+# its digest-pinned siblings, which is what oci-model-cache-operator (pinned
+# oci-model-cache alongside a tag-only hf2oci) would have done.
 _image_digests() {
 	"$HELM" show values "$@" 2>/dev/null | awk '
     function flush() {
-      if (repo != "") { print repo "\t" (digest == "" ? "UNRESOLVED" : digest) }
+      if (repo != "") { print repo "\t" digest }
       repo = ""; digest = ""
     }
     /^[[:space:]]*repository:[[:space:]]*/ { flush(); repo=$2 }
@@ -72,6 +78,10 @@ _image_digests() {
 		while IFS="$(printf '\t')" read -r repo digest; do
 			case "$repo" in
 			ghcr.io/jomcgi/*)
+				if [[ -z "$digest" ]]; then
+					echo "check-missed-bump: ${repo} is pinned by tag only (no digest in values); not comparable, skipping it." >&2
+					continue
+				fi
 				printf '%s=%s\n' "$repo" "$digest"
 				;;
 			esac
@@ -125,15 +135,11 @@ fi
 FRESH_DIGESTS=$(_image_digests "$CHART_TGZ") || FRESH_DIGESTS=""
 PUB_DIGESTS=$(_image_digests "${REPOSITORY}/${CHART_NAME}" --version "${CHART_VERSION}") || PUB_DIGESTS=""
 
-# Fail open on any unresolved or empty digest set: a chart that predates digest
-# pinning must not wedge a PR. The version-scoped detector on main is the
-# backstop for these.
-if [[ "$FRESH_DIGESTS" == *UNRESOLVED* ]] || [[ "$PUB_DIGESTS" == *UNRESOLVED* ]]; then
-	echo "check-missed-bump: WARNING: could not resolve all image digests for ${CHART_NAME}; skipping (fail open)." >&2
-	exit 0
-fi
+# Fail open when either side has nothing digest-pinned to compare (a chart with
+# only third-party or tag-only images, or one published before digest pinning).
+# The version-scoped detector on main is the backstop for these.
 if [[ -z "$FRESH_DIGESTS" ]] || [[ -z "$PUB_DIGESTS" ]]; then
-	echo "check-missed-bump: no ghcr.io/jomcgi images pinned in ${CHART_NAME}; nothing to check."
+	echo "check-missed-bump: no digest-pinned ghcr.io/jomcgi images to compare in ${CHART_NAME}; nothing to check."
 	exit 0
 fi
 

--- a/bazel/helm/check-missed-bump_test.sh
+++ b/bazel/helm/check-missed-bump_test.sh
@@ -4,14 +4,16 @@
 # The script under test compares the ghcr.io/jomcgi image digests pinned in a
 # freshly built chart against the published chart of the same version and fails
 # (exit 1) only when the version is already published AND the digests differ.
-# helm and crane are stubbed so no network or real binaries are needed. The
+# helm is stubbed so no network or real binaries are needed. The
 # stubs key their behaviour off env vars set per case:
 #   STUB_CHART_RC     exit code of `helm show chart` (0 = published)
 #   STUB_FRESH_TAG    tag `helm show values <tgz>` reports (the PR build)
 #   STUB_PUB_TAG      tag `helm show values ... --version` reports (published)
-#   STUB_FRESH_DIGEST digest crane maps STUB_FRESH_TAG to
-#   STUB_PUB_DIGEST   digest crane maps STUB_PUB_TAG to
-#   STUB_UNRESOLVED_TAG a tag crane fails to resolve (forces UNRESOLVED)
+#   STUB_FRESH_DIGEST digest pinned in the fresh chart's values
+#   STUB_PUB_DIGEST   digest pinned in the published chart's values
+#   STUB_FRESH_NO_DIGEST / STUB_PUB_NO_DIGEST
+#                     omit `digest:` from that side's values, as a chart
+#                     published before digest pinning would (forces UNRESOLVED)
 #   STUB_NO_IMAGES    if set, `helm show values` pins no images
 set -o errexit -o nounset -o pipefail
 
@@ -54,29 +56,18 @@ case "$sub" in
     exit "${STUB_CHART_RC:-0}" ;;
   "show values")
     [[ -n "${STUB_NO_IMAGES:-}" ]] && exit 0
-    if [[ "$*" == *--version* ]]; then tag="${STUB_PUB_TAG}"; else tag="${STUB_FRESH_TAG}"; fi
-    printf 'image:\n  repository: ghcr.io/jomcgi/homelab/projects/foo/backend\n  tag: %s\n' "$tag" ;;
+    if [[ "$*" == *--version* ]]; then
+      tag="${STUB_PUB_TAG}"; digest="${STUB_PUB_DIGEST:-p}"; nodigest="${STUB_PUB_NO_DIGEST:-}"
+    else
+      tag="${STUB_FRESH_TAG}"; digest="${STUB_FRESH_DIGEST:-f}"; nodigest="${STUB_FRESH_NO_DIGEST:-}"
+    fi
+    printf 'image:\n  repository: ghcr.io/jomcgi/homelab/projects/foo/backend\n  tag: %s\n' "$tag"
+    # A chart published before digest pinning emits repository+tag only.
+    [[ -n "$nodigest" ]] || printf '  digest: sha256:%s\n' "$digest" ;;
   *) exit 0 ;;
 esac
 EOF
 chmod +x "$STUB_HELM"
-
-STUB_CRANE="$TMP/crane"
-cat >"$STUB_CRANE" <<'EOF'
-#!/usr/bin/env bash
-# args: digest <ref>
-ref="${2:-}"
-tag="${ref##*:}"
-if [[ -n "${STUB_UNRESOLVED_TAG:-}" && "$tag" == "${STUB_UNRESOLVED_TAG}" ]]; then
-  exit 1
-fi
-case "$tag" in
-  "${STUB_FRESH_TAG:-__f}") echo "sha256:${STUB_FRESH_DIGEST:-f}" ;;
-  "${STUB_PUB_TAG:-__p}")   echo "sha256:${STUB_PUB_DIGEST:-p}" ;;
-  *) echo "sha256:deadbeef" ;;
-esac
-EOF
-chmod +x "$STUB_CRANE"
 
 FAKE_TGZ="$TMP/foo.tgz"
 : >"$FAKE_TGZ"
@@ -84,7 +75,7 @@ FAKE_TGZ="$TMP/foo.tgz"
 run_check() {
 	# Echoes exit code; stdout+stderr captured in $TMP/out.
 	set +e
-	env HELM="$STUB_HELM" CRANE="$STUB_CRANE" \
+	env HELM="$STUB_HELM" \
 		REPOSITORY="oci://ghcr.io/jomcgi/homelab/charts" \
 		"$@" \
 		bash "$SCRIPT" foo 1.2.3 "$FAKE_TGZ" projects/foo >"$TMP/out" 2>&1
@@ -134,10 +125,22 @@ rc=$(run_check STUB_CHART_RC=1 STUB_FRESH_TAG=fresh STUB_PUB_TAG=pub \
 	STUB_FRESH_DIGEST=aaa STUB_PUB_DIGEST=bbb)
 expect "unpublished passes" 0 "$rc" "not published yet"
 
-# 4. A digest cannot be resolved -> FAIL OPEN (never block on registry flake).
+# 4. Published chart predates digest pinning (repository+tag, no digest) ->
+# FAIL OPEN. Never block a PR on a chart we cannot compare content-wise.
 rc=$(run_check STUB_CHART_RC=0 STUB_FRESH_TAG=fresh STUB_PUB_TAG=pub \
-	STUB_UNRESOLVED_TAG=fresh STUB_FRESH_DIGEST=aaa STUB_PUB_DIGEST=bbb)
-expect "unresolved fails open" 0 "$rc" "fail open"
+	STUB_PUB_NO_DIGEST=1 STUB_FRESH_DIGEST=aaa STUB_PUB_DIGEST=bbb)
+expect "unpinned published chart fails open" 0 "$rc" "fail open"
+
+# 4b. Same on the fresh side.
+rc=$(run_check STUB_CHART_RC=0 STUB_FRESH_TAG=fresh STUB_PUB_TAG=pub \
+	STUB_FRESH_NO_DIGEST=1 STUB_FRESH_DIGEST=aaa STUB_PUB_DIGEST=bbb)
+expect "unpinned fresh chart fails open" 0 "$rc" "fail open"
+
+# 4c. Identical digests behind DIFFERENT tags still pass: the tag is not the
+# comparison, and after the PR-push removal the fresh tag is not in ghcr at all.
+rc=$(run_check STUB_CHART_RC=0 STUB_FRESH_TAG=never-pushed STUB_PUB_TAG=pub \
+	STUB_FRESH_DIGEST=same STUB_PUB_DIGEST=same)
+expect "unpushed fresh tag still compares" 0 "$rc" "digests match"
 
 # 5. No ghcr.io/jomcgi images pinned -> OK, nothing to compare.
 rc=$(run_check STUB_CHART_RC=0 STUB_NO_IMAGES=1)

--- a/bazel/helm/check-missed-bump_test.sh
+++ b/bazel/helm/check-missed-bump_test.sh
@@ -13,7 +13,8 @@
 #   STUB_PUB_DIGEST   digest pinned in the published chart's values
 #   STUB_FRESH_NO_DIGEST / STUB_PUB_NO_DIGEST
 #                     omit `digest:` from that side's values, as a chart
-#                     published before digest pinning would (forces UNRESOLVED)
+#                     published before digest pinning would
+#   STUB_TAG_ONLY_SIBLING add a second ghcr image pinned by floating tag only
 #   STUB_NO_IMAGES    if set, `helm show values` pins no images
 set -o errexit -o nounset -o pipefail
 
@@ -63,7 +64,10 @@ case "$sub" in
     fi
     printf 'image:\n  repository: ghcr.io/jomcgi/homelab/projects/foo/backend\n  tag: %s\n' "$tag"
     # A chart published before digest pinning emits repository+tag only.
-    [[ -n "$nodigest" ]] || printf '  digest: sha256:%s\n' "$digest" ;;
+    [[ -n "$nodigest" ]] || printf '  digest: sha256:%s\n' "$digest"
+    # A sibling image pinned by a floating tag with no digest (hf2oci-style).
+    [[ -z "${STUB_TAG_ONLY_SIBLING:-}" ]] ||
+      printf 'sidecar:\n  image:\n    repository: ghcr.io/jomcgi/homelab/bazel/tools/hf2oci\n    tag: main\n' ;;
   *) exit 0 ;;
 esac
 EOF
@@ -129,12 +133,25 @@ expect "unpublished passes" 0 "$rc" "not published yet"
 # FAIL OPEN. Never block a PR on a chart we cannot compare content-wise.
 rc=$(run_check STUB_CHART_RC=0 STUB_FRESH_TAG=fresh STUB_PUB_TAG=pub \
 	STUB_PUB_NO_DIGEST=1 STUB_FRESH_DIGEST=aaa STUB_PUB_DIGEST=bbb)
-expect "unpinned published chart fails open" 0 "$rc" "fail open"
+expect "unpinned published chart fails open" 0 "$rc" "nothing to check"
 
 # 4b. Same on the fresh side.
 rc=$(run_check STUB_CHART_RC=0 STUB_FRESH_TAG=fresh STUB_PUB_TAG=pub \
 	STUB_FRESH_NO_DIGEST=1 STUB_FRESH_DIGEST=aaa STUB_PUB_DIGEST=bbb)
-expect "unpinned fresh chart fails open" 0 "$rc" "fail open"
+expect "unpinned fresh chart fails open" 0 "$rc" "nothing to check"
+
+# 4d. A tag-only sibling (no digest) must NOT suppress the chart: the
+# digest-pinned image alongside it still has to catch drift. This is the
+# oci-model-cache-operator shape, and getting it wrong silently disables the
+# guard for every chart that carries one floating-tag image.
+rc=$(run_check STUB_CHART_RC=0 STUB_FRESH_TAG=fresh STUB_PUB_TAG=pub \
+	STUB_TAG_ONLY_SIBLING=1 STUB_FRESH_DIGEST=aaa STUB_PUB_DIGEST=bbb)
+expect "tag-only sibling still detects drift" 1 "$rc" "will NOT deploy"
+
+# 4e. ...and still passes when the pinned digests match.
+rc=$(run_check STUB_CHART_RC=0 STUB_FRESH_TAG=fresh STUB_PUB_TAG=pub \
+	STUB_TAG_ONLY_SIBLING=1 STUB_FRESH_DIGEST=same STUB_PUB_DIGEST=same)
+expect "tag-only sibling still passes on match" 0 "$rc" "digests match"
 
 # 4c. Identical digests behind DIFFERENT tags still pass: the tag is not the
 # comparison, and after the PR-push removal the fresh tag is not in ghcr at all.

--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -63,3 +63,22 @@ multirun(
     jobs = 0,  # 0 means unlimited parallelism
     visibility = ["//visibility:public"],
 )
+
+# Charts only. `bazel run` has to materialise every command's runfiles on the
+# runner before any command executes, so running push_all drags all ~24 images'
+# layers out of CAS even when every action is a cache hit. Off main nothing may
+# publish anyway (push.sh.tpl takes the PR path), so PR CI runs this subset: it
+# carries the pre-merge missed-chart-bump guard at chart-sized cost, while the
+# images are proven to build with `bazel build //bazel/images:push_all`.
+multirun(
+    name = "push_charts",
+    commands = [
+        "//projects/embervm/chart:chart.push",
+        "//projects/monolith-public/chart:chart.push",
+        "//projects/monolith/chart:chart.push",
+        "//projects/operators/oci-model-cache/helm/oci-model-cache-operator:chart.push",
+        "//projects/platform/signoz-addons/dashboard-sidecar:chart.push",
+    ],
+    jobs = 0,  # 0 means unlimited parallelism
+    visibility = ["//visibility:public"],
+)

--- a/bazel/images/generate-push-all.sh
+++ b/bazel/images/generate-push-all.sh
@@ -73,6 +73,7 @@ HELM_PUSH=$(
 )
 
 PUSH_TARGETS=$(echo -e "${OCI_PUSH}\n${HELM_PUSH}" | grep -v '^$' | LC_ALL=C sort)
+CHART_TARGETS=$(echo -e "${HELM_PUSH}" | grep -v '^$' | LC_ALL=C sort)
 
 if [ -z "$PUSH_TARGETS" ]; then
 	echo "No push targets found"
@@ -121,6 +122,27 @@ while IFS= read -r target; do
 done <<<"$PUSH_TARGETS"
 
 # Close the target
+cat >>"$BUILD_FILE" <<'FOOTER'
+    ],
+    jobs = 0,  # 0 means unlimited parallelism
+    visibility = ["//visibility:public"],
+)
+
+# Charts only. `bazel run` has to materialise every command's runfiles on the
+# runner before any command executes, so running push_all drags all ~24 images'
+# layers out of CAS even when every action is a cache hit. Off main nothing may
+# publish anyway (push.sh.tpl takes the PR path), so PR CI runs this subset: it
+# carries the pre-merge missed-chart-bump guard at chart-sized cost, while the
+# images are proven to build with `bazel build //bazel/images:push_all`.
+multirun(
+    name = "push_charts",
+    commands = [
+FOOTER
+
+while IFS= read -r target; do
+	echo "        \"$target\"," >>"$BUILD_FILE"
+done <<<"$CHART_TARGETS"
+
 cat >>"$BUILD_FILE" <<'FOOTER'
     ],
     jobs = 0,  # 0 means unlimited parallelism

--- a/bazel/images/validate-generate-scripts.sh
+++ b/bazel/images/validate-generate-scripts.sh
@@ -14,9 +14,12 @@ trap 'rm -rf "$TMPDIR_VALIDATE"' EXIT
 # --- Helper functions ---
 
 extract_targets_from_build() {
-	# Extract "//..." target labels from a generated BUILD file
+	# Extract "//..." target labels from a generated BUILD file.
+	# `sort -u`: the chart targets are deliberately listed twice, once in
+	# push_all and once in the push_charts subset PR CI runs, and this list is
+	# diffed against a bazel query that yields each label once.
 	local build_file="$1"
-	grep -o '"//[^"]*"' "$build_file" | tr -d '"' | grep -v '//visibility:\|//:__subpackages__\|//:__pkg__' | LC_ALL=C sort
+	grep -o '"//[^"]*"' "$build_file" | tr -d '"' | grep -v '//visibility:\|//:__subpackages__\|//:__pkg__' | LC_ALL=C sort -u
 }
 
 compare_targets() {

--- a/bazel/tools/buildbuddy/snapshots/2026-08-09.json
+++ b/bazel/tools/buildbuddy/snapshots/2026-08-09.json
@@ -1,0 +1,1328 @@
+{
+  "bucket_interval": {
+    "count": "4",
+    "type": "INTERVAL_TYPE_HOUR"
+  },
+  "buckets": [
+    {
+      "action_cache_hits": 2310,
+      "action_cache_misses": 915,
+      "bucket_start": "2026-08-02T16:00:00+00:00",
+      "builds": 56,
+      "download_bytes": 70259502335,
+      "upload_bytes": 220240731
+    },
+    {
+      "action_cache_hits": 34197,
+      "action_cache_misses": 7742,
+      "bucket_start": "2026-08-02T20:00:00+00:00",
+      "builds": 494,
+      "download_bytes": 493807653418,
+      "upload_bytes": 1896753135
+    },
+    {
+      "action_cache_hits": 21577,
+      "action_cache_misses": 3435,
+      "bucket_start": "2026-08-03T00:00:00+00:00",
+      "builds": 262,
+      "download_bytes": 181207289466,
+      "upload_bytes": 392140972
+    },
+    {
+      "action_cache_hits": 15287,
+      "action_cache_misses": 4030,
+      "bucket_start": "2026-08-03T04:00:00+00:00",
+      "builds": 290,
+      "download_bytes": 247568255953,
+      "upload_bytes": 509124511
+    },
+    {
+      "action_cache_hits": 10591,
+      "action_cache_misses": 5268,
+      "bucket_start": "2026-08-03T08:00:00+00:00",
+      "builds": 376,
+      "download_bytes": 470565460525,
+      "upload_bytes": 725929758
+    },
+    {
+      "action_cache_hits": 10302,
+      "action_cache_misses": 5256,
+      "bucket_start": "2026-08-03T12:00:00+00:00",
+      "builds": 390,
+      "download_bytes": 93133795259,
+      "upload_bytes": 145963100
+    },
+    {
+      "action_cache_hits": 4524,
+      "action_cache_misses": 1876,
+      "bucket_start": "2026-08-03T16:00:00+00:00",
+      "builds": 97,
+      "download_bytes": 84773870807,
+      "upload_bytes": 185762870
+    },
+    {
+      "action_cache_hits": 806,
+      "action_cache_misses": 587,
+      "bucket_start": "2026-08-03T20:00:00+00:00",
+      "builds": 38,
+      "download_bytes": 16779105558,
+      "upload_bytes": 2102607
+    },
+    {
+      "action_cache_hits": 8539,
+      "action_cache_misses": 3463,
+      "bucket_start": "2026-08-04T00:00:00+00:00",
+      "builds": 210,
+      "download_bytes": 100522977166,
+      "upload_bytes": 319344766
+    },
+    {
+      "action_cache_hits": 3780,
+      "action_cache_misses": 2026,
+      "bucket_start": "2026-08-04T04:00:00+00:00",
+      "builds": 119,
+      "download_bytes": 27115050023,
+      "upload_bytes": 204763870
+    },
+    {
+      "action_cache_hits": 3802,
+      "action_cache_misses": 1909,
+      "bucket_start": "2026-08-04T08:00:00+00:00",
+      "builds": 104,
+      "download_bytes": 35253291399,
+      "upload_bytes": 144994299
+    },
+    {
+      "action_cache_hits": 3117,
+      "action_cache_misses": 2512,
+      "bucket_start": "2026-08-04T12:00:00+00:00",
+      "builds": 145,
+      "download_bytes": 280583369763,
+      "upload_bytes": 268535444
+    },
+    {
+      "action_cache_hits": 10225,
+      "action_cache_misses": 7077,
+      "bucket_start": "2026-08-04T16:00:00+00:00",
+      "builds": 334,
+      "download_bytes": 444579037194,
+      "upload_bytes": 1249386295
+    },
+    {
+      "action_cache_hits": 25402,
+      "action_cache_misses": 11786,
+      "bucket_start": "2026-08-04T20:00:00+00:00",
+      "builds": 469,
+      "download_bytes": 575762907977,
+      "upload_bytes": 2106303070
+    },
+    {
+      "action_cache_hits": 11193,
+      "action_cache_misses": 5176,
+      "bucket_start": "2026-08-05T00:00:00+00:00",
+      "builds": 258,
+      "download_bytes": 209201822369,
+      "upload_bytes": 679829010
+    },
+    {
+      "action_cache_hits": 22561,
+      "action_cache_misses": 6866,
+      "bucket_start": "2026-08-05T04:00:00+00:00",
+      "builds": 558,
+      "download_bytes": 441233726240,
+      "upload_bytes": 593794019
+    },
+    {
+      "action_cache_hits": 8704,
+      "action_cache_misses": 2888,
+      "bucket_start": "2026-08-05T08:00:00+00:00",
+      "builds": 231,
+      "download_bytes": 88421721958,
+      "upload_bytes": 103495623
+    },
+    {
+      "action_cache_hits": 3132,
+      "action_cache_misses": 939,
+      "bucket_start": "2026-08-05T12:00:00+00:00",
+      "builds": 46,
+      "download_bytes": 27941258708,
+      "upload_bytes": 174904737
+    },
+    {
+      "action_cache_hits": 6823,
+      "action_cache_misses": 3120,
+      "bucket_start": "2026-08-05T16:00:00+00:00",
+      "builds": 221,
+      "download_bytes": 138626798762,
+      "upload_bytes": 250479164
+    },
+    {
+      "action_cache_hits": 1089,
+      "action_cache_misses": 446,
+      "bucket_start": "2026-08-05T20:00:00+00:00",
+      "builds": 37,
+      "download_bytes": 26224358097,
+      "upload_bytes": 3885436
+    },
+    {
+      "action_cache_hits": 3169,
+      "action_cache_misses": 3879,
+      "bucket_start": "2026-08-06T00:00:00+00:00",
+      "builds": 274,
+      "download_bytes": 224952324945,
+      "upload_bytes": 233845829
+    },
+    {
+      "action_cache_hits": 3568,
+      "action_cache_misses": 1972,
+      "bucket_start": "2026-08-06T04:00:00+00:00",
+      "builds": 153,
+      "download_bytes": 254179472329,
+      "upload_bytes": 94949555
+    },
+    {
+      "action_cache_hits": 1303,
+      "action_cache_misses": 1552,
+      "bucket_start": "2026-08-06T08:00:00+00:00",
+      "builds": 108,
+      "download_bytes": 127166713291,
+      "upload_bytes": 7186049
+    },
+    {
+      "action_cache_hits": 1498,
+      "action_cache_misses": 1757,
+      "bucket_start": "2026-08-06T12:00:00+00:00",
+      "builds": 151,
+      "download_bytes": 138179514307,
+      "upload_bytes": 28677184
+    },
+    {
+      "action_cache_hits": 18750,
+      "action_cache_misses": 33526,
+      "bucket_start": "2026-08-06T16:00:00+00:00",
+      "builds": 239,
+      "download_bytes": 970697591063,
+      "upload_bytes": 15626495723
+    },
+    {
+      "action_cache_hits": 9087,
+      "action_cache_misses": 8862,
+      "bucket_start": "2026-08-06T20:00:00+00:00",
+      "builds": 263,
+      "download_bytes": 431316305180,
+      "upload_bytes": 866328676
+    },
+    {
+      "action_cache_hits": 11597,
+      "action_cache_misses": 8505,
+      "bucket_start": "2026-08-07T00:00:00+00:00",
+      "builds": 367,
+      "download_bytes": 312938168284,
+      "upload_bytes": 971452097
+    },
+    {
+      "action_cache_hits": 353499,
+      "action_cache_misses": 13638,
+      "bucket_start": "2026-08-07T04:00:00+00:00",
+      "builds": 500,
+      "download_bytes": 619523102184,
+      "upload_bytes": 1864229939
+    },
+    {
+      "action_cache_hits": 196177,
+      "action_cache_misses": 8098,
+      "bucket_start": "2026-08-07T12:00:00+00:00",
+      "builds": 167,
+      "download_bytes": 649878507567,
+      "upload_bytes": 750711880
+    },
+    {
+      "action_cache_hits": 116375,
+      "action_cache_misses": 8893,
+      "bucket_start": "2026-08-07T16:00:00+00:00",
+      "builds": 373,
+      "download_bytes": 251611382450,
+      "upload_bytes": 1248553498
+    },
+    {
+      "action_cache_hits": 55457,
+      "action_cache_misses": 3878,
+      "bucket_start": "2026-08-07T20:00:00+00:00",
+      "builds": 185,
+      "download_bytes": 166463779127,
+      "upload_bytes": 627318082
+    },
+    {
+      "action_cache_hits": 50906,
+      "action_cache_misses": 11352,
+      "bucket_start": "2026-08-08T00:00:00+00:00",
+      "builds": 485,
+      "download_bytes": 626906715175,
+      "upload_bytes": 1168055307
+    },
+    {
+      "action_cache_hits": 499175,
+      "action_cache_misses": 37786,
+      "bucket_start": "2026-08-08T04:00:00+00:00",
+      "builds": 1221,
+      "download_bytes": 1351443118307,
+      "upload_bytes": 6508851573
+    },
+    {
+      "action_cache_hits": 166472,
+      "action_cache_misses": 5996,
+      "bucket_start": "2026-08-08T08:00:00+00:00",
+      "builds": 302,
+      "download_bytes": 119133092372,
+      "upload_bytes": 738537342
+    },
+    {
+      "action_cache_hits": 176920,
+      "action_cache_misses": 10230,
+      "bucket_start": "2026-08-08T16:00:00+00:00",
+      "builds": 525,
+      "download_bytes": 354560395207,
+      "upload_bytes": 1385036499
+    },
+    {
+      "action_cache_hits": 71307,
+      "action_cache_misses": 6917,
+      "bucket_start": "2026-08-08T20:00:00+00:00",
+      "builds": 347,
+      "download_bytes": 188718011337,
+      "upload_bytes": 1011797920
+    },
+    {
+      "action_cache_hits": 12823,
+      "action_cache_misses": 972,
+      "bucket_start": "2026-08-09T00:00:00+00:00",
+      "builds": 77,
+      "download_bytes": 55817513372,
+      "upload_bytes": 4127436
+    },
+    {
+      "action_cache_hits": 38246,
+      "action_cache_misses": 8477,
+      "bucket_start": "2026-08-09T04:00:00+00:00",
+      "builds": 506,
+      "download_bytes": 478085562931,
+      "upload_bytes": 2185172299
+    },
+    {
+      "action_cache_hits": 18471,
+      "action_cache_misses": 5005,
+      "bucket_start": "2026-08-09T08:00:00+00:00",
+      "builds": 132,
+      "download_bytes": 190484662553,
+      "upload_bytes": 2048277522
+    },
+    {
+      "action_cache_hits": 10020,
+      "action_cache_misses": 925,
+      "bucket_start": "2026-08-09T12:00:00+00:00",
+      "builds": 33,
+      "download_bytes": 20079652094,
+      "upload_bytes": 140575609
+    },
+    {
+      "action_cache_hits": 3526,
+      "action_cache_misses": 1046,
+      "bucket_start": "2026-08-09T16:00:00+00:00",
+      "builds": 55,
+      "download_bytes": 35654855784,
+      "upload_bytes": 164255989
+    }
+  ],
+  "by_role": {
+    "CI": {
+      "download_bytes": 4789119368310,
+      "download_transferred_bytes": 2489775071119,
+      "invocations": 5897,
+      "upload_bytes": 48999366446,
+      "upload_transferred_bytes": 21255472816
+    },
+    "CI_RUNNER": {
+      "download_bytes": 5789067575150,
+      "download_transferred_bytes": 2290281446737,
+      "invocations": 4730,
+      "upload_bytes": 71243274,
+      "upload_transferred_bytes": 13226565
+    },
+    "HOSTED_BAZEL": {
+      "download_bytes": 1567621501254,
+      "download_transferred_bytes": 724717110284,
+      "invocations": 784,
+      "upload_bytes": 46386066,
+      "upload_transferred_bytes": 11525432
+    },
+    "LOCAL": {
+      "download_bytes": 0,
+      "download_transferred_bytes": 0,
+      "invocations": 2,
+      "upload_bytes": 92700,
+      "upload_transferred_bytes": 92700
+    }
+  },
+  "by_source": [
+    {
+      "command": "test",
+      "download_bytes": 2846260421863,
+      "download_share": 0.23434096090176082,
+      "invocations": 1412,
+      "pattern": "//...",
+      "role": "CI",
+      "upload_bytes": 40984860941
+    },
+    {
+      "command": "workflow run",
+      "download_bytes": 2536445467012,
+      "download_share": 0.20883298782106935,
+      "invocations": 744,
+      "pattern": "Push images",
+      "role": "CI_RUNNER",
+      "upload_bytes": 1545601
+    },
+    {
+      "command": "workflow run",
+      "download_bytes": 2052193112445,
+      "download_share": 0.16896307246951014,
+      "invocations": 746,
+      "pattern": "Test",
+      "role": "CI_RUNNER",
+      "upload_bytes": 51620226
+    },
+    {
+      "command": "remote test //...",
+      "download_bytes": 1499066968796,
+      "download_share": 0.12342257624262234,
+      "invocations": 651,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 329364
+    },
+    {
+      "command": "run",
+      "download_bytes": 1409052023685,
+      "download_share": 0.1160113820416982,
+      "invocations": 767,
+      "pattern": "//bazel/images:push_all",
+      "role": "CI",
+      "upload_bytes": 6475018632
+    },
+    {
+      "command": "workflow run",
+      "download_bytes": 560972192752,
+      "download_share": 0.04618648444074069,
+      "invocations": 743,
+      "pattern": "Format check",
+      "role": "CI_RUNNER",
+      "upload_bytes": 3641948
+    },
+    {
+      "command": "workflow run",
+      "download_bytes": 347173520798,
+      "download_share": 0.02858381328655764,
+      "invocations": 744,
+      "pattern": "Buck2 rules",
+      "role": "CI_RUNNER",
+      "upload_bytes": 2419429
+    },
+    {
+      "command": "test",
+      "download_bytes": 338810824924,
+      "download_share": 0.027895288030123224,
+      "invocations": 8,
+      "pattern": "//... and 1 more",
+      "role": "CI",
+      "upload_bytes": 13987076
+    },
+    {
+      "command": "workflow run",
+      "download_bytes": 233937572431,
+      "download_share": 0.019260765843282537,
+      "invocations": 744,
+      "pattern": "BDD future features",
+      "role": "CI_RUNNER",
+      "upload_bytes": 6945096
+    },
+    {
+      "command": "build",
+      "download_bytes": 129258473728,
+      "download_share": 0.01064222890689955,
+      "invocations": 306,
+      "pattern": "//projects/monolith/frontend/visual:capture",
+      "role": "CI",
+      "upload_bytes": 51337514
+    },
+    {
+      "command": "workflow run",
+      "download_bytes": 46802681889,
+      "download_share": 0.003853401945373927,
+      "invocations": 505,
+      "pattern": "Visual regression",
+      "role": "CI_RUNNER",
+      "upload_bytes": 3216732
+    },
+    {
+      "command": "test",
+      "download_bytes": 33574177102,
+      "download_share": 0.0027642603828987506,
+      "invocations": 13,
+      "pattern": "//projects/embervm/tokenbroker/...",
+      "role": "CI",
+      "upload_bytes": 560757641
+    },
+    {
+      "command": "workflow run",
+      "download_bytes": 11543027823,
+      "download_share": 0.0009503713050919771,
+      "invocations": 504,
+      "pattern": "Manifest diff",
+      "role": "CI_RUNNER",
+      "upload_bytes": 1854242
+    },
+    {
+      "command": "remote test //projects/platform/signoz:template_test",
+      "download_bytes": 10289679020,
+      "download_share": 0.0008471794254649381,
+      "invocations": 2,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "remote build //bazel/erlang:mix_test_smoke",
+      "download_bytes": 9458513537,
+      "download_share": 0.000778747135693257,
+      "invocations": 38,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 623646
+    },
+    {
+      "command": "remote test //projects/embervm/noded/...",
+      "download_bytes": 9224518632,
+      "download_share": 0.0007594816494915676,
+      "invocations": 11,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "remote test //projects/monolith:agent_sessions_mcp_test",
+      "download_bytes": 8311222268,
+      "download_share": 0.0006842872836198188,
+      "invocations": 8,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 45194305
+    },
+    {
+      "command": "test",
+      "download_bytes": 7101604095,
+      "download_share": 0.0005846958749041281,
+      "invocations": 10,
+      "pattern": "//projects/embervm/noded/...",
+      "role": "CI",
+      "upload_bytes": 724553520
+    },
+    {
+      "command": "remote test //projects/embervm/runtimes/claude:shim_test",
+      "download_bytes": 6619704633,
+      "download_share": 0.0005450196800922687,
+      "invocations": 21,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 154560
+    },
+    {
+      "command": "remote test //projects/monolith/frontend:test",
+      "download_bytes": 6205703510,
+      "download_share": 0.0005109337544921348,
+      "invocations": 2,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "remote test //projects/embervm/noded/server/...",
+      "download_bytes": 5657076831,
+      "download_share": 0.0004657637123745375,
+      "invocations": 6,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 27318
+    },
+    {
+      "command": "test",
+      "download_bytes": 5616730064,
+      "download_share": 0.0004624418448196808,
+      "invocations": 18,
+      "pattern": "//projects/embervm/runtimes/claude:shim_test",
+      "role": "CI",
+      "upload_bytes": 2098792
+    },
+    {
+      "command": "remote test //tools/cli:knowledge_test",
+      "download_bytes": 5488903511,
+      "download_share": 0.00045191751014226115,
+      "invocations": 1,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 28365
+    },
+    {
+      "command": "test",
+      "download_bytes": 3652144804,
+      "download_share": 0.0003006917835584223,
+      "invocations": 2,
+      "pattern": "//projects/firecracker/substrate/egress-proxy/...",
+      "role": "CI",
+      "upload_bytes": 34411887
+    },
+    {
+      "command": "test",
+      "download_bytes": 3085799233,
+      "download_share": 0.0002540628931409647,
+      "invocations": 4,
+      "pattern": "//projects/monolith:agent_sessions_mcp_test",
+      "role": "CI",
+      "upload_bytes": 285470
+    },
+    {
+      "command": "remote test //projects/embervm/tokenbroker/...",
+      "download_bytes": 2904064013,
+      "download_share": 0.00023910009994138209,
+      "invocations": 13,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "build",
+      "download_bytes": 2655903922,
+      "download_share": 0.0002186683524682032,
+      "invocations": 38,
+      "pattern": "//bazel/erlang:mix_test_smoke",
+      "role": "CI",
+      "upload_bytes": 5963087
+    },
+    {
+      "command": "test",
+      "download_bytes": 2571277271,
+      "download_share": 0.00021170079231070456,
+      "invocations": 1,
+      "pattern": "//projects/embervm/runtimes/claude/...",
+      "role": "CI",
+      "upload_bytes": 9275369
+    },
+    {
+      "command": "test",
+      "download_bytes": 1610950403,
+      "download_share": 0.0001326342672315983,
+      "invocations": 3,
+      "pattern": "//projects/embervm/runtimes/claude:shim_test and 1 more",
+      "role": "CI",
+      "upload_bytes": 493191
+    },
+    {
+      "command": "remote test //projects/embervm/noded/server:server_test",
+      "download_bytes": 1585152007,
+      "download_share": 0.00013051020969212445,
+      "invocations": 7,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "remote build //projects/embervm/tokenbroker/internal/provider/codexchatgpt:codexchatgpt_test",
+      "download_bytes": 1073152001,
+      "download_share": 8.835574888940789e-5,
+      "invocations": 1,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "build",
+      "download_bytes": 1054399139,
+      "download_share": 8.681177080961514e-5,
+      "invocations": 3,
+      "pattern": "//projects/embervm/tokenbroker/internal/provider/codexchatgp",
+      "role": "CI",
+      "upload_bytes": 146714
+    },
+    {
+      "command": "test",
+      "download_bytes": 811248026,
+      "download_share": 6.679242717293675e-5,
+      "invocations": 2,
+      "pattern": "//projects/embervm/runtimes/claude:cleartext_lane_guard_test",
+      "role": "CI",
+      "upload_bytes": 44418
+    },
+    {
+      "command": "test",
+      "download_bytes": 809892166,
+      "download_share": 6.668079524607311e-5,
+      "invocations": 1,
+      "pattern": "//... and 4 more",
+      "role": "CI",
+      "upload_bytes": 163359
+    },
+    {
+      "command": "test",
+      "download_bytes": 808177578,
+      "download_share": 6.653962819179224e-5,
+      "invocations": 3,
+      "pattern": "//... and 5 more",
+      "role": "CI",
+      "upload_bytes": 478047
+    },
+    {
+      "command": "test",
+      "download_bytes": 771829396,
+      "download_share": 6.354697585700105e-5,
+      "invocations": 2,
+      "pattern": "//projects/monolith:agent_sessions_mcp_test and 2 more",
+      "role": "CI",
+      "upload_bytes": 474534
+    },
+    {
+      "command": "remote build //projects/embervm/tokenbroker/internal/provider/codexchatgpt:codexchatgpt",
+      "download_bytes": 770186473,
+      "download_share": 6.341170919216945e-5,
+      "invocations": 2,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 19337
+    },
+    {
+      "command": "test",
+      "download_bytes": 690656019,
+      "download_share": 5.686373386701827e-5,
+      "invocations": 5,
+      "pattern": "//projects/embervm/noded/server:server_test",
+      "role": "CI",
+      "upload_bytes": 24295104
+    },
+    {
+      "command": "build",
+      "download_bytes": 438858487,
+      "download_share": 3.61325052175507e-5,
+      "invocations": 5,
+      "pattern": "@pi_coding_agent//:tar_amd64",
+      "role": "CI",
+      "upload_bytes": 3689601
+    },
+    {
+      "command": "remote test //projects/embervm/runtimes/claude/...",
+      "download_bytes": 294912001,
+      "download_share": 2.4280969220155056e-5,
+      "invocations": 1,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "build",
+      "download_bytes": 241560494,
+      "download_share": 1.988838331343271e-5,
+      "invocations": 1,
+      "pattern": "//projects/embervm/tokenbroker/internal/broker:broker_test",
+      "role": "CI",
+      "upload_bytes": 133775
+    },
+    {
+      "command": "remote test //projects/embervm/tokenbroker/internal/broker:broker_test",
+      "download_bytes": 233472002,
+      "download_share": 1.9222434065441712e-5,
+      "invocations": 2,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "remote build //projects/embervm/tokenbroker/internal/broker:broker_test",
+      "download_bytes": 217088001,
+      "download_share": 1.7873491253229772e-5,
+      "invocations": 1,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "remote build //projects/embervm/proto/embervm/node/v1:node_go_src",
+      "download_bytes": 106496001,
+      "download_share": 8.768127826546477e-6,
+      "invocations": 1,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "test",
+      "download_bytes": 95251626,
+      "download_share": 7.84234548351161e-6,
+      "invocations": 2,
+      "pattern": "//projects/embervm/tokenbroker/internal/broker:broker_test",
+      "role": "CI",
+      "upload_bytes": 137772
+    },
+    {
+      "command": "remote test //projects/embervm/tokenbroker/image:image_lock_test",
+      "download_bytes": 90112002,
+      "download_share": 7.4191851790003996e-6,
+      "invocations": 2,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "run",
+      "download_bytes": 56399571,
+      "download_share": 4.6435419475552296e-6,
+      "invocations": 147,
+      "pattern": "//projects/monolith/frontend/visual:diff_bin",
+      "role": "CI",
+      "upload_bytes": 3369755
+    },
+    {
+      "command": "test",
+      "download_bytes": 49126513,
+      "download_share": 4.044729770242708e-6,
+      "invocations": 6,
+      "pattern": "//projects/embervm/noded/server/...",
+      "role": "CI",
+      "upload_bytes": 36495564
+    },
+    {
+      "command": "build",
+      "download_bytes": 22573035,
+      "download_share": 1.8585041170992658e-6,
+      "invocations": 1,
+      "pattern": "//projects/embervm/proto/embervm/node/v1:node_go_src",
+      "role": "CI",
+      "upload_bytes": 44805
+    },
+    {
+      "command": "test",
+      "download_bytes": 10342660,
+      "download_share": 8.515415047979988e-7,
+      "invocations": 1,
+      "pattern": "//projects/embervm/noded/fcvm/driver/...",
+      "role": "CI",
+      "upload_bytes": 9995728
+    },
+    {
+      "command": "remote build @pi_coding_agent//:tar_amd64",
+      "download_bytes": 8192005,
+      "download_share": 6.74471776604155e-7,
+      "invocations": 5,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "remote test //projects/embervm/runtimes/claude:cleartext_lane_guard_test",
+      "download_bytes": 8192003,
+      "download_share": 6.744716119382944e-7,
+      "invocations": 2,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "test",
+      "download_bytes": 4756950,
+      "download_share": 3.9165363274523577e-7,
+      "invocations": 2,
+      "pattern": "//projects/monolith/frontend:test",
+      "role": "CI",
+      "upload_bytes": 222027
+    },
+    {
+      "command": "remote test //projects/firecracker/substrate/egress-proxy/...",
+      "download_bytes": 4096002,
+      "download_share": 3.3723584713561235e-7,
+      "invocations": 2,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "remote build //projects/embervm/tokenbroker/image:all",
+      "download_bytes": 4096001,
+      "download_share": 3.3723576480268204e-7,
+      "invocations": 1,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "test",
+      "download_bytes": 2298464,
+      "download_share": 1.8923927628714733e-7,
+      "invocations": 1,
+      "pattern": "//projects/monolith:agent_sessions_mcp_test and 4 more",
+      "role": "CI",
+      "upload_bytes": 237680
+    },
+    {
+      "command": "run",
+      "download_bytes": 1343804,
+      "download_share": 1.1063932105605037e-7,
+      "invocations": 692,
+      "pattern": "//bazel/tools/format:format",
+      "role": "CI",
+      "upload_bytes": 40898064
+    },
+    {
+      "command": "test",
+      "download_bytes": 98488,
+      "download_share": 8.108805638447488e-9,
+      "invocations": 2,
+      "pattern": "//projects/embervm/tokenbroker/image:image_lock_test",
+      "role": "CI",
+      "upload_bytes": 74101
+    },
+    {
+      "command": "test",
+      "download_bytes": 91604,
+      "download_share": 7.542025746327915e-9,
+      "invocations": 1,
+      "pattern": "//projects/monolith:agent_sessions_mcp_test and 1 more",
+      "role": "CI",
+      "upload_bytes": 120962
+    },
+    {
+      "command": "test",
+      "download_bytes": 58158,
+      "download_share": 4.788318559832965e-9,
+      "invocations": 1,
+      "pattern": "//projects/embervm/noded/server:server_test and 2 more",
+      "role": "CI",
+      "upload_bytes": 201734
+    },
+    {
+      "command": "test",
+      "download_bytes": 45626,
+      "download_share": 3.7565222774328354e-9,
+      "invocations": 1,
+      "pattern": "//projects/monolith:agent_sessions_transport_test and 1 more",
+      "role": "CI",
+      "upload_bytes": 124519
+    },
+    {
+      "command": "test",
+      "download_bytes": 10886,
+      "download_share": 8.962762791420209e-10,
+      "invocations": 1,
+      "pattern": "//tools/cli:knowledge_test",
+      "role": "CI",
+      "upload_bytes": 70184
+    },
+    {
+      "command": "test",
+      "download_bytes": 9103,
+      "download_share": 7.494766644341187e-10,
+      "invocations": 1,
+      "pattern": "//projects/monolith:graph_policy_test and 3 more",
+      "role": "CI",
+      "upload_bytes": 55751
+    },
+    {
+      "command": "test",
+      "download_bytes": 7439,
+      "download_share": 6.124746684307821e-10,
+      "invocations": 1,
+      "pattern": "//projects/platform/signoz:template_test and 1 more",
+      "role": "CI",
+      "upload_bytes": 38686
+    },
+    {
+      "command": "test",
+      "download_bytes": 1207,
+      "download_share": 9.937584686059335e-11,
+      "invocations": 1,
+      "pattern": "//bazel/tools/ci:ci_test",
+      "role": "CI",
+      "upload_bytes": 5748
+    },
+    {
+      "command": "test",
+      "download_bytes": 777,
+      "download_share": 6.397268683569266e-11,
+      "invocations": 1,
+      "pattern": "//projects/platform/signoz:template_test",
+      "role": "CI",
+      "upload_bytes": 36542
+    },
+    {
+      "command": "remote test //projects/monolith:graph_policy_test",
+      "download_bytes": 1,
+      "download_share": 8.233293029046674e-14,
+      "invocations": 1,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "remote test //bazel/tools/ci:ci_test",
+      "download_bytes": 1,
+      "download_share": 8.233293029046674e-14,
+      "invocations": 1,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "remote test //projects/embervm/noded/fcvm/driver/...",
+      "download_bytes": 1,
+      "download_share": 8.233293029046674e-14,
+      "invocations": 1,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 9171
+    },
+    {
+      "command": "remote test //projects/monolith:agent_sessions_transport_test",
+      "download_bytes": 1,
+      "download_share": 8.233293029046674e-14,
+      "invocations": 1,
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "upload_bytes": 0
+    },
+    {
+      "command": "query",
+      "download_bytes": 0,
+      "download_share": 0.0,
+      "invocations": 2076,
+      "pattern": "",
+      "role": "CI",
+      "upload_bytes": 0
+    },
+    {
+      "command": "build",
+      "download_bytes": 0,
+      "download_share": 0.0,
+      "invocations": 350,
+      "pattern": "@multitool//tools/helm",
+      "role": "CI",
+      "upload_bytes": 14765311
+    },
+    {
+      "command": "test",
+      "download_bytes": 0,
+      "download_share": 0.0,
+      "invocations": 1,
+      "pattern": "//projects/embervm/noded/server:server_test",
+      "role": "LOCAL",
+      "upload_bytes": 26866
+    },
+    {
+      "command": "",
+      "download_bytes": 0,
+      "download_share": 0.0,
+      "invocations": 3,
+      "pattern": "",
+      "role": "CI",
+      "upload_bytes": 0
+    },
+    {
+      "command": "run",
+      "download_bytes": 0,
+      "download_share": 0.0,
+      "invocations": 1,
+      "pattern": "",
+      "role": "CI",
+      "upload_bytes": 0
+    },
+    {
+      "command": "build",
+      "download_bytes": 0,
+      "download_share": 0.0,
+      "invocations": 1,
+      "pattern": "//projects/embervm/tokenbroker/image:all",
+      "role": "CI",
+      "upload_bytes": 2841
+    },
+    {
+      "command": "test",
+      "download_bytes": 0,
+      "download_share": 0.0,
+      "invocations": 1,
+      "pattern": "//projects/embervm/noded/...",
+      "role": "LOCAL",
+      "upload_bytes": 65834
+    }
+  ],
+  "captured_at": "2026-08-09T16:48:47Z",
+  "concentration": {
+    "invocations": 11413,
+    "max_bytes": 360663783818,
+    "p50_bytes": 3.0,
+    "p90_bytes": 1982464001.0,
+    "p99_bytes": 17752064001.0,
+    "top_shares": {
+      "1%": {
+        "bytes": 4576187865451,
+        "invocations": 114,
+        "share": 0.37677095652225695
+      },
+      "10%": {
+        "bytes": 10909322463338,
+        "invocations": 1141,
+        "share": 0.8981964858902305
+      },
+      "5%": {
+        "bytes": 9094343561039,
+        "invocations": 571,
+        "share": 0.748763954448579
+      }
+    },
+    "total_bytes": 12145808444714
+  },
+  "per_day": {
+    "download_bytes": 1735115492102.0,
+    "upload_bytes": 7016726926.571428
+  },
+  "repo": "https://github.com/jomcgi/homelab",
+  "schema": 2,
+  "top_invocations": [
+    {
+      "branch": "main",
+      "command": "test",
+      "download_bytes": 360663783818,
+      "invocation_id": "de6ee4ee-7e69-4483-8283-bd404d987cf8",
+      "pattern": "//...",
+      "role": "CI",
+      "success": false,
+      "upload_bytes": 8837069409,
+      "url": "https://app.buildbuddy.io/invocation/de6ee4ee-7e69-4483-8283-bd404d987cf8"
+    },
+    {
+      "branch": "main",
+      "command": "test",
+      "download_bytes": 352068922119,
+      "invocation_id": "bcede2a3-b445-4080-bf5a-9aaa0f1d3fb7",
+      "pattern": "//...",
+      "role": "CI",
+      "success": false,
+      "upload_bytes": 6680325311,
+      "url": "https://app.buildbuddy.io/invocation/bcede2a3-b445-4080-bf5a-9aaa0f1d3fb7"
+    },
+    {
+      "branch": "main",
+      "command": "test",
+      "download_bytes": 299313864872,
+      "invocation_id": "a8c50228-0c5b-4cc0-94ae-d3db48baed23",
+      "pattern": "//... and 1 more",
+      "role": "CI",
+      "success": false,
+      "upload_bytes": 7417171,
+      "url": "https://app.buildbuddy.io/invocation/a8c50228-0c5b-4cc0-94ae-d3db48baed23"
+    },
+    {
+      "branch": "main",
+      "command": "test",
+      "download_bytes": 214240760890,
+      "invocation_id": "746e3fa2-9576-4ad2-8d21-68dcb9e82f68",
+      "pattern": "//...",
+      "role": "CI",
+      "success": true,
+      "upload_bytes": 2567214125,
+      "url": "https://app.buildbuddy.io/invocation/746e3fa2-9576-4ad2-8d21-68dcb9e82f68"
+    },
+    {
+      "branch": "fable-sprint/monolith-dead-code",
+      "command": "test",
+      "download_bytes": 184686387119,
+      "invocation_id": "72665ce2-2398-4bbc-9009-218a601a198d",
+      "pattern": "//...",
+      "role": "CI",
+      "success": true,
+      "upload_bytes": 34251678,
+      "url": "https://app.buildbuddy.io/invocation/72665ce2-2398-4bbc-9009-218a601a198d"
+    },
+    {
+      "branch": "main",
+      "command": "test",
+      "download_bytes": 156623930970,
+      "invocation_id": "18b6d4ff-11a0-4afb-9523-7866116b312e",
+      "pattern": "//...",
+      "role": "CI",
+      "success": false,
+      "upload_bytes": 86427092,
+      "url": "https://app.buildbuddy.io/invocation/18b6d4ff-11a0-4afb-9523-7866116b312e"
+    },
+    {
+      "branch": "main",
+      "command": "test",
+      "download_bytes": 94979250059,
+      "invocation_id": "244fc3fe-f657-426a-b03c-765e3669923c",
+      "pattern": "//...",
+      "role": "CI",
+      "success": true,
+      "upload_bytes": 72952764,
+      "url": "https://app.buildbuddy.io/invocation/244fc3fe-f657-426a-b03c-765e3669923c"
+    },
+    {
+      "branch": "update/semgrep-20260803",
+      "command": "test",
+      "download_bytes": 90771045487,
+      "invocation_id": "c4bc1fb3-b001-467d-9b50-41977c923c48",
+      "pattern": "//...",
+      "role": "CI",
+      "success": true,
+      "upload_bytes": 528484877,
+      "url": "https://app.buildbuddy.io/invocation/c4bc1fb3-b001-467d-9b50-41977c923c48"
+    },
+    {
+      "branch": "fix/pnpm-frozen-lockfile",
+      "command": "test",
+      "download_bytes": 86102231970,
+      "invocation_id": "b25cd8b5-f81a-4246-9940-744766ccc989",
+      "pattern": "//...",
+      "role": "CI",
+      "success": true,
+      "upload_bytes": 21747824,
+      "url": "https://app.buildbuddy.io/invocation/b25cd8b5-f81a-4246-9940-744766ccc989"
+    },
+    {
+      "branch": "main",
+      "command": "test",
+      "download_bytes": 85146619140,
+      "invocation_id": "f65e32c6-cbe8-4466-b636-6f5bfb9127bd",
+      "pattern": "//...",
+      "role": "CI",
+      "success": true,
+      "upload_bytes": 439851088,
+      "url": "https://app.buildbuddy.io/invocation/f65e32c6-cbe8-4466-b636-6f5bfb9127bd"
+    },
+    {
+      "branch": "fix/pnpm-frozen-lockfile",
+      "command": "workflow run",
+      "download_bytes": 54255616001,
+      "invocation_id": "5bae1aa5-0b6d-4e5d-a902-584c2fb6e08a",
+      "pattern": "Test",
+      "role": "CI_RUNNER",
+      "success": true,
+      "upload_bytes": 0,
+      "url": "https://app.buildbuddy.io/invocation/5bae1aa5-0b6d-4e5d-a902-584c2fb6e08a"
+    },
+    {
+      "branch": "main",
+      "command": "test",
+      "download_bytes": 54242786882,
+      "invocation_id": "99d7a135-6c0c-40ee-aa63-6aeaae6e6e93",
+      "pattern": "//...",
+      "role": "CI",
+      "success": false,
+      "upload_bytes": 130536858,
+      "url": "https://app.buildbuddy.io/invocation/99d7a135-6c0c-40ee-aa63-6aeaae6e6e93"
+    },
+    {
+      "branch": "feat/async-session-create",
+      "command": "workflow run",
+      "download_bytes": 52134440982,
+      "invocation_id": "92261439-c95c-48e3-9e0f-11b03c94df8d",
+      "pattern": "Test",
+      "role": "CI_RUNNER",
+      "success": true,
+      "upload_bytes": 0,
+      "url": "https://app.buildbuddy.io/invocation/92261439-c95c-48e3-9e0f-11b03c94df8d"
+    },
+    {
+      "branch": "main",
+      "command": "remote test //...",
+      "download_bytes": 50849925517,
+      "invocation_id": "edbf6fbc-78a8-476a-9fe8-dac5701a428a",
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "success": true,
+      "upload_bytes": 0,
+      "url": "https://app.buildbuddy.io/invocation/edbf6fbc-78a8-476a-9fe8-dac5701a428a"
+    },
+    {
+      "branch": "main",
+      "command": "remote test //...",
+      "download_bytes": 50018415989,
+      "invocation_id": "f5cb57aa-1fea-4f73-b0e6-a5b1315264e9",
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "success": false,
+      "upload_bytes": 0,
+      "url": "https://app.buildbuddy.io/invocation/f5cb57aa-1fea-4f73-b0e6-a5b1315264e9"
+    },
+    {
+      "branch": "main",
+      "command": "remote test //...",
+      "download_bytes": 43847680001,
+      "invocation_id": "ef179827-5e59-497b-807e-14f7db3cb62e",
+      "pattern": "",
+      "role": "HOSTED_BAZEL",
+      "success": false,
+      "upload_bytes": 0,
+      "url": "https://app.buildbuddy.io/invocation/ef179827-5e59-497b-807e-14f7db3cb62e"
+    },
+    {
+      "branch": "main",
+      "command": "test",
+      "download_bytes": 41773813084,
+      "invocation_id": "f0b78158-a6e8-452b-8681-4304d3740007",
+      "pattern": "//...",
+      "role": "CI",
+      "success": true,
+      "upload_bytes": 1043850944,
+      "url": "https://app.buildbuddy.io/invocation/f0b78158-a6e8-452b-8681-4304d3740007"
+    },
+    {
+      "branch": "feat/codex-login-preflight",
+      "command": "test",
+      "download_bytes": 41258659790,
+      "invocation_id": "9c7ceffd-81fc-43ec-89b7-39e490f3a9c8",
+      "pattern": "//...",
+      "role": "CI",
+      "success": true,
+      "upload_bytes": 57565911,
+      "url": "https://app.buildbuddy.io/invocation/9c7ceffd-81fc-43ec-89b7-39e490f3a9c8"
+    },
+    {
+      "branch": "claude/new-session-ga9moa",
+      "command": "test",
+      "download_bytes": 40398624143,
+      "invocation_id": "9c368d5a-ad9f-4fd8-a75a-fbb25e0bc168",
+      "pattern": "//...",
+      "role": "CI",
+      "success": false,
+      "upload_bytes": 20803746,
+      "url": "https://app.buildbuddy.io/invocation/9c368d5a-ad9f-4fd8-a75a-fbb25e0bc168"
+    },
+    {
+      "branch": "feat/agents-repo-plumbing",
+      "command": "test",
+      "download_bytes": 38971232008,
+      "invocation_id": "5384d9b1-febd-4aac-9039-31e02af49bd6",
+      "pattern": "//...",
+      "role": "CI",
+      "success": true,
+      "upload_bytes": 22960255,
+      "url": "https://app.buildbuddy.io/invocation/5384d9b1-febd-4aac-9039-31e02af49bd6"
+    }
+  ],
+  "totals": {
+    "download_bytes": 12145808444714,
+    "download_transferred_bytes": 5504773628140,
+    "invocations": 11413,
+    "upload_bytes": 49117088486,
+    "upload_transferred_bytes": 21280317513
+  },
+  "truncated": false,
+  "window": {
+    "after": "2026-08-02T16:48:36Z",
+    "before": "2026-08-09T16:48:36Z",
+    "days": 7.0
+  }
+}

--- a/bazel/tools/image/BUILD
+++ b/bazel/tools/image/BUILD
@@ -240,24 +240,13 @@ oci_image_index(
     ],
 )
 
-# Stamped tags for CI (branch + timestamp)
+# One tag per push: the timestamped build tag. The branch-name tag this used to
+# carry under --define=CI=true is gone (see bazel/tools/oci/apko_image.bzl); it
+# was also listed FIRST here, so head -1 handed helm values a branch name for
+# this one image while every macro-built image got the timestamp.
 expand_template(
-    name = "image_stamped_tags_ci",
-    out = "image_stamped_ci.tags.txt",
-    stamp_substitutions = {
-        "{STABLE_BRANCH_TAG}": "{{STABLE_BRANCH_TAG}}",
-        "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
-    },
-    template = [
-        "{STABLE_BRANCH_TAG}",
-        "{STABLE_IMAGE_TAG}",
-    ],
-)
-
-# Stamped tags for local builds (timestamp only)
-expand_template(
-    name = "image_stamped_tags_local",
-    out = "image_stamped_local.tags.txt",
+    name = "image_stamped_tags",
+    out = "image_stamped.tags.txt",
     stamp_substitutions = {
         "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
     },
@@ -267,10 +256,7 @@ expand_template(
 oci_push(
     name = "image.push",
     image = ":image",
-    remote_tags = select({
-        "//bazel/tools/oci:ci_build": "image_stamped_tags_ci",
-        "//conditions:default": "image_stamped_tags_local",
-    }),
+    remote_tags = "image_stamped_tags",
     repository = "ghcr.io/jomcgi/homelab/bazel/tools/image",
     visibility = ["//bazel/images:__pkg__"],
 )

--- a/bazel/tools/oci/BUILD
+++ b/bazel/tools/oci/BUILD
@@ -1,12 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-# Detect CI builds to conditionally apply branch tags
-config_setting(
-    name = "ci_build",
-    values = {"define": "CI=true"},
-    visibility = ["//visibility:public"],
-)
-
 # Export push template for apko_push rule
 exports_files(
     [

--- a/bazel/tools/oci/README.md
+++ b/bazel/tools/oci/README.md
@@ -68,9 +68,11 @@ by the low-level `oci_image_info` rule.
 | `repository` | File | Plain-text file containing the OCI repository URL (no trailing newline)     |
 | `image_tags` | File | Text file with one tag per line; first line is the primary tag used by Helm |
 
-The primary tag format is `YYYY.MM.DD.HH.MM.SS-shortsha` (the `STABLE_IMAGE_TAG`
-stamp variable). CI builds also write a second line with the branch name
-(`STABLE_BRANCH_TAG`). Local builds write only the timestamp tag.
+The tag format is `YYYY.MM.DD.HH.MM.SS-shortsha` (the `STABLE_IMAGE_TAG` stamp
+variable), and it is the only tag written. CI builds used to append a second
+line carrying the branch name for ArgoCD Image Updater tag filtering; there is
+no Image Updater in this cluster, and charts deploy by `repository@digest`, so
+the tag is a registry-facing alias rather than the deployed reference.
 
 ## `go_image`
 

--- a/bazel/tools/oci/apko_image.bzl
+++ b/bazel/tools/oci/apko_image.bzl
@@ -181,26 +181,17 @@ def apko_image(
     push_image = name
     use_oci_push = True
 
-    # Create stamped tags file for CI builds (branch + timestamp)
+    # One tag per push: the timestamped build tag, which is also what helm
+    # values read via `head -1`. A second branch-name tag used to be applied
+    # under --define=CI=true; its only documented consumer was ArgoCD Image
+    # Updater filtering, and this cluster has no Image Updater. Charts deploy by
+    # repository@digest (bazel/helm/images.bzl), so a tag is never the deployed
+    # reference.
     expand_template(
-        name = name + "_stamped_tags_ci",
-        out = name + "_stamped_ci.tags.txt",
+        name = name + "_stamped_tags",
+        out = name + "_stamped.tags.txt",
         template = [
-            "{STABLE_IMAGE_TAG}",  # Timestamp (primary — used by helm values via head -1)
-            "{STABLE_BRANCH_TAG}",  # Branch name (e.g., "main")
-        ],
-        stamp_substitutions = {
-            "{STABLE_BRANCH_TAG}": "{{STABLE_BRANCH_TAG}}",
-            "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
-        },
-    )
-
-    # Create stamped tags file for local builds (timestamp only)
-    expand_template(
-        name = name + "_stamped_tags_local",
-        out = name + "_stamped_local.tags.txt",
-        template = [
-            "{STABLE_IMAGE_TAG}",
+            "{STABLE_IMAGE_TAG}",  # Timestamp: YYYY.MM.DD.HH.MM.SS-shortsha
         ],
         stamp_substitutions = {
             "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
@@ -214,10 +205,7 @@ def apko_image(
             name = name + ".push",
             image = ":" + push_image,
             repository = _repository,
-            remote_tags = select({
-                "//bazel/tools/oci:ci_build": name + "_stamped_tags_ci",
-                "//conditions:default": name + "_stamped_tags_local",
-            }),
+            remote_tags = name + "_stamped_tags",
             visibility = visibility,
         )
     else:
@@ -225,10 +213,7 @@ def apko_image(
             name = name + ".push",
             image = push_image,
             repository = _repository,
-            remote_tags = select({
-                "//bazel/tools/oci:ci_build": name + "_stamped_tags_ci",
-                "//conditions:default": name + "_stamped_tags_local",
-            }),
+            remote_tags = name + "_stamped_tags",
             visibility = visibility,
         )
 
@@ -239,7 +224,7 @@ def apko_image(
     oci_image_info(
         name = name + ".info",
         repository = _repository,
-        image_tags = name + "_stamped_ci.tags.txt",
+        image_tags = name + "_stamped.tags.txt",
         image_digest = ":" + name + ".digest",
         image = ":" + name,
         visibility = ["//visibility:public"],

--- a/bazel/tools/oci/go_image.bzl
+++ b/bazel/tools/oci/go_image.bzl
@@ -141,24 +141,15 @@ def go_image(name, binary, base = "@distroless_base", repository = None, extra_t
             repo_tags = [native.package_name() + ":latest"],
         )
 
-    # Create stamped tags file for CI builds (branch + timestamp)
+    # One tag per push: the timestamped build tag, which is also what helm
+    # values read via `head -1`. A second branch-name tag used to be applied
+    # under --define=CI=true; its only documented consumer was ArgoCD Image
+    # Updater filtering, and this cluster has no Image Updater. Charts deploy by
+    # repository@digest (bazel/helm/images.bzl), so a tag is never the deployed
+    # reference.
     expand_template(
-        name = name + "_stamped_tags_ci",
-        out = name + "_stamped_ci.tags.txt",
-        template = [
-            "{STABLE_IMAGE_TAG}",  # Timestamp: YYYY.MM.DD.HH.MM.SS-shortsha (primary — used by helm values)
-            "{STABLE_BRANCH_TAG}",  # Branch name (e.g., "main", "feature-xyz")
-        ],
-        stamp_substitutions = {
-            "{STABLE_BRANCH_TAG}": "{{STABLE_BRANCH_TAG}}",
-            "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
-        },
-    )
-
-    # Create stamped tags file for local builds (timestamp only)
-    expand_template(
-        name = name + "_stamped_tags_local",
-        out = name + "_stamped_local.tags.txt",
+        name = name + "_stamped_tags",
+        out = name + "_stamped.tags.txt",
         template = [
             "{STABLE_IMAGE_TAG}",  # Timestamp: YYYY.MM.DD.HH.MM.SS-shortsha
         ],
@@ -173,10 +164,7 @@ def go_image(name, binary, base = "@distroless_base", repository = None, extra_t
         name = name + ".push",
         image = name if multi_platform else name + "_platform",
         repository = _repository,
-        remote_tags = select({
-            "//bazel/tools/oci:ci_build": name + "_stamped_tags_ci",
-            "//conditions:default": name + "_stamped_tags_local",
-        }),
+        remote_tags = name + "_stamped_tags",
         visibility = visibility,
     )
 
@@ -188,7 +176,7 @@ def go_image(name, binary, base = "@distroless_base", repository = None, extra_t
     oci_image_info(
         name = name + ".info",
         repository = _repository,
-        image_tags = name + "_stamped_ci.tags.txt",
+        image_tags = name + "_stamped.tags.txt",
         image_digest = ":" + name + ".digest",
         image = ":" + name,
         visibility = ["//visibility:public"],

--- a/bazel/tools/oci/py3_image.bzl
+++ b/bazel/tools/oci/py3_image.bzl
@@ -173,24 +173,15 @@ def py3_image(name, binary, main = None, root = "/", layer_groups = {}, env = {}
             repo_tags = [native.package_name() + ":latest"],
         )
 
-    # Create stamped tags file for CI builds (branch + timestamp)
+    # One tag per push: the timestamped build tag, which is also what helm
+    # values read via `head -1`. A second branch-name tag used to be applied
+    # under --define=CI=true; its only documented consumer was ArgoCD Image
+    # Updater filtering, and this cluster has no Image Updater. Charts deploy by
+    # repository@digest (bazel/helm/images.bzl), so a tag is never the deployed
+    # reference.
     expand_template(
-        name = name + "_stamped_tags_ci",
-        out = name + "_stamped_ci.tags.txt",
-        template = [
-            "{STABLE_IMAGE_TAG}",  # Timestamp: YYYY.MM.DD.HH.MM.SS-shortsha (primary — used by helm values via head -1)
-            "{STABLE_BRANCH_TAG}",  # Branch name (e.g., "main", "feature-xyz")
-        ],
-        stamp_substitutions = {
-            "{STABLE_BRANCH_TAG}": "{{STABLE_BRANCH_TAG}}",
-            "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
-        },
-    )
-
-    # Create stamped tags file for local builds (timestamp only)
-    expand_template(
-        name = name + "_stamped_tags_local",
-        out = name + "_stamped_local.tags.txt",
+        name = name + "_stamped_tags",
+        out = name + "_stamped.tags.txt",
         template = [
             "{STABLE_IMAGE_TAG}",  # Timestamp: YYYY.MM.DD.HH.MM.SS-shortsha
         ],
@@ -216,10 +207,7 @@ def py3_image(name, binary, main = None, root = "/", layer_groups = {}, env = {}
         name = name + ".push",
         image = name if multi_platform else name,
         repository = _repository,
-        remote_tags = select({
-            "//bazel/tools/oci:ci_build": name + "_stamped_tags_ci",
-            "//conditions:default": name + "_stamped_tags_local",
-        }),
+        remote_tags = name + "_stamped_tags",
         visibility = visibility,
     )
 
@@ -232,7 +220,7 @@ def py3_image(name, binary, main = None, root = "/", layer_groups = {}, env = {}
     oci_image_info(
         name = name + ".info",
         repository = _repository,
-        image_tags = name + "_stamped_ci.tags.txt",
+        image_tags = name + "_stamped.tags.txt",
         image_digest = ":" + name + ".digest",
         image = ":" + name,
         visibility = ["//visibility:public"],

--- a/bazel/tools/workspace_status.sh
+++ b/bazel/tools/workspace_status.sh
@@ -33,59 +33,17 @@ auto_version=$(
 # because volatile-status.txt is the binding constraint there, not this key.
 base_image_tag=$(TZ=UTC git show -s --format=%cd --date=format-local:%Y.%m.%d.%H.%M.%S HEAD)-${git_short_sha}
 
-# Get branch name (sanitized for Docker tags)
-# Check multiple CI environment variables for branch name
-if [ -n "${GITHUB_REF_NAME:-}" ]; then
-	# GitHub Actions provides this directly
-	branch="${GITHUB_REF_NAME}"
-elif [ -n "${GIT_BRANCH:-}" ]; then
-	# BuildBuddy and Jenkins provide this
-	branch="${GIT_BRANCH}"
-elif [ -n "${GITHUB_REF:-}" ]; then
-	# GitHub webhook events provide refs/heads/branch-name
-	# Extract branch name from refs/heads/ or refs/pull/
-	if [[ "${GITHUB_REF}" == refs/heads/* ]]; then
-		branch="${GITHUB_REF#refs/heads/}"
-	elif [[ "${GITHUB_REF}" == refs/pull/* ]]; then
-		# For pull requests, use PR branch name if available
-		branch="${GITHUB_HEAD_REF:-pr-${GITHUB_REF#refs/pull/}}"
-	else
-		branch="${GITHUB_REF}"
-	fi
-elif [ -n "${BUILDKITE_BRANCH:-}" ]; then
-	# Buildkite CI
-	branch="${BUILDKITE_BRANCH}"
-elif [ -n "${CIRCLE_BRANCH:-}" ]; then
-	# CircleCI
-	branch="${CIRCLE_BRANCH}"
-elif [ -n "${CI_COMMIT_BRANCH:-}" ]; then
-	# GitLab CI
-	branch="${CI_COMMIT_BRANCH}"
-else
-	# Fallback to git command (may fail in detached HEAD state)
-	branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-fi
-
-# Debug output when CI is set (only visible in build logs)
-if [ "${CI:-}" = "true" ] || [ "${CI:-}" = "1" ]; then
-	>&2 echo "workspace_status.sh: Detected branch '${branch}' from environment"
-	>&2 echo "  GITHUB_REF_NAME=${GITHUB_REF_NAME:-<not set>}"
-	>&2 echo "  GIT_BRANCH=${GIT_BRANCH:-<not set>}"
-	>&2 echo "  GITHUB_REF=${GITHUB_REF:-<not set>}"
-fi
-# Sanitize: replace / with - and convert to lowercase
-branch_tag=$(echo "${branch}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-
-# Add dev- prefix for non-main branches (for ArgoCD Image Updater filtering)
-if [ "${branch}" = "main" ]; then
-	image_tag="${base_image_tag}"
-else
-	image_tag="dev-${base_image_tag}"
-fi
+# No branch-derived stamp value is emitted. STABLE_BRANCH_TAG (a sanitized
+# branch name published as a second image tag) and the `dev-` prefix applied to
+# STABLE_IMAGE_TAG off main both existed for one consumer: ArgoCD Image Updater
+# tag filtering. This cluster has no Image Updater, and charts deploy images by
+# repository@digest (bazel/helm/images.bzl), so neither value ever reached a
+# running workload. CI also no longer pushes images off main (buildbuddy.yaml),
+# which left the CI-env branch-detection cascade that used to live here feeding
+# nothing but a debug echo.
 
 cat <<EOF
 STABLE_GIT_COMMIT ${git_commit}
 STABLE_MONOREPO_VERSION ${auto_version}
-STABLE_IMAGE_TAG ${image_tag}
-STABLE_BRANCH_TAG ${branch_tag}
+STABLE_IMAGE_TAG ${base_image_tag}
 EOF

--- a/buck2/image_tags.sh
+++ b/buck2/image_tags.sh
@@ -3,24 +3,14 @@
 #
 #   buck2 run //path:image.push -- $(buck2/image_tags.sh)
 #
-# This is the Buck2 analogue of bazel/tools/workspace_status.sh's STABLE_IMAGE_TAG
-# / STABLE_BRANCH_TAG (buck2 has no --stamp): the timestamped+sha tag plus the
-# sanitized branch. On non-main branches the timestamp tag is dev-prefixed so
-# ArgoCD Image Updater ignores it (matching the bazel side). Chart values pin by
-# digest (deterministic); these tags are human/registry-facing aliases.
+# This is the Buck2 analogue of bazel/tools/workspace_status.sh's
+# STABLE_IMAGE_TAG (buck2 has no --stamp): the timestamped+sha tag, and nothing
+# else. The second, sanitized-branch tag and the `dev-` prefix off main were
+# dropped on both sides once it was clear their only consumer was ArgoCD Image
+# Updater tag filtering, which this cluster does not run. Chart values pin by
+# digest (deterministic); this tag is a human/registry-facing alias.
 set -o errexit -o nounset -o pipefail
 
 git_short_sha="$(git rev-parse --short HEAD)"
-base_tag="$(date -u +"%Y.%m.%d.%H.%M.%S")-${git_short_sha}"
 
-# Branch from CI env (GitHub/BuildBuddy/etc.) or git, sanitized for tags.
-branch="${GITHUB_REF_NAME:-${GIT_BRANCH:-${BUILDKITE_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}}}"
-branch_tag="$(echo "${branch}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')"
-
-if [ "${branch}" = "main" ]; then
-	image_tag="${base_tag}"
-else
-	image_tag="dev-${base_tag}"
-fi
-
-echo "${image_tag} ${branch_tag}"
+echo "$(date -u +"%Y.%m.%d.%H.%M.%S")-${git_short_sha}"

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -199,11 +199,12 @@ actions:
           bazel test $TARGETS --config=ci --deleted_packages=bazel/tools/python
 
   # Push images — runs in parallel with Test (no dependency).
-  # PR images are tagged with the source branch name (not "main") so they do not
-  # touch the main rollout. This ensures image builds are verified before merge.
+  # Images are pushed on main only. PR branches build them (verifying the build
+  # before merge) and push only the charts; see the step below for why.
   # REQUIRED status check: on PR branches each helm push runs the pre-merge
   # missed-chart-bump guard (bazel/helm/check-missed-bump.sh), so a chart whose
-  # images changed without a version bump cannot merge.
+  # images changed without a version bump cannot merge. Do NOT rename this
+  # action: it is a required check in the GitHub ruleset by this exact name.
   - name: "Push images"
     container_image: "ubuntu-24.04"
     max_retries: 1
@@ -232,7 +233,34 @@ actions:
             echo "$DOCKERHUB_TOKEN" | docker login docker.io -u "$DOCKERHUB_USERNAME" --password-stdin
           fi
 
-          bazel run //bazel/images:push_all --config=ci --stamp
+          # "Am I main?" is decided by SHA, not by `git rev-parse --abbrev-ref
+          # HEAD`, which returns "HEAD" on a detached checkout (same reasoning
+          # as the Buck2 rules action). If origin/main is unresolvable the
+          # comparison fails to "none", which takes the PR path: that publishes
+          # nothing, so an unresolvable ref can never push a half-known tree.
+          git fetch origin main --quiet 2>/dev/null || true
+          if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main 2>/dev/null || echo none)" ]; then
+            bazel run //bazel/images:push_all --config=ci --stamp
+          else
+            # PR branches publish nothing: push.sh.tpl takes the PR path for
+            # charts, and PR image tags had no consumer (charts deploy by
+            # repository@digest, and the `dev-` tag's documented consumer,
+            # ArgoCD Image Updater, does not exist in this cluster).
+            #
+            # `bazel run` stages every command's runfiles on the runner before
+            # any command runs, so push_all pulled all ~24 images' layers out of
+            # CAS on every PR push even at a ~99% action-cache hit rate. That was
+            # 3.5 TB/week, 29% of this repo's entire BuildBuddy download volume.
+            # `bazel build` proves the same graph builds while
+            # --remote_download_minimal leaves the layers at rest in CAS.
+            bazel build //bazel/images:push_all --config=ci
+
+            # Charts only, which is what carries the pre-merge
+            # missed-chart-bump guard (bazel/helm/check-missed-bump.sh). The
+            # guard is digest-content based, so it does not need the images to
+            # have been pushed, only built.
+            bazel run //bazel/images:push_charts --config=ci --stamp
+          fi
 
   # Manifest diff — renders Helm manifests from main and PR, posts diff as PR comment
   # Runs in parallel with other actions (no depends_on). Mostly informational,

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -233,13 +233,22 @@ actions:
             echo "$DOCKERHUB_TOKEN" | docker login docker.io -u "$DOCKERHUB_USERNAME" --password-stdin
           fi
 
-          # "Am I main?" is decided by SHA, not by `git rev-parse --abbrev-ref
-          # HEAD`, which returns "HEAD" on a detached checkout (same reasoning
-          # as the Buck2 rules action). If origin/main is unresolvable the
-          # comparison fails to "none", which takes the PR path: that publishes
-          # nothing, so an unresolvable ref can never push a half-known tree.
-          git fetch origin main --quiet 2>/dev/null || true
-          if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main 2>/dev/null || echo none)" ]; then
+          # "Am I main?" MUST be decided the same way push.sh.tpl decides
+          # whether to publish a chart, which is `git rev-parse --abbrev-ref
+          # HEAD`. If the two layers disagree we get a torn state: images pushed
+          # but no chart published, or a main merge that pushes neither.
+          #
+          # Deliberately NOT a SHA comparison against origin/main. That looks
+          # more robust but fails the wrong way: when a second merge lands while
+          # this run is in flight, origin/main has moved, the SHAs differ, and
+          # main would quietly take the PR path and never push its images.
+          #
+          # Anything that is not an unambiguous non-main branch (a detached
+          # "HEAD", an unreadable ref) falls through to the full push, which is
+          # exactly the pre-existing behaviour, so an ambiguous checkout can
+          # only ever cost bytes, never a missed publish.
+          BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+          if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "HEAD" ] || [ "$BRANCH" = "unknown" ]; then
             bazel run //bazel/images:push_all --config=ci --stamp
           else
             # PR branches publish nothing: push.sh.tpl takes the PR path for


### PR DESCRIPTION
## What

PR CI ran `bazel run //bazel/images:push_all --config=ci --stamp` on every push.
`bazel run` stages every command's runfiles on the runner **before any command
executes**, so it pulled all ~24 images' layers out of CAS even when the build
was a ~99% action-cache hit. A representative PR run: `7,824 processes: 7,728
remote cache hit, 80 remote`, and still 9.1 GB. Nothing was recomputing; the
bytes were materialisation.

## Change

PR branches now `bazel build //bazel/images:push_all` (proves every image
builds, and `--remote_download_minimal` leaves the layers at rest in CAS) and
`bazel run //bazel/images:push_charts`, a new charts-only subset. main is
unchanged. Nothing is lost off main: `push.sh.tpl:130` already took the PR path
and published no chart, and the chart push is what carries the pre-merge
missed-chart-bump guard.

## Measured effect, and an honest limit on it

On this PR's own run, the bazel client side did what it was meant to:

| | 7-day avg per run | this PR |
|---|---|---|
| `CI run //bazel/images:push_all` | 1.8 GB | **155 MB** (91.5 MB build + 63.2 MB charts), 12x less |

That source is 1.4 TB/week (11.6% of all download), so this is worth roughly
**8 to 10% of total volume**.

**I originally claimed 29%. That was wrong and I am correcting it.** The other
half of the image-push path, `CI_RUNNER Push images` (2.5 TB/week, 20.9%), did
*not* drop here: it was 9.7 GB against a 3.4 GB average. That is runner-level
traffic, not the bazel graph, and on this cold branch every action is inflated:

| CI_RUNNER action | 7-day avg | this PR | ratio |
|---|---|---|---|
| Push images | 3.4 GB | 9.7 GB | 2.8x |
| Format check | 755 MB | 5.7 GB | 7.5x |
| Buck2 rules | 467 MB | 4.2 GB | 9.0x |

Push images is the *least* inflated of the three despite being the only one
this PR touches, so the runner numbers here are cold-branch setup rather than a
regression. Whether the runner component falls once its snapshots stop carrying
24 materialised image layers can only be answered by the 7-day re-measure, not
by this run. Same family as the trap in PR#4038: a caching change's first run
measures cache population, not the change.

## The guard had to change first

Despite its "content-stable" docstring, `check-missed-bump.sh` read the chart's
`tag:` and resolved it through `crane digest`. That requires the fresh build's
images to **already be in the registry**. With PR pushes gone the fresh,
commit-derived tag never exists in ghcr, every lookup returns `UNRESOLVED`, and
the guard silently takes its fail-open path on every PR.

It now reads the `digest:` that `helm_images_values` already pins beside
repository and tag, and that the templates already deploy by
(`deployment.yaml:32` renders `repository@digest`). No registry access at all.

The first live run then exposed a second defect: treating an unpinned image as
UNRESOLVED fail-opened the *whole* chart, and both `oci-model-cache-operator`
and `signoz-dashboard-sidecar` carry an image pinned by a floating tag, which
would have suppressed the real check on their digest-pinned siblings. Tag-only
images are now skipped with a note. They were never comparable anyway: the old
crane path resolved the identical `repo:tag` on both sides, so it could not
detect drift on them.

Live proof the guard still asserts with no images pushed:

```
check-missed-bump: embervm 0.1.476 image digests match the published chart; OK.
check-missed-bump: monolith 0.285.508 image digests match the published chart; OK.
check-missed-bump: monolith-public 0.285.508 image digests match the published chart; OK.
```

## Also drops the branch-name tag

The second image tag and the `dev-` prefix off main existed for ArgoCD Image
Updater tag filtering (`workspace_status.sh`). This cluster has no Image Updater
(CLAUDE.md, and ADR platform/009 records it as rejected repo-wide), so neither
ever reached a workload. That retires the `ci_build` config_setting and the CI
branch-detection cascade, and fixes `bazel/tools/image`, which listed the branch
tag **first** and so handed helm values a branch name where every other image
got a timestamp.

## Deploys are untouched

Chart version still drives ArgoCD; charts still deploy `repository@digest`.
Tags were never the deployed reference.

Main-detection deliberately uses `git rev-parse --abbrev-ref HEAD`, the same
predicate `push.sh.tpl` uses to decide whether a chart publishes, so the two
layers cannot disagree. A SHA comparison against `origin/main` was tried first
and is wrong: when a second merge lands mid-run, origin/main has moved and main
would quietly take the PR path and push nothing. Anything ambiguous (detached
`HEAD`, unreadable ref) falls through to the full push, the pre-existing
behaviour.

## Verification

- `ci test`: `Executed 1 out of 743 tests: 743 tests pass` (the one executed is
  `check_missed_bump_test`, whose inputs changed).
- `bb remote build //bazel/images:push_all --config=ci`: succeeds and packages
  the charts (`monolith-0.285.508.tgz`), which requires the image digests, so
  the PR path really does build the image graph.
- `bazel/helm/check-missed-bump_test.sh`: 14/14 pass, including
  `unpushed fresh tag still compares` and `tag-only sibling still detects drift`.
- New awk run against real `projects/monolith/chart/values.yaml`: pairs all
  three ghcr images to their pinned digests.

Carries the 2026-08-09 BuildBuddy snapshot. No chart bump: no deployed code
changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)