### PR TITLE
fix(embervm): defer session teardown so destroy stops leaking the guest

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.479
+version: 0.1.480

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -1018,6 +1018,7 @@ defmodule Embervm.Router do
   # DELETE /v1/sessions/:id (management auth): destroy.
   defp handle_destroy_session(conn, session_id) do
     case session_manager().destroy(session_manager_server(), session_id) do
+      {:ok, :destroying} -> send_json(conn, 202, %{session_id: session_id, state: "destroying"})
       {:ok, _} -> send_json(conn, 200, %{session_id: session_id, state: "destroyed"})
       {:error, :not_found} -> send_json(conn, 404, %{error: "session not found", session_id: session_id, retryable: false})
       {:error, reason} -> send_json(conn, 500, %{error: "destroy failed", reason: inspect(reason), session_id: session_id, retryable: true})

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -187,7 +187,8 @@ defmodule Embervm.SessionManager do
   """
   @spec destroy(GenServer.server(), String.t()) :: {:ok, term()} | {:error, term()}
   def destroy(server \\ __MODULE__, session_id) do
-    GenServer.call(server, {:destroy, session_id})
+    # Call timeout is generous (30s) even though teardown is deferred, to guard against store latency and to avoid silent failures. The slow VM teardown itself runs async in handle_continue to avoid head-of-line blocking.
+    GenServer.call(server, {:destroy, session_id}, 30_000)
   end
 
   @doc """
@@ -396,6 +397,17 @@ defmodule Embervm.SessionManager do
     {:noreply, state}
   end
 
+  def handle_continue({:do_destroy_live, session_id}, state) do
+    case SessionStore.get(state.session_store, session_id) do
+      {:ok, %{state: :destroying} = session} ->
+        {_reply, state} = destroy_live(state, session)
+        {:noreply, state}
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
   @impl true
   def handle_call({:create, workload, principal, restore_lineage}, from, state) do
     case do_create_inline(state, workload, principal, restore_lineage) do
@@ -465,8 +477,33 @@ defmodule Embervm.SessionManager do
   end
 
   def handle_call({:destroy, session_id}, _from, state) do
-    {reply, state} = do_destroy(state, session_id)
-    {:reply, reply, state}
+    case SessionStore.get(state.session_store, session_id) do
+      {:ok, %{state: session_state}} when session_state in [:expired, :evicted, :destroyed, :failed] ->
+        {:reply, {:ok, :already_terminal}, state}
+
+      {:ok, %{state: session_state} = session} when session_state in [:banked, :parked] ->
+        {reply, state} = destroy_live(state, session)
+        {:reply, reply, state}
+
+      {:ok, session} ->
+        case SessionStore.transition(
+               state.session_store,
+               session_id,
+               :begin_destroy,
+               :session_destroying,
+               %{reason: :destroyed},
+               %{}
+             ) do
+          {:ok, _} ->
+            {:reply, {:ok, :destroying}, state, {:continue, {:do_destroy_live, session_id}}}
+
+          {:error, _reason} = error ->
+            {:reply, error, state}
+        end
+
+      :error ->
+        {:reply, {:error, :not_found}, state}
+    end
   end
 
   def handle_call({:bank, session_id}, _from, state) do
@@ -626,7 +663,7 @@ defmodule Embervm.SessionManager do
       {:ok, %{principal: lineage_principal}} when lineage_principal != principal ->
         {:error, :lineage_principal_mismatch}
 
-      {:ok, %{state: session_state}} when session_state not in [:expired, :evicted, :destroyed, :failed] ->
+      {:ok, %{state: session_state}} when session_state not in [:expired, :evicted, :destroyed, :failed, :destroying] ->
         {:error, :lineage_live_heir}
 
       {:ok, _terminal_holder} ->
@@ -2289,17 +2326,21 @@ defmodule Embervm.SessionManager do
         adopt_one(acc, session, live_vms, snapshots, nodes_reporting_snaps, nodes_facts)
       end)
 
