### PR TITLE
feat(monolith): allowlist API ingress to close X-Auth-Email forgery

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.285.527
+version: 0.285.528
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.285.527
+      targetRevision: 0.285.528
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.527
+version: 0.285.528
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cilium-ingress-policy.yaml
+++ b/projects/monolith/chart/templates/cilium-ingress-policy.yaml
@@ -1,0 +1,123 @@
+{{- /*
+Allowlist ingress to the monolith app pod, so an in-cluster workload cannot
+reach the API and forge the X-Auth-Email identity header.
+
+Why ingress: here and not egressDeny. The sibling cilium-policy.yaml
+deliberately uses egressDeny because it denies only what it names and so
+cannot cause an outage by omission. This file makes the opposite trade on
+purpose: ingress: makes the selected endpoint default-deny for ALL other
+ingress, which is the only shape that actually closes header forgery from an
+arbitrary pod. That is precisely why it is gated default-false and why the
+allowlist below is exhaustive rather than illustrative. A caller omitted here
+fails as a silent dial timeout, not a readable deny (see PR #4294).
+
+The selector picks one pod carrying three containers. The monolith pod runs
+backend (containerPort 8000, named api), progress-ingest (8091, named
+progress) and frontend (3000, named http). One pod is one Cilium endpoint, so
+an ingress rule default-denies all three ports at once. That is why a policy
+about the API must also allowlist 3000 and 8091.
+
+Service ports and container ports coincide here (3000, 8000, 8091), but the
+rule is written against the pod ports on purpose. Cilium enforces policy after
+service DNAT, so a rule naming a service port that differed from its
+targetPort would silently fail to match.
+
+fromEntities: [host, health] is mandatory, not optional. kubelet probes
+originate from the node. Once any ingress rule selects the endpoint it becomes
+default-deny and the pod never goes Ready without this. The backend has a
+readiness probe on api every 5s and liveness every 10s; progress-ingest has
+liveness on progress every 20s.
+
+Provenance of each allowlist entry:
+  - envoy-gateway-system to 3000 AND 8000: the monolith-private HTTPRoute has
+    backendRefs to both monolith:3000 and monolith:8000, and monolith-github-webhook
+    routes to monolith:8000. The 8000 entry is easy to miss because the private
+    console reaches the backend over API_BASE=http://localhost:8000 (same pod,
+    so it never crosses a Cilium boundary) and short Hubble windows therefore
+    show no gateway traffic to 8000 at all.
+  - mcp to 8000: Context Forge federates to the monolith API. Observed live.
+  - monolith-workflows to 8000: Argo Workflows POST to MONOLITH_INTERNAL_URL
+    (http://monolith.monolith.svc.cluster.local:8000), set in chart/values.yaml.
+    These are periodic and short-lived, so they do not appear in a short Hubble
+    window; they come from config, not observation.
+  - monolith component: whatsapp to 8000: the whatsapp gateway posts to
+    whatsapp.monolithInboundUrl, which is .../8000/internal/whatsapp/inbound.
+    Selected by pod label rather than by opening the whole namespace.
+  - embervm to 8091: the guest egress-proxy sidecar in the noded brick pods
+    forwards guest progress to /ingest/progress.
+
+What this does NOT close, and what was already closed. EmberVM session guests
+were the originally suspected forger and they are not one: a task/session claim
+boots with no NIC at all (projects/embervm/noded/fcvm/driver/driver.go:971,
+vsock only), and their single channel is the egress proxy, which runs
+internal.default: deny with a two-entry allowlist that deliberately excludes
+port 8000. This policy is about any OTHER in-cluster workload. Also note that
+as of today no handler authorizes on X-Auth-Email: the only consumer is
+agent_sessions/router.py, which records it as the triggered_by attribution
+column. So this is insurance taken out before the preview authorization work
+starts keying on that header, not a fix for a live privilege escalation.
+
+Before flipping the gate, confirm the allowlist against live traffic with
+`hubble observe --to-namespace monolith --last 500`, remembering that periodic
+callers (Argo workflows, the hourly jobs) will not show up in a short window.
+*/}}
+{{- if .Values.ciliumPolicy.ingress.enabled }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-api-ingress
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  description: >-
+    Allowlist ingress to the monolith app pod so an in-cluster workload cannot
+    reach the API and forge the X-Auth-Email identity header.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: monolith
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: app
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+            - port: "8000"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: mcp
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monolith-workflows
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: monolith
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            app.kubernetes.io/component: whatsapp
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: embervm
+      toPorts:
+        - ports:
+            - port: "8091"
+              protocol: TCP
+    - fromEntities:
+        - host
+        - health
+{{- end }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1243,3 +1243,13 @@ ciliumPolicy:
     enabled: false
     gatewayNamespace: mcp
     gatewayPodLabel: context-forge-gateway-mcp-stack-mcpgateway
+  # Allowlist ingress to the monolith app pod, so an in-cluster workload cannot
+  # reach the API and forge the X-Auth-Email identity header (issue #4628).
+  #
+  # Unlike tokenReplayDeny above this uses `ingress`, which makes the pod
+  # default-deny for every source it does not name, so the allowlist in
+  # templates/cilium-ingress-policy.yaml must be exhaustive. Default false:
+  # merging is inert, and a deploy override opts in after confirming the
+  # allowlist covers every live caller.
+  ingress:
+    enabled: false

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.527
+      targetRevision: 0.285.528
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Closes #4628.

## What changed

A `CiliumNetworkPolicy` on the monolith app pod allowlisting ingress, gated `ciliumPolicy.ingress.enabled` and default-false, so merging is inert. The chart bump ships the template into the OCI chart, which is what makes a later gate flip possible: the gate lives in values, the template lives in the chart pinned by `targetRevision`.

## The issue's premise did not hold, and that is worth reading

#4628 said EmberVM guests could forge the header, citing `shim.py:1236` posting to `monolith:8091` as proof guests reach the cluster network. That is the opposite of what that line shows. It builds a `urllib` `ProxyHandler` pointed at the vsock egress port five lines earlier, so it is a proxied call to one of exactly two allowlisted destinations.

Guests cannot forge anything, for two independent reasons:

- A task or session claim boots with **no NIC at all**. `noded/fcvm/driver/driver.go:971` attaches one only when `cb.nic != nil`, which is the serving cold-boot path, because Firecracker cannot hot-attach a NIC to a resumed snapshot.
- Their one channel is the egress proxy, running `internal.default: deny` (`embervm/chart/values.yaml:1179`, rendered `| default "deny"` so it is fail-closed) with a two-entry allowlist that deliberately excludes port 8000.

What is true is the general case: the monolith has no ingress policy, so any *other* in-cluster pod can reach `:8000`. And no handler authorizes on `X-Auth-Email` today. The only consumer is `agent_sessions/router.py`, recording it as the `triggered_by` attribution column. So this is insurance taken out before the preview authorization work keys on that header, not a fix for live privilege escalation.

## Why the allowlist is shaped this way

An `ingress:` rule makes the endpoint default-deny for every unnamed source, unlike the sibling `cilium-policy.yaml`, which uses `egressDeny` specifically so it cannot cause an outage by omission. This file takes the opposite trade deliberately, so the allowlist has to be exhaustive.

| source | port | how it was established |
|---|---|---|
| `envoy-gateway-system` | 3000, 8000 | `monolith-private` HTTPRoute has backendRefs to both; `monolith-github-webhook` routes to 8000 |
| `mcp` | 8000 | Context Forge federation, observed live |
| `monolith-workflows` | 8000 | Argo Workflows POST `MONOLITH_INTERNAL_URL`, from config |
| `component: whatsapp` | 8000 | `whatsapp.monolithInboundUrl` |
| `embervm` | 8091 | guest egress-proxy sidecar to `/ingest/progress` |
| `host`, `health` | all | kubelet probes, or the pod never goes Ready |

Two of those would have been missed by observation alone. The gateway to `:8000` entry does not appear in a short Hubble window because the private console reaches the backend over `API_BASE=http://localhost:8000`, same pod, never crossing a Cilium boundary. The `monolith-workflows` entry comes from config only, since those jobs are periodic and short-lived.

Ports are written against pod ports on purpose. They coincide with the service ports here, but Cilium enforces after service DNAT, so a divergent targetPort would silently fail to match (cf. #4294).

## Verification

- `helm template` with the gate off renders no `monolith-api-ingress`; with `--set ciliumPolicy.ingress.enabled=true` it renders all six rules.
- `ci test`: `Executed 1 out of 750 tests: 750 tests pass`.
- Not enabled in `deploy/values.yaml`. Nothing changes in production on merge.

Before flipping the gate, confirm the allowlist against `hubble observe --to-namespace monolith --last 500`, remembering periodic callers will not appear in a short window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)