### PR TITLE
feat(monolith): link an agent session to the workflow that created it

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.515
+version: 0.285.516
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.515
+      targetRevision: 0.285.516
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -4377,6 +4377,17 @@ py_test(
 )
 
 py_test(
+    name = "agent_sessions_api_test",
+    srcs = ["agent_sessions/api_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_agent_sessions",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "agent_sessions_progress_ingest_test",
     srcs = ["agent_sessions/progress_ingest_test.py"],
     imports = ["."],

--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -21,7 +21,12 @@ from goosecracker.api import REPO_CATALOG
 
 
 def start_session_for_graph(
-    local_session_id: str, prompt: str, model: str, repo: str, branch: str
+    local_session_id: str,
+    prompt: str,
+    model: str,
+    repo: str,
+    branch: str,
+    workflow_id: str | None = None,
 ) -> int:
     """Create and schedule a graph-owned session through the normal session path.
 
@@ -43,7 +48,14 @@ def start_session_for_graph(
         existing = store.get_session_by_local_id(session, local_session_id)
     if existing is not None and existing.id is not None:
         return existing.id
-    row = _persist_session(local_session_id, "<guest>", branch, model, repo)
+    row = _persist_session(
+        local_session_id,
+        "<guest>",
+        branch,
+        model,
+        repo,
+        workflow_id=workflow_id,
+    )
     assert row.id is not None
     _persist_pending_message(row.id, prompt, model)
     try:

--- a/projects/monolith/agent_sessions/api_test.py
+++ b/projects/monolith/agent_sessions/api_test.py
@@ -1,0 +1,51 @@
+from sqlmodel import Session, SQLModel, create_engine
+
+import agent_sessions.api as api
+import agent_sessions.mcp as mcp
+from agent_sessions.models import AgentSession
+
+
+def test_start_session_for_graph_retry_preserves_original_workflow_id(
+    monkeypatch, tmp_path
+):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'api_test.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            schemas[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    monkeypatch.setattr(api, "get_engine", lambda: engine)
+    monkeypatch.setattr(mcp, "get_engine", lambda: engine)
+    monkeypatch.setattr(api, "_schedule_next_message", lambda session_id: None)
+
+    try:
+        first_id = api.start_session_for_graph(
+            "test-key",
+            "prompt1",
+            "luna",
+            "jomcgi/homelab",
+            "main",
+            workflow_id="wf-1",
+        )
+        second_id = api.start_session_for_graph(
+            "test-key",
+            "prompt1",
+            "luna",
+            "jomcgi/homelab",
+            "main",
+            workflow_id="wf-2",
+        )
+
+        assert second_id == first_id
+        with Session(engine) as session:
+            row = session.get(AgentSession, first_id)
+            assert row is not None
+            assert row.workflow_id == "wf-1"
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in schemas:
+                table.schema = schemas[table.name]

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -167,6 +167,7 @@ def _persist_session(
     *,
     discord_thread: str | None = None,
     system_prompt: str | None = None,
+    workflow_id: str | None = None,
 ) -> AgentSession:
     with Session(get_engine()) as db_session:
         return store.create_session(
@@ -178,6 +179,7 @@ def _persist_session(
             repo,
             discord_thread=discord_thread,
             system_prompt=system_prompt,
+            workflow_id=workflow_id,
         )
 
 

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -15,6 +15,9 @@ class AgentSession(SQLModel, table=True):
     workspace: str
     branch: str
     repo: str | None = None
+    # The DBOS workflow that owns this session, or None for hand-started,
+    # Discord, and MCP sessions.
+    workflow_id: str | None = Field(default=None, index=True)
     # The Discord thread this session is bound to, or None for a session started
     # from the /agents UI or an MCP tool. Unique so a thread can never fan out to
     # two sessions; Postgres allows many NULLs under a unique constraint, so the

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -137,6 +137,7 @@ def _session_payload(
         "workspace": row.workspace,
         "branch": row.branch,
         "repo": row.repo,
+        "workflow_id": row.workflow_id,
         "model": row.model,
         "status": row.status,
         "title": row.title or _fallback_title(first_turn_prompt, first_pending_prompt),

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -143,13 +143,21 @@ def test_list_sessions_title_falls_back_to_pending_prompt(client, session):
 
 
 def test_list_sessions_exposes_ember_binding(client, session):
-    _session(session, "bound", ember_session_id="s-abc123")
+    _session(
+        session,
+        "bound",
+        ember_session_id="s-abc123",
+        workflow_id="wf-123",
+    )
     _session(session, "unbound")
 
     body = client.get("/api/agents/sessions").json()
     bindings = {item["local_session_id"]: item["ember_session_id"] for item in body}
     assert bindings["bound"] == "s-abc123"
     assert bindings["unbound"] is None
+    workflow_ids = {item["local_session_id"]: item["workflow_id"] for item in body}
+    assert workflow_ids["bound"] == "wf-123"
+    assert workflow_ids["unbound"] is None
 
 
 def test_list_session_vms_maps_control_plane_states(client, monkeypatch):

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -28,6 +28,7 @@ def create_session(
     *,
     discord_thread: str | None = None,
     system_prompt: str | None = None,
+    workflow_id: str | None = None,
 ) -> AgentSession:
     row = AgentSession(
         local_session_id=local_session_id,
@@ -38,6 +39,7 @@ def create_session(
         model=model,
         progress_token=secrets.token_urlsafe(32),
         system_prompt=system_prompt,
+        workflow_id=workflow_id,
     )
     session.add(row)
     session.commit()

--- a/projects/monolith/agent_sessions/store_test.py
+++ b/projects/monolith/agent_sessions/store_test.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from sqlalchemy import inspect
 from sqlalchemy.exc import IntegrityError
 
 from sqlmodel import Session, SQLModel, create_engine, select
@@ -87,6 +88,31 @@ def test_create_session_persists_optional_system_prompt(monkeypatch, tmp_path):
 
             assert prompted.system_prompt == "X"
             assert unprompted.system_prompt is None
+    finally:
+        _restore_schemas(schemas)
+
+
+def test_create_session_persists_and_queries_workflow_id(monkeypatch, tmp_path):
+    engine, schemas = _database(monkeypatch, tmp_path)
+    try:
+        with Session(engine) as session:
+            linked = store.create_session(
+                session,
+                "linked",
+                "<guest>",
+                "main",
+                workflow_id="wf-123",
+            )
+            unlinked = store.create_session(session, "unlinked", "<guest>", "main")
+
+            assert linked.workflow_id == "wf-123"
+            assert unlinked.workflow_id is None
+            queried = session.exec(
+                select(AgentSession).where(AgentSession.workflow_id == "wf-123")
+            ).one()
+            assert queried.id == linked.id
+            indexes = inspect(engine).get_indexes("agent_sessions")
+            assert any("workflow_id" in index["column_names"] for index in indexes)
     finally:
         _restore_schemas(schemas)
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.515
+version: 0.285.516
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260810000000_agent_sessions_workflow_id.sql
+++ b/projects/monolith/chart/migrations/20260810000000_agent_sessions_workflow_id.sql
@@ -1,0 +1,10 @@
+-- The DBOS workflow that created this session (graph/workflows.py). NULL for
+-- hand-started, Discord, and MCP sessions. Threaded explicitly rather than
+-- parsed back out of local_session_id, whose "<workflow_id>-<suffix>" join
+-- is ambiguous because DBOS workflow ids can themselves contain dashes.
+
+ALTER TABLE agent_sessions.agent_sessions
+    ADD COLUMN workflow_id TEXT;
+
+CREATE INDEX agent_sessions_workflow_id
+    ON agent_sessions.agent_sessions (workflow_id);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:y8qx1KqPhvuEZ0MHlkiPMydxOrJo6NFb5gpZ+DzPgww=
+h1:BtoULEi2dx+wRzTmFa079L7GjluZvi6gR1MgzAbKaeU=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -158,3 +158,4 @@ h1:y8qx1KqPhvuEZ0MHlkiPMydxOrJo6NFb5gpZ+DzPgww=
 20260807200000_agent_sessions_title.sql h1:DsUTRT8wNkVtobGtUKt6VHLaV5CcC/fzQRjPnevFbpM=
 20260809230000_platform_probe.sql h1:kV6FxOFnySW/mfEQpdllV9V6lgkzT2giTXZYcQMujz4=
 20260809230100_platform_probe_public_grants.sql h1:mQ8fVxqyOoQnRnCvBiRFpCvETDSeDL4umDOXK3xQXzk=
+20260810000000_agent_sessions_workflow_id.sql h1:lgOBVujB+/Cp8sK7w0PnCuUnttfozKADNWhSG83M7hE=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.515
+      targetRevision: 0.285.516
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/graph/steps.py
+++ b/projects/monolith/graph/steps.py
@@ -7,7 +7,9 @@ from dbos import DBOS
 
 
 @DBOS.step(retries_allowed=True, max_attempts=3, backoff_rate=2.0)
-def start_agent_session(session_key, prompt, model, repo, branch) -> int:
+def start_agent_session(
+    session_key, prompt, model, repo, branch, workflow_id: str
+) -> int:
     """Start (or re-attach to) one agent session.
 
     ``session_key`` must be DETERMINISTIC for a given workflow and node. Steps
@@ -17,7 +19,9 @@ def start_agent_session(session_key, prompt, model, repo, branch) -> int:
     """
     from agent_sessions.api import start_session_for_graph
 
-    return start_session_for_graph(session_key, prompt, model, repo, branch)
+    return start_session_for_graph(
+        session_key, prompt, model, repo, branch, workflow_id=workflow_id
+    )
 
 
 @DBOS.step()

--- a/projects/monolith/graph/steps_test.py
+++ b/projects/monolith/graph/steps_test.py
@@ -49,3 +49,27 @@ def test_read_branch_head_raises_on_server_error(monkeypatch):
 
     with pytest.raises(httpx.HTTPStatusError):
         steps.read_branch_head.__wrapped__("jomcgi/homelab", "graph/wf-1")
+
+
+def test_start_agent_session_forwards_workflow_id(monkeypatch):
+    import agent_sessions.api as api
+
+    calls = []
+
+    def fake_start_session(*args, **kwargs):
+        calls.append((args, kwargs))
+        return 101
+
+    monkeypatch.setattr(api, "start_session_for_graph", fake_start_session)
+
+    result = steps.start_agent_session.__wrapped__(
+        "test-key", "prompt", "luna", "jomcgi/homelab", "main", workflow_id="wf-abc"
+    )
+
+    assert result == 101
+    assert calls == [
+        (
+            ("test-key", "prompt", "luna", "jomcgi/homelab", "main"),
+            {"workflow_id": "wf-abc"},
+        )
+    ]

--- a/projects/monolith/graph/workflows.py
+++ b/projects/monolith/graph/workflows.py
@@ -21,15 +21,25 @@ POLL_INTERVAL_SECONDS = 5
 
 @DBOS.workflow()
 def start_session_workflow(
-    key: str, prompt: str, model: str, repo: str, branch: str
+    key: str,
+    prompt: str,
+    model: str,
+    repo: str,
+    branch: str,
+    workflow_id: str | None = None,
 ) -> int:
     """Queue-able wrapper around the session-start step.
 
     DBOS queues enqueue WORKFLOWS, not steps, so the concurrency cap only
     applies if what we enqueue is a workflow. Enqueuing the step directly would
     not be gated by the queue at all.
+
+    The workflow_id is passed explicitly because DBOS.workflow_id inside this
+    function is the queued session workflow's id, not the caller's run id. The
+    parent's id must be threaded from the caller, not read from context, or the
+    session would record the wrong parent link.
     """
-    return start_agent_session(key, prompt, model, repo, branch)
+    return start_agent_session(key, prompt, model, repo, branch, workflow_id)
 
 
 def session_key(suffix: str) -> str:
@@ -46,9 +56,16 @@ def session_key(suffix: str) -> str:
     return f"{workflow_id}-{suffix}"
 
 
-def _queued_session(key: str, prompt: str, model: str, repo: str, branch: str) -> int:
+def _queued_session(
+    key: str,
+    prompt: str,
+    model: str,
+    repo: str,
+    branch: str,
+    workflow_id: str,
+) -> int:
     handle = codex_queue().enqueue(
-        start_session_workflow, key, prompt, model, repo, branch
+        start_session_workflow, key, prompt, model, repo, branch, workflow_id
     )
     return handle.get_result()
 
@@ -114,6 +131,7 @@ def implement_then_review(task: str, repo: str, branch: str) -> dict:
             config.implementer_model(),
             repo,
             branch,
+            workflow_id,
         )
         implementer_turn = _await_turn(
             implementer_session_id, 0, config.turn_timeout_seconds()
@@ -163,6 +181,7 @@ def implement_then_review(task: str, repo: str, branch: str) -> dict:
         config.reviewer_model(),
         repo,
         branch,
+        workflow_id,
     )
     reviewer_turn = _await_turn(reviewer_session_id, 0, config.turn_timeout_seconds())
     return {

--- a/projects/monolith/graph/workflows_test.py
+++ b/projects/monolith/graph/workflows_test.py
@@ -33,8 +33,9 @@ def run(monkeypatch, turns, heads=None):
     monkeypatch.setattr(
         workflows,
         "_queued_session",
-        lambda key, prompt, model, repo, branch: (
-            calls.append((key, prompt, model, repo, branch)) or next(sessions)
+        lambda key, prompt, model, repo, branch, workflow_id: (
+            calls.append((key, prompt, model, repo, branch, workflow_id))
+            or next(sessions)
         ),
     )
     return calls
@@ -121,10 +122,12 @@ def test_queue_receives_a_workflow_not_a_step(monkeypatch):
     binds if what is enqueued is a workflow. Enqueuing the step directly left
     the codex cap unenforced."""
     enqueued = []
+    arguments = []
 
     class RecordingQueue:
         def enqueue(self, function, *args):
             enqueued.append(function)
+            arguments.append(args)
 
             class Handle:
                 def get_result(self):
@@ -133,9 +136,26 @@ def test_queue_receives_a_workflow_not_a_step(monkeypatch):
             return Handle()
 
     monkeypatch.setattr(workflows, "codex_queue", lambda: RecordingQueue())
-    workflows._queued_session("k-1", "p", "luna", "jomcgi/homelab", "main")
+    workflows._queued_session("k-1", "p", "luna", "jomcgi/homelab", "main", "wf-123")
     assert enqueued == [workflows.start_session_workflow]
     assert enqueued[0] is not workflows.start_agent_session
+    assert arguments == [("k-1", "p", "luna", "jomcgi/homelab", "main", "wf-123")]
+
+
+def test_start_session_workflow_forwards_workflow_id(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        workflows,
+        "start_agent_session",
+        lambda *args: calls.append(args) or 101,
+    )
+
+    result = workflows.start_session_workflow.__wrapped__(
+        "k-1", "p", "luna", "jomcgi/homelab", "main", "wf-123"
+    )
+
+    assert result == 101
+    assert calls == [("k-1", "p", "luna", "jomcgi/homelab", "main", "wf-123")]
 
 
 def test_empty_commit_sha_is_not_success(monkeypatch):
@@ -160,7 +180,7 @@ def test_reviewer_has_no_lineage_argument(monkeypatch):
         },
     )
     workflow("task", "jomcgi/homelab", "main")
