### PR TITLE
feat(monolith): arm the API ingress allowlist

### DIFF
--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -338,3 +338,33 @@ scratchPostgres:
   demoListenPort: 5401
   onepassword:
     itemPath: "vaults/k8s-homelab/items/scratch-postgres"
+
+# Arm the API ingress allowlist (issue #4628, policy added inert in PR #4640).
+#
+# This is the opt-in the gated template was waiting for, so unlike the PR that
+# added it, this one DOES take effect: the CiliumNetworkPolicy renders and the
+# app pod becomes default-deny for every source the allowlist does not name.
+# The allowlist lives in chart/templates/cilium-ingress-policy.yaml, which
+# carries the provenance of each entry.
+#
+# Evidence the allowlist is complete, gathered before flipping this:
+#   - a repo-wide config audit of everything that dials the monolith service
+#   - an independent second audit that found no missing entry
+#   - a 65-minute `hubble observe` window, 151264 flows, whose complete set of
+#     pod sources into the app pod was exactly envoy-gateway-system (3000,
+#     8000), mcp (8000) and monolith-workflows (8000), plus the host entity for
+#     kubelet probes. No world, remote-node or kube-apiserver source appeared,
+#     which is why no extra fromEntities are needed.
+#
+# Two entries are allowlisted from config but were NOT observed in that window,
+# deliberately: embervm -> 8091 (no agent session ran) and the whatsapp gateway
+# -> 8000 (no inbound message). Absence of traffic is not evidence they are
+# wrong, and dropping them would break those paths the next time they run.
+#
+# If something was still missed it fails as a SILENT dial timeout, not a
+# readable deny (PR #4294). First check on any post-merge weirdness:
+#   kubectl -n kube-system exec <cilium-pod> -c cilium-agent -- \
+#     cilium-dbg monitor --type drop
+ciliumPolicy:
+  ingress:
+    enabled: true


### PR DESCRIPTION
Arms the policy added inert in #4640. Refs #4628.

**This one takes effect.** #4640 shipped a gated template that rendered nothing; this flips `ciliumPolicy.ingress.enabled` in `deploy/values.yaml`, so the `CiliumNetworkPolicy` renders and the app pod becomes default-deny for every source the allowlist does not name. That default-deny is the point: it is what actually closes in-cluster `X-Auth-Email` forgery, and it is also the risk, since a missed caller fails as a silent dial timeout rather than a readable deny (#4294).

## No chart bump, deliberately

The chart is pinned at `0.285.528`, which already carries the template, and the `$values` source reads from git `HEAD`. So this values-only change arms the policy on merge by itself. Verified the deployed revision is `0.285.528` before writing this.

## Why the allowlist is trusted

Three independent lines of evidence, because the failure mode is silent:

1. A repo-wide config audit of everything that dials the monolith service.
2. A second, independent audit that found no missing entry.
3. A 65-minute `hubble observe` window, **151264 flows**. The complete set of pod sources into the app pod was:

```
envoy-gateway-system -> 3000 (5023), 8000 (192)
mcp                  -> 8000 (798)
monolith-workflows   -> 8000 (140)
(host)               -> 3000, 8000, 8091     [kubelet probes]
```

No `world`, `remote-node` or `kube-apiserver` source appeared, which is why no additional `fromEntities` are needed.

The `envoy-gateway-system -> 8000` entry is worth calling out: it is the one nearly missed. It does not show up in a short window because the private console reaches the backend over `API_BASE=http://localhost:8000`, intra-pod, never crossing a Cilium boundary. It exists because `monolith-private` and `monolith-github-webhook` route to `:8000` directly. Config found it; observation later confirmed it.

## Two entries allowlisted but not observed, on purpose

`embervm -> 8091` and the whatsapp gateway `-> 8000` produced no traffic in the window, because no agent session ran and no inbound message arrived. Absence of traffic is not evidence the entries are wrong, and dropping them would break those paths the next time they run. Recorded in the values comment so a future reader does not "clean them up".

## Rollback and what to watch

Reverting this commit disarms the policy immediately, since `$values` tracks HEAD. After merge I will confirm the policy object exists, the pod stays Ready (probes ride `fromEntities: host`, so a mistake there surfaces as a failing readiness probe rather than silently), and check:

```
cilium-dbg monitor --type drop
```

`ci test`: `Executed 1 out of 755 tests: 755 tests pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)