### PR TITLE
feat(monolith): compute mechanical deviations and render spend against budget

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2239,6 +2239,16 @@ py_test(
 )
 
 py_test(
+    name = "deviations_test",
+    srcs = ["swarm/deviations_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_swarm",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "tier_test",
     srcs = ["swarm/tier_test.py"],
     imports = ["."],

--- a/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
@@ -75,7 +75,13 @@
       {P.labels.started}
       {ago(run.created_at)}
       {P.labels.ago}
-      {#if fmtCost(run.cost_usd)}{P.punct.dot} {fmtCost(run.cost_usd)}{/if}
+      {#if run.plan?.budget_usd != null}
+        {P.punct.dot}
+        {fmtCost(run.cost_usd)}
+        {P.labels.of}
+        {fmtCost(run.plan.budget_usd)}
+        {P.labels.budgetWord}
+      {:else if fmtCost(run.cost_usd)}{P.punct.dot} {fmtCost(run.cost_usd)}{/if}
     </div>
     <div class="rv-statusline" data-register="fact">
       {#if run.state === "running" && attempts && run.plan?.pinned}
@@ -141,6 +147,12 @@
           </div>{:else}{@render nodeCard(group[0], false)}{/if}
       {/each}
     </div>
+    {#if run.deviations?.length}<div class="deviations" data-register="fact">
+        <div class="stage-head">{P.labels.deviations}</div>
+        {#each run.deviations as deviation}<div class="deviation-text mono">
+            {deviation.text}
+          </div>{/each}
+      </div>{/if}
     <div
       class="rv-foot"
       class:stale={view.engine_tier === "stale"}

--- a/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
@@ -99,6 +99,21 @@ function entry(runValue, sessions = []) {
 }
 
 const running = run("running", "running", {
+  plan: { ...plan, budget_usd: 0.15 },
+  deviations: [
+    {
+      code: "retry_taken",
+      node_key: "implement",
+      evidence: "attempts: 2; retry finding code: head_unchanged",
+      text: "implement took 2 attempts after head_unchanged.",
+    },
+    {
+      code: "budget_exceeded",
+      node_key: "run",
+      evidence: "cost_usd: $0.20; pinned budget_usd: $0.15",
+      text: "run spent $0.20 against a pinned $0.15 budget.",
+    },
+  ],
   nodes: [
     node("implement", "implement", "running", {
       attempts: [

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -90,6 +90,7 @@ export const RUN_LEXICON = {
     createRun: "start run",
     creating: "creating…",
     startingRun: "starting…",
+    deviations: "deviations",
   },
   punct: { dot: "·", arrow: "→", colon: ":" },
   units: { s: "s", m: "m", h: "h", d: "d" },

--- a/projects/monolith/frontend/src/routes/private/agents/run-view.css
+++ b/projects/monolith/frontend/src/routes/private/agents/run-view.css
@@ -178,6 +178,15 @@
   border-top: 1px solid var(--line);
   padding-top: 12px;
 }
+.deviations {
+  margin-top: 14px;
+  border-top: 1px solid var(--line);
+  padding-top: 10px;
+}
+.deviation-text {
+  color: var(--text-soft);
+  margin-top: 4px;
+}
 .connector {
   border-left: 1px solid var(--line-strong);
   margin-left: 7px;

--- a/projects/monolith/swarm/deviations.py
+++ b/projects/monolith/swarm/deviations.py
@@ -1,0 +1,116 @@
+"""Mechanical, engine-recorded deviations from a pinned swarm plan."""
+
+from __future__ import annotations
+
+
+def _deviation(code: str, node_key: str, evidence: str, text: str) -> dict:
+    return {"code": code, "node_key": node_key, "evidence": evidence, "text": text}
+
+
+def compute_deviations(run: dict) -> list[dict]:
+    """Return deviations that can be computed from the composed run state."""
+    deviations = []
+    plan = run.get("plan") or {}
+    pinned = plan.get("pinned") is True
+    nodes = run.get("nodes") or []
+    by_key = {node.get("key"): node for node in nodes if node.get("key")}
+    implement = by_key.get("implement") or {}
+    implement_attempts = implement.get("attempts") or []
+
+    if (
+        pinned
+        and run.get("state") == "escalated"
+        and plan.get("max_attempts") is not None
+        and len(implement_attempts) == plan["max_attempts"]
+    ):
+        spent = len(implement_attempts)
+        maximum = plan["max_attempts"]
+        deviations.append(
+            _deviation(
+                "attempts_exhausted",
+                "implement",
+                f"spent attempts: {spent}; pinned max_attempts: {maximum}",
+                f"implement exhausted its {maximum} pinned attempts.",
+            )
+        )
+
+    for node in nodes:
+        attempts = node.get("attempts") or []
+        if len(attempts) <= 1:
+            continue
+        finding_codes = [
+            attempt.get("finding", {}).get("code")
+            for attempt in attempts[:-1]
+            if isinstance(attempt.get("finding"), dict)
+            and attempt.get("finding", {}).get("code")
+        ]
+        finding = finding_codes[-1] if finding_codes else None
+        evidence = f"attempts: {len(attempts)}"
+        if finding:
+            evidence += f"; retry finding code: {finding}"
+            text = f"{node.get('label', node.get('key'))} took {len(attempts)} attempts after {finding}."
+        else:
+            text = (
+                f"{node.get('label', node.get('key'))} took {len(attempts)} attempts."
+            )
+        deviations.append(_deviation("retry_taken", node["key"], evidence, text))
+
+    review = by_key.get("review") or {}
+    verdict = review.get("verdict")
+    if isinstance(verdict, dict) and verdict.get("value") is not None:
+        value = verdict["value"]
+        if value != "approve":
+            deviations.append(
+                _deviation(
+                    "verdict_not_approve",
+                    "review",
+                    f"recorded review verdict: {value}",
+                    f"review returned a {value} verdict.",
+                )
+            )
+
+    if pinned:
+        expected_models = {
+            "implement": plan.get("implementer_model"),
+            "review": plan.get("reviewer_model"),
+        }
+        for node in nodes:
+            expected = expected_models.get(node.get("key"))
+            if expected is None:
+                continue
+            for attempt in node.get("attempts") or []:
+                recorded = attempt.get("model")
+                if recorded is None or recorded == expected:
+                    continue
+                deviations.append(
+                    _deviation(
+                        "model_mismatch",
+                        node["key"],
+                        f"recorded model: {recorded}; pinned model: {expected}",
+                        f"{node.get('label', node.get('key'))} used {recorded} instead of pinned {expected}.",
+                    )
+                )
+
+        cost = run.get("cost_usd")
+        budget = plan.get("budget_usd")
+        if cost is not None and budget is not None:
+            try:
+                exceeded = float(cost) > float(budget)
+            except (TypeError, ValueError):
+                exceeded = False
+            if exceeded:
+                # Money is formatted here, not left as a raw float. cost_usd is
+                # a sum of per-turn floats, so it arrives as 0.30000000000000004
+                # and the client renders these strings verbatim.
+                spent = f"${float(cost):.2f}"
+                ceiling = f"${float(budget):.2f}"
+                deviations.append(
+                    _deviation(
+                        "budget_exceeded",
+                        "run",
+                        f"cost_usd: {spent}; pinned budget_usd: {ceiling}",
+                        f"run spent {spent} against a pinned {ceiling} budget.",
+                    )
+                )
+
+    return deviations

--- a/projects/monolith/swarm/deviations_test.py
+++ b/projects/monolith/swarm/deviations_test.py
@@ -1,0 +1,101 @@
+from swarm.deviations import compute_deviations
+
+
+def plan(**overrides):
+    value = {
+        "pinned": True,
+        "max_attempts": 2,
+        "implementer_model": "luna",
+        "reviewer_model": "opus",
+        "budget_usd": 1.0,
+    }
+    value.update(overrides)
+    return value
+
+
+def node(key, attempts=None, verdict=None, label=None):
+    return {
+        "key": key,
+        "label": label or key,
+        "attempts": attempts or [],
+        "verdict": verdict,
+    }
+
+
+def attempt(model="luna", finding=None):
+    return {"model": model, "finding": finding}
+
+
+def test_attempts_exhausted():
+    run = {
+        "state": "escalated",
+        "plan": plan(),
+        "nodes": [node("implement", [attempt(), attempt()])],
+    }
+    assert [d["code"] for d in compute_deviations(run)] == [
+        "attempts_exhausted",
+        "retry_taken",
+    ]
+    assert "2" in compute_deviations(run)[0]["evidence"]
+
+
+def test_retry_taken_includes_recorded_finding_code():
+    run = {
+        "plan": plan(),
+        "nodes": [
+            node(
+                "implement",
+                [attempt(finding={"code": "head_unchanged"}), attempt()],
+            )
+        ],
+    }
+    deviation = compute_deviations(run)[0]
+    assert deviation["code"] == "retry_taken"
+    assert "head_unchanged" in deviation["evidence"]
+
+
+def test_verdict_not_approve_includes_unparseable():
+    run = {
+        "plan": plan(),
+        "nodes": [node("review", verdict={"value": "unparseable"})],
+    }
+    assert compute_deviations(run)[0]["code"] == "verdict_not_approve"
+
+
+def test_model_mismatch():
+    run = {
+        "plan": plan(),
+        "nodes": [node("review", [attempt(model="sonnet")])],
+    }
+    deviation = compute_deviations(run)[0]
+    assert deviation["code"] == "model_mismatch"
+    assert "sonnet" in deviation["evidence"]
+    assert "opus" in deviation["evidence"]
+
+
+def test_budget_exceeded():
+    run = {"plan": plan(), "cost_usd": 1.25, "nodes": []}
+    deviation = compute_deviations(run)[0]
+    assert deviation["code"] == "budget_exceeded"
+    # Formatted, not raw: cost_usd is a sum of floats and the client renders
+    # these strings verbatim, so a bare 0.30000000000000004 would reach the page.
+    assert "$1.25" in deviation["evidence"]
+    assert "$1.00" in deviation["evidence"]
+    assert "$1.25" in deviation["text"]
+
+
+def test_pin_dependent_deviations_are_absent_when_plan_is_unpinned():
+    run = {
+        "state": "escalated",
+        "plan": plan(pinned=False),
+        "cost_usd": 2.0,
+        "nodes": [
+            node("implement", [attempt(), attempt(model="sonnet")]),
+            node("review", [attempt(model="sonnet")]),
+        ],
+    }
+    codes = {deviation["code"] for deviation in compute_deviations(run)}
+    assert "attempts_exhausted" not in codes
+    assert "model_mismatch" not in codes
+    assert "budget_exceeded" not in codes
+    assert "retry_taken" in codes

--- a/projects/monolith/swarm/view.py
+++ b/projects/monolith/swarm/view.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from swarm import config
 from swarm.rationale import parse_rationale
+from swarm.deviations import compute_deviations
 
 
 def _value(obj: Any, name: str, default: Any = None) -> Any:
@@ -361,11 +362,16 @@ def compose_run(dbos, workflow_id, session_rows, server_app_version) -> dict | N
             "evidence": None,
         },
     ]
+    cost_usd = sum(
+        float(_value(row, "total_cost_usd", _value(row, "cost_usd", 0)) or 0)
+        for row in sessions
+    )
+    state = _derived_state(raw, output, nodes, stranded)
     work_branch = output.get("work_branch") or f"claude/swarm-{workflow_id}"
     return {
         "workflow_id": workflow_id,
         "dbos_status": raw,
-        "state": _derived_state(raw, output, nodes, stranded),
+        "state": state,
         "task": {
             "text": inp.get("task", ""),
             "repo": inp.get("repo"),
@@ -379,13 +385,13 @@ def compose_run(dbos, workflow_id, session_rows, server_app_version) -> dict | N
         "app_version": app_version,
         "server_app_version": server_app_version,
         "stranded": stranded,
-        "cost_usd": sum(
-            float(_value(row, "total_cost_usd", _value(row, "cost_usd", 0)) or 0)
-            for row in sessions
-        ),
+        "cost_usd": cost_usd,
         "note": None,
         "plan": plan,
         "nodes": nodes,
+        "deviations": compute_deviations(
+            {"state": state, "cost_usd": cost_usd, "plan": plan, "nodes": nodes}
+        ),
         "cancelled_by": attrs.get("cancelled_by"),
     }
 

--- a/projects/monolith/swarm/view_test.py
+++ b/projects/monolith/swarm/view_test.py
@@ -118,6 +118,34 @@ def test_escalated_success_carries_branch_head_and_no_commit():
     assert run["state"] == "escalated"
     assert run["nodes"][1]["evidence"]["kind"] == "branch_head"
     assert run["nodes"][2]["verdict"] is None
+    assert run["deviations"] == []
+
+
+def test_composed_run_attaches_mechanical_deviations():
+    status = Status(
+        "wf-deviations",
+        "SUCCESS",
+        ["task", "repo", "main"],
+        {"status": "escalated"},
+    )
+    run = compose_run(
+        DBOS(
+            Workflow(status, {"plan": FX4_EXPECTED_PLAN}),
+            steps=[
+                {"function_name": "read_branch_head", "output": "same"},
+                {"function_name": "read_branch_head", "output": "same"},
+                {"function_name": "read_branch_head", "output": "same"},
+                {"function_name": "read_branch_head", "output": "same"},
+            ],
+        ),
+        "wf-deviations",
+        [session(1), session(2, attempt=2)],
+        "unknown",
+    )
+    assert [deviation["code"] for deviation in run["deviations"]] == [
+        "attempts_exhausted",
+        "retry_taken",
+    ]
 
 
 def test_stranded_pending_has_no_decision():


### PR DESCRIPTION
The run view could say what happened but not where it departed from the plan. Pinning the plan at run start (#4633) is what made a departure **computable from recorded state** rather than inferred, which is what makes it presentable as fact at all.

Part of #4625. This is the last slice of the run view program.

## Five codes, all engine-recorded

| code | pin required |
|---|---|
| `attempts_exhausted` | yes |
| `model_mismatch` | yes |
| `budget_exceeded` | yes |
| `retry_taken` | no |
| `verdict_not_approve` (includes `unparseable`) | no |

**Pin gating is the load-bearing part.** The three pin-dependent codes are skipped entirely when `plan.pinned` is false. Emitting them against a reconstructed baseline would present a comparison-to-an-unrecorded-value as fact, which is the same failure as the fabricated attempt denominator fixed in #4647. The other two read straight from recorded attempts and output, so they hold regardless of whether anyone wrote the plan down.

**Nothing an agent said enters the list.** No rationale, no verdict prose, no turn text. Deviations and testimony (#4656) can share a screen precisely because neither borrows the other's authority.

## Two things caught in review

- **Money is formatted server side.** `cost_usd` is a sum of per-turn floats, so the raw value reaches the page as `0.30000000000000004`, and the client renders these strings verbatim. The test now pins `$1.25` rather than `1.25`, so the formatting is actually asserted.
- **A fixture was lying.** The preview rendered "run spent 0.2 against a pinned 0.15 budget" because the fixture carried canned text written before the formatting fix. Caught by rendering the page rather than by reading the diff, which is the whole argument for the fixture preview existing.

## Deliberately absent

The two stretch codes, `head_moved_outside_window` and recovered-on-a-different-build. Neither is computable from recorded state today. Stating that rather than omitting silently, since a narrowed scope otherwise reads as full coverage.

## Verification

`ci lint` clean. `ci test`: **`Executed 57 out of 756 tests: 756 tests pass`**. Vitest 74 passed. `pnpm build` compiles.

Rendered and read from the served HTML:

```
meta:  claude/fixture-running · started 20m ago · $0.20 of $0.15 budget
block: deviations
       implement took 2 attempts after head_unchanged.
       run spent $0.20 against a pinned $0.15 budget.
```

The `escalated` fixture has no deviations and the block is absent rather than empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39