### PR TITLE
feat(monolith): record the human who triggered an agent session

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.520
+version: 0.285.521
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.520
+      targetRevision: 0.285.521
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -168,6 +168,7 @@ def _persist_session(
     discord_thread: str | None = None,
     system_prompt: str | None = None,
     workflow_id: str | None = None,
+    triggered_by: str | None = None,
 ) -> AgentSession:
     with Session(get_engine()) as db_session:
         return store.create_session(
@@ -180,6 +181,7 @@ def _persist_session(
             discord_thread=discord_thread,
             system_prompt=system_prompt,
             workflow_id=workflow_id,
+            triggered_by=triggered_by,
         )
 
 

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -18,6 +18,9 @@ class AgentSession(SQLModel, table=True):
     # The DBOS workflow that owns this session, or None for hand-started,
     # Discord, and MCP sessions.
     workflow_id: str | None = Field(default=None, index=True)
+    # The email of the human who triggered the session, projected from the
+    # X-Auth-Email header. NULL for Discord, MCP, and workflow-started sessions.
+    triggered_by: str | None = Field(default=None)
     # The Discord thread this session is bound to, or None for a session started
     # from the /agents UI or an MCP tool. Unique so a thread can never fan out to
     # two sessions; Postgres allows many NULLs under a unique constraint, so the

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlmodel import Session, func, select
@@ -139,6 +139,7 @@ def _session_payload(
         "branch": row.branch,
         "repo": row.repo,
         "workflow_id": row.workflow_id,
+        "triggered_by": row.triggered_by,
         "model": row.model,
         "status": row.status,
         "title": row.title or _fallback_title(first_turn_prompt, first_pending_prompt),
@@ -477,32 +478,35 @@ def get_session_detail(
 
 
 @router.post("/sessions")
-async def start_session(request: StartRequest) -> dict:
-    if request.repo is not None and request.repo not in REPO_CATALOG:
+async def start_session(request: Request, start_request: StartRequest) -> dict:
+    triggered_by = request.headers.get("x-auth-email")
+    triggered_by = triggered_by.strip().lower() or None if triggered_by else None
+    if start_request.repo is not None and start_request.repo not in REPO_CATALOG:
         return {
             "accepted": False,
             "error": (
-                f"unknown repo {request.repo}; catalog: {', '.join(REPO_CATALOG)}"
+                f"unknown repo {start_request.repo}; catalog: {', '.join(REPO_CATALOG)}"
             ),
         }
     try:
-        model_family(request.model)
+        model_family(start_request.model)
     except ValueError as exc:
         return {"accepted": False, "error": str(exc)}
     row = await asyncio.to_thread(
         _persist_session,
         str(uuid4()),
-        request.workspace,
-        request.branch,
-        request.model,
-        request.repo,
+        start_request.workspace,
+        start_request.branch,
+        start_request.model,
+        start_request.repo,
+        triggered_by=triggered_by,
     )
     turn = await asyncio.to_thread(
-        _persist_pending_message, row.id, request.prompt, request.model
+        _persist_pending_message, row.id, start_request.prompt, start_request.model
     )
     # Queued from the UI, so its result does not get echoed to Discord.
     _mark_ui_originated(row.id, turn)
-    login = await codex_login_gate(request.model)
+    login = await codex_login_gate(start_request.model)
     if login is not None:
 
         async def resume() -> None:

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -446,8 +446,8 @@ def test_get_session_not_found(client):
 def test_start_session_happy_path(client, session, monkeypatch):
     monkeypatch.setattr(
         "agent_sessions.router._persist_session",
-        lambda local, workspace, branch, model, repo: store.create_session(
-            session, local, workspace, branch, model, repo
+        lambda local, workspace, branch, model, repo, **kwargs: store.create_session(
+            session, local, workspace, branch, model, repo, **kwargs
         ),
     )
     monkeypatch.setattr(
@@ -466,8 +466,8 @@ def test_start_session_happy_path(client, session, monkeypatch):
 def test_start_session_persists_repo(client, session, monkeypatch):
     monkeypatch.setattr(
         "agent_sessions.router._persist_session",
-        lambda local, workspace, branch, model, repo: store.create_session(
-            session, local, workspace, branch, model, repo
+        lambda local, workspace, branch, model, repo, **kwargs: store.create_session(
+            session, local, workspace, branch, model, repo, **kwargs
         ),
     )
     monkeypatch.setattr(
@@ -486,6 +486,59 @@ def test_start_session_persists_repo(client, session, monkeypatch):
     assert body["accepted"] is True
     assert row.repo == "jomcgi/homelab"
     assert client.get("/api/agents/sessions").json()[0]["repo"] == "jomcgi/homelab"
+
+
+def test_start_session_persists_triggered_by_header(client, session, monkeypatch):
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_session",
+        lambda local, workspace, branch, model, repo, **kwargs: store.create_session(
+            session, local, workspace, branch, model, repo, **kwargs
+        ),
+    )
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_pending_message",
+        lambda session_id, prompt, model: (
+            store.create_pending_message(session, session_id, prompt, model).seq
+        ),
+    )
+    monkeypatch.setattr("agent_sessions.router._schedule_next_message", lambda _: None)
+
+    response = client.post(
+        "/api/agents/sessions",
+        json={"prompt": "Hello"},
+        headers={"X-Auth-Email": "  EXAMPLE@EXAMPLE.COM  "},
+    )
+
+    assert response.status_code == 200
+    session_id = response.json()["session_id"]
+    assert session.get(AgentSession, session_id).triggered_by == "example@example.com"
+    assert client.get("/api/agents/sessions").json()[0]["triggered_by"] == (
+        "example@example.com"
+    )
+
+
+def test_start_session_without_triggered_by_header_succeeds(
+    client, session, monkeypatch
+):
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_session",
+        lambda local, workspace, branch, model, repo, **kwargs: store.create_session(
+            session, local, workspace, branch, model, repo, **kwargs
+        ),
+    )
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_pending_message",
+        lambda session_id, prompt, model: (
+            store.create_pending_message(session, session_id, prompt, model).seq
+        ),
+    )
+    monkeypatch.setattr("agent_sessions.router._schedule_next_message", lambda _: None)
+
+    response = client.post("/api/agents/sessions", json={"prompt": "Hello"})
+
+    assert response.status_code == 200
+    session_id = response.json()["session_id"]
+    assert session.get(AgentSession, session_id).triggered_by is None
 
 
 def test_start_session_rejects_unknown_repo(client):
@@ -796,8 +849,10 @@ def test_router_start_non_codex_models_enqueue_without_broker(
     monkeypatch.setattr(mcp, "_broker_request", broker_request)
     monkeypatch.setattr(
         "agent_sessions.router._persist_session",
-        lambda local, workspace, branch, selected_model, repo: store.create_session(
-            session, local, workspace, branch, selected_model, repo
+        lambda local, workspace, branch, selected_model, repo, **kwargs: (
+            store.create_session(
+                session, local, workspace, branch, selected_model, repo, **kwargs
+            )
         ),
     )
     monkeypatch.setattr(
@@ -835,8 +890,8 @@ def test_router_start_codex_login_required_preserves_session_and_watches(
     monkeypatch.setattr(mcp, "_broker_request", broker_request)
     monkeypatch.setattr(
         "agent_sessions.router._persist_session",
-        lambda local, workspace, branch, model, repo: store.create_session(
-            session, local, workspace, branch, model, repo
+        lambda local, workspace, branch, model, repo, **kwargs: store.create_session(
+            session, local, workspace, branch, model, repo, **kwargs
         ),
     )
     monkeypatch.setattr(
@@ -937,8 +992,8 @@ def test_start_session_marks_message_ui_originated(client, session, monkeypatch)
     mcp._ui_originated.clear()
     monkeypatch.setattr(
         "agent_sessions.router._persist_session",
-        lambda local, workspace, branch, model, repo: store.create_session(
-            session, local, workspace, branch, model, repo
+        lambda local, workspace, branch, model, repo, **kwargs: store.create_session(
+            session, local, workspace, branch, model, repo, **kwargs
         ),
     )
     monkeypatch.setattr(

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -29,6 +29,7 @@ def create_session(
     discord_thread: str | None = None,
     system_prompt: str | None = None,
     workflow_id: str | None = None,
+    triggered_by: str | None = None,
 ) -> AgentSession:
     row = AgentSession(
         local_session_id=local_session_id,
@@ -40,6 +41,10 @@ def create_session(
         progress_token=secrets.token_urlsafe(32),
         system_prompt=system_prompt,
         workflow_id=workflow_id,
+        # Collapses whitespace-only to None rather than "". An empty string is a
+        # third state that reads as "owned by nobody": it passes a NULL check but
+        # matches no caller, so it would silently create rows nobody can ever read.
+        triggered_by=(triggered_by or "").strip().lower() or None,
     )
     session.add(row)
     session.commit()

--- a/projects/monolith/agent_sessions/store_test.py
+++ b/projects/monolith/agent_sessions/store_test.py
@@ -92,6 +92,33 @@ def test_create_session_persists_optional_system_prompt(monkeypatch, tmp_path):
         _restore_schemas(schemas)
 
 
+def test_create_session_persists_normalized_triggered_by(monkeypatch, tmp_path):
+    engine, schemas = _database(monkeypatch, tmp_path)
+    try:
+        with Session(engine) as session:
+            triggered = store.create_session(
+                session,
+                "triggered",
+                "<guest>",
+                "main",
+                triggered_by="  EXAMPLE@EXAMPLE.COM  ",
+            )
+            untriggered = store.create_session(
+                session, "untriggered", "<guest>", "main"
+            )
+            blank = store.create_session(
+                session, "blank", "<guest>", "main", triggered_by="   "
+            )
+
+            assert triggered.triggered_by == "example@example.com"
+            assert untriggered.triggered_by is None
+            # Whitespace-only must land as NULL, not "". An empty string passes a
+            # NULL check but matches no caller, so it would own rows nobody reads.
+            assert blank.triggered_by is None
+    finally:
+        _restore_schemas(schemas)
+
+
 def test_create_session_persists_and_queries_workflow_id(monkeypatch, tmp_path):
     engine, schemas = _database(monkeypatch, tmp_path)
     try:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.520
+version: 0.285.521
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260810010000_agent_sessions_triggered_by.sql
+++ b/projects/monolith/chart/migrations/20260810010000_agent_sessions_triggered_by.sql
@@ -1,0 +1,5 @@
+-- The email of the human who triggered the session, projected from the
+-- X-Auth-Email header. NULL for Discord, MCP, and workflow-started sessions.
+
+ALTER TABLE agent_sessions.agent_sessions
+    ADD COLUMN triggered_by TEXT;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:BtoULEi2dx+wRzTmFa079L7GjluZvi6gR1MgzAbKaeU=
+h1:8x25l0kodvRlBlZva2gjku9Fhc9afTHccqNdsvZ6LrA=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -159,3 +159,4 @@ h1:BtoULEi2dx+wRzTmFa079L7GjluZvi6gR1MgzAbKaeU=
 20260809230000_platform_probe.sql h1:kV6FxOFnySW/mfEQpdllV9V6lgkzT2giTXZYcQMujz4=
 20260809230100_platform_probe_public_grants.sql h1:mQ8fVxqyOoQnRnCvBiRFpCvETDSeDL4umDOXK3xQXzk=
 20260810000000_agent_sessions_workflow_id.sql h1:lgOBVujB+/Cp8sK7w0PnCuUnttfozKADNWhSG83M7hE=
+20260810010000_agent_sessions_triggered_by.sql h1:ZIw9yloGu+UjC4MYC4uQSzKybK7dnG9gUCj2Adhm7Gs=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.520
+      targetRevision: 0.285.521
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/agents/sessions/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/sessions/+server.js
@@ -3,9 +3,13 @@ const API_BASE = process.env.API_BASE;
 export async function POST({ request }) {
   try {
     const body = await request.json();
+    const email = request.headers.get("x-auth-email");
     const res = await fetch(`${API_BASE}/api/agents/sessions`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(email ? { "X-Auth-Email": email } : {}),
+      },
       body: JSON.stringify({
         prompt: body.prompt,
         ...(body.model ? { model: body.model } : {}),

--- a/projects/monolith/frontend/src/routes/private/agents/sessions/+server.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/sessions/+server.test.js
@@ -52,6 +52,49 @@ describe("sessions proxy", () => {
     expect(callBody.workspace).toBe("ws");
   });
 
+  test("forwards x-auth-email header when present", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ session_id: "123" }), {
+          ok: true,
+          status: 200,
+        }),
+    );
+
+    const request = new Request("http://localhost/agents/sessions", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "test" }),
+      headers: { "X-Auth-Email": "human@example.com" },
+    });
+
+    await POST({ request });
+
+    expect(global.fetch.mock.calls[0][1].headers["X-Auth-Email"]).toBe(
+      "human@example.com",
+    );
+  });
+
+  test("omits x-auth-email header when absent", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ session_id: "123" }), {
+          ok: true,
+          status: 200,
+        }),
+    );
+
+    const request = new Request("http://localhost/agents/sessions", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "test" }),
+    });
+
+    await POST({ request });
+
+    expect(
+      global.fetch.mock.calls[0][1].headers["X-Auth-Email"],
+    ).toBeUndefined();
+  });
+
   test("includes model field when provided", async () => {
     global.fetch = vi.fn(
       async () =>


### PR DESCRIPTION
Task 1 of the agent-preview feature. Adds the missing link: nothing currently records who started a run, so there is nothing for a generated preview to belong to.

## The non-obvious half

The backend change alone would have been **inert**. `/api/agents` is not in the private route's pass-through rules, so the console reaches the API through a SvelteKit SSR proxy that was building a fresh `fetch` carrying only `Content-Type`. `X-Auth-Email` died there. The proxy now forwards it when present.

The header is trustworthy on this lane: `cf-ingress.security-policy` projects it from a verified Access JWT, and the gateway-wide `ClientTrafficPolicy` strips any client-supplied copy at the listener before the auth filters run.

## NULL is a legal value

Discord, MCP, and workflow-started sessions carry no browser identity, so an absent header records NULL and the create still succeeds. There is a test asserting exactly that, because a 500 here would break every non-console path.

Whitespace-only collapses to NULL rather than `""`. That is not cosmetic: the planned publish path refuses when `triggered_by` **is NULL**, and an empty string passes that guard while matching no caller, so it would mint previews owned by nobody with no error anywhere.

## Verification

- `ci lint` clean
- `ci test`: **748 tests pass**, but the build is red on `//bazel/erlang:mix_test_smoke`, which is the known flake tracked in #4391 (`Embervm.SessionManagerTest`, "rejoin park-once disarm"). Unrelated: this PR touches Python, JS, a migration, and chart versions, no Elixir.
- Chart bumped to `0.285.521`, with `monolith-public` dragged along as coupled.
- Migration ordering and `atlas.sum` hooks both passed.

Post-merge this needs one live check CI cannot give: create a session from the console and confirm `triggered_by` is populated. Green tests prove the code path, not that the header survives the real gateway and proxy hop, which is the exact thing that was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)