### PR TITLE
fix(helm): make image digests the authority on whether to publish

### DIFF
--- a/.claude/skills/ci-triage/SKILL.md
+++ b/.claude/skills/ci-triage/SKILL.md
@@ -70,11 +70,22 @@ platforms are wrong.
   `projects/monolith/CLAUDE.md` for the first three. Fix the code, do not silence
   the rule.
 - **`Push images` failing on merge.** No longer a missed bump: PRs do not carry
-  chart versions (ADR platform/009 decision 1). Read the failing stage. If it is
-  the write-back (`write-back-versions.sh`), the charts published but main does
-  not reference them yet, so nothing deploys until it is resolved; re-running the
-  action is safe and idempotent. If it is the publish itself, treat it as a
-  normal build failure.
+  chart versions (ADR platform/009 decision 1). Read the failing stage.
+  - **write-back (`write-back-versions.sh`)**: the charts published but main
+    does not reference them yet, so nothing deploys until it is resolved.
+    Re-running the action is safe and idempotent.
+  - **"published but the image digests DIFFER ... no higher version could be
+    computed"**: the content changed under a published version and the
+    escalation could not produce a new one. Do not re-run and hope; this means
+    `chart-version.sh` returned the same version twice, so read it against that
+    chart's directory.
+  - anything else: a normal build failure.
+- **Merged but never deployed, everything green.** Check whether the chart
+  version actually moved: `git log --author=chart-version-bot -3 origin/main`.
+  A merge whose images changed must produce a write-back. If it did not, compare
+  the digests pinned in the published chart against what the run built, because
+  "nothing to publish" and "failed to notice a change" print almost the same
+  thing. This exact failure happened on 2026-08-10 (commit 2000bae).
 - **Generated files drifting.** `ci regen` runs the committed generators (home
   cluster kustomization, doc manifests, routes, orchestrator bundle). If CI
   auto-commits a regen you did not run, that is the format bot, not a failure.

--- a/bazel/helm/chart-version.sh
+++ b/bazel/helm/chart-version.sh
@@ -35,8 +35,20 @@ if [[ -z "$VERSION_COMMIT" ]]; then
 fi
 
 # --- Determine dependency directories ---
+#
+# CHART_VERSION_ALL_PATHS ignores the dependency closure and counts commits
+# across the WHOLE repo. It exists for the caller that already knows the chart's
+# content changed, because it compared image digests, and only needs a version
+# number that is deterministic per commit. The closure query cannot be trusted
+# in that situation: an incomplete package set is exactly how a real content
+# change gets reported as "no bump needed" (see the digest-authority branch in
+# push.sh.tpl). Counting repo-wide overcounts, which is harmless, rather than
+# undercounting, which silently skips a deploy.
 DEP_DIRS=""
-if [[ -n "$BAZEL_PACKAGE" ]]; then
+if [[ -n "${CHART_VERSION_ALL_PATHS:-}" ]]; then
+	echo >&2 "INFO: CHART_VERSION_ALL_PATHS set; counting commits repo-wide instead of over the dependency closure."
+	DEP_DIRS="."
+elif [[ -n "$BAZEL_PACKAGE" ]]; then
 	# Query Bazel for transitive source deps. --keep_going is load-bearing: a
 	# dependency whose external closure fails to preload (e.g. an apko image
 	# layer pulling wolfi packages) otherwise fails the WHOLE query, and we

--- a/bazel/helm/chart-version_test.sh
+++ b/bazel/helm/chart-version_test.sh
@@ -146,6 +146,32 @@ commit_in "$repo" "fix: real change"
 commit_in "$repo" "chore(demo): bump chart version to 0.1.1" "chart-version-bot"
 expect "bot commits are not counted" "0.1.1" "$(run_version "$repo")" "1 human commit"
 
+# 9. CHART_VERSION_ALL_PATHS counts commits that the chart-dir scoping misses.
+# This is the escalation path push.sh.tpl uses when the image digests prove the
+# content changed but the dependency closure reported nothing: the query that
+# just failed must not be able to veto the new version.
+repo=$(new_repo allpaths 0.1.0)
+mkdir -p "$repo/elsewhere"
+echo "change" >>"$repo/elsewhere/file.txt"
+git -C "$repo" add elsewhere/file.txt
+git -C "$repo" commit --quiet -m "fix: outside the chart dir"
+expect "chart-dir scoping misses it" "0.1.0" \
+	"$(run_version "$repo")" "commit touched no chart path"
+expect "all-paths scoping finds it" "0.1.1" \
+	"$(cd "$repo" && CHART_VERSION_ALL_PATHS=1 bash "$SCRIPT" chart 2>/dev/null)" \
+	"counted repo-wide"
+
+# 10. The escalation stays commit-derived, so two concurrent publishes taking
+# this path still cannot compute the same version. The commit has to touch a
+# real path: `git log -- <paths>` excludes empty commits even when the path is
+# the repo root, so an --allow-empty commit would not be counted here.
+echo "more" >>"$repo/elsewhere/file.txt"
+git -C "$repo" add elsewhere/file.txt
+git -C "$repo" commit --quiet -m "fix: another one"
+expect "all-paths stays commit-derived" "0.1.2" \
+	"$(cd "$repo" && CHART_VERSION_ALL_PATHS=1 bash "$SCRIPT" chart 2>/dev/null)" \
+	"strictly greater at the later commit"
+
 if [[ "$FAILURES" -gt 0 ]]; then
 	echo "${FAILURES} test(s) failed"
 	exit 1

