### PR TITLE
fix(helm): push the chart write-back as an identity main accepts

### DIFF
--- a/bazel/helm/write-back-versions.sh
+++ b/bazel/helm/write-back-versions.sh
@@ -176,10 +176,33 @@ $(printf '%s\n' "${SUMMARY[@]}")
 
 Written back by write-back-versions.sh (ADR platform/009 decision 1)."
 
-	if git push --quiet origin HEAD:main; then
+	# `|| PUSH_RC=$?` keeps errexit from aborting on the very failure this loop
+	# exists to handle, and captures the message so the two causes below can be
+	# told apart.
+	PUSH_RC=0
+	PUSH_ERR=$(git push --quiet origin HEAD:main 2>&1) || PUSH_RC=$?
+	if [[ "$PUSH_RC" -eq 0 ]]; then
 		echo "Write-back pushed on attempt ${attempt}."
 		rm -rf "$RECORD_DIR"
 		exit 0
+	fi
+	[[ -n "$PUSH_ERR" ]] && echo "$PUSH_ERR" >&2
+
+	# Distinguish a LOSABLE RACE from a PERMANENT REFUSAL.
+	#
+	# Retrying is the right answer to the race this loop was written for:
+	# another publish landed first, so the rebase at the top of the loop wins
+	# the next attempt. A repository rule violation is not that. It is the same
+	# answer every time, and calling it "another publish landed first" is how a
+	# permission problem spent five attempts wearing a race's clothes on
+	# 2026-08-10, burning the retries and reporting the wrong cause.
+	if grep -qE 'GH013|Repository rule violations|protected branch|refusing to allow' <<<"$PUSH_ERR"; then
+		{
+			echo "ERROR: main refused the write-back on a repository rule, which retrying cannot fix."
+			echo "The identity pushing this must be able to bypass the ruleset on refs/heads/main."
+			echo "The charts ARE published; main's Chart.yaml just does not reference them yet."
+		} >&2
+		exit 1
 	fi
 
 	echo "Push rejected (another publish landed first); retrying (${attempt}/${TRIES})." >&2

--- a/bazel/helm/write-back-versions_test.sh
+++ b/bazel/helm/write-back-versions_test.sh
@@ -170,6 +170,48 @@ expect "second chart written" "0.1.2" \
 expect "authored by the bot" "chart-version-bot" \
 	"$(git -C "$clone" log -1 --format='%an' origin/main)" "loop guard depends on it"
 
+# 7. A REPOSITORY RULE REFUSAL FAILS FAST instead of being retried as a race.
+#
+# On 2026-08-10 main's ruleset refused the write-back because the pushing
+# identity could not bypass the required `pr-checks`. The loop reported it as
+# "another publish landed first" and spent all five attempts on a condition that
+# is identical every time. A pre-receive hook standing in for the ruleset lets
+# this assert the two things that were wrong: the exit is immediate, and the
+# reported cause is the real one.
+clone=$(new_env ruleviolation 0.1.0)
+origin="$TMP/ruleviolation.git"
+mkdir -p "$origin/hooks"
+cat >"$origin/hooks/pre-receive" <<'HOOK'
+#!/usr/bin/env bash
+echo "$(($(cat "$GIT_DIR/push-count" 2>/dev/null || echo 0) + 1))" >"$GIT_DIR/push-count"
+echo "error: GH013: Repository rule violations found for refs/heads/main." >&2
+echo "- Required status check \"pr-checks\" is expected." >&2
+exit 1
+HOOK
+chmod +x "$origin/hooks/pre-receive"
+
+record "$TMP/rec-rule" demo projects/demo/chart 0.1.4
+set +e
+rule_out=$(cd "$clone" && WRITE_BACK_TRIES=5 bash "$SCRIPT" "$TMP/rec-rule" 2>&1)
+rule_rc=$?
+set -e
+
+expect "rule violation exits non-zero" "1" "$rule_rc" "retrying cannot fix it"
+expect "pushed exactly once" "1" \
+	"$(cat "$origin/push-count" 2>/dev/null || echo 0)" "no wasted retries"
+if grep -q "another publish landed first" <<<"$rule_out"; then
+	echo "FAIL: reported a rule violation as a lost race" >&2
+	FAILURES=$((FAILURES + 1))
+else
+	echo "ok: reports the real cause (not a lost race)"
+fi
+if grep -q "repository rule" <<<"$rule_out"; then
+	echo "ok: names the repository rule in the error"
+else
+	echo "FAIL: error does not name the repository rule" >&2
+	FAILURES=$((FAILURES + 1))
+fi
+
 if [[ "$FAILURES" -gt 0 ]]; then
 	echo "${FAILURES} test(s) failed"
 	exit 1

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -253,6 +253,27 @@ actions:
           # "nothing needed publishing", so every chart would stop deploying
           # with the action still green.
           bazel run //bazel/images:push_all --config=ci --stamp
