### PR TITLE
feat(monolith): make the swarm run view reachable from the console

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -21,6 +21,7 @@
   import "./run-view.css";
   import RunView from "./RunView.svelte";
   import MasterView from "./MasterView.svelte";
+  import { RUN_LEXICON as P } from "./run-lexicon.js";
 
   let { data } = $props();
 
@@ -42,9 +43,14 @@
   let sessions = $state(data.sessions ?? []);
   let runs = $state([]);
   let runMaster = $state({ runs: [], queues: [] });
+  let masterView = $state({
+    engine_tier: "live",
+    snapshot_age_seconds: 0,
+  });
+  let masterSnapshotFetchedAt = 0;
+  let masterHasSnapshot = false;
   let selectedRunId = $state(null);
   let runDetail = $state(null);
-  let runError = $state(false);
   let runRequestSequence = 0;
   let detail = $state(null);
   let searchQuery = $state("");
@@ -378,9 +384,19 @@
       const body = await response.json();
       runMaster = body.master ?? body;
       runs = runMaster.runs ?? [];
-      runError = false;
+      masterSnapshotFetchedAt = Date.now();
+      masterHasSnapshot = true;
+      masterView = { engine_tier: "live", snapshot_age_seconds: 0 };
     } catch {
-      runError = true;
+      masterView = masterHasSnapshot
+        ? {
+            engine_tier: "stale",
+            snapshot_age_seconds: Math.max(
+              1,
+              Math.floor((Date.now() - masterSnapshotFetchedAt) / 1000),
+            ),
+          }
+        : { engine_tier: "absent", snapshot_age_seconds: 0 };
     }
   }
 
@@ -402,11 +418,12 @@
             now: new Date().toISOString(),
             snapshot_age_seconds: 0,
           },
