### PR TITLE
fix(ci): publish before the format check so a formatter hiccup cannot block a deploy

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -168,7 +168,28 @@ actions:
           # ---- 1. tests ---------------------------------------------------
           bazel test //... --config=ci --deleted_packages=bazel/tools/python --test_tag_filters=-external,-future
 
-          # ---- 2. formatting must already be correct ----------------------
+          # PUBLISH BEFORE THE FORMAT CHECK, deliberately. Under `set -e` a
+          # formatter hiccup aborts everything after it, and on 2026-08-09 that
+          # took main's first consolidated deploy down before it pushed
+          # anything: a cold runner could not materialise prettier or rustfmt
+          # ("entry_point '.../prettier.cjs' not found", "cannot locate binary
+          # ...rustfmt"). Formatting is the flakiest stage here, because it
+          # shells out to a pile of external tools, and it is the one with no
+          # bearing on whether the images are correct.
+          #
+          # The old layout got this right by accident: "Format check" and
+          # "Push images" were separate actions, so a formatter failure never
+          # blocked a deploy. Publishing first restores that property while
+          # keeping the check FATAL, so unformatted main still turns the action
+          # red. Tests still gate the publish, which is deliberate: bad code
+          # must not ship, whereas a missing formatter binary must not stop a
+          # good build from shipping.
+          # ---- 2. publish -------------------------------------------------
+          # push.sh.tpl decides per chart whether to publish, and skips a
+          # version already in the registry, so a re-run is idempotent.
+          bazel run //bazel/images:push_all --config=ci --stamp
+
+          # ---- 3. formatting must already be correct ----------------------
           # No auto-commit on main: fail with the fix instead.
           AUTHOR="$(git log -1 --format='%an')"
           if [ "$AUTHOR" = "ci-format-bot" ]; then
@@ -191,13 +212,6 @@ actions:
               exit 1
             fi
           fi
-
-          # ---- 3. publish -------------------------------------------------
-          # push.sh.tpl decides per chart whether to publish, and skips a
-          # version already in the registry, so a re-run is idempotent.
-          bazel run //bazel/images:push_all --config=ci --stamp
-
-
 
   # TEMPORARILY DISABLED 2026-08-09: BuildBuddy asked us to cut Workflows cache
   # traffic, and this action is pure runner cost. It normally no-ops (no


### PR DESCRIPTION
**Hotfix: main is red and not deploying.**

## What broke

Main's first consolidated `deploy` (from #4590) died in the format stage on a
cold runner that could not materialise two formatter binaries:

```
FATAL: aspect_rules_js[js_binary]: entry_point '.../prettier.cjs' not found
cannot locate binary rules_rust+/tools/upstream_wrapper/rustfmt
```

Under `set -e` that aborts everything after it, so the tests and the image push
never ran.

## My regression, and the bit I missed

Consolidating `Format check` and `Push images` into one action coupled the
deploy to formatter-tool availability. The old layout avoided this **by
accident**: they were separate actions, so a formatter failure never stopped a
publish.

In #4590 I explicitly called out that tests would now gate the push and argued
that was correct. I did not think about formatting also gating it, and
formatting is the flakiest of the three stages precisely because it shells out
to prettier, rustfmt, gofumpt, ruff and friends.

## Fix

Publish before the format check. That restores the old independence while
keeping the check **fatal**, so unformatted main still turns the action red.

Tests still gate the publish, deliberately: bad code must not ship, whereas a
missing formatter binary must not stop a good build from shipping.

## Impact

None to production. #4590 was CI-only so nothing needed publishing, and chart
0.1.477 published cleanly beforehand. The next *deploying* merge would have been
blocked, which is why this is going in ahead of the queued work.

## Verification

- Both step bodies still `bash -n` clean.
- YAML parses to exactly the two live actions, with both `TEMPORARILY DISABLED`
  blocks intact.
- `pr-checks` on this PR is itself the end-to-end exercise of the new required
  check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)