### PR TITLE
feat(monolith): sidebar run rows with the shape strip

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -8,6 +8,7 @@
     groupSessions,
     groupSummary,
     isGroupExpanded as groupIsExpanded,
+    runRowModel,
     shortWorkflowId,
   } from "./grouping.js";
   import {
@@ -22,6 +23,9 @@
   import "./run-view.css";
   import RunView from "./RunView.svelte";
   import MasterView from "./MasterView.svelte";
+  import StateIcon from "./StateIcon.svelte";
+  import { nodeIconKey, nodeStateClass } from "./dag.js";
+  import { fmtCost } from "./run-format.js";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
 
   let { data } = $props();
@@ -1499,14 +1503,29 @@
 {/snippet}
 
 {#snippet sessionGroup(entry, active)}
+  {@const run = runRowModel(entry, runs)}
   <div class="session-group">
     <button
       class="group-header group-main"
       type="button"
+      title={entry.workflowId}
       onclick={() => selectRun(entry.workflowId)}
     >
-      <span class="group-id mono">{shortWorkflowId(entry.workflowId)}</span>
-      <span class="group-summary">{groupSummary(entry.counts)}</span>
+      {#if run}
+        <span class="ic-strip run-shape-strip" aria-hidden="true">
+          {#each run.shape ?? [] as node (node.key)}
+            <StateIcon icon={nodeIconKey(node)} class={nodeStateClass(node)} />
+          {/each}
+        </span>
+        <span class="group-run-title">{firstLine(run.title)}</span>
+        <span class="group-run-meta mono">
+          {P.stateWords[run.state] || run.state}{#if fmtCost(run.cost_usd)}
+            {P.punct.dot} {fmtCost(run.cost_usd)}{/if}
+        </span>
+      {:else}
+        <span class="group-id mono">{shortWorkflowId(entry.workflowId)}</span>
+        <span class="group-summary">{groupSummary(entry.counts)}</span>
+      {/if}
     </button>
     <button
       class="group-header group-chevron"
@@ -1791,6 +1810,27 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  .run-shape-strip {
+    width: auto;
+    height: 1.05em;
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    overflow: hidden;
+  }
+  .group-run-title {
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text);
+  }
+  .group-run-meta {
+    flex: 0 0 auto;
+    color: var(--muted);
+    text-align: right;
   }
   .group-id {
     flex: 0 0 auto;

--- a/projects/monolith/frontend/src/routes/private/agents/grouping.js
+++ b/projects/monolith/frontend/src/routes/private/agents/grouping.js
@@ -31,10 +31,7 @@ export function groupSessions(sessions) {
 
     const key = String(workflowId);
     const members = groups.get(key);
-    if (members.length === 1 || emittedGroups.has(key)) {
-      if (members.length === 1) entries.push({ kind: "session", session });
-      continue;
-    }
+    if (emittedGroups.has(key)) continue;
 
     emittedGroups.add(key);
     const counts = {};
@@ -56,6 +53,19 @@ export function groupSummary(counts) {
   return SUMMARY_ORDER.filter((status) => counts?.[status] > 0)
     .map((status) => `${counts[status]} ${status}`)
     .join(" · ");
+}
+
+export function runRowModel(entry, runs) {
+  const run = (runs ?? []).find(
+    (candidate) => String(candidate?.workflow_id) === String(entry?.workflowId),
+  );
+  if (!run) return null;
+  return {
+    title: run.title,
+    state: run.state,
+    cost_usd: run.cost_usd,
+    shape: run.shape,
+  };
 }
 
 // Workflow ids are time ordered (a ULID's leading characters are its

--- a/projects/monolith/frontend/src/routes/private/agents/grouping.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/grouping.test.js
@@ -3,6 +3,7 @@ import {
   groupSessions,
   groupSummary,
   isGroupExpanded,
+  runRowModel,
   shortWorkflowId,
 } from "./grouping.js";
 
@@ -38,10 +39,17 @@ describe("groupSessions", () => {
     ]);
   });
 
-  it("keeps a workflow with one session flat", () => {
+  it("groups a workflow with one session", () => {
     const session = { id: "one", workflow_id: 42 };
 
-    expect(groupSessions([session])).toEqual([{ kind: "session", session }]);
+    expect(groupSessions([session])).toEqual([
+      {
+        kind: "group",
+        workflowId: "42",
+        sessions: [session],
+        counts: { completed: 1 },
+      },
+    ]);
   });
 
   it("groups shared workflows at their first member position", () => {
@@ -80,6 +88,56 @@ describe("groupSummary", () => {
     expect(
       groupSummary({ completed: 1, running: 3, warn: 0, working: 0 }),
     ).toBe("3 running · 1 completed");
+  });
+});
+
+describe("runRowModel", () => {
+  const entry = { kind: "group", workflowId: "wf-1" };
+
+  it("joins a matching master run", () => {
+    const shape = [{ key: "plan", kind: "task", state: "running" }];
+    expect(
+      runRowModel(entry, [
+        {
+          workflow_id: "wf-1",
+          title: "Ship the fix",
+          state: "running",
+          cost_usd: 1.25,
+          shape,
+        },
+      ]),
+    ).toEqual({
+      title: "Ship the fix",
+      state: "running",
+      cost_usd: 1.25,
+      shape,
+    });
+  });
+
+  it("returns null when the workflow is not in the master list", () => {
+    expect(runRowModel(entry, [{ workflow_id: "other" }])).toBeNull();
+  });
+
+  it("returns null for an empty master list", () => {
+    expect(runRowModel(entry, [])).toBeNull();
+  });
+
+  it("keeps an absent shape absent", () => {
+    expect(
+      runRowModel(entry, [
+        {
+          workflow_id: "wf-1",
+          title: "Shape pending",
+          state: "queued",
+          cost_usd: 0,
+        },
+      ]),
+    ).toEqual({
+      title: "Shape pending",
+      state: "queued",
+      cost_usd: 0,
+      shape: undefined,
+    });
   });
 });
 


### PR DESCRIPTION
The sidebar showed a run as a truncated workflow id plus session status counts. That is a rollup of *sessions*, and it answers a different question than "what shape is this run and how is it going".

`.ic-strip` has been sitting in `run-view.css` since the run view landed, with no markup behind it. This is the fingerprint it was written for.

Part of #4625. Last slice of the run view program.

## What lands

- **A collapsed run row**: shape strip (one icon per plan node, in order), the task's first line as the title, the run state word, and cost. The workflow id demotes to a `title` attribute, since it tells a person nothing on a phone.
- **Single-member workflows now group.** They previously rendered as a plain session row with no run affordance at all, so a run that died on its first attempt, the one most worth opening, was the one you could not open.
- **`runRowModel`**, a pure join of the master run list onto a group entry, with unit tests.

## The fallback is the point

When the master list has no entry for a workflow (a finished run, or an unreachable engine), the row renders **exactly what it does today**: the short id and the `groupSummary` rollup.

That is #4615's floor and it is deliberate. With no recorded run shape, drawing role glyphs from session statuses would present a reconstruction as fact, which is the one thing this surface's register rules forbid. The strip appears only where the engine actually recorded a shape. This is the fourth place the program degrades the same way: unpinned plan drops its denominator, stale engine drops beliefs, absent engine drops to session facts, and now a run with no master data drops to counts.

Icons map through `nodeIconKey` and `nodeStateClass` from `dag.js` rather than a second copy of the mapping, so the sidebar and the run view cannot drift into disagreeing about what a state looks like.

## Verification

`ci lint` clean. Vitest **78 passed across 9 files**, up from 74: four new tests covering the join (match, miss, empty master list, absent shape) plus the updated single-member grouping contract. `pnpm build` compiles.

Not render-verified. The shape strip needs live master data, and the `?fixture=` preview deliberately bypasses the network, so the sidebar has no runs in that mode. The join is unit-tested and the fallback path is unchanged from what is already in production, but the strip itself has been seen only in tests.

No chart files touched: versions are derived post-merge now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39