### PR TITLE
feat(mcp): arm the authentik preview lane on friends.jomcgi.dev

### DIFF
--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -251,7 +251,18 @@ scopedRoutes:
 # Rotation is one field edit on vaults/k8s-homelab/items/authentik
 # (PREVIEW_OIDC_CLIENT_SECRET) plus the same value on items/preview-oidc
 # (client-secret). Both ends must move together or the handshake breaks.
+# ARMED 2026-08-10. Steps 1 to 3 above were verified against the running
+# system before this flip: both blueprints report status=successful (so the
+# !Env resolved), the provider carries authorization_code + refresh_token and
+# the self-signed signing key, its JWKS answers with 1 key, and the zone 301s
+# http to https so the post-login redirect keeps its secure cookies.
+#
+# Expect a window of 500s immediately after this lands. The OnePasswordItem is
+# only created by this flip, and the operator syncs on a fixed 600s boundary,
+# so the Secret does not exist yet. Envoy Gateway answers 500 on every route a
+# SecurityPolicy targets when it cannot build the OIDC config, which is the
+# fail-closed behaviour: a missing secret cannot open the route.
 previewAuth:
-  enabled: false
+  enabled: true
   onepassword:
     itemPath: vaults/k8s-homelab/items/preview-oidc


### PR DESCRIPTION
Flips `previewAuth.enabled`, which creates the `/preview/` route, its `SecurityPolicy`, and the `OnePasswordItem` backing the OIDC client secret. Follow-up to #4616.

## Pre-enable checks, verified against the running system

Not assumed. Each was run before this flip:

| check | result |
|---|---|
| Both blueprints applied | `status=successful`, so `!Env` resolved |
| Provider grants | `['authorization_code', 'refresh_token']` |
| Provider signing key | `authentik Self-signed Certificate` |
| **JWKS key count** | **1** (zero would 401 every request behind a healthy-looking discovery doc) |
| Secret chain | 1Password, authentik provider, and k8s Secret all agree |
| Zone forces HTTPS | 301, so the post-login redirect keeps its secure cookies |

## Expect 500s briefly after merge

The `OnePasswordItem` is created *by* this flip, and the 1Password operator syncs on a fixed 600s boundary rather than debouncing, so the Secret does not exist yet.

Envoy Gateway installs a **500 direct response** on every route a `SecurityPolicy` targets when it cannot build the OIDC config. So the gap is fail-closed: a missing secret closes the route rather than opening it. This resolves within one operator cycle.

## Verification plan

1. Unauthenticated `curl` to `/preview/` must return **302 to auth.jomcgi.dev**, never 200. A 200 means the policy is not attached.
2. Browser login, which requires membership of `homelab-admin`, should land on the placeholder page.

The backend is still a `directResponse`, so the most this can serve is a fixed string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)