### PR TITLE
fix(swarm): pin the resolved plan before the first node runs

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.523
+version: 0.285.524
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.523
+      targetRevision: 0.285.524
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.523
+version: 0.285.524
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.523
+      targetRevision: 0.285.524
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/swarm/router.py
+++ b/projects/monolith/swarm/router.py
@@ -14,6 +14,7 @@ class RunRequest(BaseModel):
     repo: str
     branch: str
     idempotency_key: str | None = None
+    budget_usd: float | None = None
 
 
 def _dbos():
@@ -36,6 +37,8 @@ def _dbos():
 def start_run(request: RunRequest) -> dict:
     if request.repo not in REPO_CATALOG:
         raise HTTPException(status_code=400, detail=f"unknown repo {request.repo}")
+    if request.budget_usd is not None and request.budget_usd <= 0:
+        raise HTTPException(status_code=400, detail="budget_usd must be positive")
     from swarm.workflows import implement_then_review
 
     dbos = _dbos()
@@ -47,11 +50,19 @@ def start_run(request: RunRequest) -> dict:
     if context:
         with context:
             handle = dbos.start_workflow(
-                implement_then_review, request.task, request.repo, request.branch
+                implement_then_review,
+                request.task,
+                request.repo,
+                request.branch,
+                request.budget_usd,
             )
     else:
         handle = dbos.start_workflow(
-            implement_then_review, request.task, request.repo, request.branch
+            implement_then_review,
+            request.task,
+            request.repo,
+            request.branch,
+            request.budget_usd,
         )
     return {"workflow_id": handle.workflow_id}
 

--- a/projects/monolith/swarm/router_test.py
+++ b/projects/monolith/swarm/router_test.py
@@ -37,7 +37,10 @@ def test_start_run(monkeypatch):
         workflow_id = "wf-1"
 
     class FakeDBOS:
+        args = None
+
         def start_workflow(self, *args):
+            self.args = args
             return Handle()
 
     monkeypatch.setattr(swarm_router.runtime, "init_dbos", lambda: FakeDBOS())
@@ -53,6 +56,47 @@ def test_start_run(monkeypatch):
     )
     assert response.status_code == 200
     assert response.json() == {"workflow_id": "wf-1"}
