### PR TITLE
fix(monolith): navigate the path the browser is on, not the route id

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -16,6 +16,7 @@
     clearSelection,
     selectRun as runSearchTransition,
     selectSession as sessionTransition,
+    withSearch,
   } from "./url-state.js";
   import { statusClass, statusLabel, vmRunning, vmState } from "./status.js";
   import "./agents-theme.css";
@@ -396,11 +397,7 @@
         selectedId != null &&
         !sessions.some((session) => String(session.id) === String(selectedId))
       ) {
-        const search = sessionTransition($page.url.searchParams, null);
-        replaceState(
-          search ? `/private/agents?${search}` : "/private/agents",
-          {},
-        );
+        replaceWith(sessionTransition($page.url.searchParams, null));
       }
     } catch (error) {
       errorMessage = error.message;
@@ -489,15 +486,30 @@
     }
   }
 
+  // `/private/agents` is the internal route id, not the address the browser is
+  // on: the reroute hook (src/hooks.js) maps private.jomcgi.dev/agents onto it,
+  // so the tier reaches this page at /agents. Pushing the internal path put a
+  // URL in the address bar that nobody types or shares, and it only failed
+  // quietly because the reroute guard skips paths already under /private/.
+  // Keep whichever path the browser actually arrived on.
+  function navigateTo(search) {
+    pushState(withSearch($page.url.pathname, search), {});
+  }
+
+  // Correcting the URL for a selection that no longer exists, so it must not
+  // add a history entry the back button has to walk back through.
+  function replaceWith(search) {
+    replaceState(withSearch($page.url.pathname, search), {});
+  }
+
   function selectRun(runOrId) {
     const id = typeof runOrId === "object" ? runOrId?.workflow_id : runOrId;
     if (id == null) return;
-    const search = runSearchTransition($page.url.searchParams, id);
-    pushState(search ? `/private/agents?${search}` : "/private/agents", {});
+    navigateTo(runSearchTransition($page.url.searchParams, id));
   }
 
   function selectRuns() {
-    pushState("/private/agents", {});
+    navigateTo("");
   }
 
   async function loadVms() {
@@ -565,8 +577,7 @@
   function selectSession(sessionOrId) {
     const id = typeof sessionOrId === "object" ? sessionOrId?.id : sessionOrId;
     if (id == null) return;
-    const search = sessionTransition($page.url.searchParams, id);
-    pushState(search ? `/private/agents?${search}` : "/private/agents", {});
+    navigateTo(sessionTransition($page.url.searchParams, id));
   }
 
   function isMobileViewport() {
@@ -578,13 +589,11 @@
 
   function returnToSessionList() {
     focusSessionId = selectedId;
-    const search = clearSelection($page.url.searchParams);
-    pushState(search ? `/private/agents?${search}` : "/private/agents", {});
+    navigateTo(clearSelection($page.url.searchParams));
   }
 
   function returnToRun() {
-    const search = backToRun($page.url.searchParams);
-    pushState(search ? `/private/agents?${search}` : "/private/agents", {});
+    navigateTo(backToRun($page.url.searchParams));
   }
 
   function closeNewPanel() {
@@ -592,8 +601,8 @@
     tick().then(() => newButtonEl?.focus({ preventScroll: true }));
   }
 
-  function openNewPanel() {
-    newPanelMode = "session";
+  function openNewPanel(mode = "session") {
+    newPanelMode = mode;
     newRun.idempotencyKey = crypto.randomUUID();
     showNewPanel = true;
   }
@@ -775,11 +784,7 @@
       );
       if (!response.ok) throw new Error("Session could not be destroyed");
       focusSessionId = selectedId;
-      const search = sessionTransition($page.url.searchParams, null);
-      replaceState(
-        search ? `/private/agents?${search}` : "/private/agents",
-        {},
-      );
+      replaceWith(sessionTransition($page.url.searchParams, null));
       await loadSessions();
     } catch (error) {
       errorMessage = error.message;
@@ -1303,11 +1308,19 @@
           onSelectSession={selectSession}
           onCancel={() => cancelRun(selectedRunId)}
         />
+        <!-- loadRunDetail's catch leaves runDetail set with run: null and the
+             tier marked absent. Without this branch that state is
+             indistinguishable from the pre-fetch one, so a ?run= naming a run
+             that does not resolve sits on "Loading run…" forever and reads as
+             broken navigation rather than a missing run. -->
+      {:else if runDetail?.view?.engine_tier === "absent"}
+        <div class="empty blank-state">{P.labels.absentNotice}</div>
       {:else}<div class="empty blank-state">Loading run…</div>{/if}
     {:else}
       <MasterView
         master={runMaster}
         onSelectRun={selectRun}
+        onStartRun={() => openNewPanel("run")}
         view={masterView}
       />
     {/if}

--- a/projects/monolith/frontend/src/routes/private/agents/MasterView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/MasterView.svelte
@@ -4,6 +4,7 @@
   let {
     master,
     onSelectRun = () => {},
+    onStartRun = () => {},
     view = { engine_tier: "live", snapshot_age_seconds: 0 },
   } = $props();
   const total = $derived(
@@ -69,7 +70,16 @@
                 {P.punct.dot} {fmtCost(run.cost_usd)}{/if}</span
             >
           </button>{/each}
-      </div>{:else}<div class="m-quiet">{P.labels.noRuns}</div>{/if}
+      </div>{:else}<div class="m-quiet m-empty">
+        <span>{P.labels.noRuns}</span>
+        <!-- Starting a run is otherwise only reachable by opening the new
+             panel and changing its mode select, which reads as "there is no
+             way to start one" on a swarm home that is empty by definition
+             until the first run exists. -->
+        <button class="m-start" type="button" onclick={() => onStartRun()}
+          >{P.labels.createRun}</button
+        >
+      </div>{/if}
     <div class="m-totals">
       {P.labels.spend}
       {P.punct.colon}
@@ -105,6 +115,22 @@
 
   .m-row {
     border-bottom: 1px solid var(--line);
+  }
+
+  .m-empty {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .m-start {
+    padding: 2px 8px;
+    color: var(--info);
+    background: transparent;
+    font: inherit;
+    font-size: var(--size-meta);
+    border: 1px solid var(--line-strong);
+    cursor: pointer;
   }
 
   .tier-stale .m-row,

--- a/projects/monolith/frontend/src/routes/private/agents/url-state.js
+++ b/projects/monolith/frontend/src/routes/private/agents/url-state.js
@@ -39,3 +39,15 @@ export function backToRun(value) {
   params.delete("session");
   return params.toString();
 }
+
+/**
+ * Joins a search string onto the path the browser is already on.
+ *
+ * The caller must pass the live pathname rather than a literal. `/private` is
+ * only the internal route prefix that src/hooks.js reroutes onto: the private
+ * tier reaches this page at `/agents`, so hardcoding `/private/agents` puts an
+ * address in the bar that nobody types or shares.
+ */
+export function withSearch(pathname, search) {
+  return search ? `${pathname}?${search}` : pathname;
+}

--- a/projects/monolith/frontend/src/routes/private/agents/url-state.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/url-state.test.js
@@ -5,6 +5,7 @@ import {
   parseUrlState,
   selectRun,
   selectSession,
+  withSearch,
 } from "./url-state.js";
 
 describe("agent URL state", () => {
@@ -35,6 +36,24 @@ describe("agent URL state", () => {
 
   test("back to run drops only the session", () => {
     expect(backToRun("run=wf-123&session=wf-123-call2")).toBe("run=wf-123");
+  });
+
+  test("keeps the path the browser is on rather than the route id", () => {
+    // private.jomcgi.dev serves this page at /agents; /private/agents is only
+    // the internal route src/hooks.js reroutes onto. Navigating to the route id
+    // rewrote the address bar to a URL nobody types.
+    expect(withSearch("/agents", "run=wf-123")).toBe("/agents?run=wf-123");
+  });
+
+  test("drops the question mark when nothing is selected", () => {
+    expect(withSearch("/agents", "")).toBe("/agents");
+  });
+
+  test("composes with the transitions it exists to serve", () => {
+    const search = selectSession(selectRun("", "wf-1"), "wf-1-call2");
+    expect(withSearch("/agents", search)).toBe(
+      "/agents?run=wf-1&session=wf-1-call2",
+    );
   });
 
   test("encodes ids and round-trips them", () => {


### PR DESCRIPTION
Reported live: navigation on `private.jomcgi.dev/agents` does not move you, and there is no visible way to start a swarm run.

Three distinct causes, all verified against the running pod.

## The address bar was rewritten to the internal route id

`src/hooks.js` reroutes `private.jomcgi.dev/<path>` onto `/private/<path>`, so the console is served at `/agents`. All five `pushState` calls and both `replaceState` calls pushed the literal `/private/agents` instead, so the first click moved the address bar off the URL you actually typed.

This never 404'd, because the reroute guard is `!pathname.startsWith('/private/')` and simply passes an already-prefixed path through. Two URLs resolve to the same page; only one is the one anybody shares.

Navigation now derives the path from `$page.url.pathname` via a `withSearch` helper in `url-state.js`, which is where the pure-module tests live.

## `?run=` on an unresolvable run hung on a spinner forever

```
$ curl -H 'Host: private.jomcgi.dev' .../agents?run=doesnotexist
blank-state">Loading run...
$ curl -o /dev/null -w '%{http_code}' .../agents/runs/doesnotexist
404
```

`loadRunDetail`'s catch leaves `runDetail` set with `run: null` and `engine_tier: "absent"`, which the template could not distinguish from the state before the fetch returned, so the only branch left was `Loading run...`. It now reports the run as unavailable.

## Starting a run was not reachable from the swarm home

`/agents/runs` returns `runs: []`, which is correct, nothing has been started yet. But the only path to creating one was: open the new panel, then change its mode `<select>` from session to run. The empty state now carries a start control that opens the panel already in run mode, so the surface that is empty by definition is also the surface that lets you fill it.

## Verification

- `Executed 2 out of 758 tests: 758 tests pass`
- `url-state.test.js` goes 6 to 9 tests, confirmed executed by running the vitest target directly: `Tests 584 passed (584)`
- Endpoint behaviour above checked through a port-forward with the private `Host` header, since the app serves the public tree without it

## Not changed

`EventSource("/private/agents/vms/stream")` still names the internal path. It resolves correctly and never appears in the address bar, so it is left alone rather than widened into this fix.