### PR TITLE
perf(monolith): stream agent VM state instead of polling it ten times a second

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.518
+version: 0.285.519
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.518
+      targetRevision: 0.285.519
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -262,7 +262,12 @@ def _publish_vm_map(new_map: dict[str, dict], error: str | None) -> None:
     an update entirely.
     """
     cache = _vm_state_cache
-    changed = new_map != cache.cache_map
+    # The error is part of what changed, not just the map. With no live
+    # sessions the map is already empty, so losing the control plane
+    # published an identical {} and woke nobody: subscribers kept a frame
+    # claiming a clean empty state while the snapshot endpoint reported the
+    # outage. Recovery was equally silent.
+    changed = new_map != cache.cache_map or error != cache.last_error
     cache.cache_map = new_map
     cache.last_refreshed_at = time.monotonic()
     cache.last_error = error
@@ -307,10 +312,15 @@ async def _start_refresher() -> None:
     # Deployment is 1 replica with HPA to 3, so worst case is 3 refreshers.
     if cache.task is None or cache.task.done():
         cache.task = asyncio.create_task(_run_vm_refresher())
-    # Give the first subscriber real data before it yields its snapshot. The
-    # task refreshes too, so this can duplicate one poll on first connect,
-    # which is harmless where a duplicated task was not.
-    if not cache.initialized:
+    # Give a joining subscriber fresh data before it yields its snapshot.
+    # Staleness, not just initialization: `initialized` latches true on the
+    # first publish and never resets, so testing it alone meant a console
+    # reopened hours after the last viewer left got a frame built from the
+    # overnight map, rendering a confident "awake" chip for a guest that
+    # parked long ago. Costs nothing while a refresher is live, since
+    # last_refreshed_at is then always under one interval old.
+    stale = time.monotonic() - cache.last_refreshed_at >= cache.refresh_interval
+    if not cache.initialized or stale:
         await _refresh_cp_state()
 
 

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -277,12 +277,21 @@ def _publish_vm_map(new_map: dict[str, dict], error: str | None) -> None:
 
 
 async def _run_vm_refresher() -> None:
-    try:
-        while True:
+    while True:
+        try:
             await _refresh_cp_state()
-            await asyncio.sleep(_vm_state_cache.refresh_interval)
-    except asyncio.CancelledError:
-        raise
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - one bad poll must not end the loop
+            # A dead refresher is invisible: subscribers keep receiving the 15s
+            # heartbeat so the connection looks healthy, no message ever
+            # arrives so the client's fallback never engages, and the snapshot
+            # endpoint sees a non-None task and stops refreshing too. The chips
+            # freeze and every surface reports fine. Publishing the outage is
+            # what makes the failure look like a failure.
+            logger.exception("agent VM refresher iteration failed")
+            _publish_vm_map({}, error=str(exc))
+        await asyncio.sleep(_vm_state_cache.refresh_interval)
 
 
 async def _start_refresher() -> None:
@@ -290,12 +299,19 @@ async def _start_refresher() -> None:
     cache.subscriber_count += 1
     if cache.change_event is None:
         cache.change_event = asyncio.Event()
+    # Create the task BEFORE awaiting anything. With the await first, the
+    # check and the set straddled a suspension point: two subscribers
+    # connecting together both saw task is None and both assigned, so the
+    # first task lost its only reference. Unreachable, uncancellable, and
+    # polling the control plane once a second until the pod restarts.
+    # Deployment is 1 replica with HPA to 3, so worst case is 3 refreshers.
     if cache.task is None or cache.task.done():
-        # Deployment is 1 replica with HPA to 3, so worst case is 3
-        # refreshers at 1s interval (acceptable). Lazy start ensures idle
-        # consoles produce zero control-plane traffic.
-        await _refresh_cp_state()
         cache.task = asyncio.create_task(_run_vm_refresher())
+    # Give the first subscriber real data before it yields its snapshot. The
+    # task refreshes too, so this can duplicate one poll on first connect,
+    # which is harmless where a duplicated task was not.
+    if not cache.initialized:
+        await _refresh_cp_state()
 
 
 async def _stop_refresher() -> None:
@@ -311,18 +327,38 @@ async def _stop_refresher() -> None:
         pass
 
 
+def _vm_frame() -> str:
+    """One SSE data frame, carrying the same payload as the snapshot endpoint.
+
+    Kept identical to `/vms` on purpose: two surfaces describing the same
+    state with different fields is how a client ends up unable to tell an
+    empty map from an outage on one of them.
+    """
+    body: dict = {"vms": _vm_state_cache.cache_map}
+    if _vm_state_cache.last_error:
+        body["error"] = _vm_state_cache.last_error
+    return f"data: {json.dumps(body)}\n\n"
+
+
 @router.get("/vms/stream")
 async def stream_session_vms() -> StreamingResponse:
     async def generate():
-        await _start_refresher()
+        # Inside the try, not before it. _start_refresher increments the
+        # subscriber count as its first statement and then awaits, and
+        # Starlette cancels this generator at its innermost await on client
+        # disconnect. Started outside, a client that vanished during that
+        # first refresh (a wedged control plane can hold it ~20s) left the
+        # count permanently above zero, so every later stop returned early
+        # and the refresher polled forever with nobody watching.
         cache = _vm_state_cache
         try:
+            await _start_refresher()
             last_generation = cache.generation
-            yield f"data: {json.dumps({'vms': cache.cache_map})}\n\n"
+            yield _vm_frame()
             while True:
                 if cache.generation != last_generation:
                     last_generation = cache.generation
-                    yield f"data: {json.dumps({'vms': cache.cache_map})}\n\n"
+                    yield _vm_frame()
                     continue
                 event = cache.change_event
                 try:
@@ -334,7 +370,7 @@ async def stream_session_vms() -> StreamingResponse:
                     continue
                 if cache.generation != last_generation:
                     last_generation = cache.generation
-                    yield f"data: {json.dumps({'vms': cache.cache_map})}\n\n"
+                    yield _vm_frame()
         finally:
             await _stop_refresher()
 
@@ -361,7 +397,11 @@ async def list_session_vms() -> dict:
     """
     cache = _vm_state_cache
     stale = time.monotonic() - cache.last_refreshed_at >= cache.refresh_interval
