### PR TITLE
fix(helm): compute chart versions from a complete history

### DIFF
--- a/bazel/helm/chart-version.sh
+++ b/bazel/helm/chart-version.sh
@@ -25,6 +25,36 @@ if [[ -z "$CURRENT_VERSION" ]]; then
 	exit 1
 fi
 
+# --- Refuse to compute anything from a truncated history ---
+#
+# Every number below comes out of a commit walk, so the whole computation
+# assumes the history is actually present. In a SHALLOW clone it is not, and it
+# fails silently rather than obviously: at the graft boundary every file reads
+# as newly ADDED, so the -S search below matches the boundary commit itself. At
+# depth 1 that is HEAD, the HEAD..HEAD range is empty by definition, and this
+# script cheerfully reports "no bump needed" for a chart whose content changed.
+#
+# A partial depth is worse than depth 1, because it returns a plausible WRONG
+# number instead of an obviously stuck one: this repo computes embervm 0.2.8 at
+# depth 10 and 0.2.30 with the full history. That breaks the property the
+# serial arithmetic below is built on, that the version is a function of the
+# COMMIT. Under a shallow clone it is a function of the commit AND the fetch
+# depth, so two publishes of the same commit on differently-deepened runners
+# disagree, and the shallower one computes the lower version.
+#
+# This is not hypothetical: it is what took main's deploy down on 2026-08-10.
+# BuildBuddy clones shallow, every chart reported "no bump needed", and the
+# publish either skipped silently or died in push.sh.tpl's escalation. The
+# deploy action now deepens the clone before publishing (buildbuddy.yaml); this
+# is the backstop for any caller that does not, and it fails loudly because a
+# wrong version is far more expensive than a red build: it wedges ArgoCD.
+if [[ "$(git rev-parse --is-shallow-repository 2>/dev/null || echo false)" == "true" ]]; then
+	echo >&2 "ERROR: refusing to compute a chart version in a shallow repository."
+	echo >&2 "The commit walk would be truncated, making the version a function of the fetch depth rather than of the commit."
+	echo >&2 "Fix: git fetch --unshallow"
+	exit 1
+fi
+
 # --- Find the commit where this version was last set ---
 VERSION_COMMIT=$(git log -1 --format=%H -S"version: ${CURRENT_VERSION}" -- "$CHART_YAML" 2>/dev/null || true)
 if [[ -z "$VERSION_COMMIT" ]]; then

--- a/bazel/helm/chart-version_test.sh
+++ b/bazel/helm/chart-version_test.sh
@@ -172,6 +172,44 @@ expect "all-paths stays commit-derived" "0.1.2" \
 	"$(cd "$repo" && CHART_VERSION_ALL_PATHS=1 bash "$SCRIPT" chart 2>/dev/null)" \
 	"strictly greater at the later commit"
 
+# 11. A SHALLOW clone must fail LOUDLY rather than return a plausible number.
+#
+# This is the failure that took main's deploy down on 2026-08-10. BuildBuddy
+# clones shallow, and in a shallow repo the -S search for the current version
+# matches the graft boundary commit, because at the boundary every file reads
+# as newly added. At depth 1 that boundary is HEAD, so the HEAD..HEAD range is
+# empty and the script reported "no bump needed" for charts whose images had
+# demonstrably changed.
+#
+# The fixture has to BE a shallow clone: the bug is invisible in every other
+# case in this file, all of which build their history locally and therefore
+# always have it complete. `file://` is load-bearing, because a plain path
+# clone is a local hardlink copy that ignores --depth entirely.
+repo=$(new_repo shallowsrc 0.1.0)
+commit_in "$repo" "fix: one"
+commit_in "$repo" "fix: two"
+expect "same repo cloned deep" "0.1.2" "$(run_version "$repo")" "full history counts both"
+
+shallow="$TMP/shallowclone"
+git clone --depth=1 --quiet "file://$repo" "$shallow"
+expect "fixture really is shallow" "true" \
+	"$(git -C "$shallow" rev-parse --is-shallow-repository)" "clone --depth=1"
+
+set +e
+shallow_out=$(cd "$shallow" && bash "$SCRIPT" chart 2>/dev/null)
+shallow_rc=$?
+set -e
+expect "shallow clone fails" "1" "$shallow_rc" "history is truncated"
+# Assert the OLD behaviour specifically. Exiting non-zero is not enough on its
+# own: the regression is the script confidently emitting the unchanged version,
+# which push.sh.tpl reads as "nothing to deploy".
+if [[ "$shallow_out" == "0.1.0" ]]; then
+	echo "FAIL: shallow clone returned the unchanged version '0.1.0' instead of failing" >&2
+	FAILURES=$((FAILURES + 1))
+else
+	echo "ok: shallow clone emitted no version (got '${shallow_out}')"
+fi
+
 if [[ "$FAILURES" -gt 0 ]]; then
 	echo "${FAILURES} test(s) failed"
 	exit 1

