### PR TITLE
test(authentik): say which !Env rejections are authentik's and which are ours

### DIFF
--- a/projects/platform/authentik/blueprint_tags_test.py
+++ b/projects/platform/authentik/blueprint_tags_test.py
@@ -17,6 +17,18 @@ IndexError escapes and aborts blueprints_discovery for the ENTIRE /blueprints
 tree. One malformed tag in one file silently stops every blueprint in the
 instance from reconciling, including authentik's own bundled defaults.
 
+Note the asymmetry in why each rejected form is rejected, because the two are
+NOT the same kind of problem:
+
+  - 1 element is authentik's actual contract. It raises IndexError and takes
+    down discovery. This is the bug the guard exists for.
+  - 3 or more elements is a LINT, not authentik's contract. The constructor
+    reads only value[0] and value[1], so extra elements are silently ignored
+    and discovery is unaffected. We still reject it, because a third element
+    is almost certainly an authoring mistake and silence is the worst outcome,
+    but do not read the failure message as "authentik rejects this". It does
+    not.
+
 This test guards against that by:
 1. Discovering all blueprints/*.yaml files and parsing them
 2. Building YAML AST without constructing objects, so we can inspect node shapes
@@ -40,6 +52,17 @@ def _assert_env_arity_node(node, label):
         return
 
     if isinstance(node, yaml.MappingNode):
+        # A mapping-form !Env matches neither isinstance branch in authentik's
+        # constructor, so `key` is never set and it does NOT break discovery: it
+        # surfaces much later as an AttributeError when the blueprint is applied.
+        # Catching it here moves that from apply time to CI, which is the whole
+        # point of this guard.
+        if node.tag == "!Env":
+            mark = node.start_mark
+            raise AssertionError(
+                f"{label}: !Env must be a scalar or a 2-element sequence, got a "
+                f"mapping at line {mark.line + 1}, column {mark.column + 1}"
+            )
         for key, value in node.value:
             _assert_env_arity_node(key, label)
             _assert_env_arity_node(value, label)
@@ -152,7 +175,13 @@ metadata:
 
 
 def test_env_sequence_form_too_many_elements_invalid():
-    """Sequence form !Env [K, default, extra] with 3+ elements is invalid."""
+    """Sequence form !Env [K, default, extra] is rejected as a LINT, not by authentik.
+
+    authentik reads only value[0] and value[1], so a third element is silently
+    ignored and discovery keeps working. We reject it anyway because it is
+    almost certainly an authoring mistake, but unlike the 1-element case this
+    is our rule, not authentik's.
+    """
     yaml_text = """
 version: 1
 metadata:
@@ -166,3 +195,22 @@ metadata:
     # Verify the error message names the issue
     assert "!Env sequence form must have exactly 2 elements" in str(exc_info.value)
     assert "got 3" in str(exc_info.value)
+
+
+def test_env_mapping_form_invalid():
+    """Mapping form !Env is rejected here rather than at apply time.
+
+    It does not raise IndexError, so it does not break discovery the way the
+    1-element sequence does. It fails later, when the blueprint is applied.
+    """
+    yaml_text = """
+version: 1
+metadata:
+  secret: !Env
+    key: MY_SECRET
+    default: fallback
+"""
+    with pytest.raises(AssertionError) as exc_info:
+        _parse_and_check_blueprint(yaml_text, "test_env_mapping_form_invalid")
+
+    assert "must be a scalar or a 2-element sequence" in str(exc_info.value)


### PR DESCRIPTION
Follow-up to #4643, from a review of that PR's decisions.

## What was wrong

The guard rejected `!Env [K, default, extra]` with the message "!Env sequence form must have exactly 2 elements", stated as though it were authentik's contract. It is not.

authentik's constructor reads only `value[0]` and `value[1]`, so a third element is **silently ignored** and blueprint discovery is entirely unaffected. Only the 1-element form raises `IndexError`, and that is the one with the blast radius that motivated #4620 in the first place: `blueprints_find()` catches only `YAMLError`, so the `IndexError` escapes and aborts discovery for the whole tree.

So the guard was conflating two things with very different consequences behind one message.

## What changed

The 3+ rejection stays, because a third element is almost certainly an authoring mistake and silently ignoring it is the worse outcome. What changes is that the test now says whose rule it is. A guard that misattributes its own rule is worse than one that is merely strict: the next person to hit it goes looking in authentik's source for a constraint that is not there.

Also added: the **mapping form** `!Env {key: X}` is now rejected. It matches neither `isinstance` branch in the constructor, so like the 3-element case it does not break discovery. It fails later, when the blueprint is applied, as an `AttributeError`. Moving that from apply time into CI is exactly what this guard is for, and it was nearly free.

The docstring now sets out the asymmetry explicitly, so the file explains which failures are authentik's semantics and which are this repo's lint.

## Verification

`ci test`: `Executed 5 out of 755 tests: 755 tests pass`. The target genuinely executed rather than cache-hitting, since the source changed.

Test-only, no chart touched, deploys nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)