### PR TITLE
feat(swarm): run detail and master list endpoints

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.525
+version: 0.285.526
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.525
+      targetRevision: 0.285.526
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2209,6 +2209,26 @@ py_test(
 )
 
 py_test(
+    name = "view_test",
+    srcs = ["swarm/view_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_swarm",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "tier_test",
+    srcs = ["swarm/tier_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "frontend_test",
     srcs = ["app/frontend_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.525
+version: 0.285.526
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.525
+      targetRevision: 0.285.526
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/swarm/router.py
+++ b/projects/monolith/swarm/router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request
@@ -35,6 +36,19 @@ def _dbos():
             status_code=503, detail="Swarm DBOS is not launched on this replica"
         )
     return instance
+
+
+def _server_app_version() -> str:
+    return os.environ.get("APP_VERSION", os.environ.get("GIT_SHA", "unknown"))
+
+
+def _session_rows(workflow_id: str):
+    from agent_sessions import store
+    from core.db import get_engine
+    from sqlmodel import Session
+
+    with Session(get_engine()) as session:
+        return store.sessions_for_workflow(session, workflow_id)
 
 
 @router.post("/runs")
@@ -73,16 +87,27 @@ def start_run(request: RunRequest) -> dict:
 
 @router.get("/runs/{workflow_id}")
 def get_run(workflow_id: str) -> dict:
-    status = _dbos().retrieve_workflow(workflow_id).get_status()
-    return _status_payload(status)
+    from swarm.view import compose_run
+
+    dbos = _dbos()
+    try:
+        result = compose_run(
+            dbos, workflow_id, _session_rows(workflow_id), _server_app_version()
+        )
+    except Exception as exc:  # DBOS uses a runtime-specific missing-workflow error.
+        if "not found" in str(exc).lower() or "non-existent" in str(exc).lower():
+            raise HTTPException(status_code=404, detail="workflow not found") from exc
+        raise
+    if result is None:
+        raise HTTPException(status_code=404, detail="workflow not found")
+    return result
 
 
 @router.get("/runs")
-def list_runs() -> list[dict]:
-    return [
-        _status_payload(status)
-        for status in _dbos().list_workflows(limit=50, sort_desc=True)
-    ]
+def list_runs(active: bool = True) -> dict:
+    from swarm.view import compose_master
+
+    return compose_master(_dbos(), active, {}, _server_app_version())
 
 
 @router.post("/runs/{workflow_id}/cancel")
@@ -123,17 +148,4 @@ async def cancel_run(workflow_id: str, request: Request) -> dict:
         "workflow_id": workflow_id,
         "cancelled": True,
         "guest_sessions": guest_sessions,
-    }
-
-
-def _status_payload(status) -> dict:
-    # `error` is a live exception object (e.g. DBOSMaxStepRetriesExceeded), which
-    # pydantic cannot serialize: returning it raw turned every failed run's
-    # status into a 500, hiding the very failure the caller was asking about.
-    error = getattr(status, "error", None)
-    return {
-        "workflow_id": status.workflow_id,
-        "status": status.status,
-        "result": getattr(status, "output", None),
-        "error": None if error is None else f"{type(error).__name__}: {error}",
     }

--- a/projects/monolith/swarm/tier_test.py
+++ b/projects/monolith/swarm/tier_test.py
@@ -1,0 +1,5 @@
+from app.modules_public import PUBLIC_MODULES
+
+
+def test_swarm_is_not_in_public_registry():
+    assert "swarm" not in {module.name for module in PUBLIC_MODULES}

--- a/projects/monolith/swarm/view.py
+++ b/projects/monolith/swarm/view.py
@@ -1,0 +1,473 @@
+"""Server-owned composition for the swarm run surfaces.
+
+This module deliberately knows nothing about FastAPI.  DBOS objects are kept at
+the edge and reduced to the v4 payload here, so the browser does not infer
+workflow state or compose evidence-bearing prose.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from swarm import config
+
+
+def _value(obj: Any, name: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _status(workflow: Any) -> Any:
+    getter = getattr(workflow, "get_status", None)
+    return getter() if getter else workflow
+
+
+def _attributes(workflow: Any, status: Any) -> dict:
+    for obj in (status, workflow):
+        attrs = _value(obj, "attributes")
+        if isinstance(attrs, dict):
+            return attrs
+        getter = getattr(obj, "get_attributes", None)
+        if getter:
+            result = getter()
+            if isinstance(result, dict):
+                return result
+    return {}
+
+
+def _input(status: Any) -> dict:
+    value = _value(status, "input", {})
+    if not isinstance(value, (dict, list, tuple)) and value is not None:
+        value = _value(value, "args", value)
+    if isinstance(value, dict) and "args" in value:
+        value = value["args"]
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, (list, tuple)):
+        names = ("task", "repo", "branch", "budget_usd")
+        return dict(zip(names, value))
+    return {}
+
+
+def _iso(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return value
+
+
+def _children(dbos: Any, workflow_id: str) -> list[Any]:
+    return list(
+        dbos.list_workflows(parent_workflow_id=workflow_id, load_input=True) or []
+    )
+
+
+def _steps(dbos: Any, workflow_id: str) -> list[Any]:
+    rows = dbos.list_workflow_steps(workflow_id) or []
+    return [
+        row
+        for row in rows
+        if "poll_turn" not in str(_value(row, "function_name", _value(row, "name", "")))
+        and "DBOS.sleep"
+        not in str(_value(row, "function_name", _value(row, "name", "")))
+    ]
+
+
+def _output(status: Any) -> dict:
+    value = _value(status, "output")
+    return value if isinstance(value, dict) else {}
+
+
+def _step_output(step: Any) -> Any:
+    return _value(step, "output", _value(step, "result"))
+
+
+def _queue_position(dbos: Any, workflow_ids: list[str]) -> int | None:
+    getter = getattr(dbos, "list_queued_workflows", None)
+    if not getter:
+        return None
+    queued = getter(queue_name="codex") or []
+    for position, row in enumerate(queued, 1):
+        if (
+            _value(row, "workflow_id", row if isinstance(row, str) else None)
+            in workflow_ids
+        ):
+            return position
+    return None
+
+
+def _short_sha(value: Any) -> Any:
+    """Commit shas render at 8 characters everywhere on this surface.
+
+    The server owns every string the client shows, so truncation happens here
+    rather than in the renderer. A full 40 character sha in a nowrap meta line
+    ellipsizes into something unreadable, and the contract fixtures are
+    explicit that these fields are short.
+    """
+    if not isinstance(value, str):
+        return value
+    return value[:8]
+
+
+def _finding(code: str | None, observed: str | None, prior: str | None) -> dict | None:
+    if not code and observed is None and prior is None:
+        return None
+    if code == "error":
+        text = "session start failed: embervm returned 502 Bad Gateway"
+    elif observed is None:
+        text = "the branch was not found on the remote after the turn completed, so the work was not pushed"
+        code = code or "branch_missing"
+    elif prior == observed:
+        text = "the branch exists on the remote but its head did not move during the turn; retried with push feedback"
+        code = code or "head_unchanged"
+    else:
+        text = "the branch head moved during this attempt"
+        code = code or "head_advanced"
+    return {"code": code, "text": text, "observed_head": _short_sha(observed)}
+
+
+def _attempts(session_rows: list[Any], steps: list[Any], node_key: str) -> list[dict]:
+    rows = sorted(
+        [r for r in session_rows if _value(r, "node_key") == node_key],
+        key=lambda r: _value(r, "node_attempt", 0) or 0,
+    )
+    observations = []
+    for step in steps:
+        name = str(_value(step, "function_name", _value(step, "name", "")))
+        if "read_branch_head" in name:
+            observations.append(_step_output(step))
+    result = []
+    for i, row in enumerate(rows):
+        prior = observations[i * 2] if i * 2 < len(observations) else None
+        observed = observations[i * 2 + 1] if i * 2 + 1 < len(observations) else None
+        if isinstance(prior, dict):
+            prior = prior.get("head", prior.get("sha"))
+        if isinstance(observed, dict):
+            observed = observed.get("head", observed.get("sha"))
+        state = _value(row, "status", "running")
+        attempt_state = "failed" if state == "warn" else state
+        result.append(
+            {
+                "n": _value(row, "node_attempt"),
+                "session_id": _value(row, "id"),
+                "local_session_id": _value(row, "local_session_id"),
+                "model": _value(row, "model"),
+                "state": "gated"
+                if state == "completed"
+                and observed == prior
+                and (prior is not None or observed is not None)
+                else attempt_state,
+                "started_at": _iso(_value(row, "created_at")),
+                "ended_at": _iso(_value(row, "last_turn_at"))
+                if state != "running"
+                else None,
+                "cost_usd": _value(row, "total_cost_usd", _value(row, "cost_usd")),
+                "finding": _finding(None, observed, prior),
+                "live": None
+                if state != "running"
+                else {
+                    "activity": _value(row, "activity"),
+                    "observed_at": _iso(_value(row, "last_turn_at")),
+                },
+            }
+        )
+    return result
+
+
+def _plan(attrs: dict) -> dict:
+    pinned = attrs.get("plan")
+    if isinstance(pinned, dict):
+        return {"pinned": True, "source": "recorded", **pinned}
+    return {
+        "pinned": False,
+        "source": "current_deploy",
+        "max_attempts": None,
+        "implementer_model": config.implementer_model(),
+        "reviewer_model": config.reviewer_model(),
+        "turn_timeout_seconds": None,
+        "version": 1,
+        "budget_usd": None,
+    }
+
+
+def _derived_state(
+    dbos_status: str, output: dict, nodes: list[dict], stranded: bool
+) -> str:
+    if dbos_status == "CANCELLED":
+        return "cancelled"
+    if stranded:
+        return "stranded"
+    if dbos_status == "SUCCESS":
+        if output.get("status") == "escalated":
+            return "escalated"
+        verdict = output.get("review_verdict") or output.get("verdict")
+        if verdict == "approve":
+            return "approved"
+        if verdict == "request_changes":
+            return "changes_requested"
+        return "escalated"
+    if any(n["state"] == "queued" for n in nodes):
+        return "queued"
+    if any(n["key"] == "review" and n["state"] == "running" for n in nodes):
+        return "reviewing"
+    if any(n["state"] == "blocked" for n in nodes):
+        return "blocked"
+    return "running"
+
+
+def compose_run(dbos, workflow_id, session_rows, server_app_version) -> dict | None:
+    workflow = dbos.retrieve_workflow(workflow_id)
+    if workflow is None:
+        return None
+    status = _status(workflow)
+    if status is None:
+        return None
+    attrs = _attributes(workflow, status)
+    if not attrs:
+        getter = getattr(dbos, "get_workflow_attributes", None)
+        if getter:
+            attrs = getter(workflow_id) or {}
+    raw_value = _value(status, "status", "PENDING")
+    raw = str(_value(raw_value, "value", raw_value))
+    inp = _input(status)
+    output = _output(status)
+    app_version = _value(
+        status, "app_version", attrs.get("app_version", inp.get("app_version"))
+    )
+    stranded = raw in ("PENDING", "ENQUEUED") and app_version != server_app_version
+    steps = _steps(dbos, workflow_id)
+    children = _children(dbos, workflow_id)
+    plan = _plan(attrs)
+    model_i = plan["implementer_model"]
+    model_r = plan["reviewer_model"]
+    sessions = list(session_rows or [])
+    implement_attempts = _attempts(sessions, steps, "implement")
+    review_attempts = _attempts(sessions, steps, "review")
+    first = implement_attempts[0] if implement_attempts else None
+    if raw == "CANCELLED":
+        implement_state = "failed" if first else "cancelled"
+        gate_state, review_state = "cancelled", "cancelled"
+    elif output.get("status") == "escalated":
+        implement_state, gate_state, review_state = "escalated", "refused", "cancelled"
+    elif output.get("review_verdict") == "approve":
+        implement_state, gate_state, review_state = "done", "passed", "done"
+    elif review_attempts and _value(review_attempts[-1], "state") == "running":
+        implement_state, gate_state, review_state = "done", "passed", "running"
+    elif implement_attempts and _value(implement_attempts[-1], "state") == "running":
+        implement_state, gate_state, review_state = "running", "waiting", "future"
+    else:
+        implement_state, gate_state, review_state = "future", "future", "future"
+    if stranded:
+        gate_state = "waiting"
+    child_ids = [
+        _value(_status(child), "workflow_id", _value(child, "workflow_id"))
+        for child in children
+    ]
+    position = _queue_position(dbos, [workflow_id, *[x for x in child_ids if x]])
+    if position and implement_state == "future":
+        implement_state = "queued"
+    gate_decision = None
+    if gate_state in ("waiting", "passed") and not stranded:
+        gate_decision = {
+            "register": "fact" if plan["pinned"] else "belief",
+            "basis": "policy.next_action"
+            if plan["pinned"]
+            else "policy.next_action with an unrecorded retry bound",
+            "outcomes": (
+                [
+                    {"when": "head moved", "then": f"review ({model_r})"},
+                    {"when": "head unchanged", "then": "escalate, no attempts left"},
+                    {"when": "turn times out", "then": "escalate, no attempts left"},
+                ]
+                if plan["pinned"]
+                else [
+                    {"when": "head moved", "then": f"review ({model_r})"},
+                    {
+                        "when": "head unchanged",
+                        "then": "retry or escalate; the bound was not recorded for this run",
+                    },
+                ]
+            ),
+        }
+    nodes = [
+        {
+            "key": "implement",
+            "kind": "work",
+            "label": "implement",
+            "state": implement_state,
+            "model": model_i,
+            "attempts": implement_attempts,
+            "queue": {"name": "codex", "position": position} if position else None,
+            "decision": None,
+            "verdict": None,
+            "note": None,
+            "deps": [],
+            "blocked_on": None,
+            "evidence": None,
+        },
+        {
+            "key": "push_gate",
+            "kind": "gate",
+            "label": "push gate",
+            "state": gate_state,
+            "model": None,
+            "attempts": [],
+            "queue": None,
+            "decision": gate_decision,
+            "verdict": None,
+            "note": None,
+            "deps": ["implement"],
+            "blocked_on": None,
+            "evidence": {
+                "kind": "branch_head",
+                "summary": (
+                    f"head {_short_sha(output.get('branch_head'))} "
+                    "observed on the remote after the turn"
+                ),
+            }
+            if output.get("branch_head")
+            else None,
+        },
+        {
+            "key": "review",
+            "kind": "work",
+            "label": "review",
+            "state": review_state,
+            "model": model_r,
+            "attempts": review_attempts,
+            "queue": None,
+            "decision": None,
+            "verdict": (
+                {
+                    "value": output.get("review_verdict"),
+                    "excerpt": (output.get("review_text") or "")[:240],
+                    "commit_sha": output.get("commit_sha"),
+                    "commit_url": f"https://github.com/{inp.get('repo')}/commit/{output.get('commit_sha')}",
+                }
+                if output.get("review_verdict")
+                else None
+            ),
+            "note": "never dispatched: nothing was verified for review"
+            if review_state == "cancelled" and gate_state == "refused"
+            else None,
+            "deps": ["push_gate"],
+            "blocked_on": None,
+            "evidence": None,
+        },
+    ]
+    work_branch = output.get("work_branch") or f"claude/swarm-{workflow_id}"
+    return {
+        "workflow_id": workflow_id,
+        "dbos_status": raw,
+        "state": _derived_state(raw, output, nodes, stranded),
+        "task": {
+            "text": inp.get("task", ""),
+            "repo": inp.get("repo"),
+            "base_branch": inp.get("branch"),
+        },
+        "work_branch": work_branch,
+        "branch_url": f"https://github.com/{inp.get('repo')}/tree/{work_branch}",
+        "created_at": _iso(_value(status, "created_at")),
+        "updated_at": _iso(_value(status, "updated_at")),
+        "completed_at": _iso(_value(status, "completed_at")),
+        "app_version": app_version,
+        "server_app_version": server_app_version,
+        "stranded": stranded,
+        "cost_usd": sum(
+            float(_value(row, "total_cost_usd", _value(row, "cost_usd", 0)) or 0)
+            for row in sessions
+        ),
+        "note": None,
+        "plan": plan,
+        "nodes": nodes,
+        "cancelled_by": attrs.get("cancelled_by"),
+    }
+
+
+def compose_master(dbos, active, session_costs, server_app_version) -> dict:
+    kwargs = {"has_parent": False, "load_input": True}
+    if active:
+        kwargs["status"] = ["PENDING", "ENQUEUED"]
+    else:
+        kwargs.update(limit=50, sort_desc=True)
+    statuses = list(dbos.list_workflows(**kwargs) or [])
+    runs = []
+    for workflow in statuses:
+        status = _status(workflow)
+        wf_id = _value(status, "workflow_id", _value(workflow, "workflow_id"))
+        rows = session_costs.get(wf_id, []) if isinstance(session_costs, dict) else []
+        run = compose_run(dbos, wf_id, rows, server_app_version)
+        if not run:
+            continue
+        current = next(
+            (
+                n
+                for n in run["nodes"]
+                if n["state"]
+                in ("running", "queued", "blocked", "escalated", "waiting")
+            ),
+            run["nodes"][-1],
+        )
+        created = run["created_at"]
+        elapsed = None
+        if created:
+            try:
+                elapsed = int(
+                    (
+                        datetime.now(timezone.utc)
+                        - datetime.fromisoformat(created.replace("Z", "+00:00"))
+                    ).total_seconds()
+                )
+            except (TypeError, ValueError):
+                pass
+        needs = None
+        if run["state"] == "escalated":
+            needs = {
+                "kind": "escalated",
+                "reason": current.get("note")
+                or f"{current['label']} needs a human look",
+            }
+        elif run["state"] == "stranded":
+            needs = {
+                "kind": "stranded",
+                "reason": f"started on build {run['app_version']}, server is on {run['server_app_version']}; will not resume unaided",
+            }
+        elif (
+            current["state"] == "blocked"
+            and (current.get("blocked_on") or {}).get("kind") == "human"
+        ):
+            needs = {"kind": "human", "reason": "waiting on your decision"}
+        runs.append(
+            {
+                "workflow_id": wf_id,
+                "state": run["state"],
+                "title": run["task"]["text"].splitlines()[0],
+                "current": {"label": current["label"], "state": current["state"]},
+                "elapsed_seconds": elapsed,
+                "bound_seconds": run["plan"]["turn_timeout_seconds"]
+                if run["plan"]["pinned"]
+                else None,
+                "cost_usd": run["cost_usd"],
+                "needs": needs,
+                "queue_position": current["queue"]["position"]
+                if current["queue"]
+                else None,
+                "updated_at": run["updated_at"],
+            }
+        )
+    queued = getattr(dbos, "list_queued_workflows", lambda **_: [])(queue_name="codex")
+    waiting = len(queued or [])
+    running = sum(1 for run in runs if run["current"]["state"] == "running")
+    return {
+        "queues": [
+            {
+                "name": "codex",
+                "concurrency": config.codex_concurrency(),
+                "running": running,
+                "waiting": waiting,
+            }
+        ],
+        "runs": runs,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }

--- a/projects/monolith/swarm/view_test.py
+++ b/projects/monolith/swarm/view_test.py
@@ -1,0 +1,210 @@
+from datetime import datetime, timezone
+
+from swarm.view import compose_run
+
+
+class Status:
+    def __init__(self, workflow_id, status, args, output=None, **extra):
+        self.workflow_id = workflow_id
+        self.status = status
+        self.input = {"args": args}
+        self.output = output
+        self.app_version = "unknown"
+        self.created_at = datetime(2026, 8, 10, 4, 6, 45, tzinfo=timezone.utc)
+        self.updated_at = datetime(2026, 8, 10, 4, 10, 58, tzinfo=timezone.utc)
+        for key, value in extra.items():
+            setattr(self, key, value)
+
+
+class Workflow:
+    def __init__(self, status, attributes=None):
+        self.status = status
+        self.attributes = attributes or {}
+
+    def get_status(self):
+        return self.status
+
+
+class DBOS:
+    def __init__(self, workflow, steps=None, queued=None):
+        self.workflow = workflow
+        self.steps = steps or []
+        self.queued = queued or []
+
+    def retrieve_workflow(self, workflow_id):
+        return (
+            self.workflow if self.workflow.status.workflow_id == workflow_id else None
+        )
+
+    def list_workflow_steps(self, workflow_id):
+        return self.steps
+
+    def list_workflows(self, **kwargs):
+        return []
+
+    def list_queued_workflows(self, **kwargs):
+        return self.queued
+
+
+def session(n, status="warn", node="implement", attempt=1):
+    return {
+        "id": 171,
+        "local_session_id": f"swarm-smoke-2-{node}-{attempt}",
+        "node_key": node,
+        "node_attempt": attempt,
+        "status": status,
+        "model": "luna",
+        "total_cost_usd": 0,
+        "created_at": datetime(2026, 8, 10, 4, 6, 57, tzinfo=timezone.utc),
+        "last_turn_at": datetime(2026, 8, 10, 4, 7, 35, tzinfo=timezone.utc),
+    }
+
+
+# Copied from contract v4 fixture fx4, the expected run fragments under test.
+FX4_EXPECTED_PLAN = {
+    "pinned": True,
+    "source": "recorded",
+    "max_attempts": 2,
+    "implementer_model": "luna",
+    "reviewer_model": "opus",
+    "turn_timeout_seconds": 1800,
+    "version": 1,
+    "budget_usd": None,
+}
+FX4_EXPECTED_CANCELLED_BY = {"actor": "joe", "at": "2026-08-10T04:10:58Z"}
+
+
+def test_cancelled_run_uses_engine_state_and_preserves_warn_session():
+    status = Status(
+        "swarm-smoke-2",
+        "CANCELLED",
+        [
+            "Add a docstring to next_action and push the branch",
+            "jomcgi/homelab",
+            "main",
+        ],
+    )
+    run = compose_run(
+        DBOS(
+            Workflow(
+                status,
+                {"plan": FX4_EXPECTED_PLAN, "cancelled_by": FX4_EXPECTED_CANCELLED_BY},
+            )
+        ),
+        "swarm-smoke-2",
+        [session(171)],
+        "b7a44d1c",
+    )
+    assert run["state"] == "cancelled"
+    assert run["dbos_status"] == "CANCELLED"
+    assert run["cancelled_by"] == FX4_EXPECTED_CANCELLED_BY
+    assert run["nodes"][0]["attempts"][0]["state"] == "failed"
+
+
+def test_escalated_success_carries_branch_head_and_no_commit():
+    status = Status(
+        "wf-1",
+        "SUCCESS",
+        ["task", "jomcgi/homelab", "main"],
+        {
+            "status": "escalated",
+            "branch_head": "e51a09c2",
+            "work_branch": "claude/wf-1",
+        },
+    )
+    run = compose_run(
+        DBOS(Workflow(status, {"plan": FX4_EXPECTED_PLAN})), "wf-1", [], "b7a44d1c"
+    )
+    assert run["state"] == "escalated"
+    assert run["nodes"][1]["evidence"]["kind"] == "branch_head"
+    assert run["nodes"][2]["verdict"] is None
+
+
+def test_stranded_pending_has_no_decision():
+    status = Status("wf-2", "PENDING", ["task", "repo", "main"], app_version="old")
+    run = compose_run(
+        DBOS(Workflow(status, {"plan": FX4_EXPECTED_PLAN})), "wf-2", [], "new"
+    )
+    assert run["state"] == "stranded"
+    assert run["stranded"] is True
+    assert run["app_version"] == "old"
+    assert run["server_app_version"] == "new"
+    assert run["nodes"][1]["decision"] is None
+
+
+def _running_implement(workflow_id):
+    """One in-flight implement attempt.
+
+    A decision renders on the ACTIVE gate only. A run with no sessions at all
+    has nothing running, so its gate is still in the future and correctly
+    carries no decision; the register distinction only exists once the gate is
+    actually being evaluated.
+    """
+    return [
+        {
+            "id": 1,
+            "local_session_id": f"{workflow_id}-implement-1",
+            "node_key": "implement",
+            "node_attempt": 1,
+            "status": "running",
+            "model": "luna",
+            "created_at": datetime(2026, 8, 10, 22, 50, tzinfo=timezone.utc),
+            "last_turn_at": datetime(2026, 8, 10, 22, 56, tzinfo=timezone.utc),
+            "total_cost_usd": 0.09,
+        }
+    ]
+
+
+def test_pinned_and_unpinned_registers_are_distinct(monkeypatch):
+    pinned_status = Status("wf-3", "PENDING", ["task", "repo", "main"])
+    pinned = compose_run(
+        DBOS(Workflow(pinned_status, {"plan": FX4_EXPECTED_PLAN})),
+        "wf-3",
+        _running_implement("wf-3"),
+        "unknown",
+    )
+    assert pinned["plan"] == FX4_EXPECTED_PLAN
+    assert pinned["nodes"][1]["decision"]["register"] == "fact"
+
+    monkeypatch.setenv("SWARM_IMPLEMENTER_MODEL", "luna")
+    unpinned_status = Status("wf-4", "PENDING", ["task", "repo", "main"])
+    unpinned = compose_run(
+        DBOS(Workflow(unpinned_status)), "wf-4", _running_implement("wf-4"), "unknown"
+    )
+    assert unpinned["plan"]["pinned"] is False
+    assert unpinned["plan"]["max_attempts"] is None
+    assert unpinned["nodes"][1]["decision"]["register"] == "belief"
+
+
+def test_queued_child_gets_codex_position():
+    status = Status("wf-5", "PENDING", ["task", "repo", "main"])
+    run = compose_run(
+        DBOS(
+            Workflow(status, {"plan": FX4_EXPECTED_PLAN}),
+            queued=[{"workflow_id": "wf-5"}],
+        ),
+        "wf-5",
+        [],
+        "unknown",
+    )
+    assert run["state"] == "queued"
+    assert run["nodes"][0]["queue"] == {"name": "codex", "position": 1}
+
+
+def test_shas_render_at_eight_characters():
+    # The contract fixtures are explicit that every sha on this surface is
+    # short, and the server owns every string the client shows. A full 40
+    # character sha in a nowrap meta line ellipsizes into nothing useful, so
+    # this pins the wording the mockup was approved against.
+    full = "86dcbf416158031d18c65a3c37120e044dc13fbc"
+    status = Status(
+        "wf-sha",
+        "SUCCESS",
+        ["task", "repo", "main"],
+        output={"status": "review", "review_verdict": "approve", "branch_head": full},
+    )
+    run = compose_run(DBOS(Workflow(status)), "wf-sha", [], "unknown")
+    gate = next(n for n in run["nodes"] if n["key"] == "push_gate")
+    assert gate["evidence"]["summary"] == (
+        "head 86dcbf41 observed on the remote after the turn"
+    )


### PR DESCRIPTION
Slice 4 of the run view program (#4625, ADR agents/054). `GET /api/swarm/runs` and `GET /api/swarm/runs/{id}`, composed per contract v4.

## The server owns epistemics

Every prose string and every register declaration is produced server side: findings, gate decisions, evidence summaries, and the fact-versus-belief marking that tells the client which visual register an element belongs to. The client maps register to style and holds no prose of its own.

This is not stylistic. Composing a sentence client side produces a string that traces to no contract field, which is exactly what the payload-driven mockup's live audit is built to catch.

## State is derived, not copied

A run can be DBOS `SUCCESS` while its output says `escalated`, so a single status field cannot drive the header. `dbos_status` passes through raw and `state` is derived beside it. `CANCELLED` takes precedence over stranded, and an unparseable verdict escalates rather than being read as approval.

**Stranding is now reported.** DBOS recovery and queue dequeue are both `app_version` scoped, so an active run on a mismatched version will not resume unaided. Given this repo deploys on nearly every merge, that is a routine state that was previously invisible everywhere.

## Review findings, fixed before this PR

- **Shas rendered at full length.** The contract fixtures are explicit that every sha on this surface is eight characters. The composition passed raw 40-character values into `observed_head` and the gate evidence summary, which in a nowrap meta line ellipsizes into nothing readable. Truncation now happens server side (the server owns the string), with a test pinning the exact approved wording.
- **A test asserting an impossible scenario.** `test_pinned_and_unpinned_registers_are_distinct` built a PENDING run with zero sessions and expected a gate decision. A decision renders on the ACTIVE gate; a run with nothing running correctly has none. Fixed the fixture to be genuinely in-flight rather than loosening the assertion.

## Structure

`view.py` imports no FastAPI and holds no DB session: DBOS records in, contract dicts out, which is what makes it testable without a server. `tier_test.py` asserts `swarm` stays absent from the public module registry, so the private-tier boundary is CI-checked rather than remembered.

## Verification

- `compose_run` / `compose_master` present; no FastAPI import in `view.py`; `poll_turn` appears only in the step-noise exclusion filter (a 30-minute turn logs hundreds of poll rows).
- `view_test.py` covers the cancelled-run case, escalated SUCCESS, stranded PENDING, pinned versus unpinned registers, and codex queue position.
- `ci test`: `Executed 55 out of 750 tests: 750 tests pass.` The total moved 748 to 750 because two new targets were added, which is the expected signature for new test files rather than new test functions.
- `ci lint` clean.

Chart bumped to 0.285.526.

Post-merge check, which closes the loop this whole program started from: `GET /api/swarm/runs/swarm-smoke-2` returns `state: "cancelled"`. The sidebar rollup reports that same run as "1 warn" because session status is all it has.