### PR TITLE
fix(monolith): stop reporting every pending swarm run as stranded

### DIFF
--- a/projects/monolith/swarm/router.py
+++ b/projects/monolith/swarm/router.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request
@@ -39,7 +38,32 @@ def _dbos():
 
 
 def _server_app_version() -> str:
-    return os.environ.get("APP_VERSION", os.environ.get("GIT_SHA", "unknown"))
+    """The app version DBOS is actually running, asked of DBOS itself.
+
+    A workflow's `app_version` is a value DBOS computes (a hash over registered
+    workflow source) unless `DBOS__APPVERSION` overrides it, and it is stored on
+    `GlobalParams` at launch. It is not a chart version and not a git sha, so
+    comparing it against an environment variable compares two different
+    namespaces and can only ever be unequal.
+
+    This previously read `APP_VERSION` then `GIT_SHA`, neither of which this
+    chart sets, so it returned the literal "unknown" on every call. No real DBOS
+    version equals "unknown", which made `compose_run` mark every PENDING or
+    ENQUEUED run stranded, banner and all, while the run was still running.
+
+    Returns "" when the version cannot be resolved, which the caller treats as
+    "cannot tell" rather than as evidence of stranding. `GlobalParams` is a
+    private module, hence the guarded import: there is no public accessor in
+    dbos 2.29.0, and a restructure upstream must degrade to "cannot tell"
+    instead of resurrecting the false positive.
+    """
+    try:
+        from dbos._utils import GlobalParams
+
+        return GlobalParams.app_version or ""
+    except Exception:
+        logger.warning("could not read the DBOS app version", exc_info=True)
+        return ""
 
 
 def _session_rows(workflow_id: str):

--- a/projects/monolith/swarm/router_test.py
+++ b/projects/monolith/swarm/router_test.py
@@ -216,3 +216,26 @@ def test_cancel_survives_attribute_write_failure(monkeypatch):
 
     assert response.status_code == 200
     assert response.json()["cancelled"] is True
+
+
+def test_server_app_version_comes_from_dbos_not_the_environment(monkeypatch):
+    """The comparison target must be DBOS's own version.
+
+    APP_VERSION and GIT_SHA are a different namespace from the hash DBOS
+    computes over workflow source, so reading them could only ever produce a
+    value no run matches, which marked every pending run stranded.
+    """
+    from dbos._utils import GlobalParams
+
+    monkeypatch.setenv("APP_VERSION", "chart-0.285.531")
+    monkeypatch.setenv("GIT_SHA", "deadbeef")
+    monkeypatch.setattr(GlobalParams, "app_version", "dbos-computed-hash")
+    assert swarm_router._server_app_version() == "dbos-computed-hash"
+
+
+def test_server_app_version_is_empty_when_dbos_has_not_launched(monkeypatch):
+    """Empty means "cannot tell", which compose_run must not read as stranded."""
+    from dbos._utils import GlobalParams
+
+    monkeypatch.setattr(GlobalParams, "app_version", "")
+    assert swarm_router._server_app_version() == ""

--- a/projects/monolith/swarm/view.py
+++ b/projects/monolith/swarm/view.py
@@ -241,7 +241,17 @@ def compose_run(dbos, workflow_id, session_rows, server_app_version) -> dict | N
     app_version = _value(
         status, "app_version", attrs.get("app_version", inp.get("app_version"))
     )
-    stranded = raw in ("PENDING", "ENQUEUED") and app_version != server_app_version
+    # Fail safe. Stranding is a terminal claim ("will not resume unaided"), so
+    # it must be positive evidence that the two versions differ, never the
+    # absence of evidence. When either side is missing the honest answer is
+    # "cannot tell", and an unknown that renders as a diagnosis is how every
+    # pending run came to carry a stranded banner while it was still running.
+    stranded = (
+        raw in ("PENDING", "ENQUEUED")
+        and bool(app_version)
+        and bool(server_app_version)
+        and app_version != server_app_version
+    )
     steps = _steps(dbos, workflow_id)
     children = _children(dbos, workflow_id)
     plan = _plan(attrs)

