### PR TITLE
fix(monolith): serve the deep health route on the confined private tier

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.512
+version: 0.285.513
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.512
+      targetRevision: 0.285.513
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/main_domain_test.py
+++ b/projects/monolith/app/main_domain_test.py
@@ -98,3 +98,26 @@ def test_main_domain_entrypoint_composes_selected_domain(monkeypatch) -> None:
     paths = _route_paths(mod.app)
     assert any(p.startswith("/api/hikes") for p in paths)
     sys.modules.pop("app.main_domain", None)
+
+
+def test_private_profile_serves_deep_health():
+    """The confined monolith must mount /api/health.
+
+    It used to opt out, which made every private-tier register_health component
+    dead code: the component composes fine and the endpoint that would run it
+    does not exist. The cd component (#4599) shipped that way and never ran.
+    """
+    from framework import PRIVATE_PROFILE
+
+    # _add_health returns before registering /api/health when this is False,
+    # so the flag IS the route's presence. Asserted on the profile rather than
+    # by composing the app, which needs the full private dependency set.
+    assert PRIVATE_PROFILE.deep_health is True
+
+
+def test_cd_component_is_registered_on_the_private_tier():
+    """Guards the join that broke: component registered, endpoint present."""
+    from app.modules_private import ALL_MODULES
+
+    names = {n for m in ALL_MODULES if m.register_health for n in m.register_health}
+    assert "cd" in names

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.512
+version: 0.285.513
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.512
+      targetRevision: 0.285.513
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/framework/core.py
+++ b/projects/monolith/framework/core.py
@@ -86,7 +86,13 @@ PRIVATE_PROFILE = Profile(
     mcp_enabled=True,
     otel_enabled=True,
     static_frontend=True,
-    deep_health=False,
+    # The confined monolith serves the deep /api/health route too. It used to
+    # opt out, which silently made every private-tier register_health component
+    # dead code: the component composes fine and the endpoint that would run it
+    # does not exist (the cd component shipped in #4599 and never executed).
+    # A private tier serving this route is already established and tested,
+    # since domain_profile() below has always set it.
+    deep_health=True,
     leader_singletons=True,
 )
 

--- a/projects/monolith/framework/core_test.py
+++ b/projects/monolith/framework/core_test.py
@@ -116,7 +116,10 @@ def test_private_tier_mounts_register_not_register_public():
     assert "/api/m/ping" in paths
     assert "/api/m/public-ping" not in paths
     assert "/healthz" in paths
-    assert "/api/health" not in paths  # private profile has no deep health
+    # The private tier serves the deep route too. It used to opt out, which
+    # made every private-tier register_health component dead code: the
+    # component composes and the endpoint that would run it does not exist.
+    assert "/api/health" in paths
 
 
 def test_public_tier_mounts_register_public_only():


### PR DESCRIPTION
Makes the `cd` component from #4599 actually run. It shipped as **dead code**.

## What was wrong

`PRIVATE_PROFILE` had `deep_health=False`, so `_add_health` returned before
registering `/api/health` (`framework/core.py:252`). Any private-tier
`register_health` component therefore composes fine into an app that never
exposes the endpoint which would run it.

Verified against production before this change: the confined monolith served
**114 routes, `/healthz` among them, and no `/api/health` at all.**

I checked that `register_health` existed and that `/api/health` folds components
in. I never checked that the tier hosting the module mounts that route. Two
correct facts, one unverified join, and the feature shipped doing nothing.

## Why flipping it is safe

`domain_profile()` has always set `deep_health=True` on a **private-tier**
profile (`core.py:122`), so a private tier serving this route is already an
established, tested configuration. Only the confined profile opted out. The
flip also gives the private tier the `SELECT 1` baseline it was missing.

## Tests

An existing assertion encoded the old behaviour and the pre-push hook caught it:

```
core_test.py:119  assert "/api/health" not in paths  # private profile has no deep health
```

Updated to assert the new behaviour with the reason inline. Two new tests guard
the **join** rather than either half: the profile flag (which *is* the route's
presence, given the early return) and `"cd"` being among the registered
component names.

## Still open

Whether UptimeRobot polls the **private** or the **public** endpoint, tracked on
#4597. If public, the component additionally needs a latch, because the tier
with cluster and GitHub access is not the tier that is externally reachable.
This PR is correct either way: it is a precondition for the private path and
harmless for the public one.

Chart bump: monolith and monolith-public to 0.285.513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)