### PR TITLE
feat(monolith): make the private agents console usable on a phone

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.514
+version: 0.285.515
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.514
+      targetRevision: 0.285.515
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.514
+version: 0.285.515
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.514
+      targetRevision: 0.285.515
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1,6 +1,13 @@
 <script>
-  import { tick } from "svelte";
+  import { onMount, tick } from "svelte";
+  import { pushState } from "$app/navigation";
   import { renderAgentMarkdown } from "./markdown.js";
+  import {
+    enterTranscript,
+    MOBILE_VIEW_LIST,
+    MOBILE_VIEW_TRANSCRIPT,
+    returnToList,
+  } from "./mobile-view.js";
   import { statusClass, statusLabel, vmRunning, vmState } from "./status.js";
   import "./agents-theme.css";
 
@@ -11,6 +18,7 @@
   const ATTENTION_MS = 60 * 60 * 1000;
 
   let selectedId = $state(null);
+  let mobileView = $state(MOBILE_VIEW_LIST);
   let sidebarCollapsed = $state(false);
   if (typeof window !== "undefined") {
     try {
@@ -30,6 +38,10 @@
   let sending = $state(false);
   let creating = $state(false);
   let showNewPanel = $state(false);
+  let newButtonEl = $state(null);
+  let newPromptEl = $state(null);
+  let titleEl = $state(null);
+  let mobileHistoryEntry = false;
   let showAllHistory = $state(false);
   let repos = $state([]);
   let branches = $state([]);
@@ -394,6 +406,51 @@
     loadDetail(id, requestSequence);
     const session = sessions.find((item) => String(item.id) === String(id));
     composerModel = session?.model || "";
+    if (isMobileViewport() && mobileView === MOBILE_VIEW_LIST) {
+      mobileView = enterTranscript({ view: mobileView }).view;
+      pushState("", { agentsMobileView: MOBILE_VIEW_TRANSCRIPT });
+      mobileHistoryEntry = true;
+      tick().then(() => {
+        if (isMobileViewport()) focusProgrammatically(titleEl);
+      });
+    }
+  }
+
+  function isMobileViewport() {
+    return (
+      typeof window !== "undefined" &&
+      window.matchMedia("(max-width: 760px)").matches
+    );
+  }
+
+  function focusProgrammatically(element) {
+    if (!element) return;
+    element.classList.add("programmatic-focus");
+    element.focus({ preventScroll: true });
+    setTimeout(() => element.classList.remove("programmatic-focus"), 0);
+  }
+
+  function returnToSessionList() {
+    mobileView = returnToList({ view: mobileView }).view;
+    if (mobileHistoryEntry) {
+      mobileHistoryEntry = false;
+      history.back();
+    }
+    tick().then(() => {
+      if (!isMobileViewport()) return;
+      focusProgrammatically(
+        document.getElementById(`agent-session-${String(selectedId)}`),
+      );
+    });
+  }
+
+  function closeNewPanel() {
+    showNewPanel = false;
+    tick().then(() => focusProgrammatically(newButtonEl));
+  }
+
+  function openNewPanel() {
+    showNewPanel = true;
   }
 
   function toggleSidebar() {
@@ -504,7 +561,7 @@
       if (!response.ok || body.accepted === false)
         throw new Error(body.error || "Session was not created");
       creating = false;
-      showNewPanel = false;
+      closeNewPanel();
       newSession = { prompt: "", model: "", repo: "", branch: "" };
       branches = [];
       await loadSessions();
@@ -533,6 +590,38 @@
 
   $effect(() => {
     if (selectedId == null && sessions.length) selectSession(sessions[0]);
+  });
+
+  $effect(() => {
+    if (showNewPanel) tick().then(() => newPromptEl?.focus());
+  });
+
+  onMount(() => {
+    const handleKeydown = (event) => {
+      if (event.key === "Escape" && showNewPanel) {
+        event.preventDefault();
+        closeNewPanel();
+      }
+    };
+    const handlePopstate = () => {
+      if (mobileView === MOBILE_VIEW_TRANSCRIPT) {
+        mobileHistoryEntry = false;
+        mobileView = returnToList({ view: mobileView }).view;
+        tick().then(() => {
+          if (isMobileViewport()) {
+            focusProgrammatically(
+              document.getElementById(`agent-session-${String(selectedId)}`),
+            );
+          }
+        });
+      }
+    };
+    window.addEventListener("keydown", handleKeydown);
+    window.addEventListener("popstate", handlePopstate);
+    return () => {
+      window.removeEventListener("keydown", handleKeydown);
+      window.removeEventListener("popstate", handlePopstate);
+    };
   });
 
   $effect(() => {
@@ -622,7 +711,11 @@
 
 <svelte:head><title>Agents</title></svelte:head>
 
-<main class:sidebar-collapsed={sidebarCollapsed} class="console">
+<main
+  class:sidebar-collapsed={sidebarCollapsed}
+  class:mobile-transcript={mobileView === MOBILE_VIEW_TRANSCRIPT}
+  class="console"
+>
   <aside class="sidebar" aria-label="Agent sessions">
     <div class="side-head">
       <div class="side-head-left">
@@ -641,7 +734,9 @@
       <button
         class="new-button"
         type="button"
-        onclick={() => (showNewPanel = !showNewPanel)}>+ new</button
+        bind:this={newButtonEl}
+        onclick={() => (showNewPanel ? closeNewPanel() : openNewPanel())}
+        >+ new</button
       >
     </div>
 
@@ -709,8 +804,21 @@
   <section class="transcript" aria-label="Agent transcript">
     {#if selectedSession}
       <header class="transcript-head">
+        <button
+          class="mobile-back"
+          type="button"
+          aria-label="Back to agent sessions"
+          onclick={returnToSessionList}>← back</button
+        >
         <div class="head-main">
-          <h1 class="session-title" title={headerTitle}>{headerTitle}</h1>
+          <h1
+            class="session-title"
+            title={headerTitle}
+            tabindex="-1"
+            bind:this={titleEl}
+          >
+            {headerTitle}
+          </h1>
           <div class="session-context mono">
             {formatRepoContext(selectedSession)} · {selectedSession.model ||
               "luna"} · {shortId(selectedSession)}
@@ -901,7 +1009,18 @@
   </section>
 
   {#if showNewPanel}
-    <section class="new-panel">
+    <button
+      class="new-panel-scrim"
+      type="button"
+      aria-label="Close new session panel"
+      onclick={closeNewPanel}
+    ></button>
+    <section
+      class="new-panel"
+      role="dialog"
+      aria-modal="true"
+      aria-label="New session"
+    >
       <div class="eyebrow">new session</div>
       <form
         onsubmit={(event) => {
@@ -912,6 +1031,7 @@
         <label
           >prompt<textarea
             bind:value={newSession.prompt}
+            bind:this={newPromptEl}
             rows="7"
             placeholder="what should the agent do?"
             onkeydown={(e) => {
@@ -973,10 +1093,8 @@
           </select>
         </label>
         <div class="new-actions">
-          <button
-            type="button"
-            class="quiet-button"
-            onclick={() => (showNewPanel = false)}>cancel</button
+          <button type="button" class="quiet-button" onclick={closeNewPanel}
+            >cancel</button
           ><button
             class="send-button"
             type="submit"
@@ -997,6 +1115,7 @@
   <button
     class:chosen={String(selectedId) === String(session.id)}
     class="session-row"
+    id={`agent-session-${String(session.id)}`}
     type="button"
     aria-label={`${sessionTitle(session)}: ${statusLabel(session)}`}
     onclick={() => selectSession(session)}
@@ -1039,6 +1158,17 @@
       >
     {/each}
   </div>
+  <label class="model-select-label">
+    <span class="sr-only">Model</span>
+    <select
+      aria-label="Model"
+      value={current}
+      onchange={(event) => choose(event.currentTarget.value)}
+    >
+      <option value="">default</option>
+      {#each MODELS as model}<option value={model}>{model}</option>{/each}
+    </select>
+  </label>
 {/snippet}
 
 <style>
@@ -1057,7 +1187,7 @@
     --size-body-mono: 12.5px;
     --size-body: 14px;
     color-scheme: light;
-    height: 100vh;
+    height: 100dvh;
     display: grid;
     grid-template-columns: 300px minmax(0, 1fr);
     background: var(--page-bg);
@@ -1101,6 +1231,9 @@
   .steps summary:focus-visible {
     outline: 2px solid var(--info);
     outline-offset: 1px;
+  }
+  .programmatic-focus:focus {
+    outline: none;
   }
   .sidebar {
     min-height: 0;
@@ -1625,12 +1758,17 @@
     top: 0;
     right: 0;
     width: min(360px, 100vw);
-    height: 100vh;
+    height: 100dvh;
     overflow: auto;
     background: var(--panel-bg);
     border-left: 1px solid var(--line-strong);
     padding: 20px;
     box-shadow: -2px 0 12px rgba(0, 0, 0, 0.07);
+  }
+  .new-panel-scrim,
+  .mobile-back,
+  .model-select-label {
+    display: none;
   }
   .new-panel form {
     display: grid;
@@ -1753,9 +1891,89 @@
       grid-template-columns: 1fr;
     }
     .sidebar {
-      max-height: 42vh;
       border-right: 0;
       border-bottom: 1px solid var(--line);
+    }
+    .console.mobile-transcript .sidebar {
+      display: none;
+    }
+    .console:not(.mobile-transcript) .transcript {
+      display: none;
+    }
+    .mobile-back {
+      display: block;
+      min-height: 44px;
+      padding: 0 8px;
+      border: 0;
+      color: var(--info);
+      background: transparent;
+    }
+    .transcript-head {
+      justify-content: flex-start;
+    }
+    .transcript-head .head-main {
+      flex: 1;
+    }
+    .new-panel-scrim {
+      display: block;
+      position: fixed;
+      z-index: 2;
+      inset: 0;
+      width: 100%;
+      min-height: 100%;
+      padding: 0;
+      border: 0;
+      border-radius: 0;
+      background: var(--scrim-bg);
+    }
+    .new-panel {
+      z-index: 3;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      top: auto;
+      width: 100%;
+      height: auto;
+      max-height: 85dvh;
+      overflow: auto;
+      border-left: 0;
+      border-top: 1px solid var(--line-strong);
+      border-radius: 10px 10px 0 0;
+    }
+    .model-chips {
+      display: none;
+    }
+    .model-select-label {
+      display: block;
+      flex: 1;
+    }
+    .model-select-label select {
+      min-height: 44px;
+    }
+    .collapse-button,
+    .new-button,
+    .destroy-button,
+    .quiet-button,
+    .send-button,
+    .chip {
+      min-height: 44px;
+    }
+    .collapse-button {
+      min-width: 44px;
+    }
+    .steps summary {
+      min-height: 44px;
+      display: inline-flex;
+      align-items: center;
+    }
+    .session-row {
+      min-height: 56px;
+    }
+    .search-label input,
+    .new-panel select,
+    .history-toggle,
+    .search-result {
+      min-height: 44px;
     }
     .sidebar-collapsed {
       grid-template-columns: 1fr;

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1,9 +1,11 @@
 <script>
   import { onMount, tick } from "svelte";
   import { pushState } from "$app/navigation";
+  import { page } from "$app/stores";
   import { renderAgentMarkdown } from "./markdown.js";
   import {
     enterTranscript,
+    MOBILE_MEDIA_QUERY,
     MOBILE_VIEW_LIST,
     MOBILE_VIEW_TRANSCRIPT,
     returnToList,
@@ -411,7 +413,7 @@
       pushState("", { agentsMobileView: MOBILE_VIEW_TRANSCRIPT });
       mobileHistoryEntry = true;
       tick().then(() => {
-        if (isMobileViewport()) focusProgrammatically(titleEl);
+        if (isMobileViewport()) titleEl?.focus({ preventScroll: true });
       });
     }
   }
@@ -419,15 +421,8 @@
   function isMobileViewport() {
     return (
       typeof window !== "undefined" &&
-      window.matchMedia("(max-width: 760px)").matches
+      window.matchMedia(MOBILE_MEDIA_QUERY).matches
     );
-  }
-
-  function focusProgrammatically(element) {
-    if (!element) return;
-    element.classList.add("programmatic-focus");
-    element.focus({ preventScroll: true });
-    setTimeout(() => element.classList.remove("programmatic-focus"), 0);
   }
 
   function returnToSessionList() {
@@ -438,15 +433,15 @@
     }
     tick().then(() => {
       if (!isMobileViewport()) return;
-      focusProgrammatically(
-        document.getElementById(`agent-session-${String(selectedId)}`),
-      );
+      document
+        .getElementById(`agent-session-${String(selectedId)}`)
+        ?.focus({ preventScroll: true });
     });
   }
 
   function closeNewPanel() {
     showNewPanel = false;
-    tick().then(() => focusProgrammatically(newButtonEl));
+    tick().then(() => newButtonEl?.focus({ preventScroll: true }));
   }
 
   function openNewPanel() {
@@ -583,13 +578,15 @@
       selectedId = null;
       detail = null;
       await loadSessions();
+      returnToSessionList();
     } catch (error) {
       errorMessage = error.message;
     }
   }
 
   $effect(() => {
-    if (selectedId == null && sessions.length) selectSession(sessions[0]);
+    if (selectedId == null && sessions.length && !isMobileViewport())
+      selectSession(sessions[0]);
   });
 
   $effect(() => {
@@ -598,20 +595,27 @@
 
   onMount(() => {
     const handleKeydown = (event) => {
-      if (event.key === "Escape" && showNewPanel) {
+      if (event.key === "Escape" && !event.isComposing && showNewPanel) {
         event.preventDefault();
         closeNewPanel();
       }
     };
     const handlePopstate = () => {
-      if (mobileView === MOBILE_VIEW_TRANSCRIPT) {
+      const nextView = $page.state?.agentsMobileView;
+      if (nextView === MOBILE_VIEW_TRANSCRIPT) {
+        mobileHistoryEntry = true;
+        mobileView = enterTranscript({ view: mobileView }).view;
+        tick().then(() => {
+          if (isMobileViewport()) titleEl?.focus({ preventScroll: true });
+        });
+      } else {
         mobileHistoryEntry = false;
         mobileView = returnToList({ view: mobileView }).view;
         tick().then(() => {
           if (isMobileViewport()) {
-            focusProgrammatically(
-              document.getElementById(`agent-session-${String(selectedId)}`),
-            );
+            document
+              .getElementById(`agent-session-${String(selectedId)}`)
+              ?.focus({ preventScroll: true });
           }
         });
       }
@@ -802,14 +806,14 @@
   </aside>
 
   <section class="transcript" aria-label="Agent transcript">
+    <button
+      class="mobile-back"
+      type="button"
+      aria-label="Back to agent sessions"
+      onclick={returnToSessionList}>← back</button
+    >
     {#if selectedSession}
       <header class="transcript-head">
-        <button
-          class="mobile-back"
-          type="button"
-          aria-label="Back to agent sessions"
-          onclick={returnToSessionList}>← back</button
-        >
         <div class="head-main">
           <h1
             class="session-title"
@@ -1015,12 +1019,7 @@
       aria-label="Close new session panel"
       onclick={closeNewPanel}
     ></button>
-    <section
-      class="new-panel"
-      role="dialog"
-      aria-modal="true"
-      aria-label="New session"
-    >
+    <section class="new-panel" role="dialog" aria-label="New session">
       <div class="eyebrow">new session</div>
       <form
         onsubmit={(event) => {
@@ -1161,11 +1160,15 @@
   <label class="model-select-label">
     <span class="sr-only">Model</span>
     <select
+      class="mono"
       aria-label="Model"
       value={current}
       onchange={(event) => choose(event.currentTarget.value)}
     >
       <option value="">default</option>
+      {#if current && !MODELS.includes(current)}
+        <option value={current}>{current}</option>
+      {/if}
       {#each MODELS as model}<option value={model}>{model}</option>{/each}
     </select>
   </label>
@@ -1231,9 +1234,6 @@
   .steps summary:focus-visible {
     outline: 2px solid var(--info);
     outline-offset: 1px;
-  }
-  .programmatic-focus:focus {
-    outline: none;
   }
   .sidebar {
     min-height: 0;
@@ -1886,13 +1886,14 @@
       opacity: 0.35;
     }
   }
+  /* Matches MOBILE_MEDIA_QUERY in mobile-view.js */
   @media (max-width: 760px) {
     .console {
       grid-template-columns: 1fr;
     }
     .sidebar {
       border-right: 0;
-      border-bottom: 1px solid var(--line);
+      border-bottom: 0;
     }
     .console.mobile-transcript .sidebar {
       display: none;
@@ -1910,6 +1911,7 @@
     }
     .transcript-head {
       justify-content: flex-start;
+      flex-wrap: wrap;
     }
     .transcript-head .head-main {
       flex: 1;
@@ -1954,8 +1956,7 @@
     .new-button,
     .destroy-button,
     .quiet-button,
-    .send-button,
-    .chip {
+    .send-button {
       min-height: 44px;
     }
     .collapse-button {
@@ -1979,7 +1980,6 @@
       grid-template-columns: 1fr;
     }
     .sidebar-collapsed .sidebar {
-      max-height: none;
       border-bottom: 0;
     }
     .transcript-head,

--- a/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
+++ b/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
@@ -35,4 +35,5 @@
 
   --code-bg: #f2f1ee; /* inline code + fenced blocks in rendered markdown */
   --dot-idle: #c2beb6; /* history sessions carry no status color */
+  --scrim-bg: rgba(27, 26, 24, 0.45); /* mobile new-session sheet scrim */
 }

--- a/projects/monolith/frontend/src/routes/private/agents/mobile-view.js
+++ b/projects/monolith/frontend/src/routes/private/agents/mobile-view.js
@@ -1,0 +1,16 @@
+export const MOBILE_VIEW_LIST = "list";
+export const MOBILE_VIEW_TRANSCRIPT = "transcript";
+
+export function enterTranscript(state) {
+  return { ...state, view: MOBILE_VIEW_TRANSCRIPT };
+}
+
+export function returnToList(state) {
+  return { ...state, view: MOBILE_VIEW_LIST };
+}
+
+export function transitionMobileView(state, action) {
+  if (action === "select-session") return enterTranscript(state);
+  if (action === "back") return returnToList(state);
+  return state;
+}

--- a/projects/monolith/frontend/src/routes/private/agents/mobile-view.js
+++ b/projects/monolith/frontend/src/routes/private/agents/mobile-view.js
@@ -1,5 +1,6 @@
 export const MOBILE_VIEW_LIST = "list";
 export const MOBILE_VIEW_TRANSCRIPT = "transcript";
+export const MOBILE_MEDIA_QUERY = "(max-width: 760px)";
 
 export function enterTranscript(state) {
   return { ...state, view: MOBILE_VIEW_TRANSCRIPT };
@@ -7,10 +8,4 @@ export function enterTranscript(state) {
 
 export function returnToList(state) {
   return { ...state, view: MOBILE_VIEW_LIST };
-}
-
-export function transitionMobileView(state, action) {
-  if (action === "select-session") return enterTranscript(state);
-  if (action === "back") return returnToList(state);
-  return state;
 }

--- a/projects/monolith/frontend/src/routes/private/agents/mobile-view.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/mobile-view.test.js
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "vitest";
 import {
   enterTranscript,
+  MOBILE_MEDIA_QUERY,
   MOBILE_VIEW_LIST,
   MOBILE_VIEW_TRANSCRIPT,
   returnToList,
-  transitionMobileView,
 } from "./mobile-view.js";
 
 describe("mobile agent views", () => {
@@ -29,14 +29,7 @@ describe("mobile agent views", () => {
     expect(returnToList(state)).toEqual({ ...state, view: MOBILE_VIEW_LIST });
   });
 
-  test("transitions only respond to mobile view actions", () => {
-    const state = { view: MOBILE_VIEW_LIST };
-    expect(transitionMobileView(state, "select-session").view).toBe(
-      MOBILE_VIEW_TRANSCRIPT,
-    );
-    expect(
-      transitionMobileView({ view: MOBILE_VIEW_TRANSCRIPT }, "back").view,
-    ).toBe(MOBILE_VIEW_LIST);
-    expect(transitionMobileView(state, "unknown")).toBe(state);
+  test("uses the shared mobile media query", () => {
+    expect(MOBILE_MEDIA_QUERY).toBe("(max-width: 760px)");
   });
 });

--- a/projects/monolith/frontend/src/routes/private/agents/mobile-view.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/mobile-view.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import {
+  enterTranscript,
+  MOBILE_VIEW_LIST,
+  MOBILE_VIEW_TRANSCRIPT,
+  returnToList,
+  transitionMobileView,
+} from "./mobile-view.js";
+
+describe("mobile agent views", () => {
+  test("entering transcript preserves unrelated state", () => {
+    const state = {
+      view: MOBILE_VIEW_LIST,
+      selectedId: 42,
+      detail: { ok: true },
+    };
+    expect(enterTranscript(state)).toEqual({
+      ...state,
+      view: MOBILE_VIEW_TRANSCRIPT,
+    });
+  });
+
+  test("returning to the list preserves the selected session and detail", () => {
+    const state = {
+      view: MOBILE_VIEW_TRANSCRIPT,
+      selectedId: 42,
+      detail: { ok: true },
+    };
+    expect(returnToList(state)).toEqual({ ...state, view: MOBILE_VIEW_LIST });
+  });
+
+  test("transitions only respond to mobile view actions", () => {
+    const state = { view: MOBILE_VIEW_LIST };
+    expect(transitionMobileView(state, "select-session").view).toBe(
+      MOBILE_VIEW_TRANSCRIPT,
+    );
+    expect(
+      transitionMobileView({ view: MOBILE_VIEW_TRANSCRIPT }, "back").view,
+    ).toBe(MOBILE_VIEW_LIST);
+    expect(transitionMobileView(state, "unknown")).toBe(state);
+  });
+});


### PR DESCRIPTION
Makes the private `/agents` console usable on a phone. Before this, the entire
responsive story was 22 lines that stacked the desktop two-column grid into two
rows, so a 42vh session list sat permanently above the transcript and the
composer rendered under Safari's URL bar.

Design converged as a mockup first:
https://claude.ai/code/artifact/83c52f67-a683-41ef-89e1-ce9892ab97c8

## What changes, all at `max-width: 760px`

- **Two views, not two stacked panes.** Selecting a session takes over the
  screen; a back control returns to the list. `selectedId` and `detail` are not
  cleared, so the polling effects and the pending-partials map survive.
- **`100dvh`** on `.console` and `.new-panel`, so the composer clears the URL
  bar. This does not fix keyboard occlusion, which would need visualViewport
  handling.
- **The new-session drawer becomes a bottom sheet** with a scrim, Escape to
  dismiss, and focus returned to the button that opened it.
- **44px touch targets**, and the eight-model chip row becomes a select,
  toggled in CSS so it is correct on the first server-rendered paint.
- **Browser back gesture** returns to the list rather than leaving the console,
  via `pushState` shallow routing.

Desktop is unchanged apart from dropping an `aria-modal` that was asserting the
page was inert while the desktop drawer leaves it fully interactive.

## Review findings applied

An Opus review found two things worth calling out:

- The pre-existing auto-select effect reached `pushState` on the first client
  flush, before the router is initialized. Beyond the timing risk, a phone user
  landed straight in the first session's transcript, never saw the list, and
  burned a history entry. Now gated on viewport.
- Destroying a session on mobile was a dead end: the back control lived inside
  the `selectedSession` block, so the blank state had no back control, no
  sidebar and no create button. The control moved out and destroy returns to
  the list.

Also fixed: a `programmatic-focus` class that stripped the focus ring from an
element a keyboard user had just navigated to (WCAG 2.4.7, specificity (0,2,0)
beating `button:focus-visible` at (0,1,1)), the breakpoint being hardcoded in
both JS and CSS with nothing linking them, and an unread shallow-routing
payload that left forward navigation broken.

## Verification

- `ci lint` clean.
- `ci test`: `Executed 1 out of 743 tests: 743 tests pass`, with
  `//projects/monolith/frontend:test` confirmed EXECUTED (1.786s, PASSED) via
  the BuildBuddy invocation rather than inferred from the summary line.
- Charts at `0.285.515`, both `targetRevision`s moved. The first rebase left
  the branch at `.513`, identical to what main had just published, which git
  saw as no conflict and would have merged as a no-op deploy.

## Not in scope

The diff walkthrough this UI was designed alongside is blocked on data that
does not exist. Tracked in #4600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39
