### PR TITLE
fix(embervm): project session_destroying in the Postgres op log

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.480
+version: 0.1.481

--- a/projects/embervm/control/lib/embervm/op_log/postgres.ex
+++ b/projects/embervm/control/lib/embervm/op_log/postgres.ex
@@ -779,6 +779,25 @@ defmodule Embervm.OpLog.Postgres do
     )
   end
 
+  # session_destroying: the durable destroy INTENT (ADR embervm/014 decision 5).
+  # A non-terminal state marker appended BEFORE the teardown, so a CP crash
+  # mid-destroy rebuilds as destroying and re-drives it rather than forgetting.
+  # session_destroyed (terminal) is appended only once teardown completes.
+  #
+  # This clause was missing while the op kind was only ever written under
+  # EMBERVM_NODE_CONFIRMED_DESTROY, which has never been armed in prod. The
+  # SQLite backend has always had it, so the two backends had drifted. Deferring
+  # the teardown made this kind reachable on the ungated path, and the missing
+  # clause raised FunctionClauseError inside the append transaction, which
+  # cascaded a crash through OpLog, SessionStore and SessionManager on every
+  # destroy of a live session.
+  defp project(conn, %Op{kind: :session_destroying} = op, _seq) do
+    exec(conn, "UPDATE sessions SET state='destroying', updated_at=$1 WHERE session_id=$2", [
+      op.ts,
+      op.session_id
+    ])
+  end
+
   defp project(conn, %Op{kind: :session_expired} = op, _seq),
     do: terminate_session(conn, op, "expired")
 

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.480
+      targetRevision: 0.1.481
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Production incident fix. Follows #4621.

## What broke

Destroying a live session crashes the control plane's session supervision tree.

```
FunctionClauseError: no function clause matching in Embervm.OpLog.Postgres.project/3
  %Op{kind: :session_destroying, session_id: "s-01KZ..."}
  op_log/postgres.ex:546 in do_append/2
-> Embervm.OpLog.Postgres terminating
-> Embervm.SessionStore terminating
-> Embervm.SessionManager terminating
```

Observed in prod at 05:47Z, four crashes, and `claude-runtime` lost its banked session accounting across the restart (`1 live / 2 banked` became `1 live / 0 banked`).

## Why

#4621 defers the teardown and appends a `session_destroying` intent before it. That op kind was previously written ONLY under `EMBERVM_NODE_CONFIRMED_DESTROY`, which has never been armed here, so `Embervm.OpLog.Postgres` never needed a clause for it and drifted from `Embervm.OpLog.SQLite`, which has had one all along with its own ADR embervm/014 comment. Deferring the teardown made the kind reachable on the ungated path, and prod runs Postgres.

## The fix

Mirror the SQLite projection exactly: a non-terminal state marker, leaving `session_destroyed` as the only terminal append.

```elixir
defp project(conn, %Op{kind: :session_destroying} = op, _seq) do
  exec(conn, "UPDATE sessions SET state='destroying', updated_at=$1 WHERE session_id=$2",
       [op.ts, op.session_id])
end
```

`sessions.state` is `TEXT NOT NULL` with no enum or check constraint, so the value needs no migration.

## Why CI did not catch it

The Postgres projector is not exercised by any test that runs in CI:

- `postgres_test.exs` is explicitly compile-time and no-connection only
- `postgres_live_test.exs` skips unless `EMBERVM_OPLOG_TEST_DSN` is set, and CI does not set it

So `1203 tests, 0 failures` was accurate and told us nothing about this module. Worth its own issue: either stand up a Postgres service for the control-plane tests, or add a database-free drift check asserting the two backends project the same set of op kinds. Deliberately not bundled here, since this diff needs to be the minimum that stops the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)