### PR TITLE
chore(embervm): bump chart to 0.1.477 for drifted image digests

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.476
+version: 0.1.477

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.476
+      targetRevision: 0.1.477
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Unblocks #4590, whose pre-merge guard caught this.

## What happened

```
ERROR: embervm 0.1.476 is already published, but its pinned image digests
differ from the published chart (an image was rebuilt).
```

At 17:32 today the same guard reported `embervm 0.1.476 image digests match the
published chart; OK`. Only #4586, #4587 and #4588 landed in between. Likeliest
cause is #4588 removing `rules_playwright` and the `visual_chromium` apko lock
from `MODULE.bazel`, perturbing the module graph. **Not proven** — stated as the
hypothesis it is.

## Why main could not catch it

`push.sh.tpl` skips a version already in the registry:

```
Chart embervm 0.1.476 is already published; skipping push.
```

Skipping the push skips the digest check with it, so **only the PR-side guard
ever compares**. Digest drift on `main` stays invisible until the next PR trips
over it. That asymmetry is worth its own issue.

## Why the bump is manual

`chart-version.sh` reports `No conventional commits found since 0.1.476, no bump
needed`: the drift produced no conventional commit against embervm's dep
closure. Version computation is commit-message-driven, so it cannot see a digest
change.

That is a direct counterexample to ADR platform/009 decision 1's premise that
"with no version in the diff there is no bump to miss". The post-merge writer
that ADR specifies must **bump on digest change**, not only on conventional
commits, or this class of drift becomes a silent permanent non-deploy once the
pre-merge guard is retired. `check-missed-bump.sh` already does the digest
comparison the writer would need; it just has to become a bump trigger rather
than only a guard.

## Deploy

Rolls the EmberVM fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)