+    # Fail-closed reconciliation toward destruction (ADR embervm/014 decision 5),
+    # Re-drive stuck destroying sessions (Direction 1 completion + alarm), and
+    # destroy reported session VMs with no CP row (Direction 2 orphans). Orphan
+    # cleanup remains gated because it requires the node-confirmed policy.
+    state = redrive_destroying(state, live_vms)
+
+    # Run orphan cleanup after destroying sessions have been redriven. A session
+    # can enter reconcile as :destroying while its node teardown is already
+    # confirmed; terminalizing it first lets the same pass evict any snapshot
+    # still reported by the node.
     state = evict_orphan_snapshots(state, facts)
     state = retire_orphan_session_volumes(state, facts, nodes_facts)
 
-    # Fail-closed reconciliation toward destruction (ADR embervm/014 decision 5),
-    # gated: re-drive stuck destroying sessions (Direction 1 completion + alarm) and
-    # destroy reported session VMs with no CP row (Direction 2 orphans). Gate off:
-    # inert, so today's behaviour is unchanged.
     if state.node_confirmed_destroy do
-      state
-      |> redrive_destroying(live_vms)
-      |> destroy_orphan_session_vms(facts, live_vms)
+      destroy_orphan_session_vms(state, facts, live_vms)
     else
       state
     end
@@ -3175,21 +3216,6 @@ defmodule Embervm.SessionManager do
   defp schedule(_msg, interval) when interval <= 0, do: :ok
   defp schedule(msg, interval), do: Process.send_after(self(), msg, interval)
 
-  # -- destroy ---------------------------------------------------------------
-
-  defp do_destroy(state, session_id) do
-    case SessionStore.get(state.session_store, session_id) do
-      {:ok, %{state: session_state}} when session_state in [:expired, :evicted, :destroyed, :failed] ->
-        {{:ok, :already_terminal}, state}
-
-      {:ok, session} ->
-        destroy_live(state, session)
-
-      :error ->
-        {{:error, :not_found}, state}
-    end
-  end
-
   # Destroy a session: tear down whatever it holds. A live session (running/banking/
   # relighting) has a process + VM, stopped and destroyed here; a banked session has
   # only a snapshot, evicted here. Any parked relight waiters are drained gone (the
@@ -3198,9 +3224,8 @@ defmodule Embervm.SessionManager do
   #
   # Two orderings, selected by EMBERVM_NODE_CONFIRMED_DESTROY (ADR embervm/014
   # decision 5):
-  #   * off (default): record session_destroyed first, then tear the VM down
-  #     asynchronously (today's behaviour). A banked session (no VM) is the same
-  #     either way: evict its snapshot, record destroyed.
+  #   * off (default): record destroying first, then tear the VM down
+  #     asynchronously. A banked session (no VM) is evicted synchronously.
   #   * on, live VM: record the destroying intent, run the node-confirmed teardown
   #     RPC, and record session_destroyed ONLY when the node confirms teardown. An
   #     unconfirmed teardown (RPC failure or teardown_confirmed=false) leaves the
@@ -3213,35 +3238,54 @@ defmodule Embervm.SessionManager do
     end
   end
 
-  # Gate-off (and banked) path: record destroyed first, tear down after.
+  # Gate-off path: tear down after the destroying intent, then record destroyed.
   defp destroy_live_legacy(state, session) do
-    if session.state in [:banked, :parked] do
-      _ = evict_snapshot(state, session)
-    else
-      _ = stop_session_process(state, session.session_id, session)
-    end
+    confirmed =
+      if session.state in [:banked, :parked] do
+        _ = evict_snapshot(state, session)
+        true
+      else
+        # A live row normally has node_id/vm_id, but a crash can leave a row in
+        # flight before residency is assigned. There is no VM to tear down in
+        # that case, so it is safe to complete destruction.
+        if is_binary(session.node_id) and is_binary(session.vm_id) do
+          stop_session_process(state, session.session_id, session)
+        else
+          _ = stop_session_process(state, session.session_id, session)
+          true
+        end
+      end
 
-    retire_session_volume(state, session)
+    if confirmed or session.state != :destroying do
+      retire_session_volume(state, session)
+      state = drain_relight_waiters(state, session.session_id, {:error, {:gone, "destroyed"}})
 
-    state = drain_relight_waiters(state, session.session_id, {:error, {:gone, "destroyed"}})
+      reply =
+        SessionStore.transition(
+          state.session_store,
+          session.session_id,
+          :destroy,
+          :session_destroyed,
+          %{reason: :destroyed},
+          %{}
+        )
 
