### PR TITLE
test(embervm): poll for the failed transition instead of racing it

### DIFF
--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -653,14 +653,21 @@ defmodule Embervm.SessionManagerTest do
     assert {:ok, _} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "rejoin"})
     assert {:error, :delivery_failed} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "fail"})
 
-    assert eventually(fn ->
-             case SessionStore.get(ctx.store, created.session_id) do
-               {:ok, session} -> session.state == :failed
-               _ -> false
-             end
-           end)
+    # Wait for the async write, then assert on the real values rather than on the
+    # poll's boolean, so a timeout still reports the state it actually observed
+    # (`:running` is the symptom in #4391). The op rides the same transition as
+    # the state, so one wait covers both assertions.
+    _ =
+      eventually(fn ->
+        case SessionStore.get(ctx.store, created.session_id) do
+          {:ok, session} -> session.state == :failed
+          _ -> false
+        end
+      end)
 
-    assert eventually(fn -> :session_failed in op_kinds_for(ctx, created.session_id) end)
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :failed
+    assert :session_failed in op_kinds_for(ctx, created.session_id)
   end
 
   test "crash-window park completes to parked on restart adoption" do
@@ -1528,15 +1535,19 @@ defmodule Embervm.SessionManagerTest do
     assert {:error, :suspect} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
 
     # The session is now failed (a guest in unknown mid-request state is not reused).
-    assert eventually(fn ->
-             case SessionStore.get(ctx.store, created.session_id) do
-               {:ok, session} ->
-                 session.state == :failed and session.terminal_reason == "failed"
+    # Same async write as the rejoin test above, so wait for it and then assert on
+    # the real values, which keeps the failure message diagnostic.
+    _ =
+      eventually(fn ->
+        case SessionStore.get(ctx.store, created.session_id) do
+          {:ok, session} -> session.state == :failed
+          _ -> false
+        end
+      end)
 
-               _ ->
-                 false
-             end
-           end)
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :failed
+    assert session.terminal_reason == "failed"
   end
 
   # -- destroy ---------------------------------------------------------------

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -653,9 +653,14 @@ defmodule Embervm.SessionManagerTest do
     assert {:ok, _} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "rejoin"})
     assert {:error, :delivery_failed} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "fail"})
 
-    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
-    assert session.state == :failed
-    assert :session_failed in op_kinds_for(ctx, created.session_id)
+    assert eventually(fn ->
+             case SessionStore.get(ctx.store, created.session_id) do
+               {:ok, session} -> session.state == :failed
+               _ -> false
+             end
+           end)
+
+    assert eventually(fn -> :session_failed in op_kinds_for(ctx, created.session_id) end)
   end
 
   test "crash-window park completes to parked on restart adoption" do
@@ -1523,10 +1528,15 @@ defmodule Embervm.SessionManagerTest do
     assert {:error, :suspect} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
 
     # The session is now failed (a guest in unknown mid-request state is not reused).
-    Process.sleep(50)
-    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
-    assert session.state == :failed
-    assert session.terminal_reason == "failed"
+    assert eventually(fn ->
+             case SessionStore.get(ctx.store, created.session_id) do
+               {:ok, session} ->
+                 session.state == :failed and session.terminal_reason == "failed"
+
+               _ ->
+                 false
+             end
+           end)
   end
 
   # -- destroy ---------------------------------------------------------------
@@ -1943,6 +1953,30 @@ defmodule Embervm.SessionManagerTest do
   end
 
   # -- gated-destroy test helpers --------------------------------------------