-          sessions: body.sessions ?? sessions,
+          sessions: (body.sessions ?? sessions).filter(
+            (session) => String(session.workflow_id) === String(id),
+          ),
         };
       }
     } catch {
-      runError = true;
       if (
         sequence === runRequestSequence &&
         String(selectedRunId) === String(id)
@@ -426,7 +443,9 @@
         } else {
           runDetail = {
             run: null,
-            sessions,
+            sessions: sessions.filter(
+              (session) => String(session.workflow_id) === String(id),
+            ),
             view: {
               engine_tier: "absent",
               now: new Date().toISOString(),
@@ -1028,7 +1047,7 @@
         <RunView
           run={runDetail.run}
           view={runDetail.view}
-          sessions={runDetail.sessions ?? sessions}
+          sessions={runDetail.sessions}
           onSelectSession={selectSession}
           onCancel={() => cancelRun(selectedRunId)}
         />
@@ -1229,7 +1248,11 @@
         </div>
       </form>
     {:else}
-      <MasterView master={runMaster} />
+      <MasterView
+        master={runMaster}
+        onSelectRun={selectRun}
+        view={masterView}
+      />
     {/if}
   </section>
 
@@ -1362,17 +1385,23 @@
 {#snippet sessionGroup(entry, active)}
   <div class="session-group">
     <button
-      class="group-header"
+      class="group-header group-main"
       type="button"
-      aria-expanded={isGroupExpanded(entry, active)}
-      onclick={() => toggleGroup(entry, active)}
+      onclick={() => selectRun(entry.workflowId)}
     >
       <span class="group-id mono">{shortWorkflowId(entry.workflowId)}</span>
       <span class="group-summary">{groupSummary(entry.counts)}</span>
-      <span class="group-toggle" aria-hidden="true"
-        >{isGroupExpanded(entry, active) ? "▾" : "▸"}</span
-      >
     </button>
+    <button
+      class="group-header group-chevron"
+      type="button"
+      aria-expanded={isGroupExpanded(entry, active)}
+      aria-label={isGroupExpanded(entry, active)
+        ? P.labels.collapseMembers
+        : P.labels.expandMembers}
+      onclick={() => toggleGroup(entry, active)}
+      >{isGroupExpanded(entry, active) ? "▾" : "▸"}</button
+    >
     {#if isGroupExpanded(entry, active)}
       <div class="group-members">
         {#each entry.sessions as session (session.id)}
@@ -1617,9 +1646,10 @@
   }
   .session-group {
     min-width: 0;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
   }
   .group-header {
-    width: 100%;
     min-width: 0;
     display: flex;
     align-items: center;
@@ -1631,6 +1661,14 @@
     text-align: left;
     font-size: var(--size-meta);
     white-space: nowrap;
+  }
+  .group-main {
+    width: 100%;
+  }
+  .group-chevron {
+    width: auto;
+    padding-right: 8px;
+    padding-left: 8px;
   }
   .group-id,
   .group-summary {
@@ -1649,6 +1687,7 @@
     flex: 0 0 auto;
   }
   .group-members {
+    grid-column: 1 / -1;
     padding-left: 10px;
   }
   .session-row,

--- a/projects/monolith/frontend/src/routes/private/agents/MasterView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/MasterView.svelte
@@ -1,61 +1,116 @@
 <script>
   import { fmtCost, fmtDur } from "./run-format.js";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
-  let { master } = $props();
+  let {
+    master,
+    onSelectRun = () => {},
+    view = { engine_tier: "live", snapshot_age_seconds: 0 },
+  } = $props();
   const total = $derived(
     master.runs.reduce((sum, run) => sum + Number(run.cost_usd || 0), 0),
   );
 </script>
 
-<div class="runview master-view">
+<div
+  class:tier-stale={view.engine_tier === "stale"}
+  class="runview master-view"
+>
   <div class="rv-eyebrow">
     <span class="eyebrow-label">{P.labels.masterEyebrow}</span><span
       class="rv-id">{master.runs.length} {P.labels.inFlight}</span
     >
   </div>
-  {#if master.runs.some((run) => run.needs)}<div class="att-band">
-      <div class="col-label">{P.labels.attention}</div>
-      {#each master.runs.filter((run) => run.needs) as run}<div class="att-row">
-          <div class="att-title">
-            {run.title}
-            <span class="entry-meta">{P.stateWords[run.state]}</span>
-          </div>
-          <div class="att-reason">{run.needs.reason}</div>
-        </div>{/each}
-    </div>{:else}<div class="m-quiet">{P.labels.nothingNeedsYou}</div>{/if}
-  {#each master.queues as queue}<div class="queue-line">
-      {queue.name}
-      {P.labels.queueWord}
-      {P.punct.dot}
-      {queue.running}
-      {P.labels.runningWord}
-      {P.labels.of}
-      {queue.concurrency}
-      {P.punct.dot}
-      {queue.waiting}
-      {P.labels.waitingWord}
-    </div>{/each}
-  {#if master.runs.length}<div class="m-list">
-      {#each master.runs as run}<div class="m-row">
-          <span class={`state-chip s-${run.state}`}
-            >{P.stateWords[run.state] || run.state}</span
-          ><span class="m-title">{run.title}</span><span class="m-meta"
-            >{run.current
-              .label}{#if run.elapsed_seconds != null && run.bound_seconds != null}
-              {P.punct.dot}
-              {fmtDur(run.elapsed_seconds)}
-              {P.labels.of}
-              {fmtDur(run.bound_seconds)}{/if}{#if fmtCost(run.cost_usd)}
-              {P.punct.dot} {fmtCost(run.cost_usd)}{/if}</span
+  {#if view.engine_tier === "absent"}
+    <div class="m-quiet">{P.labels.absentNotice}</div>
+  {:else}
+    {#if master.runs.some((run) => run.needs)}<div class="att-band">
+        <div class="col-label">{P.labels.attention}</div>
+        {#each master.runs.filter((run) => run.needs) as run}<button
+            class="att-row"
+            type="button"
+            aria-label={`${P.labels.run} ${run.title}${P.punct.colon} ${P.stateWords[run.state] || run.state}`}
+            onclick={() => onSelectRun(run.workflow_id)}
           >
-        </div>{/each}
-    </div>{:else}<div class="m-quiet">{P.labels.noRuns}</div>{/if}
-  <div class="m-totals">
-    {P.labels.spend}
-    {P.punct.colon}
-    {fmtCost(total) || "$0.00"}
-    {P.punct.dot}
-    {master.runs.length}
-    {P.labels.runsWord}
-  </div>
+            <div class="att-title">
+              {run.title}
+              <span class="entry-meta">{P.stateWords[run.state]}</span>
+            </div>
+            <div class="att-reason">{run.needs.reason}</div>
+          </button>{/each}
+      </div>{:else}<div class="m-quiet">{P.labels.nothingNeedsYou}</div>{/if}
+    {#each master.queues as queue}<div class="queue-line">
+        {queue.name}
+        {P.labels.queueWord}
+        {P.punct.dot}
+        {queue.running}
+        {P.labels.runningWord}
+        {P.labels.of}
+        {queue.concurrency}
+        {P.punct.dot}
+        {queue.waiting}
+        {P.labels.waitingWord}
+      </div>{/each}
+    {#if master.runs.length}<div class="m-list">
+        {#each master.runs as run}<button
+            class="m-row"
+            type="button"
+            aria-label={`${P.labels.run} ${run.title}${P.punct.colon} ${P.stateWords[run.state] || run.state}`}
+            onclick={() => onSelectRun(run.workflow_id)}
+          >
+            <span class={`state-chip s-${run.state}`}
+              >{P.stateWords[run.state] || run.state}</span
+            ><span class="m-title">{run.title}</span><span class="m-meta"
+              >{run.current
+                .label}{#if run.elapsed_seconds != null && run.bound_seconds != null}
+                {P.punct.dot}
+                {fmtDur(run.elapsed_seconds)}
+                {P.labels.of}
+                {fmtDur(run.bound_seconds)}{/if}{#if fmtCost(run.cost_usd)}
+                {P.punct.dot} {fmtCost(run.cost_usd)}{/if}</span
+            >
+          </button>{/each}
+      </div>{:else}<div class="m-quiet">{P.labels.noRuns}</div>{/if}
+    <div class="m-totals">
+      {P.labels.spend}
+      {P.punct.colon}
+      {fmtCost(total) || "$0.00"}
+      {P.punct.dot}
+      {master.runs.length}
+      {P.labels.runsWord}
+    </div>
+    {#if view.engine_tier === "stale"}<div class="rv-foot">
+        {P.labels.engine}{P.punct.colon}
+        {P.labels.staleShowing}
+        {fmtDur(view.snapshot_age_seconds)}
+        {P.labels.staleOld}
+      </div>{/if}
+  {/if}
 </div>
+
+<style>
+  /* These two were divs before they became selectable. The UA button border
+     and background have to go, but .m-row's bottom hairline comes from
+     run-view.css and a blanket `border: 0` here outranks it (scoped styles
+     carry the component hash), so it is re-declared rather than reset away. */
+  .m-row,
+  .att-row {
+    width: 100%;
+    color: inherit;
+    background: transparent;
+    text-align: left;
+    font: inherit;
+    border: 0;
+    cursor: pointer;
+  }
+
+  .m-row {
+    border-bottom: 1px solid var(--line);
+  }
+
+  .tier-stale .m-row,
+  .tier-stale .att-row,
+  .tier-stale .queue-line {
+    filter: grayscale(0.6);
+    opacity: 0.85;
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -38,6 +38,8 @@ export const RUN_LEXICON = {
     staleShowing: "unreachable, showing",
     staleOld: "old state",
     absentNotice: "run shape unavailable: swarm engine offline",
+    expandMembers: "expand run members",
+    collapseMembers: "collapse run members",
     sessionsOnly: "sessions only",
     cancelRun: "cancel run",
     openBranch: "open branch",


### PR DESCRIPTION
The run view and master view shipped in #4637, but `selectRun` had only two callers, both URL handling (`+page.svelte` onMount and popstate). Nothing in the UI called it, so the run view was reachable only by hand-typing `?run=<workflow_id>`. That is why it had never been seen rendered.

Part of #4625.

## What lands

- **Master view rows select their run.** The in-flight rows and the attention-band rows become buttons wired to `selectRun`.
- **The sidebar group header splits into two hit targets.** The main area opens the run, the chevron keeps `toggleGroup` and its `aria-expanded`. Siblings, not nested buttons.
- **Master view gains the three staleness tiers.** `loadRuns` previously set a `runError` flag that nothing rendered, so a dead engine silently kept serving its last snapshot. It now resolves to live, stale (aged facts plus an age stamp), or absent. `runError` was write-only in both paths and is removed rather than rendered.
- **The engine-absent run view lists only the run's sessions.** All three build sites passed the whole console session list.

## Design fidelity note

Navigation stays enabled in the stale tier. Design section 8 disables *cancel* when the engine is unreachable, not reading; making rows unopenable during a blip would be a harsher rule than the design asks for. `RunView` already disables cancel on any non-live tier.

Every user-visible string comes from `RUN_LEXICON`. Two keys added (`expandMembers`, `collapseMembers`) for the chevron's aria-label.

## Verification

- `ci lint` clean.
- `pnpm build` succeeds (Svelte compile, no unused-CSS warnings). Note this needs the three `+*.test.js` files stashed first: SvelteKit rejects the reserved `+` prefix, and `frontend/BUILD:21-23` excludes `src/**/*.test.js` from the bazel glob, which is why production builds and a raw `pnpm build` does not.
- No tests added: this is wiring, and the repo has no Svelte component test harness (logic lives in plain `.js` modules with vitest beside them).
- Not yet verified rendered. That is what this PR unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39