--- a/projects/monolith/swarm/view_test.py
+++ b/projects/monolith/swarm/view_test.py
@@ -160,6 +160,30 @@ def test_stranded_pending_has_no_decision():
     assert run["nodes"][1]["decision"] is None
 
 
+def test_unresolvable_server_version_does_not_strand():
+    """An unknown server version is not evidence of stranding.
+
+    Observed in production: the server version resolved to a placeholder no real
+    DBOS version could equal, so every PENDING run rendered a "will not resume
+    unaided" banner while its nodes were still running.
+    """
+    status = Status("wf-3", "PENDING", ["task", "repo", "main"], app_version="real")
+    run = compose_run(
+        DBOS(Workflow(status, {"plan": FX4_EXPECTED_PLAN})), "wf-3", [], ""
+    )
+    assert run["stranded"] is False
+    assert run["state"] != "stranded"
+
+
+def test_missing_run_version_does_not_strand():
+    status = Status("wf-4", "PENDING", ["task", "repo", "main"], app_version="")
+    run = compose_run(
+        DBOS(Workflow(status, {"plan": FX4_EXPECTED_PLAN})), "wf-4", [], "new"
+    )
+    assert run["stranded"] is False
+    assert run["state"] != "stranded"
+
+
 def _running_implement(workflow_id):
     """One in-flight implement attempt.
 


### PR DESCRIPTION
Observed live: a run showing a `stranded by deploy: started on an older build, will not resume unaided` banner while its review node was actively working with five-second-old activity. Both cannot be true.

## Cause

```python
# swarm/view.py
stranded = raw in ("PENDING", "ENQUEUED") and app_version != server_app_version

# swarm/router.py, before
return os.environ.get("APP_VERSION", os.environ.get("GIT_SHA", "unknown"))
```

The chart sets neither variable, confirmed against the running pod, so the right-hand side was always the literal `"unknown"`. A workflow's `app_version` is a hash DBOS computes over registered workflow source, so it never equals `"unknown"` and **every PENDING or ENQUEUED run was labelled stranded**.

Setting `APP_VERSION` in the chart would not have fixed this. A chart version and a DBOS source hash are different namespaces, so they would never match either.

## Fix

`_server_app_version` now asks DBOS for the version DBOS is running, `GlobalParams.app_version`, which is the same value DBOS compares against when deciding recovery eligibility. There is no public accessor in dbos 2.29.0, so the private import is guarded and degrades to `""`.

Stranding is now positive evidence rather than the absence of it: both versions must be present and differ. An unresolvable version reads as "cannot tell" instead of as a terminal diagnosis. That is exactly what the old code could not do, distinguish "these differ" from "I do not know what mine is".

## Verification

Four new tests, confirmed executed by name rather than inferred:

```
view_test.py::test_unresolvable_server_version_does_not_strand PASSED
view_test.py::test_missing_run_version_does_not_strand PASSED
router_test.py::test_server_app_version_comes_from_dbos_not_the_environment PASSED
router_test.py::test_server_app_version_is_empty_when_dbos_has_not_launched PASSED
```

`Executed 58 out of 698 tests: 698 tests pass`

Note the pre-existing `test_stranded_pending_has_no_decision` passed before and after. It supplies both versions directly, so it structurally cannot observe that one side is a constant in production. Same shape as a green test over broken wiring.

## Deliberately not included

Whether to pin `DBOS__APPVERSION` so deploys stop stranding runs for real. Pinning makes DBOS resume workflows whose code changed, which is the thing version scoping exists to prevent, so it wants an ADR rather than a quiet config edit. Deploys genuinely can strand in-flight runs today; this PR only stops the console claiming it when it has not happened.

Relates to #4625.