### PR TITLE
fix(monolith): reap guest sessions when a swarm run is cancelled

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.517
+version: 0.285.518
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.517
+      targetRevision: 0.285.518
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from uuid import uuid4
 
 from sqlmodel import Session
@@ -18,9 +19,11 @@ from agent_sessions.mcp import (
     _set_session_status,
     _transport,
 )
+from agent_sessions.transport import EmberSessionGone
 from core.db import get_engine
-from faas.embervm_client import EmberVMTransportError
 from goosecracker.api import REPO_CATALOG
+
+logger = logging.getLogger(__name__)
 
 
 def start_session_for_swarm(
@@ -75,11 +78,6 @@ def _sessions_for_workflow(workflow_id: str):
         return store.sessions_for_workflow(db_session, workflow_id)
 
 
-def _is_gone_error(exc: EmberVMTransportError) -> bool:
-    detail = str(exc).lower()
-    return "404" in detail or "not found" in detail or "not_found" in detail
-
-
 async def reap_sessions_for_workflow(workflow_id: str) -> dict:
     """Destroy and unbind every guest session owned by a swarm workflow.
 
@@ -87,6 +85,11 @@ async def reap_sessions_for_workflow(workflow_id: str) -> dict:
     caller reading the summary can look each one up in /agents directly. One
     session failing never stops the others: a cancelled run that leaves even
     one guest alive keeps burning a slot against the live-capacity cap.
+
+    "Already gone" is decided by ``EmberSessionGone``, which the transport
+    raises off the STATUS CODE. Sniffing the message string instead would read
+    a 500 whose URL or body merely contains "404" as success and leak the very
+    slot this reap exists to reclaim.
     """
     rows = await asyncio.to_thread(_sessions_for_workflow, workflow_id)
     summary: dict[str, list] = {"reaped": [], "failed": [], "skipped": []}
@@ -98,13 +101,21 @@ async def reap_sessions_for_workflow(workflow_id: str) -> dict:
         try:
             try:
                 await _transport.destroy_session(ember_session_id)
-            except EmberVMTransportError as exc:
-                # An already-gone session is the goal state, not a failure.
-                if not _is_gone_error(exc):
-                    raise
+            except EmberSessionGone:
+                # The goal state, not a failure: still clear the binding below.
+                pass
             await asyncio.to_thread(_clear_ember_bindings_for, ember_session_id)
             summary["reaped"].append(row.id)
         except Exception as exc:  # noqa: BLE001 - one bad session must not stop the rest
+            # Logged as well as returned: a caller that drops the response would
+            # otherwise leave a permanently leaked capacity slot with no trace.
+            logger.warning(
+                "swarm reap failed for session %s (ember %s) of workflow %s: %s",
+                row.id,
+                ember_session_id,
+                workflow_id,
+                exc,
+            )
             summary["failed"].append({"session_id": row.id, "error": str(exc)})
     return summary
 

--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -10,13 +10,16 @@ from sqlmodel import Session
 from agent_sessions import model_family, store
 from agent_sessions.codex_login import codex_login_gate, watch_for_login
 from agent_sessions.mcp import (
+    _clear_ember_bindings_for,
     _load_session_row,
     _persist_pending_message,
     _persist_session,
     _schedule_next_message,
     _set_session_status,
+    _transport,
 )
 from core.db import get_engine
+from faas.embervm_client import EmberVMTransportError
 from goosecracker.api import REPO_CATALOG
 
 
@@ -65,6 +68,45 @@ def start_session_for_swarm(
         # will claim and execute the pending message within ~5s.
         pass
     return row.id
+
+
+def _sessions_for_workflow(workflow_id: str):
+    with Session(get_engine()) as db_session:
+        return store.sessions_for_workflow(db_session, workflow_id)
+
+
+def _is_gone_error(exc: EmberVMTransportError) -> bool:
+    detail = str(exc).lower()
+    return "404" in detail or "not found" in detail or "not_found" in detail
+
+
+async def reap_sessions_for_workflow(workflow_id: str) -> dict:
+    """Destroy and unbind every guest session owned by a swarm workflow.
+
+    Every list keys on the MONOLITH session id, never the EmberVM id, so a
+    caller reading the summary can look each one up in /agents directly. One
+    session failing never stops the others: a cancelled run that leaves even
+    one guest alive keeps burning a slot against the live-capacity cap.
+    """
+    rows = await asyncio.to_thread(_sessions_for_workflow, workflow_id)
+    summary: dict[str, list] = {"reaped": [], "failed": [], "skipped": []}
+    for row in rows:
+        ember_session_id = row.ember_session_id
+        if ember_session_id is None:
+            summary["skipped"].append(row.id)
+            continue
+        try:
+            try:
+                await _transport.destroy_session(ember_session_id)
+            except EmberVMTransportError as exc:
+                # An already-gone session is the goal state, not a failure.
+                if not _is_gone_error(exc):
+                    raise
+            await asyncio.to_thread(_clear_ember_bindings_for, ember_session_id)
+            summary["reaped"].append(row.id)
+        except Exception as exc:  # noqa: BLE001 - one bad session must not stop the rest
+            summary["failed"].append({"session_id": row.id, "error": str(exc)})
+    return summary
 
 
 async def start_session_for_thread(

--- a/projects/monolith/agent_sessions/api_test.py
+++ b/projects/monolith/agent_sessions/api_test.py
@@ -1,8 +1,10 @@
+import pytest
 from sqlmodel import Session, SQLModel, create_engine
 
 import agent_sessions.api as api
 import agent_sessions.mcp as mcp
 from agent_sessions.models import AgentSession
+from faas.embervm_client import EmberVMTransportError
 
 
 def test_start_session_for_swarm_retry_preserves_original_workflow_id(
@@ -49,3 +51,76 @@ def test_start_session_for_swarm_retry_preserves_original_workflow_id(
         for table in SQLModel.metadata.tables.values():
             if table.name in schemas:
                 table.schema = schemas[table.name]
+
+
+@pytest.mark.asyncio
+async def test_reap_sessions_for_workflow_skips_reaps_and_continues_on_failure(
+    monkeypatch,
+):
+    rows = [
+        AgentSession(id=1, local_session_id="skip", workspace="w", branch="b"),
+        AgentSession(
+            id=2,
+            local_session_id="good",
+            workspace="w",
+            branch="b",
+            ember_session_id="ember-good",
+        ),
+        AgentSession(
+            id=3,
+            local_session_id="bad",
+            workspace="w",
+            branch="b",
+            ember_session_id="ember-bad",
+        ),
+    ]
+    destroyed = []
+    cleared = []
+
+    async def destroy(ember_id):
+        destroyed.append(ember_id)
+        if ember_id == "ember-bad":
+            raise EmberVMTransportError("control plane unavailable")
+        return {}
+
+    monkeypatch.setattr(api, "_sessions_for_workflow", lambda _: rows)
+    monkeypatch.setattr(api._transport, "destroy_session", destroy)
+    monkeypatch.setattr(
+        api, "_clear_ember_bindings_for", lambda ember_id: cleared.append(ember_id)
+    )
+
+    assert await api.reap_sessions_for_workflow("wf-1") == {
+        "reaped": [2],
+        "failed": [{"session_id": 3, "error": "control plane unavailable"}],
+        "skipped": [1],
+    }
+    assert destroyed == ["ember-good", "ember-bad"]
+    assert cleared == ["ember-good"]
+
+
+@pytest.mark.asyncio
+async def test_reap_sessions_for_workflow_treats_404_as_reaped(monkeypatch):
+    row = AgentSession(
+        id=1,
+        local_session_id="gone",
+        workspace="w",
+        branch="b",
+        ember_session_id="ember-gone",
+    )
+
+    async def destroy(_ember_id):
+        raise EmberVMTransportError("404 session not found")
+
+    cleared = []
+    monkeypatch.setattr(api, "_sessions_for_workflow", lambda _: [row])
+    monkeypatch.setattr(api._transport, "destroy_session", destroy)
+    monkeypatch.setattr(
+        api, "_clear_ember_bindings_for", lambda ember_id: cleared.append(ember_id)
+    )
+
+    assert await api.reap_sessions_for_workflow("wf-1") == {
+        "reaped": [1],
+        "failed": [],
+        "skipped": [],
+    }
+    assert cleared == ["ember-gone"]

--- a/projects/monolith/agent_sessions/api_test.py
+++ b/projects/monolith/agent_sessions/api_test.py
@@ -4,6 +4,7 @@ from sqlmodel import Session, SQLModel, create_engine
 import agent_sessions.api as api
 import agent_sessions.mcp as mcp
 from agent_sessions.models import AgentSession
+from agent_sessions.transport import EmberSessionGone
 from faas.embervm_client import EmberVMTransportError
 
 
@@ -109,7 +110,7 @@ async def test_reap_sessions_for_workflow_treats_404_as_reaped(monkeypatch):
     )
 
     async def destroy(_ember_id):
-        raise EmberVMTransportError("404 session not found")
+        raise EmberSessionGone("404 session not found")
 
     cleared = []
     monkeypatch.setattr(api, "_sessions_for_workflow", lambda _: [row])
@@ -124,3 +125,41 @@ async def test_reap_sessions_for_workflow_treats_404_as_reaped(monkeypatch):
         "skipped": [],
     }
     assert cleared == ["ember-gone"]
+
+
+@pytest.mark.asyncio
+async def test_reap_does_not_treat_a_500_mentioning_404_as_gone(monkeypatch):
+    """A live session must never be reported reaped.
+
+    The transport decides "gone" from the STATUS CODE. A plain transport error
+    whose text merely contains "404" (the session id itself can, and error
+    bodies routinely mention other not-found resources) has to count as a
+    FAILURE, otherwise the binding is cleared while the VM keeps burning a
+    live-capacity slot with nothing pointing at it.
+    """
+    row = AgentSession(
+        id=7,
+        local_session_id="live",
+        workspace="w",
+        branch="b",
+        ember_session_id="s-404ABCDEF",
+    )
+    cleared = []
+
+    async def destroy(_ember_id):
+        raise EmberVMTransportError(
+            "Server error '500 Internal Server Error' for url "
+            "'http://embervm/v1/sessions/s-404ABCDEF' not found upstream"
+        )
+
+    monkeypatch.setattr(api, "_sessions_for_workflow", lambda _: [row])
+    monkeypatch.setattr(api._transport, "destroy_session", destroy)
+    monkeypatch.setattr(
+        api, "_clear_ember_bindings_for", lambda ember_id: cleared.append(ember_id)
+    )
+
+    result = await api.reap_sessions_for_workflow("wf-1")
+
+    assert result["reaped"] == []
+    assert result["failed"][0]["session_id"] == 7
+    assert cleared == []

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -57,6 +57,12 @@ def get_session_by_local_id(session: Session, local_id: str) -> AgentSession | N
     ).first()
 
 
+def sessions_for_workflow(session: Session, workflow_id: str) -> list[AgentSession]:
+    return session.exec(
+        select(AgentSession).where(AgentSession.workflow_id == workflow_id)
+    ).all()
+
+
 def get_session_by_discord_thread(
     session: Session, thread_id: str
 ) -> AgentSession | None:

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -58,9 +58,11 @@ def get_session_by_local_id(session: Session, local_id: str) -> AgentSession | N
 
 
 def sessions_for_workflow(session: Session, workflow_id: str) -> list[AgentSession]:
-    return session.exec(
-        select(AgentSession).where(AgentSession.workflow_id == workflow_id)
-    ).all()
+    return list(
+        session.exec(
+            select(AgentSession).where(AgentSession.workflow_id == workflow_id)
+        ).all()
+    )
 
 
 def get_session_by_discord_thread(

--- a/projects/monolith/agent_sessions/store_test.py
+++ b/projects/monolith/agent_sessions/store_test.py
@@ -117,6 +117,21 @@ def test_create_session_persists_and_queries_workflow_id(monkeypatch, tmp_path):
         _restore_schemas(schemas)
 
 
+def test_sessions_for_workflow_returns_only_matching_rows(monkeypatch, tmp_path):
+    engine, schemas = _database(monkeypatch, tmp_path)
+    try:
+        with Session(engine) as session:
+            matching = store.create_session(
+                session, "matching", "<guest>", "main", workflow_id="wf-1"
+            )
+            store.create_session(
+                session, "other", "<guest>", "main", workflow_id="wf-2"
+            )
+            assert store.sessions_for_workflow(session, "wf-1") == [matching]
+    finally:
+        _restore_schemas(schemas)
+
+
 def test_write_progress_sync_stores_activities(monkeypatch, tmp_path):
     engine, schemas = _database(monkeypatch, tmp_path)
     activities = [{"type": "tool", "name": "shell"}]

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -30,6 +30,11 @@ logger = logging.getLogger(__name__)
 # VM-state poll; it must never inherit the turn-sized read timeout.
 LIST_SESSIONS_READ_TIMEOUT = 5.0
 
+# Destroy runs on the interactive cancel path, once per session, serially. It
+# must never inherit the turn-sized read timeout either: three sessions behind
+# a wedged control plane would otherwise hold one request for 90 minutes.
+DESTROY_SESSION_READ_TIMEOUT = 30.0
+
 
 def _retryable_from_response(exc: httpx.HTTPStatusError) -> bool:
     try:
@@ -328,7 +333,13 @@ class EmberVmShimTransport:
 
         url = f"{EMBERVM_URL}/v1/sessions/{ember_session_id}"
         headers = auth_headers()
-        timeout = httpx.Timeout(self.read_timeout, connect=SUBMIT_CONNECT_TIMEOUT)
+        # Destroy is on the interactive cancel path, and a wedged control plane
+        # that accepts the connection but never answers would otherwise hold the
+        # request for the full turn read timeout (1800s) PER session, serially.
+        # Same reasoning as LIST_SESSIONS_READ_TIMEOUT above.
+        timeout = httpx.Timeout(
+            DESTROY_SESSION_READ_TIMEOUT, connect=SUBMIT_CONNECT_TIMEOUT
+        )
 
         try:
             async with httpx.AsyncClient(timeout=timeout) as client:
@@ -348,6 +359,13 @@ class EmberVmShimTransport:
                 ember_session_id,
                 exc,
             )
+            # Distinguish "already gone" from "failed to destroy" HERE, where the
+            # status code is available. Callers that sniff the message string
+            # instead can be fooled by a 500 whose URL or body merely contains
+            # "404" or "not found", and would then treat a LIVE session as
+            # reaped, leaking the capacity slot they meant to reclaim.
+            if exc.response.status_code in (403, 404, 410):
+                raise EmberSessionGone(_status_error_detail(exc)) from exc
             raise EmberVMTransportError(_status_error_detail(exc)) from exc
         except httpx.TransportError as exc:
             logger.warning(

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -364,7 +364,15 @@ class EmberVmShimTransport:
             # instead can be fooled by a 500 whose URL or body merely contains
             # "404" or "not found", and would then treat a LIVE session as
             # reaped, leaking the capacity slot they meant to reclaim.
-            if exc.response.status_code in (403, 404, 410):
+            #
+            # 403 is deliberately NOT in this set, unlike the invoke path where
+            # it does imply a dead session. DELETE is a management-auth route
+            # authenticated with the pod ServiceAccount, not the session's own
+            # capability token, so its only 403 is "service account not
+            # permitted". That fails EVERY destroy at once, and calling it gone
+            # would report the whole fleet reaped while every VM stays alive.
+            # The control plane's destroy handler answers 200, 404, or 500.
+            if exc.response.status_code in (404, 410):
                 raise EmberSessionGone(_status_error_detail(exc)) from exc
             raise EmberVMTransportError(_status_error_detail(exc)) from exc
         except httpx.TransportError as exc:

--- a/projects/monolith/agent_sessions/transport_test.py
+++ b/projects/monolith/agent_sessions/transport_test.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 
 from agent_sessions import transport
+from agent_sessions.transport import EmberSessionGone
 from faas.embervm_client import EmberVMTransportError
 
 
@@ -24,6 +25,10 @@ class FakeAsyncClient:
 
     async def post(self, url, **kwargs):
         request = httpx.Request("POST", url, **kwargs)
+        return await self.handler(request)
+
+    async def delete(self, url, **kwargs):
+        request = httpx.Request("DELETE", url, **kwargs)
         return await self.handler(request)
 
 
@@ -963,3 +968,45 @@ def test_deliver_with_no_ember_and_no_restore_from_is_unchanged(monkeypatch):
     assert used == fresh
     assert json.loads(requests[0].content)["session_id"] == "cli-x"
     assert turn.result == "ok"
+
+
+def test_destroy_session_maps_404_to_session_gone(monkeypatch):
+    """404 is the control plane's "session not found": the goal state."""
+
+    async def handler(request):
+        return httpx.Response(
+            404,
+            json={"error": "session not found", "retryable": False},
+            request=request,
+        )
+
+    _client(monkeypatch, handler)
+    with pytest.raises(EmberSessionGone):
+        asyncio.run(transport.EmberVmShimTransport().destroy_session("s-1"))
+
+
+def test_destroy_session_keeps_403_and_500_as_plain_failures(monkeypatch):
+    """Only 404/410 mean gone on this route.
+
+    DELETE is management-auth, so its 403 is "service account not permitted",
+    which fails EVERY destroy at once. Treating that as gone would report the
+    whole fleet reaped while every VM stayed alive holding a capacity slot.
+    A 500 whose body merely mentions a missing resource must not be gone
+    either.
+    """
+    statuses = []
+
+    async def handler(request):
+        status = statuses.pop(0)
+        return httpx.Response(
+            status,
+            json={"error": "service account not permitted / not found"},
+            request=request,
+        )
+
+    _client(monkeypatch, handler)
+    for status in (403, 500):
+        statuses.append(status)
+        with pytest.raises(EmberVMTransportError) as caught:
+            asyncio.run(transport.EmberVmShimTransport().destroy_session("s-404xyz"))
+        assert not isinstance(caught.value, EmberSessionGone), status

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.517
+version: 0.285.518
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.517
+      targetRevision: 0.285.518
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/swarm/router.py
+++ b/projects/monolith/swarm/router.py
@@ -73,7 +73,16 @@ def list_runs() -> list[dict]:
 @router.post("/runs/{workflow_id}/cancel")
 async def cancel_run(workflow_id: str) -> dict:
     dbos = _dbos()
-    dbos.cancel_workflow(workflow_id)
+    # cancel_children: sessions are not created inline. The workflow enqueues
+    # start_session_workflow as a CHILD on the codex queue, so cancelling only
+    # the parent leaves a queued child that mints a fresh guest AFTER the reap
+    # sweeps, recreating the orphan this endpoint exists to prevent.
+    #
+    # ..._async, not the sync call: DBOS's cancel_workflow starts with
+    # check_async(), which raises whenever an event loop is running, so calling
+    # it from this async handler would 500 every request without cancelling
+    # anything. Unit tests with a fake DBOS cannot catch that.
+    await dbos.cancel_workflow_async(workflow_id, cancel_children=True)
     # Cancel first so no new turn is scheduled while guest sessions are reaped.
     from agent_sessions.api import reap_sessions_for_workflow
 

--- a/projects/monolith/swarm/router.py
+++ b/projects/monolith/swarm/router.py
@@ -71,16 +71,17 @@ def list_runs() -> list[dict]:
 
 
 @router.post("/runs/{workflow_id}/cancel")
-def cancel_run(workflow_id: str) -> dict:
-    _dbos().cancel_workflow(workflow_id)
-    # Cancelling the workflow does NOT reap the guest session it started, and
-    # parked sessions count against the live capacity cap, so a cancelled swarm
-    # can still deny creates cluster-wide. The compensating control-plane delete
-    # is tracked in #4578. Reported honestly rather than claiming a clean stop.
+async def cancel_run(workflow_id: str) -> dict:
+    dbos = _dbos()
+    dbos.cancel_workflow(workflow_id)
+    # Cancel first so no new turn is scheduled while guest sessions are reaped.
+    from agent_sessions.api import reap_sessions_for_workflow
+
+    guest_sessions = await reap_sessions_for_workflow(workflow_id)
     return {
         "workflow_id": workflow_id,
         "cancelled": True,
-        "guest_session_reaped": False,
+        "guest_sessions": guest_sessions,
     }
 
 

--- a/projects/monolith/swarm/router_test.py
+++ b/projects/monolith/swarm/router_test.py
@@ -72,3 +72,63 @@ def test_follower_replica_returns_503(monkeypatch):
     )
     assert response.status_code == 503
     assert "not launched" in response.json()["detail"]
+
+
+def test_cancel_reaps_after_dbos_cancel(monkeypatch):
+    monkeypatch.setenv("SWARM_ENABLED", "true")
+    events = []
+
+    class FakeDBOS:
+        def cancel_workflow(self, workflow_id):
+            events.append(("cancel", workflow_id))
+
+    async def reap(workflow_id):
+        events.append(("reap", workflow_id))
+        return {
+            "reaped": ["ember-1"],
+            "failed": [],
+            "skipped": [4],
+        }
+
+    monkeypatch.setattr(swarm_router.runtime, "init_dbos", lambda: FakeDBOS())
+    monkeypatch.setattr(swarm_router.runtime, "is_launched", lambda: True)
+    monkeypatch.setattr("agent_sessions.api.reap_sessions_for_workflow", reap)
+    response = client().post("/api/swarm/runs/wf-1/cancel")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "workflow_id": "wf-1",
+        "cancelled": True,
+        "guest_sessions": {
+            "reaped": ["ember-1"],
+            "failed": [],
+            "skipped": [4],
+        },
+    }
+    assert events == [("cancel", "wf-1"), ("reap", "wf-1")]
+
+
+def test_cancel_reports_reap_failure_without_failing(monkeypatch):
+    monkeypatch.setenv("SWARM_ENABLED", "true")
+
+    class FakeDBOS:
+        def cancel_workflow(self, workflow_id):
+            assert workflow_id == "wf-1"
+
+    async def reap(_workflow_id):
+        return {
+            "reaped": [],
+            "failed": [{"session_id": "ember-1", "error": "boom"}],
+            "skipped": [],
+        }
+
+    monkeypatch.setattr(swarm_router.runtime, "init_dbos", lambda: FakeDBOS())
+    monkeypatch.setattr(swarm_router.runtime, "is_launched", lambda: True)
+    monkeypatch.setattr("agent_sessions.api.reap_sessions_for_workflow", reap)
+    response = client().post("/api/swarm/runs/wf-1/cancel")
+
+    assert response.status_code == 200
+    assert response.json()["cancelled"] is True
+    assert response.json()["guest_sessions"]["failed"] == [
+        {"session_id": "ember-1", "error": "boom"}
+    ]

--- a/projects/monolith/swarm/router_test.py
+++ b/projects/monolith/swarm/router_test.py
@@ -79,13 +79,16 @@ def test_cancel_reaps_after_dbos_cancel(monkeypatch):
     events = []
 
     class FakeDBOS:
-        def cancel_workflow(self, workflow_id):
-            events.append(("cancel", workflow_id))
+        # async, matching the real DBOS API: the sync cancel_workflow raises
+        # from a running event loop (check_async), so a sync fake would let a
+        # production-breaking handler pass its tests.
+        async def cancel_workflow_async(self, workflow_id, cancel_children=False):
+            events.append(("cancel", workflow_id, cancel_children))
 
     async def reap(workflow_id):
         events.append(("reap", workflow_id))
         return {
-            "reaped": ["ember-1"],
+            "reaped": [2],
             "failed": [],
             "skipped": [4],
         }
@@ -100,25 +103,26 @@ def test_cancel_reaps_after_dbos_cancel(monkeypatch):
         "workflow_id": "wf-1",
         "cancelled": True,
         "guest_sessions": {
-            "reaped": ["ember-1"],
+            "reaped": [2],
             "failed": [],
             "skipped": [4],
         },
     }