+
+          # Push the write-back as jomcgi, not as the runner's own identity.
+          #
+          # main carries the `lets-not-delete-everything` ruleset, whose
+          # required_status_checks rule expects `pr-checks` on every push and
+          # whose only bypass is RepositoryRole 5 (admin). BuildBuddy's injected
+          # credentials are not an admin, so the write-back authenticated fine
+          # and was still refused:
+          #
+          #   remote: error: GH013: Repository rule violations found
+          #   remote: - Required status check "pr-checks" is expected.
+          #
+          # That left the charts published and main still pointing at the old
+          # versions, so nothing deployed. Reusing GHCR_TOKEN, which is already
+          # in this action for the docker login above, makes the push come from
+          # the repository owner and satisfy the EXISTING bypass. The ruleset is
+          # deliberately left alone: granting CI a standing bypass would weaken
+          # the guarantee for every push, not just this one.
+          #
+          # pr-checks does exactly this for the ci-format-bot commit.
+          git remote set-url origin "https://x-access-token:${GHCR_TOKEN}@github.com/jomcgi/homelab.git"
           ./bazel/helm/write-back-versions.sh .chart-version-records
 
           # ---- 3. formatting must already be correct ----------------------


### PR DESCRIPTION
Follow-up to #4663. That fixed chart version *computation*; this fixes the *write-back* that points main at what was computed.

## What #4663 achieved, and where it stopped

Main's deploy now computes real versions and publishes them. From the run on `f332d9666`:

```
INFO: Bumping 0.1.481 -> 0.1.483 (patch, 2 commit(s))
INFO: Bumping 0.2.0   -> 0.3.3   (minor, 4 commit(s))
Pushed: charts/monolith:0.286.8          Pushed: charts/embervm:0.1.483
Pushed: charts/monolith-public:0.286.8   Pushed: charts/signoz-dashboard-sidecar:0.3.3
```

All four confirmed present with `helm show chart`. The write-back then failed:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Required status check "pr-checks" is expected.
! [remote rejected] HEAD -> main
```

So the charts are published and main's `Chart.yaml` does not reference them, which is why nothing has rolled out.

## Root cause

`main` carries the `lets-not-delete-everything` ruleset, whose `required_status_checks` rule expects `pr-checks` on every push and whose **only** bypass is `RepositoryRole 5` (admin).

The deploy action never runs `git remote set-url`; only `pr-checks` does, at line 139, for the `ci-format-bot` commit. So the write-back pushed with BuildBuddy's own injected credentials, which are not a repository admin. It authenticated correctly and was refused on the rule.

This step had never executed before tonight. While versions were stuck reporting "no bump", `.chart-version-records` was never created, so `write-back-versions.sh` always exited early with nothing to push. Fixing computation exposed the next unexercised link rather than breaking anything.

## The change

1. **`buildbuddy.yaml`**: set the remote to `x-access-token:${GHCR_TOKEN}` before the write-back, exactly as `pr-checks` already does. `GHCR_TOKEN` is already present in this action for the `docker login`, so there is no new secret, and the push then comes from the repository owner and satisfies the **existing** bypass.
2. **`write-back-versions.sh`**: stop retrying a refusal that cannot change.

The ruleset is deliberately **not** modified. Adding CI as a bypass actor would grant it standing permission to skip required checks on every push to main, not just this one. Reusing an identity that already has the bypass keeps the guarantee intact.

### The retry bug

The loop was written for a lost race: another publish landed first, so the rebase at the top wins the next attempt. It reported *every* failure that way, so a permanent rule violation spent all five attempts announcing "another publish landed first". It now separates the two and fails fast naming the real cause.

The test drives a `pre-receive` hook standing in for the ruleset, and pins both properties. Against the pre-fix script it fails exactly as production did:

```
FAIL: pushed exactly once: want '1', got '5' (no wasted retries)
FAIL: reported a rule violation as a lost race
FAIL: error does not name the repository rule
```

## Warning: do not re-run the failed deploy

A re-run of the `f332d9666` deploy goes **green while changing nothing**. main still says `0.285.528`, so it recomputes `0.286.8`, finds it published, compares digests (same commit, same images, so they match), and exits "nothing to publish" **before writing a record**. Write-back then has nothing to write.

Recovery is a new commit on main, which is what merging this PR provides.

## Expected effect on merge

Merging is itself a new commit on main, so its deploy computes fresh versions, publishes, writes back, and ArgoCD rolls. The already-published `0.286.8` / `0.1.483` charts stay as unused tags, which is harmless.

Current live state is stable, not broken: monolith and embervm are Synced and Healthy on their old versions.

## Verification

- `ci lint` clean; `buildbuddy.yaml` parses and both action bodies pass `bash -n`.
- `ci test` green: `Executed 1 out of 757 tests: 757 tests pass`, with `//bazel/helm:write_back_versions_test` **PASSED** as the executed target.
- New test verified to fail against the pre-fix script with the exact production symptom (5 pushes, wrong cause).

The one thing not verifiable before merge is whether `GHCR_TOKEN` acts as an admin for ruleset bypass. It is used as `-u jomcgi` for the registry login and it is the same mechanism `pr-checks` uses to push, so this is expected to hold, and the merge itself proves it either way.

No `Chart.yaml` `version:` or `targetRevision:` changes, per ADR platform/009 decision 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
