### PR TITLE
feat(mcp): authorize the preview lane on the claim, not the header

### DIFF
--- a/projects/mcp/context-forge-gateway/chart/templates/httproute-preview.yaml
+++ b/projects/mcp/context-forge-gateway/chart/templates/httproute-preview.yaml
@@ -218,4 +218,50 @@ spec:
           - claim: email
             header: X-Auth-Email
         recomputeRoute: true
+  # Authorization decides on the CLAIM, not on the header projected above.
+  #
+  # The distinction matters and is the whole point of this block. A header can
+  # be sent by a caller; a claim is carried inside a signature Envoy just
+  # verified, so it cannot be forged at all. The listener strip in
+  # projects/platform/cloudflare-gateway makes X-Auth-Email safe to READ, but
+  # "safe to read given a separate policy elsewhere" is a weaker property than
+  # "unforgeable by construction". Enforcement uses the stronger one, and the
+  # header stays for what it is actually good at: telling a page who is looking
+  # at it.
+  #
+  # defaultAction Deny means a token that validates but carries no matching
+  # group is rejected, rather than falling through to whatever the route would
+  # otherwise serve. That is what makes this a second, independent gate rather
+  # than a restatement of authentik's own application policy binding: authentik
+  # decides who may obtain a token, this decides who may use one here, and a
+  # misconfiguration on either side fails closed on its own.
+  #
+  # `groups` is an ARRAY of group NAMES (not ids) from authentik's default
+  # profile scope mapping, which is why valueType is StringArray. Renaming a
+  # group in authentik silently stops matching here, and the symptom is a 403
+  # after a completely successful login.
+  #
+  # THIS SHAPE IS THE PROTOTYPE FOR PER-PREVIEW AUTHORIZATION. `values` is a
+  # static list, so a per-preview rule cannot be expressed at this API level:
+  # it would need one SecurityPolicy per live preview, which is a
+  # per-invocation Kubernetes object and breaks EmberVM invariant 8. The
+  # EmberVM control plane is already the sole xDS writer, so it can publish
+  # this same rule shape per preview vhost with that preview's subject as the
+  # static value: static per vhost, dynamic across vhosts, no Kubernetes object
+  # per preview. Proving the mechanism here is what makes that safe to build.
+  authorization:
+    defaultAction: Deny
+    rules:
+      - name: allow-preview-groups
+        action: Allow
+        principal:
+          jwt:
+            provider: authentik
+            claims:
+              - name: groups
+                valueType: StringArray
+                values:
+                  {{- range .Values.previewAuth.allowedGroups }}
+                  - {{ . | quote }}
+                  {{- end }}
 {{- end }}

--- a/projects/mcp/context-forge-gateway/chart/values.yaml
+++ b/projects/mcp/context-forge-gateway/chart/values.yaml
@@ -220,6 +220,16 @@ previewAuth:
   clientID: preview-friends
   # k8s Secret synced from 1Password, holding key `client-secret`.
   clientSecretName: preview-oidc-client
+  # Groups permitted to use a token here, matched against the `groups` claim
+  # rather than the projected header, because a claim inside a verified
+  # signature cannot be forged by a caller. Empty would render an invalid
+  # policy (values requires at least one entry), which fails closed at
+  # admission rather than opening the route.
+  #
+  # These are authentik group NAMES. Renaming a group there stops matching
+  # here, and the symptom is a 403 after a fully successful login.
+  allowedGroups:
+    - homelab-admin
   # This host only. The apex would attach the session cookies to every other
   # tier including the public site. Widen only when a second preview host
   # exists, and note widening is the safe direction while narrowing is not.


### PR DESCRIPTION
Follow-up to #4622. Moves enforcement off the projected `X-Auth-Email` header and onto the `groups` claim inside the signature Envoy already verified.

## Why

A header can be sent by a caller. A claim cannot be forged at all.

The listener strip added in #4616 makes `X-Auth-Email` safe to *read*, but "safe given a separate policy elsewhere" is a weaker property than "unforgeable by construction". Enforcement should use the stronger one. The header stays for what it is actually good at: telling a page who is looking at it.

This also makes the lane **two independent gates** rather than one fact restated twice. authentik's application policy binding decides who may *obtain* a token; this decides who may *use* one here. A misconfiguration on either side now fails closed on its own.

## Verified first

The provider carries all three default mappings, and authentik's `profile` scope mapping emits `groups` as an array of group **names**, which is why `valueType` is `StringArray`.

## This is the prototype for per-preview authorization

`values` is a static list, so a per-preview rule cannot be expressed at this API level without one `SecurityPolicy` per live preview, which is a per-invocation Kubernetes object and breaks EmberVM invariant 8.

The EmberVM control plane is already the sole xDS writer, so it can publish **this same rule shape** per preview vhost with that preview's subject as the static value: static per vhost, dynamic across vhosts, no Kubernetes object per preview. Proving the mechanism on a fixed group is what makes that safe to build.

## Risk

If `groups` is absent from the ID token, the result is a **403 after a fully successful login**. Fail-closed, nothing opens, one-line revert. Needs one browser reload to confirm after merge, which also finally proves the claim pipeline that a `directResponse` backend could not demonstrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)