### PR TITLE
feat(monolith): render the run payload the view already receives

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -3,6 +3,7 @@
   import { pushState } from "$app/navigation";
   import { page } from "$app/stores";
   import { renderAgentMarkdown } from "./markdown.js";
+  import { RUN_FIXTURES } from "./run-fixtures.js";
   import {
     groupSessions,
     groupSummary,
@@ -28,6 +29,15 @@
   const MODELS = ["opus", "fable", "sonnet", "luna", "terra", "sol", "qwen"];
   const RECENT_HISTORY_MS = 24 * 60 * 60 * 1000;
   const ATTENTION_MS = 60 * 60 * 1000;
+  // hasOwn, not a bare index: ?fixture=constructor would otherwise resolve to
+  // Object.prototype.constructor, which is truthy, and the preview branch would
+  // then hand RunView an undefined view and throw.
+  const fixture = $derived.by(() => {
+    const name = $page.url.searchParams.get("fixture");
+    return name && Object.hasOwn(RUN_FIXTURES, name)
+      ? RUN_FIXTURES[name]
+      : undefined;
+  });
 
   let selectedId = $state(null);
   let mobileView = $state(MOBILE_VIEW_LIST);
@@ -378,6 +388,7 @@
   }
 
   async function loadRuns() {
+    if (fixture) return;
     try {
       const response = await fetch("/agents/runs");
       if (!response.ok) throw new Error("swarm runs unavailable");
@@ -401,6 +412,7 @@
   }
 
   async function loadRunDetail(id, sequence = runRequestSequence) {
+    if (fixture) return;
     if (id == null) return;
     try {
       const response = await fetch(`/agents/runs/${encodeURIComponent(id)}`);
@@ -1042,7 +1054,14 @@
       aria-label="Back to agent sessions"
       onclick={returnToSessionList}>← back</button
     >
-    {#if selectedRunId}
+    {#if fixture}
+      <RunView
+        run={fixture.run}
+        view={fixture.view}
+        sessions={fixture.sessions}
+        onSelectSession={selectSession}
+      />
+    {:else if selectedRunId}
       {#if runDetail?.run}
         <RunView
           run={runDetail.run}

--- a/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
@@ -5,7 +5,7 @@
     isWide,
     nodeIconKey,
     nodeStateClass,
-    pipClass,
+    capacityPips,
   } from "./dag.js";
   import { fmtCost, fmtDur, ordinal, relSeconds } from "./run-format.js";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
@@ -66,7 +66,7 @@
     <div class="rv-eyebrow">
       <span class={`state-chip s-${run.state}`}
         >{P.stateWords[run.state] || run.state}</span
-      ><span class="rv-id">{run.workflow_id}</span>
+      >
     </div>
     <h2 class="rv-title">{run.task.text}</h2>
     <div class="rv-meta">
@@ -78,15 +78,17 @@
       {#if fmtCost(run.cost_usd)}{P.punct.dot} {fmtCost(run.cost_usd)}{/if}
     </div>
     <div class="rv-statusline" data-register="fact">
-      {#if run.state === "running" && attempts}
+      {#if run.state === "running" && attempts && run.plan?.pinned}
         <span class="fact-count"
           >{P.labels.attempt}
           {attempts}
           {P.labels.of}
-          {run.plan?.max_attempts || attempts}</span
+          {run.plan.max_attempts}</span
         >
-        <span data-register="belief">
-          {P.punct.dot} {P.labels.retriesRemain}</span
+      {:else if run.state === "running" && attempts}
+        <span class="fact-count">{P.labels.attempt} {attempts}</span>
+        <span data-register="belief"
+          >{P.punct.dot} {P.labels.retriesRemain}</span
         >
       {:else if run.completed_at}
         {P.stateWords[run.state] || run.state}
@@ -101,7 +103,14 @@
           {P.labels.positionWord}{/if}
       {/if}
     </div>
-    {#if run.stranded}<div class="banner">{P.labels.strandedBanner}</div>{/if}
+    {#if run.stranded}<div class="banner">
+        {P.labels.strandedBanner}
+        {P.labels.buildWord}
+        {run.app_version}
+        {P.punct.dot}
+        {P.labels.serverBuildWord}
+        {run.server_app_version}
+      </div>{/if}
     <div class="rv-actions">
       {#if active}<button
           class="btn-quiet btn-danger"
@@ -116,6 +125,9 @@
           {shortSha(
             run.nodes.find((node) => node.verdict).verdict.commit_sha,
           )}</a
+        >{/if}
+      {#if run.branch_url}<a class="link-out" href={run.branch_url}
+          >{P.labels.openBranch}</a
         >{/if}
     </div>
     <div class="staged">
@@ -134,10 +146,14 @@
       class:stale={view.engine_tier === "stale"}
       data-register="fact"
     >
-      {P.labels.engine}{P.punct.colon}
-      {view.engine_tier === "live"
-        ? P.labels.live
-        : `${P.labels.staleShowing} ${fmtDur(view.snapshot_age_seconds)} ${P.labels.staleOld}`}
+      <span class="rv-id">{run.workflow_id}</span>
+      {#if view.engine_tier !== "live"}
+        {P.punct.dot}
+        {P.labels.engine}{P.punct.colon}
+        {P.labels.staleShowing}
+        {fmtDur(view.snapshot_age_seconds)}
+        {P.labels.staleOld}
+      {/if}
     </div>
   {/if}
 </div>
@@ -153,16 +169,46 @@
       <span class="card-label">{node.label}</span><span class="entry-meta"
         >{P.nodeStates[node.state] || node.state}</span
       >
-      {#if node.attempts?.length}<span class="pips"
-          >{#each node.attempts as attempt}<span class={pipClass(attempt)}
-            ></span>{/each}</span
-        >{/if}
+      {#if node.attempts?.length}<span class="pips">
+          {#each capacityPips(run.plan, node) as pip}<span class={pip}
+            ></span>{/each}
+        </span>
+        {#if run.plan?.pinned}<span class="entry-meta"
+            >{run.plan.max_attempts} {P.labels.attempts}</span
+          >{/if}
+      {/if}
       {#if node.state === "escalated" || node.blocked_on?.kind === "human"}<span
           class="needs-tag">{P.labels.needsYou}</span
         >{/if}
     </div>
     {#if node.blocked_on}<div class="log-entry" data-register="belief">
         {node.blocked_on.note}
+      </div>{/if}
+    {#if node.model}<div class="entry-meta">{node.model}</div>{/if}
+    {#if node.queue}<div class="log-entry" data-register="fact">
+        {ordinal(node.queue.position)}
+        {P.labels.queuedOn}
+        {node.queue.name}
+        {P.labels.queueWord}
+      </div>{/if}
+    {#if node.decision}<div
+        class="decision"
+        data-register={node.decision.register}
+        title={node.decision.basis}
+      >
+        <div class="entry-meta">
+          {P.labels.gateWord}
+          {P.labels.whenTurnEnds}
+        </div>
+        <table>
+          <tbody
+            >{#each node.decision.outcomes as outcome}<tr
+                ><td>{outcome.when}</td><td>{P.punct.arrow}</td><td
+                  >{outcome.then}</td
+                ></tr
+              >{/each}</tbody
+          >
+        </table>
       </div>{/if}
     {#if node.deps?.length > 1 || node.state === "blocked"}<div
         class="dep-chips"
@@ -191,7 +237,13 @@
             ? fmtDur(relSeconds(attempt.started_at, attempt.ended_at))
             : `${P.stateWords.running} ${fmtDur(relSeconds(attempt.started_at, view.now))}`}{#if fmtCost(attempt.cost_usd)}
             {P.punct.dot} {fmtCost(attempt.cost_usd)}{/if}</span
-        >{#if attempt.finding}<span class="finding"
+        >{#if attempt.state === "running" && attempt.live?.activity}<span
+            class="live-line"
+            ><span class="live-dot"></span><span class="live-act"
+              >{attempt.live.activity}</span
+            >{ago(attempt.live.observed_at)}
+            {P.labels.ago}</span
+          >{/if}{#if attempt.finding}<span class="finding"
             >{attempt.finding.text} {attempt.finding.observed_head ?? ""}</span
           >{/if}</button
       >

--- a/projects/monolith/frontend/src/routes/private/agents/dag.js
+++ b/projects/monolith/frontend/src/routes/private/agents/dag.js
@@ -55,3 +55,10 @@ export function pipClass(attempt) {
       ? "pip run"
       : "pip bad";
 }
+
+export function capacityPips(plan, node) {
+  const spent = (node.attempts || []).map(pipClass);
+  if (!plan?.pinned || typeof plan.max_attempts !== "number") return spent;
+  const free = Math.max(0, plan.max_attempts - spent.length);
+  return [...spent, ...Array.from({ length: free }, () => "pip free")];
+}

--- a/projects/monolith/frontend/src/routes/private/agents/dag.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/dag.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { computeRanks, nodeIconKey } from "./dag.js";
+import { capacityPips, computeRanks, nodeIconKey } from "./dag.js";
 
 const chain = [
   { key: "a", deps: [] },
@@ -37,4 +37,43 @@ describe("run DAG helpers", () => {
     expect(nodeIconKey({ kind: "expansion", state: "future" })).toBe(
       "expansion",
     ));
+  test("pinned capacity adds one free pip", () =>
+    expect(
+      capacityPips(
+        { pinned: true, max_attempts: 2 },
+        { attempts: [{ state: "done" }] },
+      ),
+    ).toEqual(["pip", "pip free"]));
+  test("pinned capacity does not add free pips when all are spent", () =>
+    expect(
+      capacityPips(
+        { pinned: true, max_attempts: 2 },
+        { attempts: [{ state: "done" }, { state: "failed" }] },
+      ),
+    ).toEqual(["pip", "pip bad"]));
+  test("pinned running attempt keeps its running pip", () =>
+    expect(
+      capacityPips(
+        { pinned: true, max_attempts: 2 },
+        { attempts: [{ state: "running" }] },
+      ),
+    ).toEqual(["pip run", "pip free"]));
+  test("unpinned capacity only shows spent pips", () =>
+    expect(
+      capacityPips(
+        { pinned: false, max_attempts: 2 },
+        { attempts: [{ state: "done" }, { state: "failed" }] },
+      ),
+    ).toEqual(["pip", "pip bad"]));
+  test("missing max attempts does not add free pips", () =>
+    expect(
+      capacityPips({ pinned: true }, { attempts: [{ state: "done" }] }),
+    ).toEqual(["pip"]));
+  test("spent attempts beyond capacity do not produce negative pips", () =>
+    expect(
+      capacityPips(
+        { pinned: true, max_attempts: 1 },
+        { attempts: [{ state: "done" }, { state: "failed" }] },
+      ),
+    ).toEqual(["pip", "pip bad"]));
 });

--- a/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
@@ -1,0 +1,263 @@
+const NOW = "2026-08-10T23:00:00Z";
+
+const plan = {
+  pinned: true,
+  source: "recorded",
+  max_attempts: 2,
+  implementer_model: "luna",
+  reviewer_model: "opus",
+  turn_timeout_seconds: 1800,
+  version: 1,
+  budget_usd: null,
+};
+
+function attempt(n, state, extra = {}) {
+  return {
+    n,
+    session_id: 170 + n,
+    local_session_id: `fixture-implement-${n}`,
+    model: "luna",
+    state,
+    started_at: "2026-08-10T22:40:00Z",
+    ended_at: state === "running" ? null : "2026-08-10T22:48:00Z",
+    cost_usd: n === 1 ? 0.08 : 0.12,
+    finding: null,
+    live: null,
+    ...extra,
+  };
+}
+
+function node(key, label, state, overrides = {}) {
+  return {
+    key,
+    kind: key === "push_gate" ? "gate" : "work",
+    label,
+    state,
+    model: key === "push_gate" ? null : key === "review" ? "opus" : "luna",
+    attempts: [],
+    queue: null,
+    decision: null,
+    verdict: null,
+    note: null,
+    deps:
+      key === "implement"
+        ? []
+        : key === "push_gate"
+          ? ["implement"]
+          : ["push_gate"],
+    blocked_on: null,
+    evidence: null,
+    ...overrides,
+  };
+}
+
+function run(name, state, overrides = {}) {
+  return {
+    workflow_id: `fixture-${name}`,
+    dbos_status:
+      state === "queued"
+        ? "ENQUEUED"
+        : state === "cancelled"
+          ? "CANCELLED"
+          : "PENDING",
+    state,
+    task: {
+      text: `Fixture ${name} run`,
+      repo: "jomcgi/homelab",
+      base_branch: "main",
+    },
+    work_branch: `claude/fixture-${name}`,
+    branch_url: `https://github.com/jomcgi/homelab/tree/claude/fixture-${name}`,
+    created_at: "2026-08-10T22:40:00Z",
+    updated_at: NOW,
+    completed_at:
+      state === "running" || state === "queued" || state === "stranded"
+        ? null
+        : NOW,
+    app_version: "b7a44d1c",
+    server_app_version: "b7a44d1c",
+    stranded: state === "stranded",
+    cost_usd: 0.2,
+    note: null,
+    plan,
+    nodes: [
+      node("implement", "implement", "future"),
+      node("push_gate", "push gate", "future"),
+      node("review", "review", "future"),
+    ],
+    cancelled_by: state === "cancelled" ? { actor: "joe", at: NOW } : null,
+    ...overrides,
+  };
+}
+
+function entry(runValue, sessions = []) {
+  return {
+    run: runValue,
+    view: { engine_tier: "live", now: NOW, snapshot_age_seconds: 0 },
+    sessions,
+  };
+}
+
+const running = run("running", "running", {
+  nodes: [
+    node("implement", "implement", "running", {
+      attempts: [
+        attempt(1, "gated", {
+          finding: {
+            code: "head_unchanged",
+            text: "the branch head did not move during the turn",
+            observed_head: "86dcbf41",
+          },
+        }),
+        attempt(2, "running", {
+          live: {
+            activity: "checking branch protection rules",
+            observed_at: "2026-08-10T22:59:42Z",
+          },
+          ended_at: null,
+        }),
+      ],
+    }),
+    node("push_gate", "push gate", "waiting", {
+      decision: {
+        register: "fact",
+        basis: "policy.next_action",
+        outcomes: [
+          { when: "head moved", then: "review (opus)" },
+          { when: "head unchanged", then: "escalate, no attempts left" },
+          { when: "turn times out", then: "escalate, no attempts left" },
+        ],
+      },
+    }),
+    node("review", "review", "future"),
+  ],
+});
+
+const escalated = run("escalated", "escalated", {
+  dbos_status: "SUCCESS",
+  nodes: [
+    node("implement", "implement", "escalated"),
+    node("push_gate", "push gate", "refused", {
+      evidence: {
+        kind: "branch_head",
+        summary: "head 86dcbf41 observed on the remote after the turn",
+      },
+    }),
+    node("review", "review", "cancelled", {
+      note: "never dispatched: nothing was verified for review",
+    }),
+  ],
+});
+
+const queued = run("queued", "queued", {
+  dbos_status: "ENQUEUED",
+  nodes: [
+    node("implement", "implement", "queued", {
+      queue: { name: "codex", position: 2 },
+    }),
+    node("push_gate", "push gate", "future"),
+    node("review", "review", "future"),
+  ],
+});
+
+const cancelled = run("cancelled", "cancelled", {
+  nodes: [
+    node("implement", "implement", "failed", {
+      attempts: [attempt(1, "failed")],
+    }),
+    node("push_gate", "push gate", "cancelled"),
+    node("review", "review", "cancelled"),
+  ],
+});
+
+const approved = run("approved", "approved", {
+  dbos_status: "SUCCESS",
+  nodes: [
+    node("implement", "implement", "done", { attempts: [attempt(1, "done")] }),
+    node("push_gate", "push gate", "passed"),
+    node("review", "review", "done", {
+      verdict: {
+        value: "approve",
+        excerpt: "The change is ready to merge.",
+        commit_sha: "86dcbf41",
+        commit_url: "https://github.com/jomcgi/homelab/commit/86dcbf41",
+      },
+    }),
+  ],
+});
+
+const stranded = run("stranded", "stranded", {
+  app_version: "old-build",
+  server_app_version: "new-build",
+});
+
+const unpinned = run("unpinned", "running", {
+  plan: {
+    ...plan,
+    pinned: false,
+    source: "current_deploy",
+    max_attempts: null,
+  },
+  nodes: [
+    node("implement", "implement", "running", {
+      attempts: [attempt(1, "running")],
+    }),
+    node("push_gate", "push gate", "waiting", {
+      decision: {
+        register: "belief",
+        basis: "policy.next_action with an unrecorded retry bound",
+        outcomes: [
+          { when: "head moved", then: "review (opus)" },
+          {
+            when: "head unchanged",
+            then: "retry or escalate; the bound was not recorded for this run",
+          },
+        ],
+      },
+    }),
+    node("review", "review", "future"),
+  ],
+});
+
+const wide = run("wide", "running", {
+  nodes: [
+    node("implement", "implement", "done", {
+      deps: [],
+      attempts: [attempt(1, "done")],
+    }),
+    node("lint", "lint", "running", {
+      deps: ["implement"],
+      attempts: [attempt(1, "running")],
+    }),
+    node("review", "review", "running", {
+      deps: ["implement"],
+      attempts: [attempt(1, "running", { model: "opus" })],
+    }),
+    node("push_gate", "push gate", "future", { deps: ["lint", "review"] }),
+  ],
+});
+
+export const RUN_FIXTURES = {
+  running: entry(running, [
+    {
+      id: 171,
+      local_session_id: "fixture-running",
+      status: "running",
+      model: "luna",
+    },
+  ]),
+  escalated: entry(escalated),
+  queued: entry(queued),
+  cancelled: entry(cancelled),
+  approved: entry(approved),
+  stranded: entry(stranded),
+  unpinned: entry(unpinned, [
+    {
+      id: 171,
+      local_session_id: "fixture-unpinned",
+      status: "running",
+      model: "luna",
+    },
+  ]),
+  wide: entry(wide),
+};

--- a/projects/monolith/frontend/src/routes/private/agents/run-view.css
+++ b/projects/monolith/frontend/src/routes/private/agents/run-view.css
@@ -408,7 +408,3 @@
 [data-register="belief"] {
   color: var(--muted);
 }
-.phone-frame {
-  width: 360px;
-  max-width: 100%;
-}


### PR DESCRIPTION
`run-view.css` was ported from the design mockup close to wholesale, but three of its markup blocks never came with it. The classes sat orphaned and the payload fields behind them were dropped on the floor.

Part of #4625.

## What was missing

| orphan class | what it is | data |
|---|---|---|
| `.decision` | the gate's decision table | already composed at `swarm/view.py:270-292`, discarded by the client |
| `.live-act` | the running attempt's live activity line | already sent as `attempt.live.activity` |
| `.pip.free` | capacity pips, "one spent, one available" | derivable from the pinned plan |

The decision table is the sharpest loss. The server composes it with a **declared register** that flips from `fact` to `belief` when the plan was never pinned, and the client threw the whole thing away.

Also lands `node.model`, the on-node queue position ("2nd on the codex queue", which section 4 calls the most common question a run view must answer), `run.branch_url`, and the two build ids in the stranded banner.

## The honesty bug

The status line rendered the denominator as `run.plan?.max_attempts || attempts`. For an **unpinned** plan that falls back to the spent count, fabricating a denominator and presenting a reconstruction as a hard number, which design section 11.4 forbids. It also showed the belief-register "retries remain" phrase even when the plan *was* pinned.

Now: pinned reads `attempt 2 of 2` as fact with no hedge; unpinned reads `attempt 1 · retries remain` with no denominator at all. The absent number is the honesty signal.

## Fixture preview

`?fixture=<name>` renders `RunView` from a static module instead of the network, guarded with `Object.hasOwn` (a bare index would resolve `?fixture=constructor` to `Object.prototype.constructor`, which is truthy, and hand `RunView` an undefined view). Eight fixtures, shapes derived from `swarm/view.py` so they cannot drift from the contract.

This exists because running, escalated, queued and wide runs are otherwise only lookable when a real run happens to be in that state, and the lanes renderer had never seen data at all.

## Verification, by rendering rather than by unit test

`ci lint` clean. Vitest **74 passed across 9 files**. `pnpm build` compiles. Then served the build and read the actual HTML:

- `running`: decision table renders "when the turn ends / head moved → review (opus) / head unchanged → escalate, no attempts left"; `live-act` present; status line "attempt 2 of 2"
- `unpinned`: "attempt 1 · retries remain", zero denominators, and the decision block carries `data-register="belief"` with the server's basis "policy.next_action with an unrecorded retry bound"
- `queued`: node card reads "implement queued luna **2nd on the codex queue**"
- `wide`: 3 capacity pips, "attempt 1 of 2"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39