+
+
+def test_budget_must_be_positive(monkeypatch):
+    monkeypatch.setenv("SWARM_ENABLED", "true")
+    response = client().post(
+        "/api/swarm/runs",
+        json={
+            "task": "fix",
+            "repo": "jomcgi/homelab",
+            "branch": "main",
+            "budget_usd": -1,
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_start_run_passes_budget(monkeypatch):
+    monkeypatch.setenv("SWARM_ENABLED", "true")
+    captured = []
+
+    class Handle:
+        workflow_id = "wf-1"
+
+    class FakeDBOS:
+        def start_workflow(self, *args):
+            captured.append(args)
+            return Handle()
+
+    monkeypatch.setattr(swarm_router.runtime, "init_dbos", lambda: FakeDBOS())
+    monkeypatch.setattr(swarm_router.runtime, "is_launched", lambda: True)
+    response = client().post(
+        "/api/swarm/runs",
+        json={
+            "task": "fix",
+            "repo": "jomcgi/homelab",
+            "branch": "main",
+            "budget_usd": 2.0,
+        },
+    )
+    assert response.status_code == 200
+    assert captured[0][1:] == ("fix", "jomcgi/homelab", "main", 2.0)
 
 
 def test_follower_replica_returns_503(monkeypatch):

--- a/projects/monolith/swarm/steps.py
+++ b/projects/monolith/swarm/steps.py
@@ -6,6 +6,26 @@ import httpx
 from dbos import DBOS
 
 
+@DBOS.step()
+def pin_plan(budget_usd: float | None = None) -> dict:
+    """Resolve run config ONCE and checkpoint it.
+
+    The workflow body must never read config.* directly: recovery re-executes
+    the body and a changed env would alter a live run's control flow (#4618).
+    The step record is the pin; replay returns the recorded dict.
+    """
+    from swarm import config
+
+    return {
+        "version": 1,
+        "max_attempts": max(1, config.max_attempts()),
+        "implementer_model": config.implementer_model(),
+        "reviewer_model": config.reviewer_model(),
+        "turn_timeout_seconds": config.turn_timeout_seconds(),
+        "budget_usd": budget_usd,
+    }
+
+
 @DBOS.step(retries_allowed=True, max_attempts=3, backoff_rate=2.0)
 def start_agent_session(
     session_key, prompt, model, repo, branch, workflow_id: str

--- a/projects/monolith/swarm/steps_test.py
+++ b/projects/monolith/swarm/steps_test.py
@@ -23,6 +23,22 @@ class FakeClient:
         return self.response
 
 
+def test_pin_plan_resolves_config_once(monkeypatch):
+    monkeypatch.setenv("SWARM_MAX_ATTEMPTS", "0")
+    monkeypatch.setenv("SWARM_IMPLEMENTER_MODEL", "implementer")
+    monkeypatch.setenv("SWARM_REVIEWER_MODEL", "reviewer")
+    monkeypatch.setenv("SWARM_TURN_TIMEOUT_SECONDS", "42")
+
+    assert steps.pin_plan.__wrapped__(2.0) == {
+        "version": 1,
+        "max_attempts": 1,
+        "implementer_model": "implementer",
+        "reviewer_model": "reviewer",
+        "turn_timeout_seconds": 42,
+        "budget_usd": 2.0,
+    }
+
+
 @pytest.mark.parametrize(
     ("status", "payload", "expected"),
     [(200, {"object": {"sha": "deadbeef"}}, "deadbeef"), (404, {}, None)],

--- a/projects/monolith/swarm/workflows.py
+++ b/projects/monolith/swarm/workflows.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import logging
+
 from dbos import DBOS
 
-from swarm import config
 from swarm.policy import (
     implementer_prompt,
     next_action,
@@ -11,7 +12,9 @@ from swarm.policy import (
     work_branch,
 )
 from swarm.queues import codex_queue
-from swarm.steps import poll_turn, read_branch_head, start_agent_session
+from swarm.steps import pin_plan, poll_turn, read_branch_head, start_agent_session
+
+logger = logging.getLogger(__name__)
 
 # How long to wait between polls for a session's next turn. Each sleep is a
 # durable checkpoint, so the interval also sets how much wait is re-done after a
@@ -109,13 +112,28 @@ def _escalated(
 
 
 @DBOS.workflow()
-def implement_then_review(task: str, repo: str, branch: str) -> dict:
+def implement_then_review(
+    task: str, repo: str, branch: str, budget_usd: float | None = None
+) -> dict:
+    plan = pin_plan(budget_usd)
     try:
         workflow_id = DBOS.workflow_id
     except Exception:  # noqa: BLE001 - no workflow context
         workflow_id = None
+    if workflow_id is not None:
+        # The authoritative pin is pin_plan's own step record; this copy exists
+        # only so the run endpoint can read the plan without walking steps. A
+        # convenience write must never be able to kill a run at its first
+        # instruction, so a failure here is logged and dropped.
+        try:
+            DBOS.update_workflow_attributes(workflow_id, {"plan": plan})
+        except Exception:  # noqa: BLE001 - the step record is the real pin
+            logger.warning(
+                "failed to copy pinned plan onto workflow attributes",
+                exc_info=True,
+            )
     branch_name = work_branch(workflow_id or "unknown")
-    max_attempts = max(1, config.max_attempts())
+    max_attempts = plan["max_attempts"]
     attempt = 0
     previous_failure = None
     implementer_session_id = None
@@ -128,13 +146,13 @@ def implement_then_review(task: str, repo: str, branch: str) -> dict:
         implementer_session_id = _queued_session(
             session_key(f"implement-{attempt}"),
             implementer_prompt(task, branch_name, previous_failure),
-            config.implementer_model(),
+            plan["implementer_model"],
             repo,
             branch,
             workflow_id,
         )
         implementer_turn = _await_turn(
-            implementer_session_id, 0, config.turn_timeout_seconds()
+            implementer_session_id, 0, plan["turn_timeout_seconds"]
         )
         head_sha = read_branch_head(repo, branch_name)
         action = next_action(attempt, max_attempts, head_sha, prior_sha)
@@ -178,12 +196,12 @@ def implement_then_review(task: str, repo: str, branch: str) -> dict:
     reviewer_session_id = _queued_session(
         session_key("review"),
         reviewer_prompt(task, branch_name, commit_sha),
-        config.reviewer_model(),
+        plan["reviewer_model"],
         repo,
         branch,
         workflow_id,
     )
-    reviewer_turn = _await_turn(reviewer_session_id, 0, config.turn_timeout_seconds())
+    reviewer_turn = _await_turn(reviewer_session_id, 0, plan["turn_timeout_seconds"])
     return {
         "status": "review",
         "attempts": attempt,

--- a/projects/monolith/swarm/workflows_test.py
+++ b/projects/monolith/swarm/workflows_test.py
@@ -1,4 +1,5 @@
 import swarm.workflows as workflows
+from swarm import config
 
 
 class Queue:
@@ -27,6 +28,18 @@ def run(monkeypatch, turns, heads=None):
                 heads.extend([None, turns[session].get("commit_sha")])
     branch_heads = iter(heads)
     monkeypatch.setattr(workflows, "codex_queue", lambda: Queue())
+    monkeypatch.setattr(
+        workflows,
+        "pin_plan",
+        lambda budget_usd=None: {
+            "version": 1,
+            "max_attempts": max(1, config.max_attempts()),
+            "implementer_model": config.implementer_model(),
+            "reviewer_model": config.reviewer_model(),
+            "turn_timeout_seconds": config.turn_timeout_seconds(),
+            "budget_usd": budget_usd,
+        },
+    )
     monkeypatch.setattr(workflows, "start_agent_session", lambda *args: 0)
     monkeypatch.setattr(workflows, "_await_turn", lambda session, *_: turns[session])
     monkeypatch.setattr(workflows, "read_branch_head", lambda *_: next(branch_heads))
@@ -74,6 +87,94 @@ def test_no_commit_retries(monkeypatch):
     result = workflow("task", "jomcgi/homelab", "main")
     assert result["attempts"] == 2
     assert len(calls) == 3
+
+
+def test_pinned_attempt_bound_survives_config_change(monkeypatch):
+    monkeypatch.setenv("SWARM_MAX_ATTEMPTS", "2")
+    attributes = []
+    sessions = iter([101, 102])
+    heads = iter([None, None, None, None])
+    monkeypatch.setattr(
+        workflows,
+        "pin_plan",
+        lambda budget_usd=None: {
+            "version": 1,
+            "max_attempts": max(1, config.max_attempts()),
+            "implementer_model": config.implementer_model(),
+            "reviewer_model": config.reviewer_model(),
+            "turn_timeout_seconds": config.turn_timeout_seconds(),
+            "budget_usd": budget_usd,
+        },
+    )
+
+    class FakeDBOS:
+        workflow_id = "wf-1"
+
+        @staticmethod
+        def update_workflow_attributes(workflow_id, values):
+            attributes.append((workflow_id, values))
+
+    monkeypatch.setattr(workflows, "DBOS", FakeDBOS)
+    monkeypatch.setattr(workflows, "read_branch_head", lambda *_: next(heads))
+    monkeypatch.setattr(
+        workflows,
+        "_queued_session",
+        lambda *args: next(sessions),
+    )
+    monkeypatch.setattr(
+        workflows,
+        "_await_turn",
+        lambda session, *_: (
+            monkeypatch.setenv("SWARM_MAX_ATTEMPTS", "5")
+            or {"result_text": "no", "cost_usd": 1}
+        ),
+    )
+
+    result = workflow("task", "jomcgi/homelab", "main")
+
+    assert result["status"] == "escalated"
+    assert result["attempts"] == 2
+    assert attributes == [
+        (
+            "wf-1",
+            {
+                "plan": {
+                    "version": 1,
+                    "max_attempts": 2,
+                    "implementer_model": "luna",
+                    "reviewer_model": "opus",
+                    "turn_timeout_seconds": 1800,
+                    "budget_usd": None,
+                }
+            },
+        )
+    ]
+
+
+def test_attributes_write_failure_does_not_kill_the_run(monkeypatch):
+    # The authoritative pin is pin_plan's step record; the attributes copy is a
+    # convenience for the run endpoint. A convenience write must not be able to
+    # kill a run at its first instruction.
+    class FailingDBOS:
+        workflow_id = "wf-1"
+
+        @staticmethod
+        def update_workflow_attributes(workflow_id, values):
+            raise RuntimeError("attributes backend down")
+
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": None, "result_text": "no", "cost_usd": 1},
+            102: {"commit_sha": None, "result_text": "no", "cost_usd": 1},
+        },
+    )
+    monkeypatch.setattr(workflows, "DBOS", FailingDBOS)
+
+    result = workflow("task", "jomcgi/homelab", "main")
+
+    assert result["status"] == "escalated"
+    assert len(calls) == 2
 
 
 def test_exhausted_attempts_escalate_without_reviewer(monkeypatch):


### PR DESCRIPTION
Closes #4618. Slice 2 of the run view program (#4625, ADR agents/054).

A run's retry bound, models, turn timeout, and optional cost budget are now
resolved exactly once by a `pin_plan` step and read from that record for the
rest of the run.

## The bug

`implement_then_review` is a `@DBOS.workflow()`, and DBOS recovery re-invokes
the workflow function: completed steps return their checkpointed results, and
everything that is not a step runs again. `config.max_attempts()` was a plain
call in the body reading `os.environ`, so a recovered run re-read the
environment and its loop bound became whatever the environment said at that
moment rather than what it said when the run started.

It was armed rather than theoretical. `swarm.enabled: true` in deploy values,
and `SWARM_MAX_ATTEMPTS` is rendered from `.Values.swarm.maxAttempts`, so it
is a Helm value rather than a constant. Monolith rolls on every chart bump,
so a workflow recovering onto a freshly rolled pod is routine.

It fires only when the value changes between a run starting and recovering,
which is narrow. What it produces is not: lowering `maxAttempts` can make a
recovered run exit its loop earlier than the run it replaced, and raising it
grants attempts the original never had. Either way the run's recorded history
and its control flow disagree and nothing reports it. `chart/values.yaml`
documents `maxAttempts` as a bound the adjudicator "can never extend", and
that guarantee did not survive recovery.

## Why the fix is also a feature

"attempt 2 of 2" had a numerator from recorded children and a denominator
from live environment, so the two halves of one label had different epistemic
status while looking identical. The pin gives both the same recorded source,
which is what lets the run view state it as fact rather than as prose (ADR
agents/054). It is also what a deviation is measured against: you can only
deviate from something recorded.

## Review finding, fixed before this PR

The attributes copy was initially unguarded. `pin_plan`'s own step record is
the authoritative pin; the `update_workflow_attributes` copy exists only so
the run endpoint can read the plan without walking steps. Unguarded, a
transient failure in a convenience write would have killed the run at its
first instruction, which is worse than the bug being fixed. It is now logged
and dropped, with a test asserting a raising backend still lets the run
complete. Same rule the cancel-actor recording will follow: a recording
failure must never fail the operation it records.

## Verification

- No `config.*` reads remain in the workflow body (mechanically checked).
- `pin_plan` is a plain `@DBOS.step()`; `update_workflow_attributes` appears
  exactly once.
- **The bug is falsified by test, not described by it**: run with
  `SWARM_MAX_ATTEMPTS=2`, flip the env to `5` mid-run between attempt
  callbacks, assert the run still escalates after attempt 2 and that the
  recorded plan carries `max_attempts == 2`. That test fails against the
  previous code.
- A raising attributes backend does not fail the run.
- `budget_usd` validation: negative is 400, valid is threaded to the workflow.
- `ci test`: `Executed 53 out of 748 tests: 748 tests pass.`
- `ci lint` clean.

## Deliberately not in this slice

Serving the pin (that is the run endpoint slice) and enforcing the budget.
The budget is recorded as a ceiling and nothing halts on it: recording a limit
and enforcing a limit are different changes, and shipping them together would
turn a config read into a run-killer in the same PR that fixes how config is
read.

No `SWARM_*` env or chart template changes, so the env-rename trio rule is not
triggered. Chart bumped to 0.285.524 (monolith and monolith-public).