-    if cache.task is None and (not cache.initialized or stale):
+    # `task.done()` matters as much as `task is None`: a refresher that died
+    # is not None, so testing only for None let a crashed task freeze this
+    # endpoint too, and the fallback stopped falling back.
+    owned = cache.task is not None and not cache.task.done()
+    if not owned and (not cache.initialized or stale):
         await _refresh_cp_state()
     body = {"vms": cache.cache_map}
     if cache.last_error:

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlmodel import Session, func, select
 
@@ -189,25 +190,25 @@ _VM_AWAKE_STATES = {"creating", "running", "relighting"}
 _VM_ASLEEP_STATES = {"banking", "banked", "parking", "parked"}
 
 
-@router.get("/vms")
-async def list_session_vms() -> dict:
-    """Map ember session ids to a coarse VM state for the console UI."""
-    # The control plane retains terminal session rows for days, so the
-    # listing can exceed one page; a silently truncated page would render
-    # a parked-days-ago session as "off" (the opposite of the truth).
-    # Follow `total` across pages, bounded far above the workload cap.
-    items = []
-    offset = 0
-    try:
-        for _ in range(4):
-            page = await _transport.list_sessions(limit=500, offset=offset)
-            batch = page.get("items", [])
-            items.extend(batch)
-            offset += len(batch)
-            if not batch or offset >= int(page.get("total") or 0):
-                break
-    except EmberVMTransportError as exc:
-        return {"vms": {}, "error": str(exc)}
+class _VmStateCache:
+    refresh_interval = 1.0
+    heartbeat_interval = 15.0
+
+    def __init__(self) -> None:
+        self.cache_map: dict[str, dict] = {}
+        self.last_refreshed_at = 0.0
+        self.subscriber_count = 0
+        self.task: asyncio.Task | None = None
+        self.change_event: asyncio.Event | None = None
+        self.generation = 0
+        self.initialized = False
+        self.last_error: str | None = None
+
+
+_vm_state_cache = _VmStateCache()
+
+
+def _coarse_vm_map(items: list[dict]) -> dict[str, dict]:
     vms = {}
     for item in items:
         state = str(item.get("state", ""))
