### PR TITLE
feat(monolith): parse implementer rationale and render it as testimony

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2229,6 +2229,16 @@ py_test(
 )
 
 py_test(
+    name = "rationale_test",
+    srcs = ["swarm/rationale_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_swarm",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "tier_test",
     srcs = ["swarm/tier_test.py"],
     imports = ["."],

--- a/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
@@ -224,29 +224,59 @@
             >{/if}{/each}
       </div>{/if}
     {#each node.attempts ?? [] as attempt}
-      <button
-        class="log-entry"
-        type="button"
-        onclick={() =>
-          attempt.session_id && onSelectSession(attempt.session_id)}
-        ><span class="entry-meta"
-          >{P.labels.attempt}
-          {attempt.n}
-          {P.punct.dot}
-          {attempt.ended_at
-            ? fmtDur(relSeconds(attempt.started_at, attempt.ended_at))
-            : `${P.stateWords.running} ${fmtDur(relSeconds(attempt.started_at, view.now))}`}{#if fmtCost(attempt.cost_usd)}
-            {P.punct.dot} {fmtCost(attempt.cost_usd)}{/if}</span
-        >{#if attempt.state === "running" && attempt.live?.activity}<span
-            class="live-line"
-            ><span class="live-dot"></span><span class="live-act"
-              >{attempt.live.activity}</span
-            >{ago(attempt.live.observed_at)}
-            {P.labels.ago}</span
-          >{/if}{#if attempt.finding}<span class="finding"
-            >{attempt.finding.text} {attempt.finding.observed_head ?? ""}</span
-          >{/if}</button
-      >
+      <div>
+        <button
+          class="log-entry"
+          type="button"
+          onclick={() =>
+            attempt.session_id && onSelectSession(attempt.session_id)}
+          ><span class="entry-meta"
+            >{P.labels.attempt}
+            {attempt.n}
+            {P.punct.dot}
+            {attempt.ended_at
+              ? fmtDur(relSeconds(attempt.started_at, attempt.ended_at))
+              : `${P.stateWords.running} ${fmtDur(relSeconds(attempt.started_at, view.now))}`}{#if fmtCost(attempt.cost_usd)}
+              {P.punct.dot} {fmtCost(attempt.cost_usd)}{/if}</span
+          >{#if attempt.state === "running" && attempt.live?.activity}<span
+              class="live-line"
+              ><span class="live-dot"></span><span class="live-act"
+                >{attempt.live.activity}</span
+              >{ago(attempt.live.observed_at)}
+              {P.labels.ago}</span
+            >{/if}{#if attempt.finding}<span class="finding"
+              >{attempt.finding.text}
+              {attempt.finding.observed_head ?? ""}</span
+            >{/if}</button
+        >
+        {#if attempt.rationale?.parse_status === "parsed" || attempt.rationale?.parse_status === "unparseable"}
+          <div class="testimony" data-register="testimony">
+            <div class="testimony-attribution">
+              {node.label}
+              {P.punct.dot}
+              {P.labels.attempt}
+              {attempt.n}{#if attempt.model}
+                {P.punct.dot} {attempt.model}{/if}
+            </div>
+            {#if attempt.rationale.parse_status === "parsed"}
+              {#each attempt.rationale.areas as area}
+                <div class="testimony-line">
+                  {area.area}{#if area.why}
+                    {P.punct.dot} {area.why}{/if}
+                </div>
+              {/each}
+              {#each attempt.rationale.deviations as deviation}
+                <div class="testimony-line">
+                  {P.labels.deviationWord}
+                  {deviation}
+                </div>
+              {/each}
+            {:else}
+              <pre class="testimony-raw">{attempt.rationale.raw}</pre>
+            {/if}
+          </div>
+        {/if}
+      </div>
     {/each}
     {#if node.verdict}<div class="verdict-box" data-register="belief">
         <div class="verdict-word">{P.labels.verdict} {node.verdict.value}</div>

--- a/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
@@ -108,6 +108,16 @@ const running = run("running", "running", {
             text: "the branch head did not move during the turn",
             observed_head: "86dcbf41",
           },
+          rationale: {
+            raw: "RATIONALE\n- area: swarm/rows.py · why: carries the final turn\n- area: run view · why: shows testimony\n- deviation: kept routing unchanged",
+            parse_status: "parsed",
+            areas: [
+              { area: "swarm/rows.py", why: "carries the final turn" },
+              { area: "run view", why: "shows testimony" },
+            ],
+            deviations: ["kept routing unchanged"],
+            parser_version: 1,
+          },
         }),
         attempt(2, "running", {
           live: {
@@ -115,6 +125,13 @@ const running = run("running", "running", {
             observed_at: "2026-08-10T22:59:42Z",
           },
           ended_at: null,
+          rationale: {
+            raw: null,
+            parse_status: "none",
+            areas: [],
+            deviations: [],
+            parser_version: 1,
+          },
         }),
       ],
     }),

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -70,6 +70,7 @@ export const RUN_LEXICON = {
     parallel: "in parallel",
     byWord: "by",
     evidence: "evidence",
+    deviationWord: "deviation",
     approve: "approve",
     deny: "deny",
     blockedOnYou: "blocked on you",

--- a/projects/monolith/frontend/src/routes/private/agents/run-view.css
+++ b/projects/monolith/frontend/src/routes/private/agents/run-view.css
@@ -325,6 +325,24 @@
   color: var(--attn);
   font: var(--size-body-mono) var(--font-mono);
 }
+.testimony {
+  margin-top: 8px;
+  border-left: 2px solid var(--line-strong);
+  padding: 4px 0 4px 14px;
+  font-family: var(--font-ui);
+}
+.testimony-attribution {
+  color: var(--muted);
+  font: var(--size-meta) var(--font-mono);
+}
+.testimony-line {
+  margin-top: 3px;
+}
+.testimony-raw {
+  margin: 6px 0 0;
+  white-space: pre-wrap;
+  font: inherit;
+}
 .rv-foot {
   margin-top: 14px;
   border-top: 1px solid var(--line);

--- a/projects/monolith/swarm/rationale.py
+++ b/projects/monolith/swarm/rationale.py
@@ -1,0 +1,86 @@
+"""Display-only parsing for implementer rationale trailers."""
+
+from __future__ import annotations
+
+import re
+
+
+_RATIONALE_TAIL_LINES = 12
+_HEADER = re.compile(r"RATIONALE", re.IGNORECASE)
+_AREA = re.compile(
+    r"area\s*:\s*(?P<area>.+?)(?:\s+(?:·|-|–)\s*why\s*:\s*(?P<why>.*))?$",
+    re.IGNORECASE,
+)
+_DEVIATION = re.compile(r"deviation\s*:\s*(?P<deviation>.+)$", re.IGNORECASE)
+
+
+def _empty(status: str, raw: str | None = None) -> dict:
+    return {
+        "raw": raw,
+        "parse_status": status,
+        "areas": [],
+        "deviations": [],
+        "parser_version": 1,
+    }
+
+
+def _decorated(line: str) -> str:
+    return line.strip().strip("*#>\u2013- `\t").strip()
+
+
+def parse_rationale(text: str | None) -> dict:
+    """Parse the bounded rationale trailer, failing closed on ambiguity."""
+    try:
+        if not text:
+            return _empty("none")
+        lines = text.splitlines()
+        nonempty = [index for index, line in enumerate(lines) if line.strip()]
+        tail = set(nonempty[-_RATIONALE_TAIL_LINES:])
+        headers = [
+            index
+            for index in nonempty
+            if index in tail and _HEADER.fullmatch(_decorated(lines[index]))
+        ]
+        if not headers:
+            return _empty("none")
+        if len(headers) != 1:
+            return _empty("unparseable", "\n".join(lines[headers[0] :]))
+
+        header = headers[0]
+        raw = "\n".join(lines[header:])
+        areas = []
+        deviations = []
+        meaningful = 0
+        for line in lines[header + 1 :]:
+            stripped = _decorated(line)
+            if not stripped:
+                continue
+            bullet = stripped.lstrip("-* \t")
+            area = _AREA.fullmatch(bullet)
+            deviation = _DEVIATION.fullmatch(bullet)
+            if area:
+                meaningful += 1
+                areas.append(
+                    {
+                        "area": area.group("area").strip(),
+                        "why": (area.group("why") or "").strip(),
+                    }
+                )
+            elif deviation:
+                meaningful += 1
+                deviations.append(deviation.group("deviation").strip())
+            elif stripped in ("```", "---"):
+                continue
+            else:
+                return _empty("unparseable", raw)
+        if not meaningful:
+            return _empty("unparseable", raw)
+        return {
+            "raw": raw,
+            "parse_status": "parsed",
+            "areas": areas,
+            "deviations": deviations,
+            "parser_version": 1,
+        }
+    except Exception:
+        return _empty("unparseable")

--- a/projects/monolith/swarm/rationale_test.py
+++ b/projects/monolith/swarm/rationale_test.py
@@ -1,0 +1,66 @@
+from swarm.rationale import parse_rationale
+
+
+def test_clean_trailer_parses_areas_and_deviation():
+    result = parse_rationale(
+        "work done\nRATIONALE\n"
+        "- area: swarm/rows.py · why: carries the final turn text\n"
+        "- area: run view · why: keeps testimony with its attempt\n"
+        "- deviation: left routing unchanged because rationale is display only"
+    )
+    assert result["parse_status"] == "parsed"
+    assert result["areas"] == [
+        {"area": "swarm/rows.py", "why": "carries the final turn text"},
+        {"area": "run view", "why": "keeps testimony with its attempt"},
+    ]
+    assert result["deviations"] == [
+        "left routing unchanged because rationale is display only"
+    ]
+    assert result["parser_version"] == 1
+
+
+def test_markdown_decoration_is_tolerated():
+    result = parse_rationale(
+        "## RATIONALE\n* - area: view · why: show it\n* - deviation: none"
+    )
+    assert result["parse_status"] == "parsed"
+    assert result["areas"] == [{"area": "view", "why": "show it"}]
+
+
+def test_no_trailer_is_absent():
+    assert parse_rationale("ordinary reply") == {
+        "raw": None,
+        "parse_status": "none",
+        "areas": [],
+        "deviations": [],
+        "parser_version": 1,
+    }
+
+
+def test_garbage_header_preserves_raw():
+    result = parse_rationale("RATIONALE\nthis is not a bullet")
+    assert result["parse_status"] == "unparseable"
+    assert result["raw"] == "RATIONALE\nthis is not a bullet"
+    assert result["areas"] == []
+
+
+def test_header_outside_tail_window_is_absent():
+    assert (
+        parse_rationale("RATIONALE\n- area: old · why: old\n" + "noise\n" * 12)[
+            "parse_status"
+        ]
+        == "none"
+    )
+
+
+def test_area_without_why_does_not_invent_one():
+    result = parse_rationale("RATIONALE\n- area: an untouched file")
+    assert result["areas"] == [{"area": "an untouched file", "why": ""}]
+
+
+def test_duplicated_blocks_fail_closed():
+    result = parse_rationale(
+        "RATIONALE\n- area: one · why: first\nRATIONALE\n- area: two · why: second"
+    )
+    assert result["parse_status"] == "unparseable"
+    assert result["areas"] == []

--- a/projects/monolith/swarm/rows.py
+++ b/projects/monolith/swarm/rows.py
@@ -59,9 +59,27 @@ def swarm_session_views(
         .group_by(AgentTurn.session_id)
         .subquery()
     )
+    latest_turns = (
+        select(AgentTurn.session_id, func.max(AgentTurn.seq).label("latest_seq"))
+        .group_by(AgentTurn.session_id)
+        .subquery()
+    )
     statement = (
-        select(AgentSession, func.coalesce(totals.c.total_cost_usd, 0))
+        select(
+            AgentSession,
+            func.coalesce(totals.c.total_cost_usd, 0),
+            AgentTurn.result_text,
+        )
         .outerjoin(totals, totals.c.session_id == AgentSession.id)
+        .outerjoin(
+            latest_turns,
+            latest_turns.c.session_id == AgentSession.id,
+        )
+        .outerjoin(
+            AgentTurn,
+            (AgentTurn.session_id == latest_turns.c.session_id)
+            & (AgentTurn.seq == latest_turns.c.latest_seq),
+        )
         .where(AgentSession.workflow_id.is_not(None))
     )
     if workflow_id is not None:
@@ -80,7 +98,7 @@ def swarm_session_views(
             pending_by_session.setdefault(pending.session_id, []).append(pending)
 
     result: dict[str, list[dict]] = {}
-    for row, total_cost in rows:
+    for row, total_cost, result_text in rows:
         pending = pending_by_session.get(row.id, [])
         claimed = [item for item in pending if item.claimed_by_replica is not None]
         current = (
@@ -105,6 +123,7 @@ def swarm_session_views(
             "status": row.status,
             "model": row.model,
             "total_cost_usd": float(total_cost or 0),
+            "final_result_text": result_text,
             "created_at": row.created_at,
             "last_turn_at": row.last_turn_at,
             "activity": _activity_line(activity) if activity is not None else None,

--- a/projects/monolith/swarm/rows_test.py
+++ b/projects/monolith/swarm/rows_test.py
@@ -65,6 +65,27 @@ def test_costs_are_grouped_and_zero_without_turns(db):
     assert by_id[first]["total_cost_usd"] == pytest.approx(0.6)
     assert by_id[second]["total_cost_usd"] == 0.0
     assert isinstance(by_id[first]["created_at"], datetime)
+    assert by_id[first]["final_result_text"] == "result"
+    assert by_id[second]["final_result_text"] is None
+
+
+def test_final_result_text_comes_from_highest_turn_seq(db):
+    session_id = add_session(db, local_id="last-turn")
+    with Session(db) as session:
+        session.add_all(
+            [
+                AgentTurn(
+                    session_id=session_id, seq=1, prompt="p", result_text="first"
+                ),
+                AgentTurn(session_id=session_id, seq=3, prompt="p", result_text="last"),
+                AgentTurn(
+                    session_id=session_id, seq=2, prompt="p", result_text="middle"
+                ),
+            ]
+        )
+        session.commit()
+        row = swarm_session_views(session)["wf-1"][0]
+    assert row["final_result_text"] == "last"
 
 
 def test_workflow_filter_and_grouping(db):

--- a/projects/monolith/swarm/view.py
+++ b/projects/monolith/swarm/view.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from swarm import config
+from swarm.rationale import parse_rationale
 
 
 def _value(obj: Any, name: str, default: Any = None) -> Any:
@@ -164,6 +165,7 @@ def _attempts(session_rows: list[Any], steps: list[Any], node_key: str) -> list[
                 else None,
                 "cost_usd": _value(row, "total_cost_usd", _value(row, "cost_usd")),
                 "finding": _finding(None, observed, prior),
+                "rationale": parse_rationale(_value(row, "final_result_text")),
                 "prior_head": _short_sha(prior),
                 "live": None
                 if state != "running"

--- a/projects/monolith/swarm/view_test.py
+++ b/projects/monolith/swarm/view_test.py
@@ -151,6 +151,10 @@ def _running_implement(workflow_id):
             "created_at": datetime(2026, 8, 10, 22, 50, tzinfo=timezone.utc),
             "last_turn_at": datetime(2026, 8, 10, 22, 56, tzinfo=timezone.utc),
             "total_cost_usd": 0.09,
+            "final_result_text": (
+                "RATIONALE\n- area: swarm/view.py · why: attaches testimony\n"
+                "- deviation: no routing changes"
+            ),
         }
     ]
 
@@ -174,6 +178,28 @@ def test_pinned_and_unpinned_registers_are_distinct(monkeypatch):
     assert unpinned["plan"]["pinned"] is False
     assert unpinned["plan"]["max_attempts"] is None
     assert unpinned["nodes"][1]["decision"]["register"] == "belief"
+
+
+def test_attempt_carries_parsed_rationale_and_absence():
+    parsed = compose_run(
+        DBOS(Workflow(Status("wf-rationale", "PENDING", ["task", "repo", "main"]))),
+        "wf-rationale",
+        _running_implement("wf-rationale"),
+        "unknown",
+    )
+    assert parsed["nodes"][0]["attempts"][0]["rationale"]["parse_status"] == "parsed"
+
+    absent_row = _running_implement("wf-rationale")[0]
+    absent_row["final_result_text"] = None
+    absent = compose_run(
+        DBOS(
+            Workflow(Status("wf-rationale-none", "PENDING", ["task", "repo", "main"]))
+        ),
+        "wf-rationale-none",
+        [absent_row],
+        "unknown",
+    )
+    assert absent["nodes"][0]["attempts"][0]["rationale"]["parse_status"] == "none"
 
 
 def test_queued_child_gets_codex_position():


### PR DESCRIPTION
Since #4631 every implementer has been prompted to end its reply with a `RATIONALE` trailer. That text has been landing verbatim in `AgentTurn.result_text` and nothing has ever read it, so the run view could show *what* an implementer did but never *why*.

Part of #4625. Lands the third register.

## The parser

`swarm/rationale.py`, modelled on `parse_review_verdict` (`policy.py:75`): bounded tail window, decoration stripped, no guessing, never raises.

| input | `parse_status` | rendered |
|---|---|---|
| clean trailer | `parsed` | areas and deviations, attributed |
| header present, content garbage | `unparseable` | the raw block verbatim |
| no trailer | `none` | **nothing at all** |

The `none` case matters most: every turn predating the prompt returns it, which is most of the history. Absence is a fact, not an error, and it should look like silence rather than breakage. Same instinct as the unpinned plan dropping its denominator rather than inventing one.

**The parser is display only.** Nothing in `workflows.py` or `policy.py` calls it, and a missing trailer cannot fail a node. Routing on an agent's own account of itself is exactly the coupling ADR 053 exists to prevent.

## One deliberate departure from the design doc

The document specified `nodes[].rationale`. This attaches it to `attempts[]` instead: rationale is produced per turn, and the design's own attribution grain is "implementer, attempt 2". Flagging rather than silently correcting. Trivial to mirror onto the node if you want the letter.

## The testimony register

Quoted, attributed, and **never extracted into fact-shaped chrome**: no chip, count, badge or icon is derived from anything an agent said. Juxtaposition beside mechanical evidence is allowed, restatement is not.

Unlike belief, testimony **survives the stale tier**. An old snapshot does not make it less true that the words were said, so it desaturates rather than disappearing. It is deliberately not added to the `.tier-stale [data-register="belief"] { display: none }` rule.

## Verification

`ci lint` clean. `ci test`: **`Executed 58 out of 756 tests: 756 tests pass`**. Vitest 74 passed across 9 files. `pnpm build` compiles.

Rendered and read from the served HTML via `?fixture=running`:

```
implement · attempt 1 · luna
swarm/rows.py · carries the final turn
run view · shows testimony
deviation  kept routing unchanged
```

The second attempt in that fixture carries `parse_status: "none"` and renders no testimony block while still showing its mechanical live activity line, which is the fact-beside-testimony case working.

No chart files touched: versions are derived post-merge now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39