--- a/bazel/helm/push.sh.tpl
+++ b/bazel/helm/push.sh.tpl
@@ -145,15 +145,24 @@ if [[ "$CURRENT_BRANCH" == "main" ]]; then
       if [[ $SHOW_RC -eq 0 ]]; then
         # DIGEST CONTENT IS THE AUTHORITY, NOT THE COMMIT WALK.
         #
-        # chart-version.sh decides a bump from conventional commits scoped to
-        # `bazel query deps(...)`, and that package set can come back
-        # INCOMPLETE, at which point a real content change is reported as "no
-        # bump needed" and this branch silently skips a deploy. That is not
-        # hypothetical: it happened on the very first merge of the post-merge
-        # versioning change (2000bae, 2026-08-10). monolith's backend and jobs
-        # images changed because the docs manifests are baked into them, the
-        # closure query did not return projects/monolith, the walk found
-        # nothing, and chart 0.285.528 stayed pinned to the previous digests.
+        # chart-version.sh decides a bump from a walk over conventional
+        # commits, and that walk has more than one way to report "no bump
+        # needed" for content that demonstrably changed. The dependency closure
+        # from `bazel query deps(...)` can come back INCOMPLETE, and the git
+        # history the walk runs over can be TRUNCATED.
+        #
+        # The truncation is the one that actually bit, on the very first merge
+        # of the post-merge versioning change (2000bae, 2026-08-10) and again
+        # loudly at 60ebba4. BuildBuddy clones shallow, and in a shallow clone
+        # the walk anchors to the graft boundary, so its range was empty and
+        # EVERY chart reported no bump. The deploy action now deepens the clone
+        # and chart-version.sh refuses to run shallow at all, so that specific
+        # cause is fixed at the source rather than absorbed here.
+        #
+        # An earlier revision of this comment blamed the closure query for
+        # 2000bae. That was a guess and it was wrong, which is worth recording:
+        # the two causes are indistinguishable from this side, because both
+        # surface only as a version that failed to move.
         #
         # So do not trust the walk to say "nothing changed". Ask the artifact.
         # check-missed-bump.sh compares the ghcr.io digests pinned in the fresh

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -182,6 +182,43 @@ actions:
           # ---- 1. tests ---------------------------------------------------
           bazel test //... --config=ci --deleted_packages=bazel/tools/python --test_tag_filters=-external,-future
 
+          # ---- 1.5 deepen the clone ---------------------------------------
+          # The publish below derives every chart version from a walk over the
+          # conventional commits since the commit that last set that version
+          # (chart-version.sh). BuildBuddy clones SHALLOW, and in a shallow
+          # clone that walk is not merely short, it is EMPTY: at the graft
+          # boundary every file reads as newly added, so the `-S"version: X"`
+          # search matches the boundary commit itself, and at depth 1 that is
+          # HEAD, whose exclusive HEAD..HEAD range contains nothing.
+          #
+          # The result is that every chart computes "no bump needed" and either
+          # silently skips its deploy or, now that image digests are the
+          # authority on whether to publish, fails the action outright. That is
+          # what took main's deploy down on 2026-08-10 (60ebba4, and inertly on
+          # 2000bae before it): the escalation could not compute a higher
+          # version because the range it walked was empty, not because the
+          # dependency closure was incomplete.
+          #
+          # Deepening restores the assumption the arithmetic is built on, that
+          # the version is a function of the COMMIT. It is not enough to fetch
+          # "some" history: at depth 10 this repo computes embervm 0.2.8 where
+          # the full history gives 0.2.30, so a bounded --deepen would just
+          # trade a stuck version for a wrong one. BuildBuddy reuses the runner
+          # workspace between runs, so the cost is paid per cold runner rather
+          # than per deploy, and the guard is skipped once the repo is complete.
+          # Deliberately NOT fatal, unlike the test step above. `set -e` is
+          # load-bearing there because a failed test must not publish images.
+          # Here the opposite applies: if this fetch cannot run, because the
+          # runner's clone has no remote configured or the network blips,
+          # aborting would skip the image pushes as well and leave main worse
+          # off than the bug being fixed. chart-version.sh refuses to compute a
+          # version in a shallow repo, so a failed deepen surfaces as a precise
+          # per-chart error instead of a raw git failure with nothing attempted.
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --unshallow --quiet ||
+              echo "WARNING: could not deepen the clone; chart versions will fail loudly below." >&2
+          fi
+
           # PUBLISH BEFORE THE FORMAT CHECK, deliberately. Under `set -e` a
           # formatter hiccup aborts everything after it, and on 2026-08-09 that
           # took main's first consolidated deploy down before it pushed


