### PR TITLE
fix(monolith): the swarm run payload tells the truth about cost and activity

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2219,6 +2219,16 @@ py_test(
 )
 
 py_test(
+    name = "rows_test",
+    srcs = ["swarm/rows_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "tier_test",
     srcs = ["swarm/tier_test.py"],
     imports = ["."],

--- a/projects/monolith/frontend/src/routes/private/agents/runs/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/runs/+server.js
@@ -1,8 +1,11 @@
 const API_BASE = process.env.API_BASE;
 
-export async function GET() {
+export async function GET({ url }) {
   try {
-    const res = await fetch(`${API_BASE}/api/swarm/runs`, {
+    const active = url.searchParams.get("active");
+    const query =
+      active === null ? "" : `?active=${encodeURIComponent(active)}`;
+    const res = await fetch(`${API_BASE}/api/swarm/runs${query}`, {
       signal: AbortSignal.timeout(10000),
     });
     return new Response(res.body, {

--- a/projects/monolith/frontend/src/routes/private/agents/runs/[id]/cancel/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/runs/[id]/cancel/+server.js
@@ -9,6 +9,13 @@ export async function POST({ params, request }) {
         headers: {
           "Content-Type":
             request.headers.get("content-type") || "application/json",
+          ...(request.headers.get("Cf-Access-Authenticated-User-Email")
+            ? {
+                "Cf-Access-Authenticated-User-Email": request.headers.get(
+                  "Cf-Access-Authenticated-User-Email",
+                ),
+              }
+            : {}),
         },
         body: await request.text(),
         signal: AbortSignal.timeout(10000),

--- a/projects/monolith/swarm/router.py
+++ b/projects/monolith/swarm/router.py
@@ -43,12 +43,12 @@ def _server_app_version() -> str:
 
 
 def _session_rows(workflow_id: str):
-    from agent_sessions import store
     from core.db import get_engine
     from sqlmodel import Session
+    from swarm.rows import swarm_session_views
 
     with Session(get_engine()) as session:
-        return store.sessions_for_workflow(session, workflow_id)
+        return swarm_session_views(session, workflow_id).get(workflow_id, [])
 
 
 @router.post("/runs")
@@ -106,8 +106,13 @@ def get_run(workflow_id: str) -> dict:
 @router.get("/runs")
 def list_runs(active: bool = True) -> dict:
     from swarm.view import compose_master
+    from core.db import get_engine
+    from sqlmodel import Session
+    from swarm.rows import swarm_session_views
 
-    return compose_master(_dbos(), active, {}, _server_app_version())
+    with Session(get_engine()) as session:
+        session_costs = swarm_session_views(session)
+    return compose_master(_dbos(), active, session_costs, _server_app_version())
 
 
 @router.post("/runs/{workflow_id}/cancel")

--- a/projects/monolith/swarm/rows.py
+++ b/projects/monolith/swarm/rows.py
@@ -1,0 +1,114 @@
+"""Database projections used by the swarm run views."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from sqlmodel import Session, func, select
+
+from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
+
+
+def _decode(value: str | None, default: Any):
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return default
+
+
+def _compact_input(value: Any) -> str:
+    if value is None:
+        return ""
+    text = value if isinstance(value, str) else json.dumps(value, separators=(",", ":"))
+    text = re.sub(r"\s+", " ", text)
+    return text[:110] + "…" if len(text) > 110 else text
+
+
+def _activity_line(activity: Any) -> str:
+    if isinstance(activity, str):
+        return activity
+    if not isinstance(activity, dict):
+        return "step"
+    kind = str(
+        activity.get("type") or activity.get("tool") or activity.get("name") or ""
+    ).lower()
+    if kind in ("edit", "write"):
+        detail = activity.get("file_path") or activity.get("path") or ""
+        return f"{kind} {detail}".rstrip()
+    if kind in ("bash", "shell"):
+        detail = activity.get("command") or _compact_input(activity.get("input"))
+        return f"run {detail}".rstrip()
+    if activity.get("name"):
+        return f"{activity['name']} {_compact_input(activity.get('input'))}".rstrip()
+    return f"{kind or 'step'} {_compact_input(activity.get('input'))}".rstrip()
+
+
+def swarm_session_views(
+    session: Session, workflow_id: str | None = None
+) -> dict[str, list[dict]]:
+    """Return the enriched, plain-dict session rows consumed by swarm views."""
+    totals = (
+        select(
+            AgentTurn.session_id,
+            func.coalesce(func.sum(AgentTurn.cost_usd), 0).label("total_cost_usd"),
+        )
+        .group_by(AgentTurn.session_id)
+        .subquery()
+    )
+    statement = (
+        select(AgentSession, func.coalesce(totals.c.total_cost_usd, 0))
+        .outerjoin(totals, totals.c.session_id == AgentSession.id)
+        .where(AgentSession.workflow_id.is_not(None))
+    )
+    if workflow_id is not None:
+        statement = statement.where(AgentSession.workflow_id == workflow_id)
+    rows = session.exec(statement).all()
+    session_ids = [row[0].id for row in rows if row[0].id is not None]
+
+    pending_by_session: dict[int, list[PendingMessage]] = {}
+    if session_ids:
+        pending_rows = session.exec(
+            select(PendingMessage)
+            .where(PendingMessage.session_id.in_(session_ids))
+            .order_by(PendingMessage.session_id, PendingMessage.seq)
+        ).all()
+        for pending in pending_rows:
+            pending_by_session.setdefault(pending.session_id, []).append(pending)
+
+    result: dict[str, list[dict]] = {}
+    for row, total_cost in rows:
+        pending = pending_by_session.get(row.id, [])
+        claimed = [item for item in pending if item.claimed_by_replica is not None]
+        current = (
+            max(
+                claimed,
+                key=lambda item: (item.claimed_at or item.created_at, item.seq),
+            )
+            if claimed
+            else (pending[0] if pending else None)
+        )
+        activities = _decode(current.partial_activities, []) if current else []
+        activity = (
+            activities[-1] if isinstance(activities, list) and activities else None
+        )
+        observed_at = (current.claimed_at or current.created_at) if current else None
+        view = {
+            "id": row.id,
+            "local_session_id": row.local_session_id,
+            "workflow_id": row.workflow_id,
+            "node_key": row.node_key,
+            "node_attempt": row.node_attempt,
+            "status": row.status,
+            "model": row.model,
+            "total_cost_usd": float(total_cost or 0),
+            "created_at": row.created_at,
+            "last_turn_at": row.last_turn_at,
+            "activity": _activity_line(activity) if activity is not None else None,
+            "activity_observed_at": observed_at,
+        }
+        result.setdefault(row.workflow_id, []).append(view)
+    return result

--- a/projects/monolith/swarm/rows_test.py
+++ b/projects/monolith/swarm/rows_test.py
@@ -1,0 +1,134 @@
+import json
+from datetime import datetime
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
+from swarm.rows import swarm_session_views
+
+
+@pytest.fixture
+def db(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'rows.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            schemas[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in schemas:
+                table.schema = schemas[table.name]
+
+
+def add_session(db, workflow_id="wf-1", local_id="local", **kwargs):
+    with Session(db) as session:
+        row = AgentSession(
+            local_session_id=local_id,
+            workspace="workspace",
+            branch="main",
+            workflow_id=workflow_id,
+            node_key="implement",
+            node_attempt=1,
+            **kwargs,
+        )
+        session.add(row)
+        session.commit()
+        session.refresh(row)
+        return row.id
+
+
+def test_costs_are_grouped_and_zero_without_turns(db):
+    first = add_session(db, local_id="first")
+    second = add_session(db, local_id="second")
+    with Session(db) as session:
+        for seq, cost in enumerate((0.1, 0.2, 0.3), 1):
+            session.add(
+                AgentTurn(
+                    session_id=first,
+                    seq=seq,
+                    prompt="prompt",
+                    result_text="result",
+                    cost_usd=cost,
+                )
+            )
+        session.commit()
+        rows = swarm_session_views(session)["wf-1"]
+    by_id = {row["id"]: row for row in rows}
+    assert by_id[first]["total_cost_usd"] == pytest.approx(0.6)
+    assert by_id[second]["total_cost_usd"] == 0.0
+    assert isinstance(by_id[first]["created_at"], datetime)
+
+
+def test_workflow_filter_and_grouping(db):
+    first = add_session(db, "wf-1", "first")
+    second = add_session(db, "wf-1", "second")
+    other = add_session(db, "wf-2", "other")
+    with Session(db) as session:
+        filtered = swarm_session_views(session, "wf-1")
+        grouped = swarm_session_views(session)
+    assert {row["id"] for row in filtered["wf-1"]} == {first, second}
+    assert set(grouped) == {"wf-1", "wf-2"}
+    assert [row["id"] for row in grouped["wf-2"]] == [other]
+
+
+@pytest.mark.parametrize(
+    ("activity", "expected"),
+    [
+        ({"type": "edit", "file_path": "a.py"}, "edit a.py"),
+        ({"tool": "write", "path": "a.py"}, "write a.py"),
+        ({"type": "bash", "command": "git status"}, "run git status"),
+        (
+            {"name": "grep", "input": {"pattern": "x", "path": "a"}},
+            'grep {"pattern":"x","path":"a"}',
+        ),
+        ("thinking", "thinking"),
+        ({"input": "next"}, "step next"),
+    ],
+)
+def test_activity_grammar(db, activity, expected):
+    session_id = add_session(db, local_id=expected)
+    with Session(db) as session:
+        session.add(
+            PendingMessage(
+                session_id=session_id,
+                seq=1,
+                message_text="prompt",
+                partial_activities=json.dumps([{"type": "old"}, activity]),
+                claimed_by_replica="replica-a",
+            )
+        )
+        session.commit()
+        row = swarm_session_views(session)["wf-1"][0]
+    assert row["activity"] == expected
+    assert isinstance(row["activity_observed_at"], datetime)
+
+
+def test_activity_null_and_malformed_json_are_none(db):
+    null_id = add_session(db, local_id="null")
+    bad_id = add_session(db, local_id="bad")
+    with Session(db) as session:
+        session.add_all(
+            [
+                PendingMessage(session_id=null_id, seq=1, message_text="prompt"),
+                PendingMessage(
+                    session_id=bad_id,
+                    seq=1,
+                    message_text="prompt",
+                    partial_activities="{not-json",
+                ),
+            ]
+        )
+        session.commit()
+        rows = swarm_session_views(session)["wf-1"]
+    assert {row["local_session_id"]: row["activity"] for row in rows} == {
+        "null": None,
+        "bad": None,
+    }

--- a/projects/monolith/swarm/view.py
+++ b/projects/monolith/swarm/view.py
@@ -164,11 +164,14 @@ def _attempts(session_rows: list[Any], steps: list[Any], node_key: str) -> list[
                 else None,
                 "cost_usd": _value(row, "total_cost_usd", _value(row, "cost_usd")),
                 "finding": _finding(None, observed, prior),
+                "prior_head": _short_sha(prior),
                 "live": None
                 if state != "running"
                 else {
                     "activity": _value(row, "activity"),
-                    "observed_at": _iso(_value(row, "last_turn_at")),
+                    "observed_at": _iso(
+                        _value(row, "activity_observed_at", _value(row, "last_turn_at"))
+                    ),
                 },
             }
         )
@@ -449,6 +452,11 @@ def compose_master(dbos, active, session_costs, server_app_version) -> dict:
                 if run["plan"]["pinned"]
                 else None,
                 "cost_usd": run["cost_usd"],
+                "active": run["dbos_status"] in ("PENDING", "ENQUEUED"),
+                "shape": [
+                    {"key": node["key"], "kind": node["kind"], "state": node["state"]}
+                    for node in run["nodes"]
+                ],
                 "needs": needs,
                 "queue_position": current["queue"]["position"]
                 if current["queue"]

--- a/projects/monolith/swarm/view_test.py
+++ b/projects/monolith/swarm/view_test.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from swarm.view import compose_run
+from swarm.view import compose_master, compose_run
 
 
 class Status:
@@ -208,3 +208,43 @@ def test_shas_render_at_eight_characters():
     assert gate["evidence"]["summary"] == (
         "head 86dcbf41 observed on the remote after the turn"
     )
+
+
+def test_attempt_carries_prior_head_alongside_finding():
+    status = Status("wf-prior", "SUCCESS", ["task", "repo", "main"])
+    run = compose_run(
+        DBOS(
+            Workflow(status),
+            steps=[
+                {"function_name": "read_branch_head", "output": "1234567890"},
+                {"function_name": "read_branch_head", "output": "abcdef0123"},
+            ],
+        ),
+        "wf-prior",
+        [session(1, status="completed")],
+        "unknown",
+    )
+    attempt = run["nodes"][0]["attempts"][0]
+    assert attempt["prior_head"] == "12345678"
+    assert attempt["finding"]["observed_head"] == "abcdef01"
+
+
+def test_master_rows_include_active_and_shape():
+    status = Status("wf-master", "PENDING", ["task", "repo", "main"])
+
+    class ListingDBOS(DBOS):
+        def list_workflows(self, **kwargs):
+            return [self.workflow]
+
+    result = compose_master(
+        ListingDBOS(Workflow(status)),
+        True,
+        {"wf-master": []},
+        "unknown",
+    )
+    assert result["runs"][0]["active"] is True
+    assert result["runs"][0]["shape"] == [
+        {"key": "implement", "kind": "work", "state": "future"},
+        {"key": "push_gate", "kind": "gate", "state": "future"},
+        {"key": "review", "kind": "work", "state": "future"},
+    ]


### PR DESCRIPTION
The run contract has claimed three fields since #4636 that production never carried.

`swarm/router.py:_session_rows` returned bare `AgentSession` ORM rows via `store.sessions_for_workflow`. That model has **no `total_cost_usd` and no `activity` column**: cost lives in an aggregate over `AgentTurn.cost_usd` (`agent_sessions/router.py:64`), and live activity lives in `PendingMessage.partial_activities` (`models.py:108`). So in production:

- `run.cost_usd` was always `0` (`view.py:377` sums a field that does not exist)
- `attempts[].cost_usd` was always `null`
- `attempt.live.activity` was always `null`

`list_runs` compounded it by passing `session_costs={}` (`router.py:110`), so every master row composed against zero session rows and the sidebar in-flight spend was structurally $0.

Part of #4625.

## Why this is structural rather than a patch

`swarm/view_test.py` has been green throughout, because its fixtures are plain dicts that carry the fields a real row does not have. Patching the composer would have left that hole open.

So the shaping moves into `swarm/rows.py`, one function, and `swarm/rows_test.py` drives **real ORM objects** through a sqlite `create_all` database. The dicts the composer sees are now ones the database can actually produce. It lives in `swarm/` rather than `agent_sessions/` because swarm is its only consumer, and both packages are gazelle-excluded so the test target is hand-written either way.

Activity is composed into a line **server side**, mirroring the client's `activityParts` grammar (`+page.svelte:242-266`), because the server owns every string this surface renders (design decision 3).

## Also lands

- `attempts[].prior_head` beside the finding's `observed_head`. Both are recorded step outputs and the pair is what makes a per-attempt delta renderable.
- Master rows gain `active` and `shape`, which feed the sidebar fingerprint strip in a later slice.
- The cancel proxy forwards `Cf-Access-Authenticated-User-Email`, which it was dropping, so `cancelled_by.actor` was always the literal `"operator"`.
- The runs proxy forwards the `active` query param.

## Verification

- `ci lint` clean.
- `ci test`: **`Executed 57 out of 751 tests: 751 tests pass`**.
- Chart bumped to 0.285.530 (0.285.528 and 0.285.529 were already claimed by open PRs; monolith-public dragged along by the shared image).
- **`ci test` cannot prove the fix.** The whole bug was invisible to it. Post-merge this needs a live curl of a run with real spend: `GET /api/swarm/runs/<id>` must show non-zero `cost_usd` and per-attempt costs, and `GET /api/swarm/runs` rows must carry cost. The cancel actor needs one real cancel to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39