### PR TITLE
fix(helm): record a published version main does not yet reference

### DIFF
--- a/bazel/helm/BUILD
+++ b/bazel/helm/BUILD
@@ -32,6 +32,12 @@ sh_test(
     data = [":write-back-versions.sh"],
 )
 
+sh_test(
+    name = "push_test",
+    srcs = ["push_test.sh"],
+    data = [":push.sh.tpl"],
+)
+
 sh_binary(
     name = "validate_manifests",
     srcs = ["ci-validate-manifests.sh"],

--- a/bazel/helm/push.sh.tpl
+++ b/bazel/helm/push.sh.tpl
@@ -186,7 +186,35 @@ if [[ "$CURRENT_BRANCH" == "main" ]]; then
         fi
 
         if [[ "$DIGESTS_MATCH" == "true" ]]; then
-          echo "Chart ${CHART_NAME} ${CHART_VERSION} is already published and the digests match; nothing to publish."
+          # PUBLISHING IS DONE, BUT MAIN MAY STILL NOT REFERENCE THIS VERSION.
+          #
+          # The record below is the only input to the write-back, and it used to
+          # be written solely on the publish path. So "published, but the
+          # write-back was refused" was unrecoverable: the chart sits in the
+          # registry, main's Chart.yaml still names the older version, and every
+          # later run recomputes this same version, finds it published with
+          # matching digests, and exits here without a record. Nothing ever
+          # reconciles the two.
+          #
+          # For a chart whose content keeps changing that self-heals, because
+          # the next content change moves the digests and takes the escalation
+          # path below. For a chart that goes quiet it is PERMANENT: on
+          # 2026-08-10 signoz-dashboard-sidecar sat at 0.2.0 on main against a
+          # published 0.3.3 for exactly this reason, while embervm escaped only
+          # because an unrelated dependency bump happened to touch it.
+          #
+          # The state that matters is not "did this run publish" but "does main
+          # reference what is published", so record whenever those disagree.
+          # This converges: once the write-back lands, CURRENT_VERSION equals
+          # CHART_VERSION and later runs take the quiet branch.
+          if [[ "$CHART_VERSION" != "$CURRENT_VERSION" ]]; then
+            echo "Chart ${CHART_NAME} ${CHART_VERSION} is published and its digests match, but main still says ${CURRENT_VERSION}; recording it so the write-back can align main."
+            RECORD_DIR="${WORKSPACE}/.chart-version-records"
+            mkdir -p "$RECORD_DIR"
+            printf '%s %s\n' "$CHART_DIR" "$CHART_VERSION" > "${RECORD_DIR}/${CHART_NAME}"
+          else
+            echo "Chart ${CHART_NAME} ${CHART_VERSION} is already published and the digests match; nothing to publish."
+          fi
           exit 0
         fi
 

--- a/bazel/helm/push_test.sh
+++ b/bazel/helm/push_test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Unit tests for push.sh.tpl's "already published" branch.
+#
+# push.sh.tpl decides, per chart, whether to publish and whether to record a
+# version for the batched write-back. That record is the ONLY input to
+# write-back-versions.sh, so a path that exits without writing one is a path on
+# which main silently never learns the published version. This file drives the
+# rendered template directly, because every failure of this feature so far has
+# been in a branch that no test executed.
+#
+# The template is rendered rather than mocked: the seven {{...}} substitutions
+# are plain string replacements, so the code under test is byte for byte what
+# `bazel run` executes. `rlocation` is stubbed to the identity function and the
+# substitutions are absolute paths, which is what makes that possible without a
+# bazel runfiles tree.
+set -o errexit -o nounset -o pipefail
+
+TPL_REL="bazel/helm/push.sh.tpl"
+TPL=""
+for candidate in \
+	"${RUNFILES_DIR:-}/_main/${TPL_REL}" \
+	"${TEST_SRCDIR:-}/_main/${TPL_REL}" \
+	"${BASH_SOURCE[0]%/*}/push.sh.tpl"; do
+	if [[ -f "$candidate" ]]; then
+		TPL="$candidate"
+		break
+	fi
+done
+if [[ -z "$TPL" ]]; then
+	echo "ERROR: cannot locate push.sh.tpl in runfiles" >&2
+	exit 1
+fi
+TPL="$(cd "$(dirname "$TPL")" && pwd)/$(basename "$TPL")"
+
+TMP="${TEST_TMPDIR:-$(mktemp -d)}"
+FAILURES=0
+
+expect() {
+	local what="$1" want="$2" got="$3" why="$4"
+	if [[ "$want" == "$got" ]]; then
+		echo "ok: ${what} (${why})"
+	else
+		echo "FAIL: ${what}: want '${want}', got '${got}' (${why})" >&2
+		FAILURES=$((FAILURES + 1))
+	fi
+}
+
+# Build a workspace plus the stubs the template resolves, and render it.
+# `published` decides whether `helm show chart` succeeds, and `digests_match`
+# whether the missed-bump guard passes, which together select the branch.
+setup() {
+	local name="$1" current="$2" computed="$3" published="$4" digests_match="$5"
+	local ws="$TMP/$name" stubs="$TMP/$name-stubs"
+	mkdir -p "$ws/projects/demo/chart" "$stubs/bazel_tools/tools/bash/runfiles"
+
+	# The template sources this and calls rlocation on each substitution. The
+	# identity function is correct here precisely because we substitute absolute
+	# paths below.
+	cat >"$stubs/bazel_tools/tools/bash/runfiles/runfiles.bash" <<-'RUNFILES'
+		rlocation() { echo "$1"; }
+	RUNFILES
+
+	printf 'name: demo\nversion: %s\n' "$current" >"$ws/projects/demo/chart/Chart.yaml"
+	git -C "$ws" init --quiet --initial-branch=main
+	git -C "$ws" config user.email "t@e.com"
+	git -C "$ws" config user.name "t"
+	git -C "$ws" add -A
+	git -C "$ws" commit --quiet -m "chore: seed"
+
+	printf '#!/usr/bin/env bash\necho "%s"\n' "$computed" >"$stubs/chart-version.sh"
+	# `helm show chart` exiting 0 is how the template reads "already published".
+	printf '#!/usr/bin/env bash\nexit %s\n' "$([[ "$published" == "yes" ]] && echo 0 || echo 1)" \
+		>"$stubs/helm"
+	printf '#!/usr/bin/env bash\nexit 0\n' >"$stubs/crane"
+	printf '#!/usr/bin/env bash\nexit %s\n' "$([[ "$digests_match" == "yes" ]] && echo 0 || echo 1)" \
+		>"$stubs/check-missed-bump.sh"
+	: >"$stubs/chart.tgz"
+	chmod +x "$stubs"/*.sh "$stubs/helm" "$stubs/crane"
+
+	sed \
+		-e "s|{{HELM}}|$stubs/helm|" \
+		-e "s|{{CRANE}}|$stubs/crane|" \
+		-e "s|{{CHART_TGZ}}|$stubs/chart.tgz|" \
+		-e "s|{{REPOSITORY}}|oci://example.test/charts|" \
+		-e "s|{{CHART_VERSION_SH}}|$stubs/chart-version.sh|" \
+		-e "s|{{CHART_DIR}}|projects/demo/chart|" \
+		-e "s|{{CHECK_MISSED_BUMP}}|$stubs/check-missed-bump.sh|" \
+		"$TPL" >"$stubs/push.sh"
+	chmod +x "$stubs/push.sh"
+	echo "$ws"
+}
+
+run_push() {
+	local ws="$1" name="$2"
+	(
+		cd "$ws" &&
+			RUNFILES_DIR="$TMP/$name-stubs" \
+				BUILD_WORKSPACE_DIRECTORY="$ws" \
+				bash "$TMP/$name-stubs/push.sh" 2>&1
+	) || true
+}
+
+record_version() {
+	local ws="$1"
+	if [[ -f "$ws/.chart-version-records/demo" ]]; then
+		awk '{print $2}' "$ws/.chart-version-records/demo"
+	else
+		echo "(no record)"
+	fi
+}
+
+# 1. THE ORPHAN. The computed version is already published and its digests
+# match, but main's Chart.yaml still names an older one. That is the state left
+# behind when a publish succeeds and its write-back is then refused, which is
+# exactly what happened on 2026-08-10. Recording is the only way main ever
+# catches up: with no record the write-back has nothing to do, every later run
+# recomputes this same version and lands here again, and a chart whose content
+# never changes stays stranded forever.
+ws=$(setup orphan 0.2.0 0.3.3 yes yes)
+out=$(run_push "$ws" orphan)
+expect "records the published version" "0.3.3" "$(record_version "$ws")" \
+	"main was behind at 0.2.0"
+if grep -q "main still says 0.2.0" <<<"$out"; then
+	echo "ok: says why it recorded"
+else
+	echo "FAIL: did not report that main was behind" >&2
+	FAILURES=$((FAILURES + 1))
+fi
+
+# 2. CONVERGENCE. Once the write-back has landed, main names the published
+# version and this must go quiet. Without this the previous case would rewrite
+# the same record on every run forever, and the write-back would commit to main
+# on every merge with nothing to change.
+ws=$(setup aligned 0.3.3 0.3.3 yes yes)
+out=$(run_push "$ws" aligned)
+expect "aligned records nothing" "(no record)" "$(record_version "$ws")" \
+	"main already names it"
+if grep -q "nothing to publish" <<<"$out"; then
+	echo "ok: reports nothing to publish"
+else
+	echo "FAIL: expected the quiet 'nothing to publish' branch" >&2
+	FAILURES=$((FAILURES + 1))
+fi
+
+if [[ "$FAILURES" -gt 0 ]]; then
+	echo "${FAILURES} test(s) failed"
+	exit 1
+fi
+echo "All push tests passed"


### PR DESCRIPTION
Third and last fix in tonight's chain, after #4663 (version computation) and #4664 (write-back identity). Those two got the pipeline working end to end. This closes the state they left stranded behind them.

## The orphan state

The per-chart record is the **only** input to `write-back-versions.sh`, and it was written solely on the publish path. So "published, but the write-back was then refused" had no way back:

1. the chart is in the registry
2. main's `Chart.yaml` still names the older version
3. every later run recomputes the same version, finds it published with matching digests, and exits at `push.sh.tpl:188` **without a record**
4. the write-back has nothing to write, so main never catches up

Left over from the run whose write-back was refused:

| chart | main says | published |
|---|---|---|
| embervm | `0.1.481` | `0.1.483` |
| signoz-dashboard-sidecar | `0.2.0` | `0.3.3` |

## Why this is permanent, not merely slow

For a chart whose content keeps changing it self-heals, because the next change moves the digests onto the escalation path. **embervm escaped exactly that way while this was being written**, when Renovate's dependency pin happened to touch it, taking it to `0.1.484`. That rescue was luck, not design.

For a chart that goes quiet it never resolves. `signoz-dashboard-sidecar` computed **exactly `0.3.3` on two separate runs tonight**, because the count is scoped to its dependency closure and that closure rarely changes. Its version does not drift upward, so nothing will ever move it off `0.2.0` on main.

## The change

The state that matters is not "did this run publish" but "does main reference what is published", so record whenever those disagree.

It converges rather than looping: once the write-back lands, the computed version equals the one on main and later runs take the quiet branch. The second test pins that, because the failure mode of getting it wrong is committing to main on every single merge forever.

## The first test for push.sh.tpl

`push.sh.tpl` is where all three of tonight's failures lived, and it had **no test at all**. It looked untestable: a bazel template full of `rlocation` calls, registry round trips, and a main-only branch.

It was not untestable, only unrendered. The seven `{{...}}` substitutions are plain string replacements, so the test renders the real template and drives the real branch with stub binaries, `rlocation` stubbed to identity and absolute paths substituted in. The code under test is byte for byte what `bazel run` executes.

Verified to fail against the current template with the exact orphan symptom:

```
FAIL: records the published version: want '0.3.3', got '(no record)' (main was behind at 0.2.0)
FAIL: did not report that main was behind
```

Given that every "only a merge to main can tell us" claim tonight turned out to be false on inspection, this harness is arguably worth more than the fix.

## Expected effect on merge

The next deploy records `signoz-dashboard-sidecar` at its published version and writes it back, aligning main. embervm is already aligned at `0.1.484`.

## Verification

- `ci lint` clean.
- `ci test` green: `Executed 2 out of 758 tests: 758 tests pass` (up from 757, the new target), with `//bazel/helm:push_test` **PASSED** as an executed target.
- New test verified to fail against the pre-fix template and pass after, with the convergence case passing on both so it is not a false positive.

No `Chart.yaml` `version:` or `targetRevision:` changes, per ADR platform/009 decision 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