@@ -223,7 +224,131 @@ async def list_session_vms() -> dict:
             "last_invoke_at": item.get("last_invoke_at"),
             "expires_at": item.get("expires_at"),
         }
-    return {"vms": vms}
+    return vms
+
+
+async def _refresh_cp_state() -> None:
+    items = []
+    offset = 0
+    try:
+        for _ in range(4):
+            page = await _transport.list_sessions(limit=500, offset=offset)
+            batch = page.get("items", [])
+            items.extend(batch)
+            offset += len(batch)
+            if not batch or offset >= int(page.get("total") or 0):
+                break
+    except EmberVMTransportError as exc:
+        _vm_state_cache.initialized = True
+        _vm_state_cache.last_error = str(exc)
+        logger.warning("failed to refresh agent VM state: %s", exc)
+        return
+
+    new_map = _coarse_vm_map(items)
+    changed = new_map != _vm_state_cache.cache_map
+    _vm_state_cache.cache_map = new_map
+    _vm_state_cache.last_refreshed_at = time.monotonic()
+    _vm_state_cache.last_error = None
+    _vm_state_cache.initialized = True
+    if changed:
+        _vm_state_cache.generation += 1
+        old_event = _vm_state_cache.change_event
+        _vm_state_cache.change_event = asyncio.Event()
+        if old_event is not None:
+            old_event.set()
+
+
+async def _run_vm_refresher() -> None:
+    try:
+        while True:
+            await _refresh_cp_state()
+            await asyncio.sleep(_vm_state_cache.refresh_interval)
+    except asyncio.CancelledError:
+        raise
+
+
+async def _start_refresher() -> None:
+    cache = _vm_state_cache
+    cache.subscriber_count += 1
+    if cache.change_event is None:
+        cache.change_event = asyncio.Event()
+    if cache.task is None or cache.task.done():
+        # Deployment is 1 replica with HPA to 3, so worst case is 3
+        # refreshers at 1s interval (acceptable). Lazy start ensures idle
+        # consoles produce zero control-plane traffic.
+        await _refresh_cp_state()
+        cache.task = asyncio.create_task(_run_vm_refresher())
+
+
+async def _stop_refresher() -> None:
+    cache = _vm_state_cache
+    cache.subscriber_count = max(0, cache.subscriber_count - 1)
+    if cache.subscriber_count or cache.task is None:
+        return
+    task, cache.task = cache.task, None
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+@router.get("/vms/stream")
+async def stream_session_vms() -> StreamingResponse:
+    async def generate():
+        await _start_refresher()
+        cache = _vm_state_cache
+        try:
+            last_generation = cache.generation
+            yield f"data: {json.dumps({'vms': cache.cache_map})}\n\n"
+            while True:
+                if cache.generation != last_generation:
+                    last_generation = cache.generation
+                    yield f"data: {json.dumps({'vms': cache.cache_map})}\n\n"
+                    continue
+                event = cache.change_event
+                try:
+                    await asyncio.wait_for(
+                        event.wait(), timeout=cache.heartbeat_interval
+                    )
+                except asyncio.TimeoutError:
+                    yield ": ping\n\n"
+                    continue
+                if cache.generation != last_generation:
+                    last_generation = cache.generation
+                    yield f"data: {json.dumps({'vms': cache.cache_map})}\n\n"
+        finally:
+            await _stop_refresher()
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@router.get("/vms")
+async def list_session_vms() -> dict:
+    """Return the shared VM snapshot, refreshing it when nothing is feeding it.
+
+    This is the console's fallback for a broken event stream, so it must NOT
+    depend on a stream subscriber having connected first. With no refresher
+    running, a cache-only read stays empty forever and the chip reads "off"
+    for every session, which is the opposite of the truth and precisely the
+    case the fallback exists to cover.
+
+    The refresh is skipped while a refresher owns the cache, and rate limited
+    to the same interval otherwise, so a fallback poll cannot reintroduce
+    per-request control-plane load.
+    """
+    cache = _vm_state_cache
+    stale = time.monotonic() - cache.last_refreshed_at >= cache.refresh_interval
+    if cache.task is None and (not cache.initialized or stale):
+        await _refresh_cp_state()
+    body = {"vms": cache.cache_map}
+    if cache.last_error:
+        body["error"] = cache.last_error
+    return body
 
 
 @router.get("/sessions/{session_id}")

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -239,23 +239,41 @@ async def _refresh_cp_state() -> None:
             if not batch or offset >= int(page.get("total") or 0):
                 break
     except EmberVMTransportError as exc:
-        _vm_state_cache.initialized = True
-        _vm_state_cache.last_error = str(exc)
+        # Drop the map rather than serving the last known one. A stale entry
+        # renders as a confident "awake" chip for a guest that may be long
+        # gone, where an absent entry renders "off" alongside the error, which
+        # is what this endpoint promised before it was cached. Losing the CP
+        # means we do not know, and the honest rendering of not knowing is the
+        # one the console already had.
         logger.warning("failed to refresh agent VM state: %s", exc)
+        _publish_vm_map({}, error=str(exc))
         return
 
-    new_map = _coarse_vm_map(items)
-    changed = new_map != _vm_state_cache.cache_map
-    _vm_state_cache.cache_map = new_map
-    _vm_state_cache.last_refreshed_at = time.monotonic()
-    _vm_state_cache.last_error = None
-    _vm_state_cache.initialized = True
-    if changed:
-        _vm_state_cache.generation += 1
-        old_event = _vm_state_cache.change_event
-        _vm_state_cache.change_event = asyncio.Event()
-        if old_event is not None:
-            old_event.set()
+    _publish_vm_map(_coarse_vm_map(items), error=None)
+
+
+def _publish_vm_map(new_map: dict[str, dict], error: str | None) -> None:
+    """Store a map and wake subscribers only when it actually differs.
+
+    The generation counter, rather than a bare Event, is what lets each
+    subscriber tell whether it already saw a change: a single shared Event
+    cannot distinguish "woke for this change" from "woke for the previous
+    one", so a client waking between set and clear would double-send or miss
+    an update entirely.
+    """
+    cache = _vm_state_cache
+    changed = new_map != cache.cache_map
+    cache.cache_map = new_map
+    cache.last_refreshed_at = time.monotonic()
+    cache.last_error = error
+    cache.initialized = True
+    if not changed:
+        return
+    cache.generation += 1
+    old_event = cache.change_event
+    cache.change_event = asyncio.Event()
+    if old_event is not None:
+        old_event.set()
 
 
 async def _run_vm_refresher() -> None:

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -11,6 +11,7 @@ from sqlmodel import Session, SQLModel, create_engine
 
 from agent_sessions import api, store
 from agent_sessions import mcp
+import agent_sessions.router as agent_router
 from agent_sessions.codex_login import codex_login_gate
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.router import router
@@ -172,6 +173,7 @@ def test_list_session_vms_maps_control_plane_states(client, monkeypatch):
         }
 
     monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
+    asyncio.run(agent_router._refresh_cp_state())
     body = client.get("/api/agents/vms").json()
     assert body["vms"]["s-run"]["state"] == "awake"
     assert body["vms"]["s-park"]["state"] == "asleep"
@@ -196,6 +198,7 @@ def test_list_session_vms_follows_pagination(client, monkeypatch):
         return {"total": 501, "items": [{"session_id": "s-tail", "state": "running"}]}
 
     monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
+    asyncio.run(agent_router._refresh_cp_state())
     body = client.get("/api/agents/vms").json()
     # The CP retains terminal rows for days; the tail page must be
     # fetched or an old parked session silently renders as "off".
@@ -209,9 +212,77 @@ def test_list_session_vms_degrades_when_embervm_is_down(client, monkeypatch):
         raise EmberVMTransportError("control plane unreachable")
 
     monkeypatch.setattr(mcp._transport, "list_sessions", broken_list_sessions)