-    assert events == [("cancel", "wf-1"), ("reap", "wf-1")]
+    assert events == [("cancel", "wf-1", True), ("reap", "wf-1")]
 
 
 def test_cancel_reports_reap_failure_without_failing(monkeypatch):
     monkeypatch.setenv("SWARM_ENABLED", "true")
 
     class FakeDBOS:
-        def cancel_workflow(self, workflow_id):
+        async def cancel_workflow_async(self, workflow_id, cancel_children=False):
             assert workflow_id == "wf-1"
+            assert cancel_children is True
 
     async def reap(_workflow_id):
         return {
             "reaped": [],
-            "failed": [{"session_id": "ember-1", "error": "boom"}],
+            "failed": [{"session_id": 3, "error": "boom"}],
             "skipped": [],
         }
 
@@ -130,5 +134,5 @@ def test_cancel_reports_reap_failure_without_failing(monkeypatch):
     assert response.status_code == 200
     assert response.json()["cancelled"] is True
     assert response.json()["guest_sessions"]["failed"] == [
-        {"session_id": "ember-1", "error": "boom"}
+        {"session_id": 3, "error": "boom"}
     ]

--- a/projects/monolith/swarm/router_test.py
+++ b/projects/monolith/swarm/router_test.py
@@ -82,7 +82,7 @@ def test_cancel_reaps_after_dbos_cancel(monkeypatch):
         # async, matching the real DBOS API: the sync cancel_workflow raises
         # from a running event loop (check_async), so a sync fake would let a
         # production-breaking handler pass its tests.
