### PR TITLE
feat(monolith): group swarm sessions by workflow_id in the agents sidebar

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.519
+version: 0.285.520
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.519
+      targetRevision: 0.285.520
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.519
+version: 0.285.520
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.519
+      targetRevision: 0.285.520
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -7,6 +7,7 @@
     groupSessions,
     groupSummary,
     isGroupExpanded as groupIsExpanded,
+    shortWorkflowId,
   } from "./grouping.js";
   import {
     enterTranscript,
@@ -1196,7 +1197,7 @@
       aria-expanded={isGroupExpanded(entry, active)}
       onclick={() => toggleGroup(entry, active)}
     >
-      <span class="group-id mono">{entry.workflowId.slice(0, 8)}</span>
+      <span class="group-id mono">{shortWorkflowId(entry.workflowId)}</span>
       <span class="group-summary">{groupSummary(entry.counts)}</span>
       <span class="group-toggle" aria-hidden="true"
         >{isGroupExpanded(entry, active) ? "▾" : "▸"}</span

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -4,6 +4,11 @@
   import { page } from "$app/stores";
   import { renderAgentMarkdown } from "./markdown.js";
   import {
+    groupSessions,
+    groupSummary,
+    isGroupExpanded as groupIsExpanded,
+  } from "./grouping.js";
+  import {
     enterTranscript,
     MOBILE_MEDIA_QUERY,
     MOBILE_VIEW_LIST,
@@ -66,6 +71,7 @@
   let renderedPending = $state({});
   let vms = $state({});
   let turnsEl = $state(null);
+  let expandedGroups = $state({});
 
   const selectedSession = $derived(
     sessions.find((session) => String(session.id) === String(selectedId)) ??
@@ -75,6 +81,7 @@
   const activeSessions = $derived(
     sessions.filter((session) => isActive(session)).sort(compareSessions),
   );
+  const activeEntries = $derived(groupSessions(activeSessions));
   const historySessions = $derived(
     sessions.filter((session) => !isActive(session)).sort(compareSessions),
   );
@@ -86,6 +93,7 @@
   const visibleHistorySessions = $derived(
     showAllHistory ? historySessions : recentHistorySessions,
   );
+  const historyEntries = $derived(groupSessions(visibleHistorySessions));
   const visibleSearchResults = $derived(searchResults ?? []);
   const hasActiveSessions = $derived(
     sessions.some((session) => isActive(session)) ||
@@ -103,6 +111,18 @@
 
   function isActive(session) {
     return session?.status === "running" || Number(session?.pending_count) > 0;
+  }
+
+  function isGroupExpanded(entry, active) {
+    return groupIsExpanded(entry, {
+      active,
+      selectedId,
+      expanded: expandedGroups,
+    });
+  }
+
+  function toggleGroup(entry, active) {
+    expandedGroups[entry.workflowId] = !isGroupExpanded(entry, active);
   }
 
   function compareSessions(a, b) {
@@ -801,15 +821,23 @@
           Active <span>{activeSessions.length}</span>
         </div>
         <div class="session-list">
-          {#each activeSessions as session (session.id)}
-            {@render sessionRow(session)}
+          {#each activeEntries as entry (entry.kind === "group" ? "wf:" + entry.workflowId : entry.session.id)}
+            {#if entry.kind === "group"}
+              {@render sessionGroup(entry, true)}
+            {:else}
+              {@render sessionRow(entry.session)}
+            {/if}
           {/each}
         </div>
       {/if}
       <div class="group-title history-title">Recent</div>
       <div class="session-list">
-        {#each visibleHistorySessions as session (session.id)}
-          {@render sessionRow(session)}
+        {#each historyEntries as entry (entry.kind === "group" ? "wf:" + entry.workflowId : entry.session.id)}
+          {#if entry.kind === "group"}
+            {@render sessionGroup(entry, false)}
+          {:else}
+            {@render sessionRow(entry.session)}
+          {/if}
         {:else}<div class="empty">
             {activeSessions.length ? "No recent sessions" : "No sessions yet"}
           </div>{/each}
@@ -1160,6 +1188,30 @@
   </button>
 {/snippet}
 
+{#snippet sessionGroup(entry, active)}
+  <div class="session-group">
+    <button
+      class="group-header"
+      type="button"
+      aria-expanded={isGroupExpanded(entry, active)}
+      onclick={() => toggleGroup(entry, active)}
+    >
+      <span class="group-id mono">{entry.workflowId.slice(0, 8)}</span>
+      <span class="group-summary">{groupSummary(entry.counts)}</span>
+      <span class="group-toggle" aria-hidden="true"
+        >{isGroupExpanded(entry, active) ? "▾" : "▸"}</span
+      >
+    </button>
+    {#if isGroupExpanded(entry, active)}
+      <div class="group-members">
+        {#each entry.sessions as session (session.id)}
+          {@render sessionRow(session)}
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/snippet}
+
 {#snippet modelPicker(current, choose)}
   <div class="model-chips" role="group" aria-label="Model">
     <button
@@ -1319,7 +1371,8 @@
   .quiet-button:hover,
   .collapse-button:hover,
   .session-row:hover,
-  .search-result:hover {
+  .search-result:hover,
+  .group-header:hover {
     background: var(--hover);
   }
   .session-row.chosen {
@@ -1390,6 +1443,42 @@
     min-height: 0;
     display: grid;
     gap: 2px;
+  }
+  .session-group {
+    min-width: 0;
+  }
+  .group-header {
+    width: 100%;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 8px;
+    border: 1px solid transparent;
+    color: var(--muted);
+    background: transparent;
+    text-align: left;
+    font-size: var(--size-meta);
+    white-space: nowrap;
+  }
+  .group-id,
+  .group-summary {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .group-id {
+    flex: 0 0 auto;
+  }
+  .group-summary {
+    min-width: 0;
+    flex: 1;
+  }
+  .group-toggle {
+    flex: 0 0 auto;
+  }
+  .group-members {
+    padding-left: 10px;
   }
   .session-row,
   .search-result {

--- a/projects/monolith/frontend/src/routes/private/agents/grouping.js
+++ b/projects/monolith/frontend/src/routes/private/agents/grouping.js
@@ -58,6 +58,17 @@ export function groupSummary(counts) {
     .join(" · ");
 }
 
+// Workflow ids are time ordered (a ULID's leading characters are its
+// timestamp) or carry a producer prefix, so the LEADING characters are
+// exactly the part two different runs share. Taking the head collapses
+// swarm-smoke-1 and swarm-smoke-2 to the same "swarm-sm", which was visible
+// against live data. The tail is the part that distinguishes them, and the
+// leading ellipsis keeps a fragment from reading as a whole id.
+export function shortWorkflowId(workflowId) {
+  const id = String(workflowId ?? "");
+  return id.length <= 8 ? id : `…${id.slice(-8)}`;
+}
+
 export function isGroupExpanded(entry, { active, selectedId, expanded }) {
   const explicit = expanded?.[entry.workflowId];
   if (typeof explicit === "boolean") return explicit;

--- a/projects/monolith/frontend/src/routes/private/agents/grouping.js
+++ b/projects/monolith/frontend/src/routes/private/agents/grouping.js
@@ -1,0 +1,69 @@
+import { statusClass } from "./status.js";
+
+const SUMMARY_ORDER = [
+  "running",
+  "working",
+  "needs_input",
+  "warn",
+  "completed",
+];
+
+export function groupSessions(sessions) {
+  const groups = new Map();
+
+  for (const session of sessions) {
+    const workflowId = session?.workflow_id;
+    if (workflowId == null || workflowId === "") continue;
+    const key = String(workflowId);
+    const group = groups.get(key) ?? [];
+    group.push(session);
+    groups.set(key, group);
+  }
+
+  const entries = [];
+  const emittedGroups = new Set();
+  for (const session of sessions) {
+    const workflowId = session?.workflow_id;
+    if (workflowId == null || workflowId === "") {
+      entries.push({ kind: "session", session });
+      continue;
+    }
+
+    const key = String(workflowId);
+    const members = groups.get(key);
+    if (members.length === 1 || emittedGroups.has(key)) {
+      if (members.length === 1) entries.push({ kind: "session", session });
+      continue;
+    }
+
+    emittedGroups.add(key);
+    const counts = {};
+    for (const member of members) {
+      const cls = statusClass(member);
+      counts[cls] = (counts[cls] ?? 0) + 1;
+    }
+    entries.push({
+      kind: "group",
+      workflowId: key,
+      sessions: members,
+      counts,
+    });
+  }
+  return entries;
+}
+
+export function groupSummary(counts) {
+  return SUMMARY_ORDER.filter((status) => counts?.[status] > 0)
+    .map((status) => `${counts[status]} ${status}`)
+    .join(" · ");
+}
+
+export function isGroupExpanded(entry, { active, selectedId, expanded }) {
+  const explicit = expanded?.[entry.workflowId];
+  if (typeof explicit === "boolean") return explicit;
+
+  return (
+    active ||
+    entry.sessions.some((session) => String(session.id) === String(selectedId))
+  );
+}

--- a/projects/monolith/frontend/src/routes/private/agents/grouping.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/grouping.test.js
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { groupSessions, groupSummary, isGroupExpanded } from "./grouping.js";
+
+describe("groupSessions", () => {
+  it("keeps sessions without workflow ids flat", () => {
+    const entries = groupSessions([
+      { id: "one", workflow_id: null },
+      { id: "two", workflow_id: undefined },
+      { id: "three", workflow_id: "" },
+    ]);
+
+    expect(entries).toEqual([
+      { kind: "session", session: { id: "one", workflow_id: null } },
+      { kind: "session", session: { id: "two", workflow_id: undefined } },
+      { kind: "session", session: { id: "three", workflow_id: "" } },
+    ]);
+  });
+
+  it("keeps a workflow with one session flat", () => {
+    const session = { id: "one", workflow_id: 42 };
+
+    expect(groupSessions([session])).toEqual([{ kind: "session", session }]);
+  });
+
+  it("groups shared workflows at their first member position", () => {
+    const first = { id: "first", workflow_id: "wf", status: "running" };
+    const unrelated = { id: "unrelated", workflow_id: null };
+    const second = {
+      id: "second",
+      workflow_id: "wf",
+      status: "completed",
+    };
+
+    expect(groupSessions([first, unrelated, second])).toEqual([
+      {
+        kind: "group",
+        workflowId: "wf",
+        sessions: [first, second],
+        counts: { running: 1, completed: 1 },
+      },
+      { kind: "session", session: unrelated },
+    ]);
+  });
+
+  it("rolls up status classes", () => {
+    expect(
+      groupSessions([
+        { id: "one", workflow_id: "wf", status: "running" },
+        { id: "two", workflow_id: "wf", status: "running", pending_count: 1 },
+        { id: "three", workflow_id: "wf", status: "needs_input" },
+      ])[0],
+    ).toMatchObject({ counts: { running: 1, working: 1, needs_input: 1 } });
+  });
+});
+
+describe("groupSummary", () => {
+  it("omits zero counts and orders running before completed", () => {
+    expect(
+      groupSummary({ completed: 1, running: 3, warn: 0, working: 0 }),
+    ).toBe("3 running · 1 completed");
+  });
+});
+
+describe("isGroupExpanded", () => {
+  const recentGroup = {
+    workflowId: "recent",
+    sessions: [{ id: "selected" }, { id: "other" }],
+  };
+
+  it("lets an explicit false collapse a group containing the selection", () => {
+    expect(
+      isGroupExpanded(recentGroup, {
+        active: false,
+        selectedId: "selected",
+        expanded: { recent: false },
+      }),
+    ).toBe(false);
+  });
+
+  it("lets an explicit true expand a collapsed Recent group", () => {
+    expect(
+      isGroupExpanded(
+        { workflowId: "recent", sessions: [{ id: "other" }] },
+        { active: false, selectedId: "selected", expanded: { recent: true } },
+      ),
+    ).toBe(true);
+  });
+
+  it("defaults Active groups expanded and Recent groups collapsed", () => {
+    expect(
+      isGroupExpanded(
+        { workflowId: "active", sessions: [{ id: "other" }] },
+        { active: true, selectedId: "selected", expanded: {} },
+      ),
+    ).toBe(true);
+    expect(
+      isGroupExpanded(
+        { workflowId: "recent", sessions: [{ id: "other" }] },
+        { active: false, selectedId: "selected", expanded: {} },
+      ),
+    ).toBe(false);
+  });
+
+  it("defaults a Recent group containing the selection expanded", () => {
+    expect(
+      isGroupExpanded(recentGroup, {
+        active: false,
+        selectedId: "selected",
+        expanded: {},
+      }),
+    ).toBe(true);
+  });
+});

--- a/projects/monolith/frontend/src/routes/private/agents/grouping.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/grouping.test.js
@@ -1,5 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { groupSessions, groupSummary, isGroupExpanded } from "./grouping.js";
+import {
+  groupSessions,
+  groupSummary,
+  isGroupExpanded,
+  shortWorkflowId,
+} from "./grouping.js";
+
+describe("shortWorkflowId", () => {
+  it("distinguishes ids that share a prefix", () => {
+    // Taking the head collapsed both of these to "swarm-sm" against live data.
+    expect(shortWorkflowId("swarm-smoke-1")).not.toBe(
+      shortWorkflowId("swarm-smoke-2"),
+    );
+  });
+
+  it("returns a short id unchanged, with no ellipsis", () => {
+    expect(shortWorkflowId("wf-1")).toBe("wf-1");
+  });
+
+  it("coerces a non-string id", () => {
+    expect(shortWorkflowId(42)).toBe("42");
+  });
+});
 
 describe("groupSessions", () => {
   it("keeps sessions without workflow ids flat", () => {


### PR DESCRIPTION
Closes #4605.

A five-session swarm run listed as five unrelated rows in the `/agents`
sidebar. Sessions sharing a `workflow_id` now collapse under a header with a
rollup of their members' status, `3 running · 1 completed`.

## Where the aggregate comes from

Client side, from the session rows already fetched. `workflow_id` has been
serialized on every session since #4604 (`agent_sessions/router.py:141`), so
this needs no endpoint, no DBOS read, and no migration.

The issue left this open: either the run endpoint supplies real DAG state, or
the group summarises what the session rows support. Chose the latter. The DAG
state that would answer "3 of 5 implemented, 1 escalated" lives in DBOS and is
ADR 053 territory, depending on decisions #4584 has not made. The sidebar is a
navigation surface, and a rollup of what the rows already say is what
navigation needs.

Consequence worth stating: the `workflow_id` index added by #4604 stays
unused, because no `?workflow_id=` filter was added. Leaving an index unused
is the cheaper mistake than adding an endpoint the UI does not need.

## What does not change

- Ungrouped sessions (hand-started, Discord, MCP) keep exactly their previous
  flat rendering. They are the common case.
- A `workflow_id` holding a single session in a list also renders flat. A
  group of one is noise rather than structure.
- `sessionRow` markup is untouched, and the search-results block is untouched.

## Ordering

A group takes the position of its first member in the already-sorted input,
so grouping cannot disagree with `compareSessions`. The alternative, sorting
groups by their newest member, would restate that ordering contract in a
second place and the two would drift.

A swarm straddling Active and Recent renders as two groups. That follows the
existing Active/Recent split rather than fighting it.

## Expand precedence

The predicate lives in `grouping.js` rather than the component, because it is
the part with real precedence: an explicit collapse must beat the defaults.
An earlier revision had the selection check as an unconditional first clause
of an OR chain, so `toggleGroup` wrote `false` and the clause still returned
`true`. The header was inert on the one group most likely to be clicked, the
one holding the selected session. It is now a guard clause that returns before
the defaults are consulted, and the first test in the `isGroupExpanded` block
asserts that case directly.

## Verification

- `//projects/monolith/frontend:test` PASSED, 9 vitest cases in
  `grouping.test.js`.
- `ci test`: `Executed 2 out of 746 tests: 746 tests pass.` The total does not
  move because Bazel counts test targets, and `test_lib` globs
  `src/**/*.test.js`, so a new test file joins the existing target.
- `ci lint` clean.

Chart bumped to 0.285.520 (monolith and monolith-public together).