+    asyncio.run(agent_router._refresh_cp_state())
     body = client.get("/api/agents/vms").json()
     assert body["vms"] == {}
     assert "unreachable" in body["error"]
+
+
+def test_vm_cache_refreshes_at_interval_and_stops_when_unused(monkeypatch):
+    calls = []
+
+    async def fake_list_sessions(limit=50, offset=0):
+        calls.append((limit, offset))
+        return {"items": [{"session_id": "s-1", "state": "running"}]}
+
+    async def exercise():
+        monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
+        cache = agent_router._vm_state_cache
+        monkeypatch.setattr(cache, "refresh_interval", 0.01)
+        await agent_router._start_refresher()
+        await asyncio.sleep(0.025)
+        assert len(calls) >= 2
+        assert cache.subscriber_count == 1
+        await agent_router._stop_refresher()
+        assert cache.subscriber_count == 0
+        assert cache.task is None
+
+    asyncio.run(exercise())
+
+
+def test_vm_stream_emits_initial_and_changed_snapshots(monkeypatch):
+    state = [{"session_id": "s-1", "state": "running"}]
+
+    async def fake_list_sessions(limit=50, offset=0):
+        return {"items": state}
+
+    async def exercise():
+        monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
+        cache = agent_router._vm_state_cache
+        monkeypatch.setattr(cache, "heartbeat_interval", 0.01)
+        response = await agent_router.stream_session_vms()
+        stream = response.body_iterator
+        initial = await stream.__anext__()
+        assert '"s-1"' in initial
+        generation = cache.generation
+        await agent_router._refresh_cp_state()
+        assert cache.generation == generation
+        assert not cache.change_event.is_set()
+        state[0] = {"session_id": "s-1", "state": "parked"}
+        await agent_router._refresh_cp_state()
+        changed = await stream.__anext__()
+        assert '"asleep"' in changed
+        await stream.aclose()
+        assert cache.subscriber_count == 0
+
+    asyncio.run(exercise())
+
+
+def test_vm_stream_heartbeats_when_idle(monkeypatch):
+    async def fake_list_sessions(limit=50, offset=0):
+        return {"items": []}
+
+    async def exercise():
+        monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
+        cache = agent_router._vm_state_cache
+        monkeypatch.setattr(cache, "heartbeat_interval", 0.01)
+        response = await agent_router.stream_session_vms()
+        stream = response.body_iterator
+        await stream.__anext__()
+        assert await stream.__anext__() == ": ping\n\n"
+        await stream.aclose()
+
+    asyncio.run(exercise())
 
 
 def test_get_session_detail(client, session):

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -304,6 +304,67 @@ def test_vm_stream_emits_initial_and_changed_snapshots(monkeypatch):
     asyncio.run(exercise())
 
 
+def test_refresher_survives_an_iteration_that_raises(monkeypatch):
+    """A refresher that dies is invisible, so prove it does not.
+
+    Before this loop caught broad exceptions, one malformed control-plane
+    page killed it for good while every surface still looked healthy:
+    subscribers kept getting heartbeats, no message ever arrived so the
+    client fallback never engaged, and the snapshot endpoint saw a non-None
+    task and stopped refreshing too.
+    """
+    calls = []
+
+    async def flaky_list_sessions(limit=50, offset=0):
+        calls.append(1)
+        if len(calls) == 1:
+            raise ValueError("malformed page")
+        return {"items": [{"session_id": "s-1", "state": "running"}]}
+
+    async def exercise():
+        monkeypatch.setattr(mcp._transport, "list_sessions", flaky_list_sessions)
+        cache = agent_router._vm_state_cache
+        monkeypatch.setattr(cache, "refresh_interval", 0.01)
+        task = asyncio.create_task(agent_router._run_vm_refresher())
+        cache.task = task
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        # It kept polling past the failure, and the failure was published
+        # rather than swallowed into a frozen map.
+        assert len(calls) >= 2
+        assert cache.cache_map.get("s-1", {}).get("state") == "awake"
+
+    asyncio.run(exercise())
+
+
+def test_snapshot_reclaims_a_dead_refresher(monkeypatch):
+    """A finished task is not None, so `task is None` alone froze this too."""
+    calls = []
+
+    async def fake_list_sessions(limit=50, offset=0):
+        calls.append(1)
+        return {"items": [{"session_id": "s-1", "state": "running"}]}
+
+    async def dead():
+        return None
+
+    async def exercise():
+        monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
+        cache = agent_router._vm_state_cache
+        finished = asyncio.create_task(dead())
+        await finished
+        cache.task = finished
+        body = await agent_router.list_session_vms()
+        assert calls, "a done() task must not count as owning the cache"
+        assert body["vms"]["s-1"]["state"] == "awake"
+
+    asyncio.run(exercise())
+
+
 def test_vm_stream_heartbeats_when_idle(monkeypatch):
     async def fake_list_sessions(limit=50, offset=0):
         return {"items": []}

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -40,6 +40,33 @@ def session_fixture(tmp_path):
                 table.schema = original_schemas[table.name]
 
 