-        async def cancel_workflow_async(self, workflow_id, cancel_children=False):
+        async def cancel_workflow_async(self, workflow_id, *, cancel_children=False):
             events.append(("cancel", workflow_id, cancel_children))
 
     async def reap(workflow_id):
@@ -115,7 +115,7 @@ def test_cancel_reports_reap_failure_without_failing(monkeypatch):
     monkeypatch.setenv("SWARM_ENABLED", "true")
 
     class FakeDBOS:
-        async def cancel_workflow_async(self, workflow_id, cancel_children=False):
+        async def cancel_workflow_async(self, workflow_id, *, cancel_children=False):
             assert workflow_id == "wf-1"
             assert cancel_children is True
 


### PR DESCRIPTION
## Summary

Closes #4578 (issue #4584 item 6).

Cancelling a swarm run called `cancel_workflow` and then returned a hardcoded `guest_session_reaped: false`. The EmberVM guest sessions the run created stayed alive, and parked sessions count against the cluster-wide live-capacity cap, so a cancelled run kept denying creates until someone deleted the session by hand.

`cancel_run` now cancels first (so no new turn is scheduled mid-teardown) and then destroys and unbinds every session the workflow owns, found via the indexed `workflow_id` column that landed with the session/workflow linking work. It reports the real per-session outcome:

```json
{"workflow_id": "...", "cancelled": true,
 "guest_sessions": {"reaped": [2], "failed": [{"session_id": 3, "error": "..."}], "skipped": [1]}}
```

Design notes:

- **One failure never stops the rest.** A cancelled run that leaves even one guest alive keeps burning a capacity slot, so the loop continues and collects outcomes rather than aborting.
- **An already-gone session counts as reaped**, not failed: that is the goal state.
- **Cleanup failure does not fail the request.** The workflow really was cancelled; reporting a 500 because teardown was partial would hide that.
- **Every list keys on the monolith session id**, never the EmberVM id, so a caller can look each one up in `/agents` directly.

## Test plan

- `ci lint` clean, `ci test` green: `Executed 0 out of 745 tests: 745 tests pass` (cache hits)
- Because three changed test files returning zero executions deserves proof, the affected targets were force-run with `--nocache_test_results`: `Executed 3 out of 3 tests: 3 tests pass`
- Covered: cancel-before-reap ordering, reap failure still reports `cancelled: true`, skip when no guest exists, clean destroy, transport error isolated to one session, 404 treated as reaped

Chart bumps to 0.285.518 ride along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)