### PR TITLE
feat(swarm): prompt implementers for a turn-time rationale trailer

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.521
+version: 0.285.522
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.521
+      targetRevision: 0.285.522
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.521
+version: 0.285.522
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.521
+      targetRevision: 0.285.522
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/swarm/policy.py
+++ b/projects/monolith/swarm/policy.py
@@ -40,6 +40,12 @@ def implementer_prompt(task: str, branch: str, previous_failure: str | None) -> 
         f"Implement this task: {task}\n"
         f"Create branch {branch} from the base branch, make the change, commit it, "
         f"and push {branch} to GitHub. Do not open a pull request. Do not push to main."
+        "\nEnd your reply with a plain-text trailer in exactly this shape:\n"
+        "\nRATIONALE\n"
+        "- area: <file or component> · why: <one or two sentences>\n"
+        "- area: ... (repeat per important area, most important first)\n"
+        "- deviation: <anything you did differently from the task, and why> (zero or more)\n"
+        "\nKeep it under 12 lines. Do not use markdown formatting inside the trailer."
     )
     if previous_failure:
         prompt += f"\nPrevious attempt failed: {previous_failure}"

--- a/projects/monolith/swarm/policy_test.py
+++ b/projects/monolith/swarm/policy_test.py
@@ -66,6 +66,21 @@ def test_prompt_builders():
     )
 
 
+def test_implementer_prompt_contains_rationale_trailer_instruction():
+    prompt = implementer_prompt("t", "b", None)
+    assert "RATIONALE" in prompt
+    assert "- deviation:" in prompt
+
+
+def test_implementer_retry_appends_previous_failure_after_rationale():
+    prompt = implementer_prompt("t", "b", "x")
+    assert prompt.index("RATIONALE") < prompt.index("Previous attempt failed")
+
+
+def test_reviewer_prompt_does_not_contain_rationale_trailer_instruction():
+    assert "RATIONALE" not in reviewer_prompt("t", "b", "sha")
+
+
 @pytest.mark.parametrize(
     ("text", "expected"),
     [


### PR DESCRIPTION
Closes #4624. Slice 1 of the run view program (#4625, ADR agents/054).

Every implementer turn now ends with a plain-text `RATIONALE` trailer naming
the areas it changed and why, plus zero or more deviations. Capture only: no
parsing, no endpoint, no UI, no schema.

## Why this lands first

Rationale cannot be backfilled. A summary written later by a model reading a
diff is inference, and #4600 already recorded why that is unacceptable: it
produces a caption that reads as sourced when it is not. Prompted at turn
time it is first-person and contemporaneous, so it is recorded output rather
than a guess.

Which means every run until this deploys has no rationale and never will.
That is the same shape as `AgentTurn.commit_sha`, which sat declared and
indexed and unpopulated, and is now the blocker in #4600.

## Why it costs nothing to land early

`AgentTurn.result_text` is an unbounded text column stored verbatim
(`agent_sessions/models.py:81`), so the trailer is durable from the first
prompted turn with no schema change, no migration, and no endpoint. Parsing
comes later as a versioned, re-runnable step over stored text, fail-closed
like `parse_review_verdict`, which is exactly why the raw form is stored
first: the parse can be improved retroactively over already-captured turns.

Roughly 100 to 200 output tokens per turn against turns that already cost
around $0.46.

## The boundary this must not cross

Rationale is never routing input. Verified: only the reviewer's `result_text`
is parsed anywhere in the workflow (`swarm/workflows.py:194,196`), never the
implementer's, so a missing or malformed block cannot fail a node, change a
gate outcome, or influence retry. That keeps ADR 053's
claims-are-not-evidence boundary intact, and it is why the trailer went into
`implementer_prompt` alone and `reviewer_prompt` was left untouched: two
competing trailer formats in one reply is how parsing dies.

A missing block is the expected case, not an exceptional one.

## Verification

- `RATIONALE` appears in `swarm/policy.py` once, inside `implementer_prompt`;
  it appears nowhere in `swarm/workflows.py`.
- Three tests added: the trailer is present, the retry form appends
  `Previous attempt failed` AFTER the trailer instruction (index ordering, so
  retry context stays last), and `reviewer_prompt` does not contain it.
- `ci test`: `Executed 54 out of 748 tests: 748 tests pass.`
- `ci lint` clean.

Chart bumped to 0.285.522 (monolith and monolith-public together). Prompt text
only takes effect in the cluster, so this deploys.

Post-merge verification: after rollout, start one swarm smoke run and confirm
the implementer turn's stored answer ends with a `RATIONALE` block.