+@pytest.fixture(autouse=True)
+def reset_vm_state_cache():
+    """Clear the shared VM cache around every test.
+
+    The cache is deliberately module level, since it is shared by all SSE
+    subscribers in a replica, which makes it leak between tests in the same
+    process: a test that populated 500 sessions made a later "control plane
+    is down" assertion fail against the earlier test's data, and the failure
+    depended on test ORDER rather than on either test being wrong. Autouse so
+    a future test touching VM state inherits the isolation without knowing to
+    ask for it.
+    """
+    cache = agent_router._vm_state_cache
+    cache.cache_map = {}
+    cache.last_refreshed_at = 0.0
+    cache.subscriber_count = 0
+    cache.task = None
+    cache.change_event = None
+    cache.generation = 0
+    cache.initialized = False
+    cache.last_error = None
+    yield
+    cache.cache_map = {}
+    cache.task = None
+    cache.subscriber_count = 0
+
+
 @pytest.fixture(name="client")
 def client_fixture(session):
     app = FastAPI()

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -53,6 +53,11 @@ def reset_vm_state_cache():
     ask for it.
     """
     cache = agent_router._vm_state_cache
+    # task is dropped rather than cancelled, which is safe only because every
+    # test that starts a refresher does so inside asyncio.run, whose loop
+    # teardown cancels outstanding tasks. A session-scoped loop, or driving
+    # the stream through TestClient (its portal loop outlives the call),
+    # would strand the task instead. Cancel here if either becomes true.
     cache.cache_map = {}
     cache.last_refreshed_at = 0.0
     cache.subscriber_count = 0
@@ -200,7 +205,11 @@ def test_list_session_vms_maps_control_plane_states(client, monkeypatch):
         }
 
     monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
-    asyncio.run(agent_router._refresh_cp_state())
+    # Deliberately NOT pre-refreshed. The autouse fixture leaves the cache
+    # uninitialized, so this exercises the on-demand refresh inside the
+    # endpoint, which is the whole reason the snapshot route survives a
+    # broken stream. Pre-populating here would let that branch be deleted
+    # with every test still green.
     body = client.get("/api/agents/vms").json()
     assert body["vms"]["s-run"]["state"] == "awake"
     assert body["vms"]["s-park"]["state"] == "asleep"

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.518
+version: 0.285.519
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/httproute-private.yaml
+++ b/projects/monolith/chart/templates/httproute-private.yaml
@@ -72,6 +72,17 @@ spec:
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.cfIngress.private.servicePort | int }}
+    # Long-lived Server-Sent Events stream; requires extended timeouts to prevent intermediate reaping.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /private/agents/vms/stream
+      timeouts:
+        request: 600s
+        backendRequest: 600s
+      backendRefs:
+        - name: {{ include "monolith.fullname" . }}
+          port: {{ .Values.cfIngress.private.servicePort | int }}
     # Everything else — SvelteKit reroute hook maps to /private/ internally
     - matches:
         - path:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.518
+      targetRevision: 0.285.519
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -681,29 +681,37 @@
     }
   });
 
-  // Guest VM state polls at the transcript ladder's 100ms cadence: this
-  // page has one private viewer, the control-plane listing is a cheap
-  // in-memory read, and the 20s idle-park should flip the chip the
-  // moment it happens. Self-scheduling (like the ladder) so a slow
-  // fetch never stacks requests; a hidden tab skips the fetch entirely
-  // because unlike the ladder this loop runs for the life of the page.
+  // Subscribe to the shared VM state stream. A slow poll is only a fallback
+  // after the stream has failed repeatedly.
   $effect(() => {
-    let stopped = false;
-    let timeoutHandle;
-    const schedulePoll = async () => {
-      if (stopped) return;
-      const startTime = Date.now();
-      if (!document.hidden) await loadVms();
-      if (stopped) return;
-      timeoutHandle = setTimeout(
-        schedulePoll,
-        Math.max(0, 100 - (Date.now() - startTime)),
-      );
+    const source = new EventSource("/agents/vms/stream");
+    let failures = 0;
+    let fallbackInterval;
+
+    const startFallback = () => {
+      if (fallbackInterval) return;
+      fallbackInterval = setInterval(loadVms, 2000);
+      loadVms();
     };
-    schedulePoll();
+
+    source.onmessage = (event) => {
+      failures = 0;
+      clearInterval(fallbackInterval);
+      fallbackInterval = undefined;
+      try {
+        vms = JSON.parse(event.data).vms ?? {};
+      } catch {
+        // Ignore malformed advisory state and retain the last snapshot.
+      }
+    };
+    source.onerror = () => {
+      failures += 1;
+      if (failures >= 3) startFallback();
+    };
+
     return () => {
-      stopped = true;
-      clearTimeout(timeoutHandle);
+      source.close();
+      clearInterval(fallbackInterval);
     };
   });
 

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -684,7 +684,14 @@
   // Subscribe to the shared VM state stream. A slow poll is only a fallback
   // after the stream has failed repeatedly.
   $effect(() => {
-    const source = new EventSource("/agents/vms/stream");
+    // The literal /private path, matching private/chat, NOT the short
+    // /agents form the other fetches here use. The /private prefix is added
+    // by the reroute hook inside this Node process, long after the gateway
+    // has picked an HTTPRoute rule, so a short path reaches Envoy as
+    // /agents/... , matches the catch-all, and never gets the long timeout
+    // the stream needs. Envoy then resets it at its 15s default and
+    // EventSource reconnects forever, roughly four times a minute.
+    const source = new EventSource("/private/agents/vms/stream");
     let failures = 0;
     let fallbackInterval;
 
@@ -706,7 +713,14 @@
     };
     source.onerror = () => {
       failures += 1;
-      if (failures >= 3) startFallback();
+      // A fatal error (non-200, or a content type that is not
+      // text/event-stream, which is what an expired Cloudflare Access
+      // session returns) closes the source permanently and fires exactly
+      // ONE error. Counting to three never gets there, so the case the
+      // fallback exists for was the one case it could not cover.
+      if (source.readyState === EventSource.CLOSED || failures >= 3) {
+        startFallback();
+      }
     };
 
     return () => {

--- a/projects/monolith/frontend/src/routes/private/agents/vms/stream/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/vms/stream/+server.js
@@ -1,0 +1,20 @@
+// No localhost fallback, matching the sibling vms/+server.js: an unset
+// API_BASE must fail loudly rather than quietly stream from nowhere.
+const API_BASE = process.env.API_BASE;
+
+export async function GET() {
+  try {
+    const res = await fetch(`${API_BASE}/api/agents/vms/stream`);
+    return new Response(res.body, {
+      status: res.status,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "X-Accel-Buffering": "no",
+        Connection: "keep-alive",
+      },
+    });
+  } catch {
+    return new Response("vm state stream unavailable", { status: 502 });
+  }
+}


### PR DESCRIPTION
The private `/agents` console polled `/agents/vms` every **100ms**, and every
one of those requests fanned out to up to four paginated `list_sessions` calls
against the EmberVM control plane. One open tab was roughly 10 requests a
second to the monolith and up to 40 control-plane calls a second, permanently,
to watch a 20 second idle-park event. That is polling something about 200 times
more often than it can change.

## What replaces it

- A shared cache in front of the control-plane read, refreshed once a second.
- `GET /api/agents/vms/stream`, server-sent events. Initial snapshot on
  connect, then a frame only when the coarse state map actually differs, plus a
  15s heartbeat. An idle console receives nothing but heartbeats rather than
  600 responses a minute.
- The refresher is reference counted and lazily started, so a page nobody is
  watching produces **zero** control-plane traffic. That is better than the old
  behaviour, where an open tab polled forever regardless.
- `GET /api/agents/vms` stays as a cache-backed fallback and refreshes on
  demand when no stream owns the cache, so a broken stream cannot leave it
  empty.

Deliberately not a leader-elected singleton: each replica serves its own
subscribers and needs its own cache, and lazy start avoids adding a lifespan
task whose count is asserted across six `app/main*` test files.

## SSE rather than WebSockets

The flow is one way, it needs no protocol upgrade through Cloudflare Access and
cloudflared, and `EventSource` reconnects natively across the brief ingress
losses this cluster sees.

Worth being precise about the precedent, since an earlier version of this
description overstated it: `private/chat` streams SSE *framing* over a POST and
a ReadableStream reader. `EventSource` is new here, and the two properties this
choice leans on (native reconnect, fatal versus transient error semantics) are
exactly the ones that precedent does not exercise. Both are handled explicitly
below.

## Four commits, because review found real bugs

Three review rounds over code whose failure modes are all invisible to the test
suite. The most serious:

- **The route rule could never match.** The client requested
  `/agents/vms/stream`, but the `/private` prefix is added by the reroute hook
  inside the Node process, long after the gateway picks an HTTPRoute rule. Envoy
  saw the short path, matched the catch-all, and applied its 15s default instead
  of the new 600s rule. Headers are already sent by then, so it resets mid body,
  `EventSource` retries, and the result is a 15s-on / 3s-off cycle forever with
  a full control-plane fan-out per reconnect. It never tripped the fallback
  either, because each reconnect's snapshot reset the failure count. The client
  now requests the literal `/private` path, as `private/chat` already does.
- **Two subscriber leaks.** The count was incremented outside the generator's
  `try`, so a client vanishing during the first refresh left it above zero
  forever. And the task was checked and assigned either side of an `await`, so
  two simultaneous connects orphaned a task nothing could cancel. Both turned
  "zero traffic when nobody is watching" into a permanent leak, under exactly
  the conditions the route bug created.
- **A refresher crash was invisible.** Anything other than `CancelledError`
  killed the loop for good while every surface still looked healthy: heartbeats
  kept flowing, no message ever arrived so the client fallback never engaged,
  and the snapshot endpoint saw a non-`None` task and stopped refreshing too.
- **A fatal `EventSource` error fires once and closes**, so counting to three
  could never fire the fallback in the case it was written for.

A fourth round caught two more: the cold-connect refresh tested only
`initialized`, which latches true on the first publish and never resets, so a
console reopened after an idle gap rendered an overnight map as current. And
change detection compared only the map, so with no live sessions losing the
control plane published an identical empty map and woke nobody.

## Verification

`ci lint` clean. `ci test`: `Executed 64 out of 745 tests: 745 tests pass`, with
`//projects/monolith:agent_sessions_router_test` confirmed executed (6.251s,
PASSED) via the BuildBuddy invocation rather than inferred from the summary.
The total does not move because these are new assertions inside an existing
target, and the build system counts targets rather than individual tests.

None of the bugs above were caught by tests, and none could have been: they need
a real gateway, a real disconnect, and a real transport error. That is why this
went through review rather than merging on green.

## Known and deliberate

- `timeouts.request: 600s` rather than `0s`. Now that the rule matches, a
  10-minute recycle is cheap insurance given that both serious bugs here were
  leaked server-side state, and 600s is already proven by `/private/chat`.
- The stream carries no connection-state affordance yet. Replacing visible
  polling with a silent stream means healthy and dead now look alike to the
  user. Worth a small indicator on the vm chip, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39