--- a/bazel/helm/push.sh.tpl
+++ b/bazel/helm/push.sh.tpl
@@ -58,9 +58,15 @@ done
 
 # _fail_missed_bump lived here. It told the author to run bump-chart.sh, which
 # is advice that no longer applies: with the version computed post-merge there
-# is no bump for a PR to miss. CHECK_MISSED_BUMP above is now unused and is
-# unwired, along with check-missed-bump.sh and bump-chart.sh themselves, in the
-# follow-up cleanup for ADR platform/009 decision 1.
+# is no bump for a PR to miss.
+#
+# CHECK_MISSED_BUMP is very much still wired, despite ADR platform/009 saying
+# the guard is "retired". Retiring it PRE-MERGE was right, because a PR carries
+# no version. Retiring it on MAIN was wrong: there it is not a bump guard at
+# all, it is the only content-stable answer to "did this chart actually
+# change", and the commit walk that replaced it depends on a dependency query
+# that can silently come back incomplete. Deleting it caused a silent
+# non-deploy on the first merge. See the digest-authority branch below.
 
 # --- Determine branch and workspace ---
 PUSH_TGZ="$CHART_TGZ"
@@ -137,8 +143,79 @@ if [[ "$CURRENT_BRANCH" == "main" ]]; then
       SHOW_RC=$?
       set -e
       if [[ $SHOW_RC -eq 0 ]]; then
-        echo "Chart ${CHART_NAME} ${CHART_VERSION} is already published; nothing to publish."
-        exit 0
+        # DIGEST CONTENT IS THE AUTHORITY, NOT THE COMMIT WALK.
+        #
+        # chart-version.sh decides a bump from conventional commits scoped to
+        # `bazel query deps(...)`, and that package set can come back
+        # INCOMPLETE, at which point a real content change is reported as "no
+        # bump needed" and this branch silently skips a deploy. That is not
+        # hypothetical: it happened on the very first merge of the post-merge
+        # versioning change (2000bae, 2026-08-10). monolith's backend and jobs
+        # images changed because the docs manifests are baked into them, the
+        # closure query did not return projects/monolith, the walk found
+        # nothing, and chart 0.285.528 stayed pinned to the previous digests.
+        #
+        # So do not trust the walk to say "nothing changed". Ask the artifact.
+        # check-missed-bump.sh compares the ghcr.io digests pinned in the fresh
+        # chart against the published chart of this version, reads them straight
+        # out of the chart values (no registry round trip, no race with the
+        # image pushes in this same multirun), and is content-stable. If they
+        # match there is genuinely nothing to publish. If they differ, the
+        # content moved and this version must not be reused: republishing it in
+        # place is what wedges ArgoCD into permanent OutOfSync (ADR 011).
+        DIGESTS_MATCH="true"
+        if [[ -n "$CHECK_MISSED_BUMP" ]] && [[ -f "$CHECK_MISSED_BUMP" ]]; then
+          if [[ -f "${ABS_CHART_DIR}/application.yaml" ]]; then
+            GUARD_PROJECT_DIR="$CHART_DIR"
+          else
+            GUARD_PROJECT_DIR=$(dirname "$CHART_DIR")
+          fi
+          if ! env HELM="$HELM" REPOSITORY="$REPOSITORY" \
+            bash "$CHECK_MISSED_BUMP" "$CHART_NAME" "$CHART_VERSION" "$CHART_TGZ" "$GUARD_PROJECT_DIR"; then
+            DIGESTS_MATCH="false"
+          fi
+        fi
+
+        if [[ "$DIGESTS_MATCH" == "true" ]]; then
+          echo "Chart ${CHART_NAME} ${CHART_VERSION} is already published and the digests match; nothing to publish."
+          exit 0
+        fi
+
+        # The content changed under a published version. Escalate to a version
+        # derived from the commit REPO-WIDE, which needs no closure query, so
+        # the thing that just failed us cannot veto the escalation. It stays a
+        # function of HEAD, so concurrent publishes still cannot collide.
+        echo "Chart ${CHART_NAME} ${CHART_VERSION} is published but the image digests DIFFER; escalating the version." >&2
+        ESCALATED_VERSION=""
+        if [[ "$CAN_VERSION" == "true" ]]; then
+          ESCALATED_VERSION=$(cd "$WORKSPACE" && env CHART_VERSION_ALL_PATHS=1 "$CHART_VERSION_SH" "$CHART_DIR" "//${CHART_DIR}:chart.package") || ESCALATED_VERSION=""
+        fi
+        if [[ -z "$ESCALATED_VERSION" ]] || [[ "$ESCALATED_VERSION" == "$CHART_VERSION" ]]; then
+          {
+            echo "ERROR: ${CHART_NAME} ${CHART_VERSION} is published with DIFFERENT image digests, and no higher version could be computed."
+            echo "Publishing in place would mutate a deployed chart and wedge ArgoCD; skipping would silently not deploy."
+            echo "This needs a human: check bazel/helm/chart-version.sh against ${CHART_DIR}."
+          } >&2
+          exit 1
+        fi
+        echo "Escalated ${CHART_NAME}: ${CHART_VERSION} -> ${ESCALATED_VERSION}"
+        CHART_VERSION="$ESCALATED_VERSION"
+
+        # Re-check the ESCALATED version. SHOW_OUT below describes the old one,
+        # and reusing a published version is the exact mutation this branch
+        # exists to prevent, so the escalation has to be verified free rather
+        # than assumed free.
+        set +e
+        SHOW_OUT=$("${HELM}" show chart "${REPOSITORY}/${CHART_NAME}" --version "${CHART_VERSION}" 2>&1)
+        SHOW_RC=$?
+        set -e
+        if [[ $SHOW_RC -eq 0 ]]; then
+          {
+            echo "ERROR: escalated version ${CHART_NAME} ${CHART_VERSION} is ALSO already published."
+            echo "Publishing in place would mutate a deployed chart. This needs a human."
+          } >&2
+          exit 1
+        fi
       fi
       if echo "$SHOW_OUT" | grep -qiE 'not found|manifest unknown|404'; then
         echo "Publishing ${CHART_NAME}: ${CURRENT_VERSION} -> ${CHART_VERSION}"


