### PR TITLE
fix(bazel): archive the bazel-demo layer with --no-recursion so it is stable

### DIFF
--- a/bazel/tools/http/BUILD
+++ b/bazel/tools/http/BUILD
@@ -1,10 +1,24 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 """HTTP utilities for downloading and packaging binaries"""
 
 exports_files(
     ["multiarch_http_file.bzl"],
     visibility = ["//visibility:public"],
+)
+
+# Fetched by label from bazel_demo_workspace.bzl's repository rule, so the repo
+# re-fetches when the archiving changes.
+exports_files(
+    ["stage_layer_tar.sh"],
+    visibility = ["//visibility:public"],
+)
+
+sh_test(
+    name = "stage_layer_tar_test",
+    srcs = ["stage_layer_tar_test.sh"],
+    data = [":stage_layer_tar.sh"],
 )
 
 bzl_library(

--- a/bazel/tools/http/bazel_demo_workspace.bzl
+++ b/bazel/tools/http/bazel_demo_workspace.bzl
@@ -15,10 +15,12 @@ one arch-independent tar layer the apko_image consumes via `multiarch_tars`:
     filename + sha256, so the upstream filenames MUST be preserved exactly.
 
 The repo rule stages both under a single `root/` dir laid out exactly as the in-image
-tree (root/opt/abseil, root/opt/distdir), then tars it IN THE REPOSITORY RULE with a
-trivial `tar -C root .` (repo rules run outside the sandbox on the real staged tree,
-so there is no $(location)/genrule-prerequisite plumbing and no sandbox symlinks to
-dereference). It exposes the single resulting `layer.tar` under `:tar_amd64` /
+tree (root/opt/abseil, root/opt/distdir), then tars it IN THE REPOSITORY RULE via
+stage_layer_tar.sh (repo rules run outside the sandbox on the real staged tree, so
+there is no $(location)/genrule-prerequisite plumbing and no sandbox symlinks to
+dereference). That script pins every field a tar would otherwise take from the
+building machine; see its header, and #4594 for what drifted.
+It exposes the single resulting `layer.tar` under `:tar_amd64` /
 `:tar_arm64` filegroups plus a `:tar` alias tagged `multiarch_tar`, mirroring
 k3s_archive: apko_image appends `_amd64` / `_arm64` to the base label, so the image
 references `@bazel_demo_workspace//:tar`. The content is IDENTICAL across arches
@@ -97,7 +99,7 @@ def _bazel_demo_workspace_impl(repository_ctx):
     # anchor is only legal if that exact file is a declared prerequisite (it was
     # not, so analysis failed), and any dirname-counting anchor can silently place
     # the layer at the wrong depth. A repository rule runs OUTSIDE the sandbox on
-    # the real staged tree, so `tar -C root .` is exact and needs no $(location),
+    # the real staged tree, so archiving root/ is exact and needs no $(location),
     # no prerequisite plumbing, and no symlink dereferencing (root/ holds real
     # files, not sandbox symlinks). The content is arch-independent (Abseil source
     # + dep archives), so both per-arch tars are byte-identical; we produce ONE tar
@@ -107,28 +109,20 @@ def _bazel_demo_workspace_impl(repository_ctx):
     # The tar archives root/'s CONTENTS (opt/abseil, opt/distdir) at the tar
     # root, so the layer unpacks to /opt/abseil + /opt/distdir in-image.
     #
-    # It MUST be byte-reproducible across machines. A plain `tar -C root .`
-    # records readdir order and the extraction-time mtimes, and because this
-    # runs in a REPOSITORY RULE it re-executes on every runner that fetches the
-    # repo fresh. That made the layer, and therefore the embervm image digest,
-    # depend on which runner happened to build it: main kept reusing a warm
-    # runner whose output_base already had this repo, so its digest looked
-    # stable across commits, while any PR that landed on a cold runner produced
-    # a different digest for identical sources. The missed-bump guard then
-    # failed the PR for a rebuild that never happened (issue #4594).
+    # It MUST be byte-reproducible across machines. This runs in a REPOSITORY
+    # RULE, so it re-executes on every runner that fetches the repo fresh, and
+    # anything machine-derived it records becomes a different embervm image
+    # digest per runner. That is issue #4594: the missed-bump guard failed PRs
+    # for a rebuild that never happened.
     #
-    # Determinism without GNU-only flags, so the rule still fetches under BSD
-    # tar: pin every mtime with `touch -t`, feed tar a LC_ALL=C sorted member
-    # list on stdin (`-T -`, supported by GNU tar and bsdtar) instead of
-    # --sort, and use --numeric-owner so no name lookup leaks in.
-    tar_result = repository_ctx.execute([
-        "sh",
-        "-c",
-        "cd root && " +
-        "find . -exec touch -h -t 197001010000 {} + && " +
-        "find . -print | LC_ALL=C sort | " +
-        "tar --numeric-owner -cf ../layer.tar -T -",
-    ])
+    # The archiving itself lives in stage_layer_tar.sh so it can be unit tested,
+    # which is what the first attempt at this lacked: #4598 sorted the member
+    # list but left tar recursing into the directories in that list, so the
+    # sort was inert and the layer stayed in readdir order (and held 13113
+    # entries for 1601 unique paths). Referencing the script by Label also makes
+    # the repo re-fetch when the archiving changes.
+    layer_script = repository_ctx.path(Label("//bazel/tools/http:stage_layer_tar.sh"))
+    tar_result = repository_ctx.execute(["sh", str(layer_script), "root", "layer.tar"])
     if tar_result.return_code != 0:
         fail("bazel_demo_workspace: tar of staged root/ failed (%d): %s" % (
             tar_result.return_code,

--- a/bazel/tools/http/bazel_demo_workspace.bzl
+++ b/bazel/tools/http/bazel_demo_workspace.bzl
@@ -69,7 +69,7 @@ def _basename(url):
 
 def _bazel_demo_workspace_impl(repository_ctx):
     # Stage everything under root/ laid out exactly as the in-image tree, so the
-    # tar step below is a plain `tar -C root .` with no path surgery.
+    # tar step below archives it as-is with no path surgery.
 
     # Extract the Abseil release directly to root/opt/abseil (stripPrefix drops the
     # top-level abseil-cpp-<ver>/ so the tree root is /opt/abseil in-image).

--- a/bazel/tools/http/stage_layer_tar.sh
+++ b/bazel/tools/http/stage_layer_tar.sh
@@ -11,7 +11,9 @@
 # that is easy to get wrong:
 #
 #   mtime   `touch -h -t` pins every entry to the epoch, so extraction time
-#           does not leak in.
+#           does not leak in. It MUST run under TZ=UTC: `touch -t` reads the
+#           timestamp as LOCAL time, so the same tree staged in Sydney stores
+#           mtime -36000 and produces different bytes than one staged in UTC.
 #   owner   `--owner=0 --group=0` (with `--numeric-owner`, so no name lookup
 #           happens either). `--numeric-owner` ALONE is not enough: it only
 #           suppresses the uid to name lookup and still records the building
@@ -46,8 +48,9 @@ esac
 
 cd "$ROOT"
 
-# Pin every mtime, symlinks included, to the epoch.
-find . -exec touch -h -t 197001010000 {} +
+# Pin every mtime, symlinks included, to the epoch. The TZ prefix propagates to
+# the -exec children and is what makes 197001010000 mean the epoch everywhere.
+TZ=UTC find . -exec touch -h -t 197001010000 {} +
 
 # Materialise the sorted member list instead of piping it. /bin/sh on the CI
 # runner is dash, which has no `pipefail`, so a failing `find` in a pipeline

--- a/bazel/tools/http/stage_layer_tar.sh
+++ b/bazel/tools/http/stage_layer_tar.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+# stage_layer_tar.sh: archive a staged tree into a byte-reproducible tar layer.
+#
+# Usage: stage_layer_tar.sh <staged_root> <output_tar>
+#
+# The archive MUST be identical on every machine that builds it: it becomes an
+# image layer, so any drift changes the image digest and makes the chart look
+# like it pins a rebuilt image (issue #4594).
+#
+# Three environment-derived fields have to be pinned, and the third is the one
+# that is easy to get wrong:
+#
+#   mtime   `touch -h -t` pins every entry to the epoch, so extraction time
+#           does not leak in.
+#   owner   `--owner=0 --group=0` (with `--numeric-owner`, so no name lookup
+#           happens either). `--numeric-owner` ALONE is not enough: it only
+#           suppresses the uid to name lookup and still records the building
+#           user's numeric uid, which is how the published layer ended up
+#           recording uid/gid 1001.
+#   order   a sorted member list AND `--no-recursion`. Sorting the list on its
+#           own does nothing, because tar treats every DIRECTORY in a `-T` list
+#           as "archive this subtree" and walks it in readdir order. Feeding it
+#           a list that starts with `.` therefore re-derives the whole tree in
+#           the machine's readdir order and appends the sorted files after it.
+#           That is what #4598 shipped: the published layer held 13113 entries
+#           for 1601 unique paths, still in readdir order, so the digest kept
+#           drifting per machine. `--no-recursion` makes the list authoritative.
+#
+# File modes are deliberately NOT normalised. Nothing observed has drifted
+# there, and a blanket chmod would have to preserve the executable bit on the
+# scripts in the staged tree, which `a=,u+rwX` does not do (the `a=` clears the
+# bit before `X` tests for it).
+#
+# Portability: every flag used here is accepted by both GNU tar and bsdtar, so
+# the repo rule that calls this still fetches on a Mac.
+set -eu
+
+ROOT="${1:?staged root dir required}"
+OUT="${2:?output tar path required}"
+
+# Resolve the output before cd, so a relative path stays relative to the caller.
+case "$OUT" in
+/*) ;;
+*) OUT="$(pwd)/$OUT" ;;
+esac
+
+cd "$ROOT"
+
+# Pin every mtime, symlinks included, to the epoch.
+find . -exec touch -h -t 197001010000 {} +
+
+# Materialise the sorted member list instead of piping it. /bin/sh on the CI
+# runner is dash, which has no `pipefail`, so a failing `find` in a pipeline
+# would silently produce a short (or empty) tar that still exits 0.
+LIST="${TMPDIR:-/tmp}/stage_layer_tar.$$.list"
+trap 'rm -f "$LIST"' EXIT
+find . -print | LC_ALL=C sort >"$LIST"
+# `find .` always emits "." itself, so a one-line list means either the staged
+# root is empty or find failed. Either way the layer would ship nothing, which
+# is a silent failure once it is inside an image.
+if [ "$(wc -l <"$LIST")" -lt 2 ]; then
+	echo "stage_layer_tar: staged root '$ROOT' holds no entries, refusing to write an empty layer" >&2
+	exit 1
+fi
+
+tar --no-recursion --numeric-owner --owner=0 --group=0 -cf "$OUT" -T "$LIST"

--- a/bazel/tools/http/stage_layer_tar_test.sh
+++ b/bazel/tools/http/stage_layer_tar_test.sh
@@ -87,6 +87,11 @@ fi
 # --- 3. owner is pinned, not the building user ------------------------------
 # GNU tar prints the pair as "0/0"; bsdtar prints uid and gid as separate
 # columns. Accept either, and print the offending line if neither holds.
+#
+# This case can only distinguish pinned from unpinned when the test runs as a
+# non-root uid, since an unpinned tar run as root also records 0. That holds
+# where it matters: the layer this guards recorded uid 1001 when it drifted, so
+# the CI executor is not root.
 OWNER_LINE=$(tar -tvf "$TMP/forward.tar" | head -1)
 if grep -qE '(^|[[:space:]])0/0([[:space:]]|$)' <<<"$OWNER_LINE" ||
 	awk '{exit !($3 == 0 && $4 == 0)}' <<<"$OWNER_LINE"; then
@@ -107,6 +112,31 @@ if [[ "$MTIME" == "1970" || "$MTIME" == "0" ]]; then
 	pass "mtimes are pinned to the epoch"
 else
 	fail "mtime is not pinned, got: $MTIME"
+fi
+
+# --- 4b. modes survive ------------------------------------------------------
+# The staged tree carries an executable script, and the script under test
+# deliberately does NOT normalise modes. Without this assertion the executable
+# staged above is decorative: a future blanket chmod would strip the bit and
+# every other case would still pass.
+if [[ -x "$EXTRACT/opt/abseil/run.sh" ]]; then
+	pass "the executable bit survives archiving"
+else
+	fail "the executable bit was stripped from opt/abseil/run.sh"
+fi
+
+# --- 4c. the epoch is UTC, not the builder's local midnight -----------------
+# `touch -t` reads its argument as LOCAL time, so without a TZ pin the same
+# tree staged in two timezones stores different mtimes and therefore different
+# bytes. Uses a POSIX offset string rather than a zone name so it does not
+# depend on tzdata being present.
+TZSHIFT="$TMP/tzshift"
+stage_tree "$TZSHIFT" zeta mid alpha rules_cc platforms
+TZ='XXX-10' sh "$SCRIPT" "$TZSHIFT" "$TMP/tzshift.tar"
+if cmp -s "$TMP/tzshift.tar" "$TMP/forward.tar"; then
+	pass "the archive is identical regardless of the builder's timezone"
+else
+	fail "the builder's timezone changes the archive bytes"
 fi
 
 # --- 5. an empty staged root is refused, not silently archived --------------

--- a/bazel/tools/http/stage_layer_tar_test.sh
+++ b/bazel/tools/http/stage_layer_tar_test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Unit tests for stage_layer_tar.sh.
+#
+# The script archives a staged tree into an image layer, so its ONE job is to
+# be byte-identical on every machine. The assertions below are the three fields
+# that are actually machine-derived (order, owner, mtime) plus the empty-input
+# guard. The order assertion is the load-bearing one: #4598 sorted the member
+# list but let tar recurse into the directories in that list, which silently
+# re-derived readdir order and shipped 13113 entries for 1601 unique paths.
+set -o errexit -o nounset -o pipefail
+
+SCRIPT_REL="bazel/tools/http/stage_layer_tar.sh"
+SCRIPT=""
+for candidate in \
+	"${RUNFILES_DIR:-}/_main/${SCRIPT_REL}" \
+	"${TEST_SRCDIR:-}/_main/${SCRIPT_REL}" \
+	"${BASH_SOURCE[0]%/*}/stage_layer_tar.sh"; do
+	if [[ -f "$candidate" ]]; then
+		SCRIPT="$candidate"
+		break
+	fi
+done
+if [[ -z "$SCRIPT" ]]; then
+	echo "ERROR: cannot locate stage_layer_tar.sh in runfiles" >&2
+	exit 1
+fi
+# Absolute, because one case below runs the script from a different cwd.
+SCRIPT="$(cd "${SCRIPT%/*}" && pwd)/${SCRIPT##*/}"
+
+TMP="${TEST_TMPDIR:-$(mktemp -d)}"
+FAILURES=0
+
+fail() {
+	echo "FAIL: $*" >&2
+	FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+	echo "ok: $*"
+}
+
+# Stage the same logical tree twice, creating the entries in opposite orders so
+# the two directories differ in readdir order on filesystems that return
+# creation order. Content is identical, so the layers must be too.
+stage_tree() {
+	local root="$1"
+	shift
+	mkdir -p "$root/opt/distdir" "$root/opt/abseil/absl"
+	for name in "$@"; do
+		echo "content of $name" >"$root/opt/distdir/$name"
+		echo "source of $name" >"$root/opt/abseil/absl/$name.cc"
+	done
+	# One executable file, to catch a future mode normalisation that would
+	# strip the bit off the scripts in the staged tree.
+	printf '#!/bin/sh\necho hi\n' >"$root/opt/abseil/run.sh"
+	chmod 755 "$root/opt/abseil/run.sh"
+}
+
+FORWARD="$TMP/forward"
+REVERSE="$TMP/reverse"
+stage_tree "$FORWARD" zeta mid alpha rules_cc platforms
+stage_tree "$REVERSE" platforms rules_cc alpha mid zeta
+
+sh "$SCRIPT" "$FORWARD" "$TMP/forward.tar"
+sh "$SCRIPT" "$REVERSE" "$TMP/reverse.tar"
+
+# --- 1. byte-identical across creation orders -------------------------------
+if cmp -s "$TMP/forward.tar" "$TMP/reverse.tar"; then
+	pass "same content staged in a different order produces an identical tar"
+else
+	fail "tars differ between two identical trees staged in different orders"
+fi
+
+# --- 2. members follow the sorted list, exactly once each -------------------
+# Compared against the sorted find list rather than checked for sortedness on
+# its own: this catches duplicates and dropped entries at the same time. tar
+# prints directories with a trailing slash, which find does not, so strip it.
+(cd "$FORWARD" && find . -print | LC_ALL=C sort) >"$TMP/expected"
+tar -tf "$TMP/forward.tar" | sed 's:/$::' >"$TMP/actual"
+if diff -u "$TMP/expected" "$TMP/actual" >"$TMP/order.diff"; then
+	pass "archived members match the sorted member list with no duplicates"
+else
+	fail "archived members are not the sorted list (readdir order or duplicates):"
+	head -20 "$TMP/order.diff" >&2
+fi
+
+# --- 3. owner is pinned, not the building user ------------------------------
+# GNU tar prints the pair as "0/0"; bsdtar prints uid and gid as separate
+# columns. Accept either, and print the offending line if neither holds.
+OWNER_LINE=$(tar -tvf "$TMP/forward.tar" | head -1)
+if grep -qE '(^|[[:space:]])0/0([[:space:]]|$)' <<<"$OWNER_LINE" ||
+	awk '{exit !($3 == 0 && $4 == 0)}' <<<"$OWNER_LINE"; then
+	pass "owner and group are recorded as 0"
+else
+	fail "owner is not normalised, tar records: $OWNER_LINE"
+fi
+
+# --- 4. mtimes are pinned to the epoch --------------------------------------
+# Read the stored mtime numerically so the check does not depend on the local
+# timezone (bsdtar renders epoch 0 as 31 Dec 1969 west of UTC).
+EXTRACT="$TMP/extract"
+mkdir -p "$EXTRACT"
+tar -xf "$TMP/forward.tar" -C "$EXTRACT"
+MTIME=$(TZ=UTC date -r "$EXTRACT/opt/distdir/alpha" -u '+%Y' 2>/dev/null ||
+	stat -c '%Y' "$EXTRACT/opt/distdir/alpha")
+if [[ "$MTIME" == "1970" || "$MTIME" == "0" ]]; then
+	pass "mtimes are pinned to the epoch"
+else
+	fail "mtime is not pinned, got: $MTIME"
+fi
+
+# --- 5. an empty staged root is refused, not silently archived --------------
+mkdir -p "$TMP/empty"
+if sh "$SCRIPT" "$TMP/empty" "$TMP/empty.tar" 2>/dev/null; then
+	fail "an empty staged root produced a layer instead of failing"
+else
+	pass "an empty staged root is refused"
+fi
+
+# --- 6. a relative output path resolves against the caller's cwd ------------
+(cd "$TMP" && sh "$SCRIPT" "$FORWARD" "relative.tar")
+if [[ -f "$TMP/relative.tar" ]] && cmp -s "$TMP/relative.tar" "$TMP/forward.tar"; then
+	pass "a relative output path is written relative to the caller"
+else
+	fail "a relative output path did not land next to the caller's cwd"
+fi
+
+if ((FAILURES > 0)); then
+	echo "$FAILURES stage-layer-tar test(s) failed" >&2
+	exit 1
+fi
+echo "All stage-layer-tar tests passed"

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.478
+version: 0.1.479

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.478
+      targetRevision: 0.1.479
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Residual root cause of #4594. #4598 fixed one of the two ordering problems and I
reported it as closing the false positive; it did not. The guard is still firing
on every PR that builds this image.

## What is still wrong

`tar -T <list>` treats every DIRECTORY named in the list as "archive this
subtree" and walks it in readdir order. The list from `find . -print | sort`
starts with `.`, so tar re-derived the whole tree in the building machine's
readdir order and appended the sorted files afterwards. The sort was inert.

Reproduced in isolation:

```
$ find . -print | LC_ALL=C sort | tar -cf recurse.tar -T -      # what #4598 ships
./  ./d/  ./d/zeta  ./d/mid  ./d/alpha   <- readdir order
./d/  ./d/zeta  ./d/mid  ./d/alpha       <- again, from ./d
./d/alpha  ./d/mid  ./d/zeta             <- and finally the sorted list

$ find . -print | LC_ALL=C sort | tar --no-recursion -cf norecurse.tar -T -
./  ./d/  ./d/alpha  ./d/mid  ./d/zeta
```

The published layer has exactly that signature. `runtimes/bazel@sha256:3381782c`,
which chart 0.1.478 pins and which main built from c5ebc5b (so, after #4598):

```
13113 entries for 1601 unique paths, in readdir order, uid/gid 1001
```

The extras are zero-size self-referential hardlink entries (`h` type, "link to"
themselves), so they cost about 5.6 MiB of headers on an 18.0 MiB layer rather
than duplicating content. bsdtar 3.5.3 fails to extract that archive; it
extracts the fixed one cleanly.

## The drift is live, and it is not PR-only

| build | commit | digest |
|---|---|---|
| main, pre-fix | 3523f75 | `7584144f` |
| main, pre-fix | 18405c0 | `ec073d58` |
| main, post-fix | c5ebc5b and the 5 commits after it | `3381782c` |
| PR #4602, post-fix | af51ea77b | `57c9b428` |

18405c0 changed only `buildbuddy.yaml`, nothing the image reads, yet the digest
moved. So main drifts too whenever the action genuinely re-executes instead of
hitting cache; it just re-executes rarely. PR #4602 already carried #4598 (it
packaged 0.1.478) and still produced a third value.

## The fix

- `--no-recursion`, so the sorted member list is authoritative.
- `--owner=0 --group=0`. `--numeric-owner` alone only suppresses the uid to name
  lookup and still records the building user's numeric uid, which is how 1001
  got in there.
- Both flags are accepted by GNU tar and bsdtar, so the rule still fetches on a
  Mac. Verified against bsdtar 3.5.3 locally.
- File modes are deliberately left alone. Nothing observed has drifted there,
  and a blanket chmod would have to preserve the executable bit on the scripts
  in the staged tree, which `a=,u+rwX` does not do.

The archiving moves into `stage_layer_tar.sh` with a unit test. That is the part
that matters for not repeating this: the reason the first fix shipped broken is
that the command was a string inside a repository rule, where nothing could
assert on its output, so it could only be checked by merging it and reading the
next image digest. The test stages the same tree in two creation orders and
asserts the tars are byte-identical, that the members match the sorted list
exactly (which catches duplicates and readdir order at once), that the owner is
0, that mtimes are epoch, and that an empty staged root is refused rather than
silently archived.

## Runtime impact

None expected. `/opt/abseil` and `/opt/distdir` are read-only in the guest
(`guest-init/cmd/main.go`: bazel's output base and HOME are on tmpfs), and the
modes are unchanged at 0755/0644, so recording owner 0 instead of 1001 changes
nothing about read or traverse. The layer shrinks by roughly 5.6 MiB of
duplicate headers.

## Chart bump

The layer bytes change, so the embervm image digest changes: 0.1.478 to 0.1.479.

## What this does NOT do

It does not restore the missed-bump guard to blocking. That needs evidence, not
a second prediction: after this merges, main publishes 0.1.479 built from the
fixed layer, and the next PR that builds this image should report
`image digests match the published chart; OK`. Restoring the guard is a
follow-up on #4594 once that is observed.

Closes #4594 (reopen if the digest still moves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
