### PR TITLE
fix(monolith): restrict the workflows ingress grant to this chart's job pods

### DIFF
--- a/projects/monolith/chart/templates/cilium-ingress-policy.yaml
+++ b/projects/monolith/chart/templates/cilium-ingress-policy.yaml
@@ -36,10 +36,26 @@ Provenance of each allowlist entry:
     so it never crosses a Cilium boundary) and short Hubble windows therefore
     show no gateway traffic to 8000 at all.
   - mcp to 8000: Context Forge federates to the monolith API. Observed live.
-  - monolith-workflows to 8000: Argo Workflows POST to MONOLITH_INTERNAL_URL
+  - jobs.workflowNamespace to 8000, RESTRICTED to this chart's own job pods:
+    Argo Workflows POST to MONOLITH_INTERNAL_URL
     (http://monolith.monolith.svc.cluster.local:8000), set in chart/values.yaml.
     These are periodic and short-lived, so they do not appear in a short Hubble
     window; they come from config, not observation.
+
+    The namespace is NOT enough on its own. renovate deploys into the same
+    namespace (projects/platform/renovate/application.yaml), and it is a large
+    third-party executor that processes untrusted registry and dependency
+    metadata while holding a GitHub token, which makes it a more plausible
+    forger than anything this policy was originally aimed at. Of the 35
+    CronWorkflows in that namespace, 33 belong to this release and the only two
+    that do not are renovate's.
+
+    So the rule also matches app.kubernetes.io/part-of: <release>-jobs, which
+    cronworkflows.yaml stamps onto the job pods via workflowSpec.podMetadata.
+    Label and selector are rendered by the same chart and cannot drift apart.
+    The namespace itself comes from .Values.jobs.workflowNamespace rather than a
+    literal, for the same reason: a literal would leave the grant behind if that
+    value ever moved, and every cron POST would die as a silent dial timeout.
   - monolith component: whatsapp to 8000: the whatsapp gateway posts to
     whatsapp.monolithInboundUrl, which is .../8000/internal/whatsapp/inbound.
     Selected by pod label rather than by opening the whole namespace.
@@ -70,8 +86,10 @@ metadata:
     {{- include "monolith.labels" . | nindent 4 }}
 spec:
   description: >-
-    Allowlist ingress to the monolith app pod so an in-cluster workload cannot
-    reach the API and forge the X-Auth-Email identity header.
+    Allowlist ingress to the monolith app pod. Defence in depth for the
+    X-Auth-Email identity header: it removes most of the cluster from the set
+    that can reach the API, but the named sources can still send the header, so
+    nothing may authorize on it without verifying the JWT in the handler.
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: monolith
@@ -96,7 +114,8 @@ spec:
               protocol: TCP
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: monolith-workflows
+            k8s:io.kubernetes.pod.namespace: {{ .Values.jobs.workflowNamespace }}
+            app.kubernetes.io/part-of: {{ .Release.Name }}-jobs
       toPorts:
         - ports:
             - port: "8000"

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -43,6 +43,18 @@ spec:
   failedJobsHistoryLimit: {{ .failedJobsHistoryLimit | default 5 }}
   workflowSpec:
     entrypoint: run
+    # Stamp the JOB PODS, not just the CronWorkflow object. The labels above land
+    # on the CR and do not propagate, so without this the pods carry no chart
+    # labels at all and the only way to select them is by namespace.
+    #
+    # cilium-ingress-policy.yaml keys its monolith-workflows -> :8000 allow on
+    # this exact label, so that the grant covers THIS chart's jobs rather than
+    # everything sharing the namespace (renovate also deploys there and is a far
+    # larger third-party executor). Label and selector are rendered by the same
+    # chart, so they cannot drift apart.
+    podMetadata:
+      labels:
+        app.kubernetes.io/part-of: {{ $.Release.Name }}-jobs
     # Most jobs use the shared executor SA; a job needing extra cluster access
     # (e.g. stats_rollup reading node/pod counts) sets its own least-privilege SA.
     serviceAccountName: {{ .serviceAccountName | default "argo-workflow" }}


### PR DESCRIPTION
Post-merge review follow-up to #4628. Refs #4660.

## The gap

The allowlist I armed in #4654 granted the **entire** workflow namespace access to `:8000`. That namespace also hosts **renovate**, a large third-party executor that parses untrusted registry and dependency metadata while holding a GitHub token.

So the policy left in place a more plausible `X-Auth-Email` forger than the EmberVM guests the original issue was written about, while its own `spec.description` claimed to stop forgery. That is the part worth owning: the control was real but its stated scope was wrong.

The counting made the fix clean:

| CronWorkflows in the namespace | 35 |
|---|---|
| owned by the `monolith` release | 33 |
| not owned by it | 2, both renovate's |

So restricting to a label this chart stamps evicts exactly renovate and nothing legitimate.

## Changes

**1. The grant is now namespace + label.** `app.kubernetes.io/part-of: <release>-jobs`.

**2. `cronworkflows.yaml` stamps that label onto the job pods.** This is why the rule was namespace-wide in the first place: the existing `monolith.labels` sit on the CronWorkflow *object* and do not propagate to pods, so the pods carried no chart labels at all and namespace was the only selector available. `workflowSpec.podMetadata` fixes that. One chart renders both the label and the selector, so unlike a hand-maintained allowlist they cannot drift apart.

**3. The namespace comes from `.Values.jobs.workflowNamespace`, not a literal.** This was a latent bug: `cronworkflows.yaml:29` already renders callers into that value while the policy hardcoded `monolith-workflows`. Changing the value would have moved every caller and left the grant behind, killing each cron POST as a silent dial timeout. Same class as the env-rename drift in #4606.

**4. `spec.description` corrected.** It claimed the policy stops header forgery. It does not: the named sources can still send the header. The 60-line template comment was already honest, but the description is the string an operator reads off the live object, so it was the one that mattered.

## Verification

`helm template` needs `jobs.image` set, since the CronWorkflows are guarded on the build-time image pin and a plain render produces zero of them. With it pinned: **33 CronWorkflows render, 34 `part-of: monolith-jobs` occurrences** (33 pod stamps plus the one policy rule), and 33 matches the 33 monolith-owned CronWorkflows live in the cluster exactly.

`ci test`: `Executed 1 out of 757 tests: 757 tests pass`.

## Rollout note

ArgoCD applies the policy and the CronWorkflow updates together, but a CronWorkflow change only affects **future** pods. A job already running at apply time will not carry the label and could lose access mid-run. These jobs are short (the synthetics finish in ~10s) and Argo retries, so the exposure is a single cycle at worst. Worth knowing rather than being surprised by.

## Deliberately not included

Narrowing `envoy-gateway-system` to exclude cloudflared, and `mcp` to the gateway pod. Both are right in principle and filed as #4660. The envoy one is held back on purpose: if envoy-gateway relabels its proxies during an upgrade the selector stops matching and **all ingress dies as silent dial timeouts**. The workflows label has no such exposure because one chart owns both sides. Better done deliberately, ideally after #4659 makes policy drops visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)