-    reply =
-      SessionStore.transition(
-        state.session_store,
-        session.session_id,
-        :destroy,
-        :session_destroyed,
-        %{reason: :destroyed},
-        %{}
+      Logger.info("embervm session destroyed",
+        session_id: session.session_id,
+        workload: session.workload,
+        principal: session.principal
       )
 
-    Logger.info("embervm session destroyed",
-      session_id: session.session_id,
-      workload: session.workload,
-      principal: session.principal
-    )
+      {reply, state}
+    else
+      Logger.warning("embervm session teardown unconfirmed, left destroying",
+        session_id: session.session_id,
+        workload: session.workload,
+        vm_id: session.vm_id
+      )
 
-    {reply, state}
+      {{:ok, :destroying}, state}
+    end
   end
 
   # Gate-on path for a live-VM session: destroying intent -> node-confirmed teardown
@@ -3251,14 +3295,18 @@ defmodule Embervm.SessionManager do
     # 1. Durable destroying intent BEFORE the RPC, so a CP crash mid-destroy rebuilds
     #    as destroying and re-drives the teardown rather than forgetting it.
     intent =
-      SessionStore.transition(
-        state.session_store,
-        session.session_id,
-        :begin_destroy,
-        :session_destroying,
-        %{reason: :destroyed},
-        %{}
-      )
+      if session.state == :destroying do
+        {:ok, session}
+      else
+        SessionStore.transition(
+          state.session_store,
+          session.session_id,
+          :begin_destroy,
+          :session_destroying,
+          %{reason: :destroyed},
+          %{}
+        )
+      end
 
     state = drain_relight_waiters(state, session.session_id, {:error, {:gone, "destroyed"}})
 
@@ -3349,7 +3397,8 @@ defmodule Embervm.SessionManager do
   # unconfirmed). A dial failure, an RPC error, or a raised/thrown fault all read as
   # unconfirmed (false), keeping the session in destroying under the node-confirmed
   # gate; the legacy path discards this and proceeds as today.
-  defp destroy_vm(state, %{node_id: node_id, vm_id: vm_id}) when is_binary(node_id) and is_binary(vm_id) do
+  defp destroy_vm(state, %{node_id: node_id, vm_id: vm_id})
+       when is_binary(node_id) and is_binary(vm_id) do
     # Dial the OWNING instance running this live vm_id, not the node-name alias.
     dial_key = Embervm.WakeInstance.dial_for_session_vm(state.capacity_table, node_id, vm_id)
 

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -80,6 +80,8 @@ defmodule Embervm.RouterTest do
     def invoke(_srv, _id, _req), do: {:error, :not_found}
 
     def destroy(_srv, "s-live"), do: {:ok, :destroyed}
+    def destroy(_srv, "s-destroying"), do: {:ok, :destroying}
+    def destroy(_srv, "s-error"), do: {:error, :backend_down}
     def destroy(_srv, _id), do: {:error, :not_found}
   end
 
@@ -872,8 +874,16 @@ defmodule Embervm.RouterTest do
   test "DELETE /v1/sessions/:id destroys (management auth)" do
     with_session_fakes()
 
-    assert req(:delete, "/v1/sessions/s-live", auth("good")).status == 200
+    destroyed = req(:delete, "/v1/sessions/s-live", auth("good"))
+    assert destroyed.status == 200
+    assert json(destroyed.body)["state"] == "destroyed"
+
+    destroying = req(:delete, "/v1/sessions/s-destroying", auth("good"))
+    assert destroying.status == 202
+    assert json(destroying.body)["state"] == "destroying"
+
     assert req(:delete, "/v1/sessions/s-nope", auth("good")).status == 404
+    assert req(:delete, "/v1/sessions/s-error", auth("good")).status == 500
     # Management auth required.
     assert req(:delete, "/v1/sessions/s-live").status == 401
   end

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -588,6 +588,7 @@ defmodule Embervm.SessionBankRelightTest do
     put_workload(ctx, "wl")
     {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
     {:ok, _} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert_receive {:destroyed, _vm_id}
 
     # The node still reports a snapshot for the destroyed session: it must be evicted.
     NodeCapacity.put(ctx.cap_table, "node-4", node_fact("wl", session_snapshots: [snap_fact(created.session_id)]))

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -603,7 +603,7 @@ defmodule Embervm.SessionManagerTest do
 
     {:ok, created_row} = SessionStore.get(ctx.store, created.session_id)
     assert created_row.volume_node_id == "node-4"
-    assert {:ok, _} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
     assert_receive {:retired, ^session_id}, 1_000
   end
 
@@ -1057,9 +1057,11 @@ defmodule Embervm.SessionManagerTest do
   # INSTANCE dial place_create actually placed on.
   test "cold restore dials the placed INSTANCE, never the bare node name" do
     {:ok, dialed} = Agent.start_link(fn -> [] end)
+    parent = self()
 
     strict_channel_fun = fn node ->
       Agent.update(dialed, &[node | &1])
+      send(parent, {:dialed, node})
 
       case node do
         "node-4/inst-a" -> {:ok, :fake_channel}
@@ -1103,7 +1105,15 @@ defmodule Embervm.SessionManagerTest do
     put_brick(ctx, wl, "inst-a", [])
 
     {:ok, original} = SessionManager.create(ctx.mgr, wl, "p1")
-    {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+    {:ok, :destroying} = SessionManager.destroy(ctx.mgr, original.session_id)
+
+    # Destroy now returns at intent, so the teardown dials AFTER this call. Wait
+    # for the specific dial that would otherwise leak into the restore's window
+    # (retire_session_volume runs in a spawn and dials the bare node name,
+    # because this lineage has no session_volumes fact locating it). Waiting on
+    # the event rather than on a timer keeps the boundary deterministic: a fixed
+    # sleep would silently reintroduce the leak on a slow machine.
+    assert_receive {:dialed, "node-4"}, 1_000
     Agent.update(dialed, fn _ -> [] end)
 
     assert {:ok, restored} = SessionManager.create(ctx.mgr, wl, "p1", original.session_id)
@@ -1396,6 +1406,17 @@ defmodule Embervm.SessionManagerTest do
     assert :session_destroyed in op_kinds_for(ctx, created.session_id)
   end
 
+  test "banked session destruction is synchronous and evicts" do
+    ctx = start_stack()
+    put_session_workload(ctx, "wl-banked-destroy")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-banked-destroy", "p1")
+    bank_session(ctx, created.session_id)
+
+    assert {:ok, _} = SessionManager.destroy(ctx.mgr, created.session_id)
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :destroyed
+  end
+
   test "destroyed parked persistence session fires node-owned retirement" do
     parent = self()
     ctx = start_stack(
@@ -1515,9 +1536,9 @@ defmodule Embervm.SessionManagerTest do
     put_session_workload(ctx, "wl-d")
     {:ok, created} = SessionManager.create(ctx.mgr, "wl-d", "p1")
 
-    assert {:ok, _} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
 
-    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    session = wait_for_state(ctx, created.session_id, :destroyed)
     assert session.state == :destroyed
 
     # The process is gone.
@@ -1539,6 +1560,28 @@ defmodule Embervm.SessionManagerTest do
     assert {:error, :not_found} = SessionManager.destroy(ctx.mgr, "s-nope")
   end
 
+  test "failed live teardown stays destroying and reconcile retries it" do
+    {:ok, attempts} = Agent.start_link(fn -> 0 end)
+
+    ctx =
+      start_stack(
+        destroy_fun: fn _ch, _vm ->
+          attempt = Agent.get_and_update(attempts, fn n -> {n, n + 1} end)
+          {:ok, %{teardown_confirmed: attempt > 0}}
+        end
+      )
+
+    put_session_workload(ctx, "wl-retry-destroy")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-retry-destroy", "p1")
+
+    assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :destroying).state == :destroying
+
+    report_session_vm(ctx, created.session_id, "wl-retry-destroy")
+    assert :ok = SessionManager.reconcile(ctx.mgr)
+    assert wait_for_state(ctx, created.session_id, :destroyed).state == :destroyed
+  end
+
   # -- node-confirmed destroy (ADR embervm/014 decision 5, gated) -------------
 
   test "gated: destroy with a confirming node records destroying then destroyed" do
@@ -1553,9 +1596,9 @@ defmodule Embervm.SessionManagerTest do
     put_session_workload(ctx, "wl-ncd")
     {:ok, created} = SessionManager.create(ctx.mgr, "wl-ncd", "p1")
 
-    assert {:ok, _} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
 
-    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    session = wait_for_state(ctx, created.session_id, :destroyed)
     assert session.state == :destroyed
 
     kinds = op_kinds_for(ctx, created.session_id)

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.479
+      targetRevision: 0.1.480
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -371,7 +371,7 @@ class EmberVmShimTransport:
             # capability token, so its only 403 is "service account not
             # permitted". That fails EVERY destroy at once, and calling it gone
             # would report the whole fleet reaped while every VM stays alive.
-            # The control plane's destroy handler answers 200, 404, or 500.
+            # The control plane's destroy handler answers 200 (destroyed), 202 (destroying), 404 (not found), or 500 (error).
             if exc.response.status_code in (404, 410):
                 raise EmberSessionGone(_status_error_detail(exc)) from exc
             raise EmberVMTransportError(_status_error_detail(exc)) from exc


### PR DESCRIPTION
Fixes the leak half of #4405.

## What was wrong

`DELETE /v1/sessions/:id` on a running session returned 500 and left the VM alive.

`handle_call({:destroy, ...})` ran the whole teardown inline. `stop_session_process/3` calls `DynamicSupervisor.terminate_child/2`, which blocks until the child exits or its shutdown timeout elapses, and the OTP default for a worker is 5000ms. That is the entire router budget, consumed before `destroy_vm/2` has even dialled the node. A session mid-turn does not exit promptly, so the `GenServer.call` timed out and the `session_destroyed` transition at the end of the function never ran. The process was gone, the store still said live.

Observed live on 2026-08-10 04:07Z, triggered by a swarm cancel:

```
** (exit) exited in: GenServer.call(Embervm.SessionManager, {:destroy, "s-01KZ..."}, 5000)
    ** (EXIT) time out
    embervm/router.ex:1020: handle_destroy_session/2
```

The control plane logged neither `session destroyed` nor `session parked` for that id, and `workloads.embervm.dev/claude-runtime` held `1 live / 2 banked` for over ten minutes with `idleBankSeconds: 20`. #4405 previously concluded the destroy completed asynchronously and only the reply was lost. That does not hold on this path: the guest leaks and holds a live slot until `maxLifetimeSeconds` (21600) expires it.

## What this does

Record the destroying intent, reply, and tear down in `handle_continue`. This mirrors the `:bank` handler directly below, which already defers its slow half and carries a comment explaining that doing it inline killed the caller mid-call.

- Router answers **202** for the accepted destroy, and still 200, 404 and 500 for the other outcomes.
- Banked and parked sessions stay **synchronous**: they have no VM and no session process, so they are fast. They continue to record `session_destroyed` and log at INFO, so an operator-requested destroy is never recorded as a system-initiated eviction.
- An unconfirmed teardown leaves the session in `:destroying` for the reconcile loop, so `redrive_destroying` now runs ungated. It terminalizes by absence when the owning node reports and no longer lists the VM, so an unconfirmed teardown costs one reconcile tick rather than leaking.
- Sessions in `:destroying` no longer count as a live heir. Without this, destroying a session denied a restore of its own lineage with `lineage_live_heir`. Restore reads the workspace from S3 via `safe_restore_artifact` rather than the heir's live volume, and `adopt_one` skips `:destroying`, so this does not create a second writer.
- `destroy/2` passes an explicit 30s call timeout rather than relying on the implicit 5000ms default that caused this.

## Client

`agent_sessions/transport.py` needs no logic change: `raise_for_status()` does not raise on 202, so an accepted destroy already counts as success. Only the stale comment listing the possible responses is updated.

## Testing

`ci test`: **1203 tests, 0 failures, 6 skipped.**

Four pre-existing tests encoded contracts this change had to preserve, and each caught a real problem during development: the parked-destroy terminal state, the lineage heir ordering, the gated orphan dial route, and a test boundary that assumed destroy was synchronous. The last one is fixed by waiting on the leaked dial rather than a timer, since `retire_session_volume` runs in a `spawn` and is concurrent with the deferred teardown rather than sequenced by it.

## Follow-up, not in this PR

`dial_for_session_volume` returns the bare node id when no `session_volumes` fact locates a lineage, and that dial fails `:unknown_node`. The error is logged and discarded, so it may strand a volume. It predates this change and only became visible through it. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)