### PR TITLE
feat(swarm): record node identity and the cancelling actor

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.524
+version: 0.285.525
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.524
+      targetRevision: 0.285.525
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -33,6 +33,8 @@ def start_session_for_swarm(
     repo: str,
     branch: str,
     workflow_id: str | None = None,
+    node_key: str | None = None,
+    node_attempt: int | None = None,
 ) -> int:
     """Create and schedule a swarm-owned session through the normal session path.
 
@@ -61,6 +63,8 @@ def start_session_for_swarm(
         model,
         repo,
         workflow_id=workflow_id,
+        node_key=node_key,
+        node_attempt=node_attempt,
     )
     assert row.id is not None
     _persist_pending_message(row.id, prompt, model)

--- a/projects/monolith/agent_sessions/api_test.py
+++ b/projects/monolith/agent_sessions/api_test.py
@@ -33,6 +33,8 @@ def test_start_session_for_swarm_retry_preserves_original_workflow_id(
             "jomcgi/homelab",
             "main",
             workflow_id="wf-1",
+            node_key="implement",
+            node_attempt=2,
         )
         second_id = api.start_session_for_swarm(
             "test-key",
@@ -48,6 +50,8 @@ def test_start_session_for_swarm_retry_preserves_original_workflow_id(
             row = session.get(AgentSession, first_id)
             assert row is not None
             assert row.workflow_id == "wf-1"
+            assert row.node_key == "implement"
+            assert row.node_attempt == 2
     finally:
         for table in SQLModel.metadata.tables.values():
             if table.name in schemas:

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -169,6 +169,8 @@ def _persist_session(
     system_prompt: str | None = None,
     workflow_id: str | None = None,
     triggered_by: str | None = None,
+    node_key: str | None = None,
+    node_attempt: int | None = None,
 ) -> AgentSession:
     with Session(get_engine()) as db_session:
         return store.create_session(
@@ -182,6 +184,8 @@ def _persist_session(
             system_prompt=system_prompt,
             workflow_id=workflow_id,
             triggered_by=triggered_by,
+            node_key=node_key,
+            node_attempt=node_attempt,
         )
 
 

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -18,6 +18,8 @@ class AgentSession(SQLModel, table=True):
     # The DBOS workflow that owns this session, or None for hand-started,
     # Discord, and MCP sessions.
     workflow_id: str | None = Field(default=None, index=True)
+    node_key: str | None = Field(default=None)
+    node_attempt: int | None = Field(default=None)
     # The email of the human who triggered the session, projected from the
     # X-Auth-Email header. NULL for Discord, MCP, and workflow-started sessions.
     triggered_by: str | None = Field(default=None)

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -139,6 +139,8 @@ def _session_payload(
         "branch": row.branch,
         "repo": row.repo,
         "workflow_id": row.workflow_id,
+        "node_key": row.node_key,
+        "node_attempt": row.node_attempt,
         "triggered_by": row.triggered_by,
         "model": row.model,
         "status": row.status,

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -193,6 +193,20 @@ def test_list_sessions_exposes_ember_binding(client, session):
     assert workflow_ids["unbound"] is None
 
 
+def test_list_sessions_exposes_node_identity(client, session):
+    _session(
+        session,
+        "implement-2",
+        workflow_id="wf-123",
+        node_key="implement",
+        node_attempt=2,
+    )
+
+    item = client.get("/api/agents/sessions").json()[0]
+    assert item["node_key"] == "implement"
+    assert item["node_attempt"] == 2
+
+
 def test_list_session_vms_maps_control_plane_states(client, monkeypatch):
     async def fake_list_sessions(limit=50, offset=0):
         return {

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -30,6 +30,8 @@ def create_session(
     system_prompt: str | None = None,
     workflow_id: str | None = None,
     triggered_by: str | None = None,
+    node_key: str | None = None,
+    node_attempt: int | None = None,
 ) -> AgentSession:
     row = AgentSession(
         local_session_id=local_session_id,
@@ -41,6 +43,8 @@ def create_session(
         progress_token=secrets.token_urlsafe(32),
         system_prompt=system_prompt,
         workflow_id=workflow_id,
+        node_key=node_key,
+        node_attempt=node_attempt,
         # Collapses whitespace-only to None rather than "". An empty string is a
         # third state that reads as "owned by nobody": it passes a NULL check but
         # matches no caller, so it would silently create rows nobody can ever read.

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.524
+version: 0.285.525
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260811000000_agent_sessions_node_key.sql
+++ b/projects/monolith/chart/migrations/20260811000000_agent_sessions_node_key.sql
@@ -1,0 +1,19 @@
+ALTER TABLE agent_sessions.agent_sessions
+  ADD COLUMN node_key TEXT,
+  ADD COLUMN node_attempt INTEGER;
+
+CREATE INDEX agent_sessions_workflow_node_idx
+  ON agent_sessions.agent_sessions (workflow_id, node_key, node_attempt)
+  WHERE workflow_id IS NOT NULL;
+
+-- Backfill the two historical suffix grammars. Anything else stays NULL.
+UPDATE agent_sessions.agent_sessions
+SET node_key = 'implement',
+    node_attempt = (regexp_match(local_session_id, '-implement-(\d+)$'))[1]::int
+WHERE workflow_id IS NOT NULL
+  AND local_session_id ~ '-implement-\d+$';
+
+UPDATE agent_sessions.agent_sessions
+SET node_key = 'review', node_attempt = 1
+WHERE workflow_id IS NOT NULL
+  AND local_session_id LIKE '%-review';

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:8x25l0kodvRlBlZva2gjku9Fhc9afTHccqNdsvZ6LrA=
+h1:8YShU9L8gw6A/dBbsJ+t2TAz6vJ0RVUFb7rJzdmzr/k=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -160,3 +160,4 @@ h1:8x25l0kodvRlBlZva2gjku9Fhc9afTHccqNdsvZ6LrA=
 20260809230100_platform_probe_public_grants.sql h1:mQ8fVxqyOoQnRnCvBiRFpCvETDSeDL4umDOXK3xQXzk=
 20260810000000_agent_sessions_workflow_id.sql h1:lgOBVujB+/Cp8sK7w0PnCuUnttfozKADNWhSG83M7hE=
 20260810010000_agent_sessions_triggered_by.sql h1:ZIw9yloGu+UjC4MYC4uQSzKybK7dnG9gUCj2Adhm7Gs=
+20260811000000_agent_sessions_node_key.sql h1:4zzYZjEKvM2Qc6jKM+CrclVaiuFvXrbEi8E/BryWdgw=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.524
+      targetRevision: 0.285.525
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/swarm/router.py
+++ b/projects/monolith/swarm/router.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from swarm import config, runtime
 from goosecracker.api import REPO_CATALOG
 
 router = APIRouter(prefix="/api/swarm", tags=["swarm"])
+logger = logging.getLogger(__name__)
 
 
 class RunRequest(BaseModel):
@@ -82,7 +86,7 @@ def list_runs() -> list[dict]:
 
 
 @router.post("/runs/{workflow_id}/cancel")
-async def cancel_run(workflow_id: str) -> dict:
+async def cancel_run(workflow_id: str, request: Request) -> dict:
     dbos = _dbos()
     # cancel_children: sessions are not created inline. The workflow enqueues
     # start_session_workflow as a CHILD on the codex queue, so cancelling only
@@ -98,6 +102,23 @@ async def cancel_run(workflow_id: str) -> dict:
     from agent_sessions.api import reap_sessions_for_workflow
 
     guest_sessions = await reap_sessions_for_workflow(workflow_id)
+    actor = request.headers.get("Cf-Access-Authenticated-User-Email") or "operator"
+    try:
+        await dbos.update_workflow_attributes_async(
+            workflow_id,
+            {
+                "cancelled_by": {
+                    "actor": actor,
+                    "at": datetime.now(timezone.utc).isoformat(),
+                }
+            },
+        )
+    except Exception:  # noqa: BLE001 - cancellation must not fail on metadata
+        logger.warning(
+            "failed to record cancellation actor for workflow %s",
+            workflow_id,
+            exc_info=True,
+        )
     return {
         "workflow_id": workflow_id,
         "cancelled": True,

--- a/projects/monolith/swarm/router_test.py
+++ b/projects/monolith/swarm/router_test.py
@@ -129,6 +129,9 @@ def test_cancel_reaps_after_dbos_cancel(monkeypatch):
         async def cancel_workflow_async(self, workflow_id, *, cancel_children=False):
             events.append(("cancel", workflow_id, cancel_children))
 
+        async def update_workflow_attributes_async(self, workflow_id, values):
+            events.append(("attributes", workflow_id, values["cancelled_by"]["actor"]))
+
     async def reap(workflow_id):
         events.append(("reap", workflow_id))
         return {
@@ -140,7 +143,10 @@ def test_cancel_reaps_after_dbos_cancel(monkeypatch):
     monkeypatch.setattr(swarm_router.runtime, "init_dbos", lambda: FakeDBOS())
     monkeypatch.setattr(swarm_router.runtime, "is_launched", lambda: True)
     monkeypatch.setattr("agent_sessions.api.reap_sessions_for_workflow", reap)
-    response = client().post("/api/swarm/runs/wf-1/cancel")
+    response = client().post(
+        "/api/swarm/runs/wf-1/cancel",
+        headers={"Cf-Access-Authenticated-User-Email": "alice@example.com"},
+    )
 
     assert response.status_code == 200
     assert response.json() == {
@@ -152,7 +158,11 @@ def test_cancel_reaps_after_dbos_cancel(monkeypatch):
             "skipped": [4],
         },
     }
-    assert events == [("cancel", "wf-1", True), ("reap", "wf-1")]
+    assert events == [
+        ("cancel", "wf-1", True),
+        ("reap", "wf-1"),
+        ("attributes", "wf-1", "alice@example.com"),
+    ]
 
 
 def test_cancel_reports_reap_failure_without_failing(monkeypatch):
@@ -162,6 +172,10 @@ def test_cancel_reports_reap_failure_without_failing(monkeypatch):
         async def cancel_workflow_async(self, workflow_id, *, cancel_children=False):
             assert workflow_id == "wf-1"
             assert cancel_children is True
+
+        async def update_workflow_attributes_async(self, workflow_id, values):
+            assert workflow_id == "wf-1"
+            assert values["cancelled_by"]["actor"] == "operator"
 
     async def reap(_workflow_id):
         return {
@@ -180,3 +194,25 @@ def test_cancel_reports_reap_failure_without_failing(monkeypatch):
     assert response.json()["guest_sessions"]["failed"] == [
         {"session_id": 3, "error": "boom"}
     ]
+
+
+def test_cancel_survives_attribute_write_failure(monkeypatch):
+    monkeypatch.setenv("SWARM_ENABLED", "true")
+
+    class FakeDBOS:
+        async def cancel_workflow_async(self, workflow_id, *, cancel_children=False):
+            pass
+
+        async def update_workflow_attributes_async(self, workflow_id, values):
+            raise RuntimeError("attribute store unavailable")
+
+    async def reap(_workflow_id):
+        return {"reaped": [], "failed": [], "skipped": []}
+
+    monkeypatch.setattr(swarm_router.runtime, "init_dbos", lambda: FakeDBOS())
+    monkeypatch.setattr(swarm_router.runtime, "is_launched", lambda: True)
+    monkeypatch.setattr("agent_sessions.api.reap_sessions_for_workflow", reap)
+    response = client().post("/api/swarm/runs/wf-1/cancel")
+
+    assert response.status_code == 200
+    assert response.json()["cancelled"] is True

--- a/projects/monolith/swarm/steps.py
+++ b/projects/monolith/swarm/steps.py
@@ -28,7 +28,14 @@ def pin_plan(budget_usd: float | None = None) -> dict:
 
 @DBOS.step(retries_allowed=True, max_attempts=3, backoff_rate=2.0)
 def start_agent_session(
-    session_key, prompt, model, repo, branch, workflow_id: str
+    session_key,
+    prompt,
+    model,
+    repo,
+    branch,
+    workflow_id: str,
+    node_key: str | None = None,
+    node_attempt: int | None = None,
 ) -> int:
     """Start (or re-attach to) one agent session.
 