### PR DESCRIPTION
Fixes the silent non-deploy caused by #4648. Refs #3890.

## What went wrong

The first merge of post-merge versioning (`2000bae`) published nothing and deployed nothing, with every check green.

monolith's `backend` and `jobs` images changed, because the docs manifests are baked into them. But `bazel query deps(//projects/monolith/chart:chart.package)` did not return `projects/monolith`, so `chart-version.sh` walked an incomplete package set, reported `No conventional commits found since 0.285.528`, and main skipped the publish. Chart 0.285.528 stayed pinned to the previous digests.

Verified against the registry:

| Image | chart 0.285.528 pins | `2000bae` built | |
|---|---|---|---|
| backend | `054a2dbb` | `e2eadd08` | differs |
| jobs | `250ee1d7` | `595df333` | differs |
| frontend | `e0594d2c` | `e0594d2c` | same |
| progress | `033cbd74` | `033cbd74` | same |
| whatsapp | `9d7b0986` | `9d7b0986` | same |

Only the two images containing the manifests moved, so this is a content change, not query flakiness.

## Why it happened

#4648 deleted the digest comparison from main's publish. ADR platform/009 says the missed-bump guard is retired because "with no version in the diff there is no bump to miss". That retires it **pre-merge** correctly. On **main** it was never a bump guard: it is the only content-stable answer to "did this chart actually change", and the commit walk that replaced it rests on a query whose under-scoping the code's own comments already documented, including a previous incident where "a frontend change once merged with no bump and never deployed".

The two detectors guarded different failure modes. They were not redundant, and I removed the one that does not depend on the query.

## The fix

When the computed version is already published, compare digests before believing "nothing to publish":

- **match** -> nothing to do (unchanged common path)
- **differ** -> escalate to a version counted REPO-WIDE (`CHART_VERSION_ALL_PATHS=1`), re-check it is free, publish
- **differ but no higher version computable** -> exit 1 with a message saying it needs a human

Repo-wide scoping is deliberate on both counts: it routes around the query that just under-scoped, so the failing mechanism cannot veto its own correction, and it keeps the version a function of HEAD, so concurrent publishes still cannot collide. A plain `+1` would reintroduce exactly that collision. The escalated version is re-checked against the registry because reusing a published version is the in-place mutation that wedges ArgoCD (ADR platform/011).

## Verification

`ci test`: `Executed 1 out of 755 tests: 755 tests pass.`

`chart-version_test.sh` gains two cases aimed at this: chart-dir scoping *misses* a commit outside the chart while all-paths finds it (the shape of the production failure), and the escalation stays strictly increasing across commits.

**This merge is its own end-to-end test.** monolith's digests currently differ from published 0.285.528, so a correct fix must escalate and publish on merge, which also deploys the docs from #4648. No `chart-version-bot` commit appearing is an immediate signal the fix is wrong.

## Follow-up

`check-missed-bump.sh` must NOT be deleted in the ADR platform/009 cleanup. Only `bump-chart.sh` and the pre-merge call site go.