### PR DESCRIPTION
Fixes #4662. Fixes #4653.

Main's `deploy` has been red since 60ebba4c7 and publishing nothing since 2000bae72, so no chart has deployed since post-merge versioning landed.

## Root cause, confirmed

BuildBuddy's runner fetches with `--depth=1`. This is visible in its own log:

```
Configuring remote "origin"...
$ git fetch --force --progress --depth=1 origin 60ebba4c7813...
```

`chart-version.sh` derives every number from a walk over the commits since the one that last set the version. In a shallow clone that walk is not merely short, it is **empty**:

1. At the graft boundary every file reads as newly **added**, so `git log -S"version: X" -- Chart.yaml` matches the boundary commit.
2. At depth 1 the boundary commit **is HEAD**.
3. `HEAD..HEAD` is empty by definition, so the walk counts zero commits.
4. `BUMP` stays `none` and the script returns the version unchanged.

Reproduced locally, printing CI's message byte for byte:

```
$ git clone --depth=1 file://$PWD /tmp/shallow && cd /tmp/shallow
$ CHART_VERSION_ALL_PATHS=1 ./bazel/helm/chart-version.sh projects/embervm/chart
INFO: No conventional commits found since 0.1.481, no bump needed
0.1.481
```

### One correction to the issue

#4662 has the mechanism nearly right but says `VERSION_COMMIT` "comes back empty". It does not. An empty `VERSION_COMMIT` takes the branch at line 30 and prints `No previous version commit found`, which is **not** what CI printed. The observed `No conventional commits found since ...` is only reachable with a **non-empty** `VERSION_COMMIT`, which is the graft boundary. The distinction matters because it is what makes `CHART_VERSION_ALL_PATHS` inert: that flag widens the pathspec, and the range was already empty.

## Why depth is not just a truncation

A partial depth is worse than depth 1, because it returns a plausible wrong number instead of an obviously stuck one:

| clone depth | embervm | monolith |
|---|---|---|
| 1 (CI today) | 0.1.481 (no bump, hard error) | 0.285.528 (no bump, hard error) |
| 10 | 0.2.8 | 0.286.8 |
| 50 | 0.2.30 | 0.286.8 |
| full | **0.2.30** | **0.286.8** |

That falsifies the property the serial arithmetic is built on, stated in `chart-version.sh`: "Counting qualifying commits instead makes the version a function of HEAD." Under a shallow clone it is a function of HEAD **and the fetch depth**, so two publishes of the same commit on differently deepened runners disagree, and the shallower one computes the lower version.

## The change

1. **`buildbuddy.yaml`**: the deploy action deepens the clone before publishing, guarded by `git rev-parse --is-shallow-repository` so it is a no-op once complete. BuildBuddy reuses the runner workspace, so the cost is per cold runner, not per deploy.
2. **`chart-version.sh`**: refuses to compute a version in a shallow repository at all. This is the backstop that turns any future truncation into a precise error rather than a wrong version, and it is why a bounded `--deepen` was not used.
3. **`chart-version_test.sh`**: a regression case whose fixture is an actual `--depth=1` clone. Verified to fail against the pre-fix script with the exact production symptom (`returned the unchanged version '0.1.0'`) and pass after.
4. **`push.sh.tpl`**: corrects a comment that attributed 2000bae to an incomplete `bazel query` closure. That was a guess and it was wrong.

The deepen is deliberately **not** fatal. If it cannot run, the images still publish and the per-chart guard says precisely why, rather than aborting the action before anything ships.

## Deliberately not done

#4662 suggests a fallback that escalates to `patch+1` over the published version. That is the read-then-add scheme post-merge versioning exists to avoid: two concurrent publishes read the same registry state and compute the same next version, so the loser's images ship under no version at all. Fixing the history is what keeps the version a function of the commit.

## Expected effect on merge

The next deploy computes real versions for the two wedged charts, which unwedges #4662 item 3 without a manual bump:

- embervm `0.1.481` to `0.2.30`
- monolith `0.285.528` to `0.286.8`

Both are genuine increases (the minor moves), though embervm's patch component drops, which is expected for a minor bump and not a regression.

## Verification

- `ci lint` clean.
- `ci test` green: `Executed 2 out of 757 tests: 757 tests pass`, with `//bazel/helm:chart_version_test` **PASSED** as one of the executed targets, confirming the `--depth=1` fixture works inside the Linux sandbox.
- End to end against a real depth-1 clone of this repo: guard fires, the `buildbuddy.yaml` snippet deepens it to 11790 commits, and the versions above are computed.

No `Chart.yaml` `version:` or `targetRevision:` changes, per ADR platform/009 decision 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