+
+  # SessionManager's invoke failure path replies before the :session_failed
+  # transition lands in SessionStore, so a bare read after invoke returns races
+  # that write. This polling helper covers the production-side ordering tracked
+  # by issue #4644 and fixes the test flake from issue #4391.
+  defp eventually(fun, timeout_ms \\ 1_000, interval_ms \\ 5) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    eventually_until(fun, deadline, interval_ms)
+  end
+
+  defp eventually_until(fun, deadline, interval_ms) do
+    if fun.() do
+      true
+    else
+      remaining_ms = deadline - System.monotonic_time(:millisecond)
+
+      if remaining_ms <= 0 do
+        false
+      else
+        Process.sleep(min(interval_ms, remaining_ms))
+        eventually_until(fun, deadline, interval_ms)
+      end
+    end
+  end
 
   defp op_kinds_for(ctx, session_id) do
     {:ok, ops} = SQLite.read_from(ctx.op_log, 0)


### PR DESCRIPTION
Closes #4391. Test-only, nothing under `control/lib/` is touched.

## The issue's diagnosis was wrong

#4391 reads the failure as test-order sensitivity: "some earlier test under that ordering leaves state that lets the rejoin succeed". It is not. There is no leaked state and no ordering dependence.

It is a read-before-write race. `Embervm.Session.handle_info({:invoke_done, ...})` orders its two branches oppositely, and only one says why. Success records durably **before** replying, and documents the invariant: "so the caller never sees a response the op-log has not accounted." Failure does the reverse:

```elixir
{:error, reason} ->
  GenServer.reply(from, {:error, reason})
  fail_and_stop(state, reason)     # <- this performs the :session_failed transition
```

`fail_and_stop` calls `destroy_vm` (a gRPC round trip) before the transition, so `SessionManager.invoke/3` returns to the test while the write is still pending. The test then reads `SessionStore`, a **separate** process, so nothing orders that read against the pending write. When the read wins, it sees the pre-failure state, `:running`. That is exactly the reported symptom.

The seed did not leak state; it changed scheduling.

## The evidence

Three sites in this file assert `state == :failed`. The two stable ones each have a barrier. The flaky one has none.

| line | barrier before the read | stable? |
|---|---|---|
| 657 | none | **flakes** |
| 1528 | `Process.sleep(50)` | yes |
| 1754 | synchronous `SessionManager.reconcile` | yes |

Someone had already hit this race at 1526 and papered over it with a sleep, which is why it never got named.

## What changed

An `eventually/3` helper polls with a monotonic deadline (the interval is capped by the remaining time, so the bound cannot drift across recursive calls). It replaces the bare read at 657 and retires the fixed `Process.sleep(50)` at 1526, which is both faster in the common case and more robust under load. Line 1754 is left alone: its synchronous `reconcile` is a real barrier already.

Every other `Process.sleep` in the file is untouched. Several model genuinely time-based behaviour, such as idle timers, and are not this bug.

The second commit matters more than its size suggests. Asserting on the poll's boolean (`assert eventually(fn -> ... end)`) fails with "Expected truthy, got false", which tells you nothing. For a flake fix that is the wrong trade: the next person to hit this needs to see `:running` to recognise the race. So the poll now runs as a barrier and the original assertions follow it unchanged, keeping the diagnostic failure message.

## Not in scope

The production-side ordering asymmetry is real but is deliberately left alone here, and is filed as #4644. In production the exposure is small, since real callers do not read the store the instant `invoke` returns and a stale read self-heals on the next poll. Both candidate fixes change FSM ordering in a component with an STPA model, so they want a deliberate decision rather than a drive-by change.

## Verification

The Elixir suite genuinely re-ran (editing the test invalidates the genrule, so this is not a cached result):

```
Finished in 20.1 seconds (5.1s async, 14.9s sync)
1203 tests, 0 failures, 6 skipped
```

`ci test` reports `Executed 0 out of 750 tests: 750 tests pass` for the bazel test targets, which are all cache hits. That line is not the signal for this change; the mix output above is, because the Elixir suite runs as a genrule.

I could not pin `EXUNIT_SEED=893821` through the `ci test` harness, so I have not reproduced the original ordering directly. The fix does not depend on reproducing it: the barrier removes the race regardless of scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)