-    assert len(calls[1]) == 5
+    assert len(calls[1]) == 6
     assert all("lineage" not in str(value) for value in calls[1])
 
 


### PR DESCRIPTION
Gives an `AgentSession` an explicit parent link to the DBOS workflow that
created it. Data layer only; the console grouping that consumes it is a
separate change.

## Why

`projects/monolith/graph/` creates real agent sessions for its DAG runs, but
nothing recorded which run a session belonged to. The only trace was that
`session_key()` mints `local_session_id` as `"<workflow_id>-<suffix>"`, so
membership was an accidental string prefix on an idempotency key. That prefix
is genuinely ambiguous, because DBOS workflow ids can themselves contain
dashes, which is why the value is threaded explicitly rather than parsed back
out.

ADR 053 turns the graph from a chain into a feature-scale DAG of interdependent
sessions. At that width, a flat list of unrelated rows stops being workable.

## What changes

- Nullable indexed `workflow_id` on `AgentSession`, with a migration.
- Threaded explicitly from `graph/workflows.py` through `steps.py` and
  `api.py`. **Required** at the two graph hops so a missed thread is a
  `TypeError` rather than a silently NULL parent link; optional at the creation
  funnel, where the Discord, UI and MCP paths legitimately pass nothing.
- Added to `_session_payload`, so both `GET /sessions` and `GET /sessions/{id}`
  carry it.