@@ -40,7 +47,14 @@ def start_agent_session(
     from agent_sessions.api import start_session_for_swarm
 
     return start_session_for_swarm(
-        session_key, prompt, model, repo, branch, workflow_id=workflow_id
+        session_key,
+        prompt,
+        model,
+        repo,
+        branch,
+        workflow_id=workflow_id,
+        node_key=node_key,
+        node_attempt=node_attempt,
     )
 
 

--- a/projects/monolith/swarm/steps_test.py
+++ b/projects/monolith/swarm/steps_test.py
@@ -86,6 +86,10 @@ def test_start_agent_session_forwards_workflow_id(monkeypatch):
     assert calls == [
         (
             ("test-key", "prompt", "luna", "jomcgi/homelab", "main"),
-            {"workflow_id": "wf-abc"},
+            {
+                "workflow_id": "wf-abc",
+                "node_key": None,
+                "node_attempt": None,
+            },
         )
     ]

--- a/projects/monolith/swarm/workflows.py
+++ b/projects/monolith/swarm/workflows.py
@@ -30,6 +30,8 @@ def start_session_workflow(
     repo: str,
     branch: str,
     workflow_id: str | None = None,
+    node_key: str | None = None,
+    node_attempt: int | None = None,
 ) -> int:
     """Queue-able wrapper around the session-start step.
 
@@ -42,7 +44,16 @@ def start_session_workflow(
     parent's id must be threaded from the caller, not read from context, or the
     session would record the wrong parent link.
     """
-    return start_agent_session(key, prompt, model, repo, branch, workflow_id)
+    return start_agent_session(
+        key,
+        prompt,
+        model,
+        repo,
+        branch,
+        workflow_id,
+        node_key,
+        node_attempt,
+    )
 
 
 def session_key(suffix: str) -> str:
@@ -66,9 +77,19 @@ def _queued_session(
     repo: str,
     branch: str,
     workflow_id: str,
+    node_key: str | None = None,
+    node_attempt: int | None = None,
 ) -> int:
     handle = codex_queue().enqueue(
-        start_session_workflow, key, prompt, model, repo, branch, workflow_id
+        start_session_workflow,
+        key,
+        prompt,
+        model,
+        repo,
+        branch,
+        workflow_id,
+        node_key,
+        node_attempt,
     )
     return handle.get_result()
 
@@ -150,6 +171,8 @@ def implement_then_review(
             repo,
             branch,
             workflow_id,
+            node_key="implement",
+            node_attempt=attempt,
         )
         implementer_turn = _await_turn(
             implementer_session_id, 0, plan["turn_timeout_seconds"]
@@ -200,6 +223,8 @@ def implement_then_review(
         repo,
         branch,
         workflow_id,
+        node_key="review",
+        node_attempt=1,
     )
     reviewer_turn = _await_turn(reviewer_session_id, 0, plan["turn_timeout_seconds"])
     return {

--- a/projects/monolith/swarm/workflows_test.py
+++ b/projects/monolith/swarm/workflows_test.py
@@ -46,8 +46,10 @@ def run(monkeypatch, turns, heads=None):
     monkeypatch.setattr(
         workflows,
         "_queued_session",
-        lambda key, prompt, model, repo, branch, workflow_id: (
-            calls.append((key, prompt, model, repo, branch, workflow_id))
+        lambda key, prompt, model, repo, branch, workflow_id, node_key=None, node_attempt=None: (
+            calls.append(
+                (key, prompt, model, repo, branch, workflow_id, node_key, node_attempt)
+            )
             or next(sessions)
         ),
     )
@@ -73,6 +75,8 @@ def test_commit_on_first_attempt_goes_to_review(monkeypatch):
     assert result["review_verdict"] == "approve"
     assert result["work_branch"] == "claude/swarm-unknown"
     assert len(calls) == 2
+    assert calls[0][-2:] == ("implement", 1)
+    assert calls[1][-2:] == ("review", 1)
 
 
 def test_no_commit_retries(monkeypatch):
@@ -87,6 +91,11 @@ def test_no_commit_retries(monkeypatch):
     result = workflow("task", "jomcgi/homelab", "main")
     assert result["attempts"] == 2
     assert len(calls) == 3
+    assert [call[-2:] for call in calls] == [
+        ("implement", 1),
+        ("implement", 2),
+        ("review", 1),
+    ]
 
 
 def test_pinned_attempt_bound_survives_config_change(monkeypatch):
@@ -119,7 +128,7 @@ def test_pinned_attempt_bound_survives_config_change(monkeypatch):
     monkeypatch.setattr(
         workflows,
         "_queued_session",
-        lambda *args: next(sessions),
+        lambda *args, **kwargs: next(sessions),
     )
     monkeypatch.setattr(
         workflows,
@@ -240,7 +249,9 @@ def test_queue_receives_a_workflow_not_a_step(monkeypatch):
     workflows._queued_session("k-1", "p", "luna", "jomcgi/homelab", "main", "wf-123")
     assert enqueued == [workflows.start_session_workflow]
     assert enqueued[0] is not workflows.start_agent_session
-    assert arguments == [("k-1", "p", "luna", "jomcgi/homelab", "main", "wf-123")]
+    assert arguments == [
+        ("k-1", "p", "luna", "jomcgi/homelab", "main", "wf-123", None, None)
+    ]
 
 
 def test_start_session_workflow_forwards_workflow_id(monkeypatch):
@@ -256,7 +267,9 @@ def test_start_session_workflow_forwards_workflow_id(monkeypatch):
     )
 
     assert result == 101
-    assert calls == [("k-1", "p", "luna", "jomcgi/homelab", "main", "wf-123")]
+    assert calls == [
+        ("k-1", "p", "luna", "jomcgi/homelab", "main", "wf-123", None, None)
+    ]
 
 
 def test_empty_commit_sha_is_not_success(monkeypatch):
@@ -281,7 +294,11 @@ def test_reviewer_has_no_lineage_argument(monkeypatch):
         },
     )
     workflow("task", "jomcgi/homelab", "main")
-    assert len(calls[1]) == 6
+    # Six positional plus node_key and node_attempt. The arity is asserted so a
+    # NEW argument cannot appear unnoticed; the substring check below is the
+    # property that actually matters (ADR 038 decision 3: the reviewer is never
+    # handed the implementer's lineage).
+    assert len(calls[1]) == 8
     assert all("lineage" not in str(value) for value in calls[1])
 
 


### PR DESCRIPTION
Slice 3 of the run view program (#4625, ADR agents/054). Unblocked by #4630 landing; this migration sorts after its `20260810010000_agent_sessions_triggered_by.sql`.

## Node identity stops being a naming convention

Sessions minted by a swarm run now carry `node_key` and `node_attempt` as explicit columns, passed down from the workflow rather than parsed back out of `local_session_id`.

The convention still holds (`local_session_id` remains the idempotency key and keeps its suffix grammar), but nothing downstream has to trust a string shape that was never an API promise. That matters because the run view is about to build node structure on it, and `{workflow_id}-implement-{n}` has no uniqueness guarantee behind it, only the absence of a collision so far.

The migration backfills the two historical grammars, `-implement-N` and `-review`, and leaves anything else NULL rather than guessing. Schema plus two bounded UPDATEs over a table with tens of rows, so the migrations ConfigMap size rule is not in play.

## Cancellation records who did it

DBOS has no canceller field, which is why the mockup originally cut "cancelled by you" as unsourceable. Our own endpoint can record it. That is the distinction the program keeps drawing: data we genuinely cannot have stays absent, data nobody had bothered to write down becomes recording work.

Two failure-mode details worth review attention:

- It calls `update_workflow_attributes_async` on the instance. The sync classmethod opens with `check_async()`, which raises whenever an event loop is running, and this handler is async. That is the same trap that previously broke swarm cancel outright.
- The write is guarded. A failed metadata write must never fail the cancel it describes, matching the rule the plan pin already follows.

## Test fixtures

`ci test` caught two failures on the first run, both fixture breakage from the new keyword arguments rather than product defects:

- The env-flip test's `_queued_session` stub needed `**kwargs`.
- `test_reviewer_has_no_lineage_argument` asserts arity, which moved 6 to 8.

That second number is a tripwire for ADR 038 decision 3 (the reviewer is never handed the implementer's lineage, because an injected implementer could otherwise prepare its auditor's room), not an implementation detail. It has two assertions and only one carries the property; a comment now says which, so the next person updating a count knows what they would be weakening. A ninth argument still fails it.

## Verification

- `node_key`/`node_attempt` present in models and serialized by the sessions payload; both call sites in the workflow pass them.
- Migration sorts after the `triggered_by` migration and its hash is in `atlas.sum`.
- `ci test`: `Executed 1 out of 748 tests: 748 tests pass.` Only one target's inputs changed; confirmed on BuildBuddy that `//projects/monolith:swarm_workflows_test` PASSED in that invocation (2.3s) rather than reading the count alone.
- `ci lint` clean.

Chart bumped to 0.285.525. Post-merge: a sessions payload row exposes `node_key`, and a historical swarm row shows the backfilled value.