### PR TITLE
ci: run pr-checks on merge queue branches

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -24,6 +24,20 @@ actions:
         branches:
           - "*"
         merge_with_base: false
+      # Merge queue. GitHub pushes each queued candidate to a temporary
+      # gh-readonly-queue/<base>/pr-<n>-<sha> branch and waits for the REQUIRED
+      # checks to report on it. Those arrive as PUSH events, not pull_request
+      # ones, so without this trigger the queue would wait forever on a check
+      # that never runs, which blocks every merge in the repo. A BuildBuddy
+      # branch pattern's `*` matches across `/`, so one entry covers every base.
+      #
+      # Scoped to the queue prefix deliberately: a bare "*" here would run
+      # pr-checks on every push to every feature branch, on top of the
+      # pull_request run, which is the opposite of why the queue is being
+      # enabled.
+      push:
+        branches:
+          - "gh-readonly-queue/*"
     steps:
       - run: |
           # errexit is LOAD-BEARING. A BuildBuddy step is one shell script and


### PR DESCRIPTION
Prerequisite for enabling the GitHub merge queue. Lands alone, with the queue still OFF.

## Why it must land first

GitHub pushes each queued candidate to a temporary `gh-readonly-queue/<base>/pr-<n>-<sha>` branch and waits for the required checks to report on that ref. Those arrive as **push** events; `pr-checks` currently triggers on `pull_request` only. Enable the queue without this and every merge in the repo hangs forever on a check that never runs.

## Why the queue is wanted

Measured over the 7 days to 2026-08-10:

```
PR-branch runner invocations:              3,392
superseded within 10 min on same branch:     979
bytes in those superseded runs:            2.0 TB
share of all CI_RUNNER-tree download:      23.9%
```

That churn is the strict "up to date with main" rule forcing `update-branch` and a full re-run on every open PR whenever anything merges. The skill records this lever as "policy, not config"; a merge queue is the config answer, because the queue tests the merged candidate so open PRs no longer need to be individually up to date.

It is also the only remaining lever that cuts latency as well as bytes: it removes a mandatory rebase-and-wait before every merge.

## It preserves the property the strict rule protected

The missed-bump guard needs to evaluate against post-merge main to catch a rebase-merge version collision. A queue candidate **is** the merge result, so the guard runs against exactly that.

## Scope

`gh-readonly-queue/*` rather than `*`. A bare wildcard would run `pr-checks` on every push to every feature branch on top of the `pull_request` run, which is the opposite of the point. A BuildBuddy branch pattern's `*` matches across `/`, per their merge-queue docs, so one entry covers every base.

## Verification

`ci lint` clean. Deliberately no `ci test`: `buildbuddy.yaml` is not a bazel input, so a full remote suite would spend the exact bytes this work is cutting for no signal. The real validation is this PR's own `pr-checks` run starting at all, since a malformed config fails to parse and no action runs.

Caveat on the 23.9%: it is an upper bound. Some of those 979 are a developer pushing a genuine fix within ten minutes, which a queue does not remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
