### PR TITLE
test(authentik): guard blueprint YAML tag arity

### DIFF
--- a/projects/platform/authentik/BUILD
+++ b/projects/platform/authentik/BUILD
@@ -1,4 +1,5 @@
 load("//bazel/helm:defs.bzl", "argocd_app", "helm_chart")
+load("//bazel/semgrep/defs:defs.bzl", "semgrep_test")
 load("//bazel/tools/pytest:defs.bzl", "py_test")
 
 helm_chart(
@@ -36,4 +37,10 @@ py_test(
         "@pip//pytest",
         "@pip//pyyaml",
     ],
+)
+
+semgrep_test(
+    name = "blueprint_tags_test_semgrep_test",
+    srcs = ["blueprint_tags_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
 )

--- a/projects/platform/authentik/BUILD
+++ b/projects/platform/authentik/BUILD
@@ -1,4 +1,5 @@
 load("//bazel/helm:defs.bzl", "argocd_app", "helm_chart")
+load("//bazel/tools/pytest:defs.bzl", "py_test")
 
 helm_chart(
     name = "chart",
@@ -21,4 +22,18 @@ argocd_app(
         "template",
     ],
     values_files = ["values.yaml"],
+)
+
+# Hand-written test target because this directory is gazelle-excluded for Python.
+# The `data` glob materializes the blueprints/*.yaml files as runfiles so the
+# test can read them during execution. See blueprint_tags_test.py for why this
+# test exists: it guards against malformed !Env tags breaking blueprints discovery.
+py_test(
+    name = "blueprint_tags_test",
+    srcs = ["blueprint_tags_test.py"],
+    data = glob(["blueprints/*.yaml"]),
+    deps = [
+        "@pip//pytest",
+        "@pip//pyyaml",
+    ],
 )

--- a/projects/platform/authentik/blueprint_tags_test.py
+++ b/projects/platform/authentik/blueprint_tags_test.py
@@ -90,6 +90,20 @@ def _blueprint_files():
     return []
 
 
+def test_blueprints_are_discovered():
+    """Fail loudly if the data glob stops materialising the blueprints.
+
+    Without this, a broken `data` dep in BUILD would leave _blueprint_files()
+    empty, parametrize would generate zero cases, and the file-driven guard
+    below would vanish while the suite still reported green. An empty
+    parametrize list is a silent pass, which is the one outcome a guard must
+    never produce.
+    """
+    assert BLUEPRINT_DIR.is_dir(), f"blueprint dir missing: {BLUEPRINT_DIR}"
+    found = _blueprint_files()
+    assert len(found) >= 2, f"expected at least 2 blueprints, found {len(found)}"
+
+
 @pytest.mark.parametrize("blueprint_file", _blueprint_files(), ids=lambda p: p.name)
 def test_blueprint_yaml_arity(blueprint_file):
     """Assert all blueprint YAML files have valid !Env arity."""

--- a/projects/platform/authentik/blueprint_tags_test.py
+++ b/projects/platform/authentik/blueprint_tags_test.py
@@ -1,0 +1,154 @@
+"""Guard authentik blueprint YAML tags so malformed !Env cannot break discovery.
+
+authentik's !Env tag constructor reads node.value[1] with no length check:
+  if isinstance(node, SequenceNode):
+    self.key = loader.construct_object(node.value[0])
+    self.default = loader.construct_object(node.value[1])   # IndexError on a 1-element list
+
+Valid forms are:
+  - !Env KEY (scalar form)
+  - !Env [KEY, default] (2-element sequence form)
+
+Invalid form that raises IndexError:
+  - !Env [KEY] (1-element sequence form)
+
+The blast radius: authentik's blueprints_find() catches only YAMLError, so an
+IndexError escapes and aborts blueprints_discovery for the ENTIRE /blueprints
+tree. One malformed tag in one file silently stops every blueprint in the
+instance from reconciling, including authentik's own bundled defaults.
+
+This test guards against that by:
+1. Discovering all blueprints/*.yaml files and parsing them
+2. Building YAML AST without constructing objects, so we can inspect node shapes
+3. Asserting that any !Env in sequence form has exactly 2 elements
+4. Failing with a message naming the offending file and line/column if found
+"""
+
+import pathlib
+import pytest
+import yaml
+
+
+def _assert_env_arity_node(node, label):
+    """Recursively assert !Env arity in a node tree.
+
+    Checks that any SequenceNode with tag '!Env' has exactly 2 elements.
+    Leaves other custom tags alone (their arity requirements are unconfirmed).
+    See issue #4620 for extending this to guard other tags.
+    """
+    if node is None:
+        return
+
+    if isinstance(node, yaml.MappingNode):
+        for key, value in node.value:
+            _assert_env_arity_node(key, label)
+            _assert_env_arity_node(value, label)
+    elif isinstance(node, yaml.SequenceNode):
+        # Check if this node has the !Env tag
+        if node.tag == "!Env":
+            if len(node.value) != 2:
+                mark = node.start_mark
+                raise AssertionError(
+                    f"{label}: !Env sequence form must have exactly 2 elements, "
+                    f"got {len(node.value)} at line {mark.line + 1}, column {mark.column + 1}"
+                )
+        # Recurse into children
+        for child in node.value:
+            _assert_env_arity_node(child, label)
+    elif isinstance(node, yaml.ScalarNode):
+        pass  # Scalars have no children
+
+
+def _parse_and_check_blueprint(yaml_text, label):
+    """Parse YAML AST and assert !Env arity.
+
+    Args:
+        yaml_text: YAML content as a string
+        label: human-readable label for error messages (e.g., filename)
+
+    Raises:
+        AssertionError if an !Env sequence form has != 2 elements
+        yaml.YAMLError if the YAML is malformed
+    """
+    try:
+        # Build the AST using compose_all; this builds nodes without calling
+        # constructors, so we can inspect the raw tag and structure.
+        for event in yaml.compose_all(yaml_text, Loader=yaml.SafeLoader):
+            _assert_env_arity_node(event, label)
+    except yaml.YAMLError as e:
+        raise yaml.YAMLError(f"{label}: {e}") from e
+
+
+# Real blueprint files
+BLUEPRINT_DIR = pathlib.Path(__file__).resolve().parent / "blueprints"
+
+
+def _blueprint_files():
+    """Discover all YAML blueprint files."""
+    if BLUEPRINT_DIR.exists():
+        return sorted(BLUEPRINT_DIR.glob("*.yaml"))
+    return []
+
+
+@pytest.mark.parametrize("blueprint_file", _blueprint_files(), ids=lambda p: p.name)
+def test_blueprint_yaml_arity(blueprint_file):
+    """Assert all blueprint YAML files have valid !Env arity."""
+    content = blueprint_file.read_text()
+    _parse_and_check_blueprint(content, blueprint_file.name)
+
+
+# Planted tests: valid and invalid forms of !Env
+
+
+def test_env_scalar_form_valid():
+    """Scalar form !Env KEY is always valid."""
+    yaml_text = """
+version: 1
+metadata:
+  secret: !Env MY_SECRET
+"""
+    _parse_and_check_blueprint(yaml_text, "test_env_scalar_form_valid")
+
+
+def test_env_sequence_form_with_default_valid():
+    """Sequence form !Env [KEY, default] with 2 elements is valid."""
+    yaml_text = """
+version: 1
+metadata:
+  secret: !Env [MY_SECRET, "default-value"]
+"""
+    _parse_and_check_blueprint(yaml_text, "test_env_sequence_form_with_default_valid")
+
+
+def test_env_sequence_form_missing_default_invalid():
+    """Sequence form !Env [KEY] with 1 element is invalid (IndexError in authentik)."""
+    yaml_text = """
+version: 1
+metadata:
+  secret: !Env [MY_SECRET]
+"""
+    with pytest.raises(AssertionError) as exc_info:
+        _parse_and_check_blueprint(
+            yaml_text, "test_env_sequence_form_missing_default_invalid"
+        )
+
+    # Verify the error message names the issue
+    assert "!Env sequence form must have exactly 2 elements" in str(exc_info.value)
+    assert "got 1" in str(exc_info.value)
+
+
+def test_env_sequence_form_too_many_elements_invalid():
+    """Sequence form !Env [K, default, extra] with 3+ elements is invalid."""
+    yaml_text = """
+version: 1
+metadata:
+  secret: !Env [MY_SECRET, "default", "extra"]
+"""
+    with pytest.raises(AssertionError) as exc_info:
+        _parse_and_check_blueprint(
+            yaml_text, "test_env_sequence_form_too_many_elements_invalid"
+        )
+
+    # Verify the error message names the issue
+    assert "!Env sequence form must have exactly 2 elements" in str(exc_info.value)
+    assert "got 3" in str(exc_info.value)


### PR DESCRIPTION
Closes #4620.

## Why

authentik's `!Env` tag constructor reads `node.value[1]` with no length check, so `!Env [KEY]` raises `IndexError`. The valid forms are `!Env KEY` and `!Env [KEY, default]`.

The blast radius is what makes it worth a test. `blueprints_find()` catches only `YAMLError`, so an `IndexError` escapes and aborts `blueprints_discovery` for the **entire** `/blueprints` tree. One malformed tag in one file silently stops every blueprint in the instance from reconciling, including authentik's own bundled defaults. Nothing errors, they just stop being applied.

Nothing in this repo would have caught it. The chart's only test proves the blueprint is embedded as a ConfigMap string, not that it parses (and `helm_chart` here sets `lint = False`). `ci lint` runs prettier, which is perfectly happy with `!Env [KEY]` because it is valid YAML. The bug is in authentik's tag semantics, not in YAML.

## What the test does

`blueprint_tags_test.py` composes each `blueprints/*.yaml` with `yaml.compose_all`, which builds the node tree without invoking any constructor, so the shapes can be inspected without authentik installed. It then asserts that any `!Env` in sequence form has exactly 2 elements, failing with the file name plus line and column from the node's `start_mark`.

Scope is deliberately narrow. `!Env` arity is confirmed from authentik's source, so it is asserted. `!Find`, `!KeyOf` and friends parse but their arity is **not** asserted, because guessing an arity would turn a valid blueprint red. #4620 records extending that once the requirements are confirmed.

## The part that carries the evidence

A guard that only parses two currently-valid files would pass identically if the assertion were `assert True`. So the suite plants the bad input directly:

- `!Env KEY` accepted
- `!Env [KEY, default]` accepted
- `!Env [KEY]` **rejected**
- `!Env [K, default, extra]` **rejected**

Planted into a real blueprint, the guard reports:

```
FAILED blueprint_tags_test.py::test_blueprint_yaml_arity[preview-auth.yaml]
AssertionError: preview-auth.yaml: !Env sequence form must have exactly 2 elements, got 1 at line 61, column 21
```

The planted edit was reverted; `git diff` against the blueprints directory is empty.

The second commit closes a vacuity hole in the first: `_blueprint_files()` returns `[]` when the directory is missing, and an empty `parametrize` list generates zero cases, so a broken `data` dep would have made the file-driven guard silently disappear while the suite stayed green. `test_blueprints_are_discovered` now asserts the directory exists and holds at least two files.

## Notes

The `py_test` target is hand-written because this directory is gazelle-excluded for Python, and uses `@pip//` via `aspect_rules_py` (this repo does not use `@rules_python`, so `requirement()` would be wrong). The `data` glob is what materialises the blueprints as runfiles.

The test file sits inside the Helm chart directory, which `helm_chart` globs as `**/*`. That is inert: Helm renders only `templates/`, this chart is not `publish = True`, and `BUILD` and `README.md` already live there on the same terms. Verified the chart still templates cleanly.

`ci test`: `Executed 3 out of 751 tests: 751 tests pass`. No chart bump, this adds a test and deploys nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)