### PR TITLE
fix(bazel): make the bazel-demo layer tar reproducible across machines

### DIFF
--- a/bazel/tools/http/bazel_demo_workspace.bzl
+++ b/bazel/tools/http/bazel_demo_workspace.bzl
@@ -104,17 +104,30 @@ def _bazel_demo_workspace_impl(repository_ctx):
     # and expose it under both arch names via filegroups for apko_image's
     # multiarch_tars label-suffixing (_amd64 / _arm64).
     #
-    # `tar -C root .` archives root/'s CONTENTS (opt/abseil, opt/distdir) at the
-    # tar root, so the layer unpacks to /opt/abseil + /opt/distdir in-image. Plain
-    # portable flags only (matching k3s_archive's genrule): GNU-only extras like
-    # --sort are avoided so the rule fetches on either GNU or BSD tar.
+    # The tar archives root/'s CONTENTS (opt/abseil, opt/distdir) at the tar
+    # root, so the layer unpacks to /opt/abseil + /opt/distdir in-image.
+    #
+    # It MUST be byte-reproducible across machines. A plain `tar -C root .`
+    # records readdir order and the extraction-time mtimes, and because this
+    # runs in a REPOSITORY RULE it re-executes on every runner that fetches the
+    # repo fresh. That made the layer, and therefore the embervm image digest,
+    # depend on which runner happened to build it: main kept reusing a warm
+    # runner whose output_base already had this repo, so its digest looked
+    # stable across commits, while any PR that landed on a cold runner produced
+    # a different digest for identical sources. The missed-bump guard then
+    # failed the PR for a rebuild that never happened (issue #4594).
+    #
+    # Determinism without GNU-only flags, so the rule still fetches under BSD
+    # tar: pin every mtime with `touch -t`, feed tar a LC_ALL=C sorted member
+    # list on stdin (`-T -`, supported by GNU tar and bsdtar) instead of
+    # --sort, and use --numeric-owner so no name lookup leaks in.
     tar_result = repository_ctx.execute([
-        "tar",
-        "-C",
-        "root",
-        "-cf",
-        "layer.tar",
-        ".",
+        "sh",
+        "-c",
+        "cd root && " +
+        "find . -exec touch -h -t 197001010000 {} + && " +
+        "find . -print | LC_ALL=C sort | " +
+        "tar --numeric-owner -cf ../layer.tar -T -",
     ])
     if tar_result.return_code != 0:
         fail("bazel_demo_workspace: tar of staged root/ failed (%d): %s" % (

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.477
+version: 0.1.478

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.477
+      targetRevision: 0.1.478
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Root cause and fix for #4594.

## The bug

`bazel_demo_workspace` builds its `/opt/abseil` + `/opt/distdir` layer with a
plain `tar -C root .` **inside a repository rule**. That records readdir order
and the extraction-time mtimes, and repository rules re-execute on every runner
that fetches the repo fresh. So the layer, and therefore the embervm image
digest, depended on **which runner built it** rather than on the sources.

That is why the digest looked stable on main and moved on PRs: main kept landing
on warm runners whose `output_base` already held this repo, so the tar was never
rebuilt, while a PR on a cold runner re-fetched and produced a different layer
for identical sources.

## Consequences it caused

- The pre-merge missed-bump guard failed #4590 twice for a rebuild that never
  happened.
- #4591's chart bump to 0.1.477 was treating the symptom, and predictably did
  not help: the next PR build differed again.
- Diagnosis cost three wrong hypotheses (a `MODULE.bazel` change, `--stamp`,
  the `push_charts` split), all killed by the fact that published 0.1.476 and
  0.1.477 pin byte-identical digests across all 13 images.

## Proof

Two identical trees whose only difference is file mtimes:

```
OLD  tar -C root -cf layer.tar .
  a: f61049182b02d400
  b: 9348b84524a424cf     *** DIFFERS -> different image digest ***

NEW  normalised + sorted
  a: c53894d8cde461b4
  b: c53894d8cde461b4     identical -> stable image digest
```

## The fix

Determinism that keeps the portability the original was protecting (the comment
explains it avoided `--sort` so the rule fetches under BSD tar too):

- pin every mtime with `touch -h -t`
- feed tar an `LC_ALL=C` sorted member list on stdin (`-T -`, honoured by both
  GNU tar and bsdtar) instead of `--sort`
- `--numeric-owner`, so no uid/gid name lookup leaks in

## Scope

The other nine plain `tar -cf` calls in the repo are **genrules**, where bazel
normalises the sandbox and outputs are content-addressed. This repository rule
is the only one archiving a real staged tree outside the sandbox, which is why
it alone drifted. Not churning the rest without evidence.

## Chart bump

The layer bytes change, so the embervm image digest changes: 0.1.477 -> 0.1.478.
Verified 0.1.478 is not already published.

Once this lands, the missed-bump guard should go back to blocking (it was made
advisory in #4590 for exactly this false positive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)