The at-least-once re-attach path returns the existing row before reaching the
constructor, so a retry cannot rewrite the parent. That was correct by
construction and previously unguarded; it now has a test.

## On DBOS replay

`start_session_workflow` is a `@DBOS.workflow()` enqueued through a queue, so
adding a parameter changes the arity of something recoverable from a
checkpoint. This was checked against the dbos 2.29.0 source and is safe twice
over: `compute_app_version` is an md5 over the source of every registered
workflow, and both the recovery filter and the queue dequeue predicate match on
`application_version` with no backward acceptance, so a pre-deploy workflow
cannot be picked up post-deploy at all. Arity would have been safe regardless,
since a stored 5-tuple binds against a 6-parameter signature with a trailing
default and `validate_args` is not set.

Worth knowing, and not introduced by this PR: because the app version moves,
any graph run in flight at rollout is stranded and never resumes. That is
inherent to editing any `@DBOS.workflow` here, and `graph.enabled` is true.
Check `GET /api/graph/runs` before merging if a run may be active.

## Verification

`ci test`: `Executed 65 out of 744 tests: 744 tests pass`, with
`//projects/monolith:agent_sessions_api_test` confirmed PASSED (7.945s) via the
BuildBuddy invocation.

Both numbers matter. An earlier run on this branch reported a green
`Executed 4 out of 743` that never compiled the change: the migration was
untracked, so `bb remote` never received it, and the two pre-commit migration
hooks reported "no files to check" for the same reason. 65 matches the real
blast radius of touching `agent_sessions/**` and `graph/**`, and 744 confirms
the hand-written `py_test` registered, which matters because `agent_sessions`
is gazelle-excluded and a new test file there otherwise never runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39
