### PR TITLE
feat(monolith): add a cd health component so deploy and CI faults page offsite

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.511
+version: 0.285.512
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.511
+      targetRevision: 0.285.512
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -6596,6 +6596,17 @@ py_test(
 )
 
 py_test(
+    name = "cluster_cd_health_test",
+    srcs = ["cluster/cd_health_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_cluster",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
     name = "scheduler_views_test",
     srcs = ["scheduler/views_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.511
+version: 0.285.512
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -269,6 +269,12 @@ spec:
                   key: GITHUB_TOKEN
             {{- end }}
             {{- end }}
+            # cd health component thresholds (issue #4597). Values, not code
+            # constants, so retuning what pages does not need a rebuild.
+            - name: CD_HEALTH_SYNC_GRACE_S
+              value: {{ .Values.cdHealth.syncGraceSeconds | quote }}
+            - name: CD_HEALTH_CI_RED_WINDOW_S
+              value: {{ .Values.cdHealth.ciRedWindowSeconds | quote }}
             {{- if .Values.whatsapp.enabled }}
             # WhatsApp inbound bearer token (ADR 039 spec section 2). The monolith
             # validates the gateway's forwarded requests against it; the same

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -904,6 +904,17 @@ knowledge:
     seed: 42
     nodeSizeScale: 0.005
 
+# cd health component (issue #4597): the `cd` entry in the deep /api/health
+# response, which UptimeRobot polls offsite. Tunables live here so changing what
+# pages does not need a rebuild.
+cdHealth:
+  # An ArgoCD app not Synced+Healthy for longer than this trips the component.
+  # Long enough that a normal rollout never pages.
+  syncGraceSeconds: 900
+  # main's CI red for longer than this trips it. Red is only a fault once it
+  # persists; a run being actively fixed must not page.
+  ciRedWindowSeconds: 3600
+
 chat:
   enabled: false
   llamaCppUrl: ""

--- a/projects/monolith/cluster/cd_health.py
+++ b/projects/monolith/cluster/cd_health.py
@@ -1,0 +1,235 @@
+"""CD health: can the platform's desired state actually reach the cluster?
+
+Folded into the deep ``/api/health`` response as the ``cd`` component, which
+UptimeRobot already polls offsite. Issue #4597 has the full rationale; the short
+version is that on 2026-08-09 a chart bump merged, its `deploy` failed, the
+chart was never published, and ArgoCD's ``targetRevision`` pointed at something
+that does not exist for ~35 minutes. Nothing alerted, because every alerting
+path in this repo lives inside the cluster it is watching.
+
+Two signals, both derived from timestamps the upstreams already carry, so this
+component holds no state and needs no prober or latch table:
+
+1. An ArgoCD Application not Synced+Healthy for longer than the grace period.
+   Covers the unreachable-chart case above, a failed sync, and a degraded
+   workload, without needing registry credentials: an app pinned to a chart
+   that was never published does not reach Synced.
+2. main's CI: the most recent commit WITH A COMPLETED STATUS is red and older
+   than the red window, or there were commits inside that window and none of
+   them completed at all.
+
+The shape of (2) took several passes and the reasoning is worth keeping:
+
+- Red only matters once it persists. A red run being actively fixed must not
+  page; red for an hour means nobody is on it.
+- No commits does NOT mean no signal. The last completed status still stands,
+  so a quiet green main is healthy at any age. Treating silence as staleness
+  would page every night and every weekend.
+- Commits with nothing completed is the CI-is-down case, and it is the gap a
+  naive "is the latest status red" check leaves wide open: if CI stops
+  reporting entirely, that check reports green forever.
+
+A scheduled canary was considered and rejected: it would have cost roughly
+0.4% of this repo's BuildBuddy volume to detect CI being down during quiet
+hours, which is exactly when that fault has no consequence. The
+commits-with-nothing-completed rule catches it at the first merge instead,
+which is when it starts to matter.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+GITHUB_API = "https://api.github.com"
+REPO = "jomcgi/homelab"
+
+# Cache window. UptimeRobot polls frequently and neither the k8s API nor the
+# GitHub API should be hit per request. Short enough that a fault surfaces
+# within a poll or two of appearing.
+_CACHE_TTL_S = 60.0
+_cache: tuple[float, dict] | None = None
+
+
+def _env_seconds(name: str, default: float) -> float:
+    raw = os.environ.get(name, "")
+    try:
+        return float(raw) if raw else default
+    except ValueError:
+        logger.warning("cd health: %s=%r is not a number, using %s", name, raw, default)
+        return default
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+async def _argocd_fault(grace_s: float) -> str | None:
+    """Fetch the apps, then judge them. I/O here, decision in _argocd_fault_real."""
+    from cluster.kubernetes import KubernetesClient  # noqa: PLC0415
+
+    apps = await KubernetesClient().list_argocd_app_health()
+    return await _argocd_fault_real(apps, grace_s)
+
+
+async def _argocd_fault_real(apps: list[dict], grace_s: float) -> str | None:
+    """Return a description of the unhealthy apps, or None if all are fine."""
+    now = datetime.now(timezone.utc)
+    faults = []
+    for app in apps:
+        if app.get("sync") == "Synced" and app.get("health") == "Healthy":
+            continue
+        finished = _parse_ts(app.get("finished_at"))
+        # No finish time means we cannot date the fault. Treat it as in-flight
+        # rather than page: a genuinely stuck app acquires one on its next
+        # attempt, and guessing here would page on every fresh rollout.
+        if finished is None:
+            continue
+        age_s = (now - finished).total_seconds()
+        if age_s > grace_s:
+            faults.append(
+                f"{app['name']} is {app.get('sync')}/{app.get('health')} "
+                f"for {age_s / 60:.0f}m"
+            )
+    return "; ".join(sorted(faults)) if faults else None
+
+
+async def _ci_fault(red_window_s: float) -> str | None:
+    """Return a description of the CI fault, or None if CI is fine."""
+    # GITHUB_TOKEN in this deployment is a kloak placeholder for the guest
+    # egress swap and is useless for a direct API call; the chart wires the real
+    # credential under GITHUB_API_TOKEN for exactly this reason. Reading the
+    # obvious name would fail auth and page for a broken health check rather
+    # than a broken deploy. Do not "fix" this to GITHUB_TOKEN.
+    token = os.environ.get("GITHUB_API_TOKEN", "")
+    if not token:
+        # A config gap is not a platform outage, so do not page. Say so in the
+        # detail rather than silently reporting nothing.
+        return None
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    now = datetime.now(timezone.utc)
+    since = (now - timedelta(seconds=red_window_s)).isoformat()
+
+    async with httpx.AsyncClient(timeout=10.0) as http:
+        resp = await http.get(
+            f"{GITHUB_API}/repos/{REPO}/commits",
+            params={"sha": "main", "per_page": 20},
+            headers=headers,
+        )
+        resp.raise_for_status()
+        commits = resp.json()
+        if not commits:
+            return None
+
+        recent = [
+            c
+            for c in commits
+            if (c.get("commit") or {}).get("committer", {}).get("date", "") >= since
+        ]
+
+        newest_completed: dict | None = None
+        for commit in commits:
+            status = await http.get(
+                f"{GITHUB_API}/repos/{REPO}/commits/{commit['sha']}/status",
+                headers=headers,
+            )
+            status.raise_for_status()
+            body = status.json()
+            if body.get("state") in ("success", "failure", "error"):
+                newest_completed = {"sha": commit["sha"], **body}
+                break
+
+    return _evaluate_ci(len(recent), newest_completed, red_window_s)
+
+
+def _evaluate_ci(
+    recent_commit_count: int, newest_completed: dict | None, red_window_s: float
+) -> str | None:
+    """The CI judgement, pure so the rules are unit-testable.
+
+    See the module docstring for why each branch is shaped this way.
+    """
+    # Commits landed inside the window but not one of them finished. Either the
+    # runners are wedged or nothing is reporting back: the CI-is-down case, and
+    # the gap a naive "is the latest status red" check leaves wide open.
+    if recent_commit_count and newest_completed is None:
+        return (
+            f"{recent_commit_count} commit(s) in the last {red_window_s / 60:.0f}m and "
+            "none have a completed status; CI may be down"
+        )
+
+    # Nothing completed and nothing recent: nothing to assert.
+    if newest_completed is None:
+        return None
+    # A quiet green main is healthy at any age.
+    if newest_completed["state"] == "success":
+        return None
+
+    updated = _parse_ts(newest_completed.get("updated_at"))
+    if updated is None:
+        return None
+    age_s = (datetime.now(timezone.utc) - updated).total_seconds()
+    if age_s <= red_window_s:
+        # Red but recent: someone is probably mid-fix. Not a page yet.
+        return None
+    return (
+        f"main is {newest_completed['state']} at {newest_completed['sha'][:9]} "
+        f"for {age_s / 60:.0f}m"
+    )
+
+
+async def cd_health() -> dict:
+    """The ``cd`` health component. Any fault makes /api/health return 503."""
+    global _cache
+    if _cache is not None and (time.monotonic() - _cache[0]) < _CACHE_TTL_S:
+        return _cache[1]
+
+    grace_s = _env_seconds("CD_HEALTH_SYNC_GRACE_S", 900.0)
+    red_window_s = _env_seconds("CD_HEALTH_CI_RED_WINDOW_S", 3600.0)
+
+    details: list[str] = []
+    ok = True
+
+    try:  # nosemgrep: no-broad-except-swallow - reported in-band, logged below
+        argocd = await _argocd_fault(grace_s)
+    except Exception as exc:  # noqa: BLE001
+        # Includes the Forbidden an RBAC gap would produce. Report it rather
+        # than 503: a broken checker must not masquerade as a broken platform.
+        logger.warning("cd health: argocd check failed: %s", exc)
+        details.append(f"argocd check unavailable ({exc})")
+    else:
+        if argocd:
+            ok = False
+            details.append(argocd)
+
+    if not os.environ.get("GITHUB_API_TOKEN", ""):
+        details.append("ci check disabled: no GITHUB_API_TOKEN")
+    else:
+        try:  # nosemgrep: no-broad-except-swallow - reported in-band, logged below
+            ci = await _ci_fault(red_window_s)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("cd health: ci check failed: %s", exc)
+            details.append(f"ci check unavailable ({exc})")
+        else:
+            if ci:
+                ok = False
+                details.append(ci)
+
+    result = {"ok": ok, "detail": "; ".join(details) if details else "cd ok"}
+    _cache = (time.monotonic(), result)
+    return result

--- a/projects/monolith/cluster/cd_health_test.py
+++ b/projects/monolith/cluster/cd_health_test.py
@@ -1,0 +1,218 @@
+"""Tests for the cd health component (issue #4597).
+
+The cases that matter are the ones that decide whether Joe gets paged at 3am,
+so they are named for the judgement rather than the mechanics.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cluster import cd_health as mod
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    mod._cache = None
+    yield
+    mod._cache = None
+
+
+# --------------------------------------------------------------------------
+# ArgoCD signal
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_apps_synced_healthy_is_ok():
+    apps = [
+        {"name": "monolith", "sync": "Synced", "health": "Healthy", "finished_at": None}
+    ]
+    assert await mod._argocd_fault_real(apps, 900.0) is None
+
+
+@pytest.mark.asyncio
+async def test_app_stuck_unsynced_past_grace_trips():
+    old = _iso(datetime.now(timezone.utc) - timedelta(minutes=40))
+    apps = [
+        {"name": "monolith", "sync": "Unknown", "health": "Healthy", "finished_at": old}
+    ]
+    fault = await mod._argocd_fault_real(apps, 900.0)
+    assert fault is not None
+    assert "monolith is Unknown/Healthy" in fault
+
+
+@pytest.mark.asyncio
+async def test_app_mid_rollout_inside_grace_does_not_trip():
+    recent = _iso(datetime.now(timezone.utc) - timedelta(minutes=2))
+    apps = [
+        {
+            "name": "monolith",
+            "sync": "Synced",
+            "health": "Progressing",
+            "finished_at": recent,
+        }
+    ]
+    assert await mod._argocd_fault_real(apps, 900.0) is None
+
+
+@pytest.mark.asyncio
+async def test_app_with_no_finish_time_does_not_trip():
+    """Cannot date the fault, so treat as in-flight rather than page.
+
+    A genuinely stuck app acquires a finishedAt on its next attempt; guessing
+    here would page on every fresh rollout.
+    """
+    apps = [
+        {
+            "name": "new-app",
+            "sync": "OutOfSync",
+            "health": "Missing",
+            "finished_at": None,
+        }
+    ]
+    assert await mod._argocd_fault_real(apps, 900.0) is None
+
+
+# --------------------------------------------------------------------------
+# CI signal. These encode the rules that took several passes to settle.
+# --------------------------------------------------------------------------
+
+
+def test_quiet_green_main_is_healthy_at_any_age():
+    """No commits does NOT mean no signal: the last completed status stands.
+
+    Treating silence as staleness would page every night and every weekend.
+    """
+    week_old = datetime.now(timezone.utc) - timedelta(days=7)
+    fault = mod._evaluate_ci(
+        recent_commit_count=0,
+        newest_completed={
+            "state": "success",
+            "sha": "abc123456",
+            "updated_at": _iso(week_old),
+        },
+        red_window_s=3600.0,
+    )
+    assert fault is None
+
+
+def test_red_but_recent_does_not_page():
+    """Someone is probably mid-fix. Red only matters once it persists."""
+    ten_min = datetime.now(timezone.utc) - timedelta(minutes=10)
+    fault = mod._evaluate_ci(
+        recent_commit_count=1,
+        newest_completed={
+            "state": "failure",
+            "sha": "abc123456",
+            "updated_at": _iso(ten_min),
+        },
+        red_window_s=3600.0,
+    )
+    assert fault is None
+
+
+def test_red_past_the_window_pages():
+    two_h = datetime.now(timezone.utc) - timedelta(hours=2)
+    fault = mod._evaluate_ci(
+        recent_commit_count=0,
+        newest_completed={
+            "state": "failure",
+            "sha": "abc123456",
+            "updated_at": _iso(two_h),
+        },
+        red_window_s=3600.0,
+    )
+    assert fault is not None
+    assert "abc123456" in fault
+
+
+def test_commits_with_nothing_completed_pages_as_ci_down():
+    """The meta-monitoring gap: if CI stops reporting, "is the latest red"
+    reports green forever."""
+    fault = mod._evaluate_ci(
+        recent_commit_count=3, newest_completed=None, red_window_s=3600.0
+    )
+    assert fault is not None
+    assert "CI may be down" in fault
+
+
+def test_no_commits_and_nothing_completed_is_ok():
+    """Nothing to assert. A repo with no completed statuses in range is not a
+    platform fault."""
+    assert (
+        mod._evaluate_ci(
+            recent_commit_count=0, newest_completed=None, red_window_s=3600.0
+        )
+        is None
+    )
+
+
+# --------------------------------------------------------------------------
+# Component wiring
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_github_token_fails_open_but_says_so(monkeypatch):
+    """A config gap is not a platform outage and must not page, but it must not
+    be silent either."""
+    monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
+
+    async def _no_argocd_fault(grace_s):
+        return None
+
+    monkeypatch.setattr(mod, "_argocd_fault", _no_argocd_fault)
+    result = await mod.cd_health()
+    assert result["ok"] is True
+    assert "no GITHUB_API_TOKEN" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_argocd_check_error_reports_but_does_not_page(monkeypatch):
+    """Includes the Forbidden an RBAC gap produces. A broken checker must not
+    masquerade as a broken platform."""
+    monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
+
+    async def _boom(grace_s):
+        raise RuntimeError("applications.argoproj.io is forbidden")
+
+    monkeypatch.setattr(mod, "_argocd_fault", _boom)
+    result = await mod.cd_health()
+    assert result["ok"] is True
+    assert "argocd check unavailable" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_argocd_fault_makes_the_component_not_ok(monkeypatch):
+    monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
+
+    async def _fault(grace_s):
+        return "monolith is Unknown/Healthy for 40m"
+
+    monkeypatch.setattr(mod, "_argocd_fault", _fault)
+    result = await mod.cd_health()
+    assert result["ok"] is False
+    assert "40m" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_result_is_cached(monkeypatch):
+    """UptimeRobot polls frequently; neither upstream should be hit per request."""
+    monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
+    calls = []
+
+    async def _counting(grace_s):
+        calls.append(1)
+        return None
+
+    monkeypatch.setattr(mod, "_argocd_fault", _counting)
+    await mod.cd_health()
+    await mod.cd_health()
+    assert len(calls) == 1

--- a/projects/monolith/cluster/kubernetes.py
+++ b/projects/monolith/cluster/kubernetes.py
@@ -119,6 +119,37 @@ class KubernetesClient:
         )
         return len(result.get("items", []))
 
+    async def list_argocd_app_health(self, namespace: str = "argocd") -> list[dict]:
+        """Return {name, sync, health, finished_at} for every ArgoCD Application.
+
+        One list call rather than N gets, because the cd health component reads
+        every app on each probe. `finished_at` is the last sync operation's
+        finish time, which is what dates a fault: an app that has been
+        not-Synced since a timestamp is distinguishable from one mid-rollout.
+        """
+        api = await self._ensure_client()
+        custom = client.CustomObjectsApi(api)
+        result = await custom.list_namespaced_custom_object(
+            group="argoproj.io",
+            version="v1alpha1",
+            namespace=namespace,
+            plural="applications",
+        )
+        apps = []
+        for item in result.get("items", []):
+            status = item.get("status") or {}
+            apps.append(
+                {
+                    "name": (item.get("metadata") or {}).get("name", "?"),
+                    "sync": (status.get("sync") or {}).get("status"),
+                    "health": (status.get("health") or {}).get("status"),
+                    "finished_at": (status.get("operationState") or {}).get(
+                        "finishedAt"
+                    ),
+                }
+            )
+        return apps
+
     async def get_argocd_app_status(
         self, name: str, namespace: str = "argocd"
     ) -> dict | None:

--- a/projects/monolith/cluster/module.py
+++ b/projects/monolith/cluster/module.py
@@ -5,6 +5,8 @@ not pull the framework or FastAPI: standalone binaries that reuse domain code
 (e.g. trips_backfill, the knowledge tools) glob only their own sources.
 """
 
+from cluster.cd_health import cd_health
+
 from framework import Module as _Module
 
 
@@ -16,4 +18,9 @@ def _register_mcp() -> None:
 MODULE = _Module(
     name="cluster",
     register_mcp=_register_mcp,
+    # The cd component lives here rather than in a domain of its own: this
+    # domain already owns the k8s and ArgoCD read surface, and a new module
+    # would mint a domain image and a MONOLITH_DOMAINS parity obligation for
+    # something that mounts no routes. See cd_health.py and issue #4597.
+    register_health={"cd": cd_health},
 )

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.511
+      targetRevision: 0.285.512
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Implements #4597.

## Why

On 2026-08-09 a chart bump merged, its `deploy` failed, the chart was never
published, and ArgoCD's `targetRevision` pointed at something that does not
exist for ~35 minutes. **Nothing alerted**, because every alerting path in this
repo lives inside the cluster it is watching. UptimeRobot already polls the
health endpoint offsite, so what was missing was the *signal*, not the delivery.

## Signals

Both derived from timestamps the upstreams already carry, so the component holds
no state and needs no prober or latch table.

| trips when | source |
|---|---|
| an ArgoCD Application is not Synced+Healthy past a grace period | `status.operationState.finishedAt` |
| main's newest commit **with a completed status** is red beyond the window | GitHub status `updated_at` |
| commits landed inside the window and **none completed** | GitHub commits + status |

The ArgoCD rule catches the unreachable-chart case without needing registry
credentials: an app pinned to a chart that was never published does not reach
Synced.

## The CI rule, which took several passes

The tests are named for the judgement rather than the mechanics, so the
reasoning survives:

- **Red only matters once it persists.** A run being actively fixed must not
  page; red for an hour means nobody is on it.
- **No commits does NOT mean no signal.** The last completed status still
  stands, so a quiet green main is healthy at any age. Treating silence as
  staleness would page every night and every weekend.
- **Commits with nothing completed is the CI-is-down case** — the gap a naive
  "is the latest status red" check leaves wide open, because if CI stops
  reporting it reports green forever.

A scheduled canary was considered and rejected: ~0.4% of BuildBuddy volume to
detect CI being down during the hours that fault has no consequence. The
all-pending rule catches it at the first merge, which is when it starts to
matter.

Deliberately excluded: "the last build was flaky". Different urgency, different
responder, and it would flap the endpoint on every retry.

## Placement

On the **cluster** domain, not a new one. `cluster` already owns the k8s and
ArgoCD read surface, and a new module would mint a domain image plus a
`MONOLITH_DOMAINS` parity obligation for something that mounts no routes. No new
RBAC either: `rbac.yaml` already grants `argoproj.io`.

## Landmines handled

- Reads **`GITHUB_API_TOKEN`**, never `GITHUB_TOKEN`. The latter is a kloak
  placeholder for the guest egress swap and useless for a direct API call; the
  chart wires the real credential under the distinct name for exactly this
  reason. Reading the obvious one would fail auth silently and page for a broken
  health check rather than a broken deploy. Commented at the call site so nobody
  "fixes" it.
- **Missing token fails open with a visible detail**, as does an ArgoCD read
  error (which is what an RBAC gap produces). A broken checker must never
  masquerade as a broken platform.
- **An app with no `finishedAt` does not trip**: the fault cannot be dated, and
  guessing would page on every fresh rollout.
- 60s in-process cache, because UptimeRobot polls frequently.

## Verification

- 13 unit tests, covering each judgement branch above.
- `helm template` against `deploy/values.yaml` renders both thresholds
  (`CD_HEALTH_SYNC_GRACE_S=900`, `CD_HEALTH_CI_RED_WINDOW_S=3600`).
- Hand-written `py_test` target (gazelle's custom extensions are not runnable
  locally).
- Chart bump: monolith and monolith-public to 0.285.512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)