### PR TITLE
fix(monolith): stop the run view fabricating and misattributing evidence

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
@@ -28,6 +28,15 @@
   // shows.
   const shortSha = (sha) => String(sha || "").slice(0, 8);
   const ago = (value) => fmtDur(relSeconds(value, view.now));
+
+  // "running 2m" when the elapsed time is known, bare "running" when it is
+  // not. Interpolating the duration directly would print the text "null" now
+  // that formatters report absence honestly, which is a louder fabrication
+  // than the "0s" it replaced. The phrase layer generalises this.
+  const withDur = (word, seconds) => {
+    const duration = fmtDur(seconds);
+    return duration ? `${word} ${duration}` : word;
+  };
   const path = (i, suffix) => `run.nodes[${i}]${suffix}`;
 </script>
 
@@ -248,7 +257,10 @@
             {P.punct.dot}
             {attempt.ended_at
               ? fmtDur(relSeconds(attempt.started_at, attempt.ended_at))
-              : `${P.stateWords.running} ${fmtDur(relSeconds(attempt.started_at, view.now))}`}{#if fmtCost(attempt.cost_usd)}
+              : withDur(
+                  P.stateWords.running,
+                  relSeconds(attempt.started_at, view.now),
+                )}{#if fmtCost(attempt.cost_usd)}
               {P.punct.dot} {fmtCost(attempt.cost_usd)}{/if}</span
           >{#if attempt.state === "running" && attempt.live?.activity}<span
               class="live-line"

--- a/projects/monolith/frontend/src/routes/private/agents/run-format.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-format.js
@@ -1,10 +1,25 @@
 import { RUN_LEXICON } from "./run-lexicon.js";
 
-export const relSeconds = (a, b) =>
-  Math.max(0, Math.round((Date.parse(b) - Date.parse(a)) / 1000));
+// A console for a durable workflow engine has to keep three things apart that
+// these formatters used to collapse into one: a measured zero, a value not
+// observed yet, and a value that failed to parse. Only the first is a fact.
+// Absent input returns null, which renders as nothing, so no clause can print
+// a number nobody measured.
+
+export const relSeconds = (a, b) => {
+  const from = Date.parse(a);
+  const to = Date.parse(b);
+  if (!Number.isFinite(from) || !Number.isFinite(to)) return null;
+  return Math.max(0, Math.round((to - from) / 1000));
+};
 
 export function fmtDur(seconds) {
-  const s = Math.max(0, Number(seconds) || 0);
+  const n = Number(seconds);
+  // `Number(seconds) || 0` was the laundering step: an unparseable timestamp
+  // became NaN upstream and printed here as "0s ago", a fabricated "just now"
+  // sitting beside a real elapsed time.
+  if (seconds == null || !Number.isFinite(n)) return null;
+  const s = Math.max(0, n);
   if (s < 60) return `${s}${RUN_LEXICON.units.s}`;
   if (s < 3600) return `${Math.floor(s / 60)}${RUN_LEXICON.units.m}`;
   if (s < 172800) {
@@ -18,7 +33,13 @@ export function fmtDur(seconds) {
 }
 
 export function fmtCost(value) {
-  const n = Number(value || 0);
+  // null means "no figure to show", the empty string means "measured, and it
+  // is zero". Callers that need a sentence operand must treat them
+  // differently: a missing spend omits its clause, a zero spend says so. The
+  // observed "of $50.00 budget" fragment came from having only one falsy
+  // answer for both.
+  const n = Number(value);
+  if (value == null || !Number.isFinite(n)) return null;
   if (!(n > 0)) return "";
   return n >= 0.01 ? `$${n.toFixed(2)}` : `$${n.toFixed(4)}`;
 }

--- a/projects/monolith/frontend/src/routes/private/agents/run-format.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-format.test.js
@@ -18,4 +18,26 @@ describe("run formatting", () => {
     expect(relSeconds("2026-08-10T00:00:00Z", "2026-08-10T00:01:02Z")).toBe(
       62,
     ));
+
+  test("reports an unreadable timestamp as absent, not as zero", () => {
+    // The observed defect: a run header rendered "started 0s ago" beside a
+    // real "attempt 1 · 2m", because an unparseable timestamp became NaN and
+    // `Number(x) || 0` laundered it into a measurement.
+    expect(relSeconds("not-a-timestamp", "2026-08-10T00:00:00Z")).toBe(null);
+    expect(relSeconds(undefined, "2026-08-10T00:00:00Z")).toBe(null);
+    expect(fmtDur(relSeconds(null, "2026-08-10T00:00:00Z"))).toBe(null);
+  });
+
+  test("distinguishes a measured zero from an absent value", () => {
+    expect(fmtDur(0)).toBe("0s");
+    expect(fmtDur(null)).toBe(null);
+    expect(fmtDur(undefined)).toBe(null);
+    expect(fmtDur(NaN)).toBe(null);
+    // Zero spend is measured, so it stays falsy-but-present; no spend at all
+    // is null, so a sentence can omit the clause instead of printing "of
+    // $50.00 budget" with nothing in front of it.
+    expect(fmtCost(0)).toBe("");
+    expect(fmtCost(null)).toBe(null);
+    expect(fmtCost(undefined)).toBe(null);
+  });
 });

--- a/projects/monolith/swarm/view.py
+++ b/projects/monolith/swarm/view.py
@@ -53,10 +53,28 @@ def _input(status: Any) -> dict:
     return {}
 
 
-def _iso(value: Any) -> Any:
+def _iso(value: Any) -> str | None:
+    """Serialize a timestamp, or emit nothing at all.
+
+    Any non-datetime used to pass through untouched, so a value the server
+    could not serialize still reached the client and was parsed there. The run
+    header timestamp comes from the DBOS workflow status while attempt
+    timestamps come from session rows, and when the workflow side arrived as
+    something else, `Date.parse` returned NaN and the client's `Number(x) || 0`
+    laundered it into a confident "0s ago" printed beside a real elapsed time.
+
+    A timestamp that cannot be serialized is absent, and absent has to look
+    absent. Strings are trusted only if they parse as a timestamp.
+    """
     if isinstance(value, datetime):
         return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-    return value
+    if isinstance(value, str) and value:
+        try:
+            datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return value
+    return None
 
 
 def _children(dbos: Any, workflow_id: str) -> list[Any]:
@@ -129,16 +147,39 @@ def _finding(code: str | None, observed: str | None, prior: str | None) -> dict 
     return {"code": code, "text": text, "observed_head": _short_sha(observed)}
 
 
-def _attempts(session_rows: list[Any], steps: list[Any], node_key: str) -> list[dict]:
-    rows = sorted(
-        [r for r in session_rows if _value(r, "node_key") == node_key],
-        key=lambda r: _value(r, "node_attempt", 0) or 0,
-    )
+def _branch_head_observations(steps: list[Any]) -> list[Any]:
+    """Every read_branch_head output in the run, in call order.
+
+    `implement_then_review` calls it only inside the implement loop, twice per
+    attempt: once before the turn and once after (`workflows.py:166,180`). The
+    list is therefore implement-lane evidence in `[prior, observed]` pairs, and
+    belongs to no other node.
+    """
     observations = []
     for step in steps:
         name = str(_value(step, "function_name", _value(step, "name", "")))
         if "read_branch_head" in name:
             observations.append(_step_output(step))
+    return observations
+
+
+def _attempts(
+    session_rows: list[Any], observations: list[Any], node_key: str
+) -> list[dict]:
+    """Attempts for one node, paired against observations that node produced.
+
+    Observations are passed in rather than derived from the run's steps.
+    Deriving them here gave every node the same undifferentiated list, so the
+    review node, which produces no head reads at all, was annotated with
+    implement attempt 1's pair and displayed its finding verbatim. Branch-head
+    movement is the routing signal in ADR 038 decision 1, so evidence attached
+    to the wrong node is the exact confusion that decision exists to prevent.
+    A caller that has no observations for a node passes none.
+    """
+    rows = sorted(
+        [r for r in session_rows if _value(r, "node_key") == node_key],
+        key=lambda r: _value(r, "node_attempt", 0) or 0,
+    )
     result = []
     for i, row in enumerate(rows):
         prior = observations[i * 2] if i * 2 < len(observations) else None
@@ -258,8 +299,13 @@ def compose_run(dbos, workflow_id, session_rows, server_app_version) -> dict | N
     model_i = plan["implementer_model"]
     model_r = plan["reviewer_model"]
     sessions = list(session_rows or [])
-    implement_attempts = _attempts(sessions, steps, "implement")
-    review_attempts = _attempts(sessions, steps, "review")
+    # Only the implement lane reads the branch head, so only it gets the
+    # observations. The reviewer runs after the gate has already decided on
+    # them and never takes a reading of its own.
+    implement_attempts = _attempts(
+        sessions, _branch_head_observations(steps), "implement"
+    )
+    review_attempts = _attempts(sessions, [], "review")
     first = implement_attempts[0] if implement_attempts else None
     if raw == "CANCELLED":
         implement_state = "failed" if first else "cancelled"

--- a/projects/monolith/swarm/view_test.py
+++ b/projects/monolith/swarm/view_test.py
@@ -307,6 +307,54 @@ def test_attempt_carries_prior_head_alongside_finding():
     assert attempt["finding"]["observed_head"] == "abcdef01"
 
 
+def test_review_does_not_inherit_the_implement_lane_head_reads():
+    """Branch head reads belong to the implement lane alone.
+
+    `implement_then_review` calls read_branch_head only inside the implement
+    loop, so the reviewer takes no reading of its own. Pairing its single
+    attempt against the run's undifferentiated observation list handed it
+    implement attempt 1's pair, and the console printed implement's finding
+    verbatim under review. Branch head movement is the routing signal in ADR
+    038 decision 1, so evidence on the wrong node is the confusion that
+    decision exists to prevent.
+    """
+    status = Status("wf-lanes", "SUCCESS", ["task", "repo", "main"])
+    run = compose_run(
+        DBOS(
+            Workflow(status),
+            steps=[
+                {"function_name": "read_branch_head", "output": "1234567890"},
+                {"function_name": "read_branch_head", "output": "abcdef0123"},
+            ],
+        ),
+        "wf-lanes",
+        [
+            session(1, status="completed", node="implement", attempt=1),
+            session(2, status="completed", node="review", attempt=1),
+        ],
+        "unknown",
+    )
+    implement, review = run["nodes"][0], run["nodes"][2]
+    assert implement["attempts"][0]["prior_head"] == "12345678"
+    assert implement["attempts"][0]["finding"]["observed_head"] == "abcdef01"
+    review_attempt = review["attempts"][0]
+    assert review_attempt["finding"] is None
+    assert review_attempt["prior_head"] is None
+
+
+def test_unserializable_timestamp_is_absent_not_passed_through():
+    """A timestamp the server cannot serialize must not reach the client.
+
+    It used to pass through untouched, where Date.parse returned NaN and the
+    client's `Number(x) || 0` printed it as a confident "0s ago" beside a real
+    elapsed time.
+    """
+    status = Status("wf-clock", "SUCCESS", ["task", "repo", "main"])
+    status.created_at = 1786423167
+    run = compose_run(DBOS(Workflow(status)), "wf-clock", [], "unknown")
+    assert run["created_at"] is None
+
+
 def test_master_rows_include_active_and_shape():
     status = Status("wf-master", "PENDING", ["task", "repo", "main"])
 


### PR DESCRIPTION
First of five PRs from the UX review of a live swarm run. This one is all correctness: three defects that turned out to be one habit, reporting something the engine never observed. No visual changes.

## The review node was reading implement's evidence

`_attempts` derived its observations from the run's whole step list, so both calls built the same undifferentiated array and indexed into it by row position:

```python
observations = [o for step in steps if "read_branch_head" in name]  # every node
prior    = observations[i * 2]
observed = observations[i * 2 + 1]
```

`implement_then_review` calls `read_branch_head` only inside the implement loop (`workflows.py:166,180`), twice per attempt. The reviewer takes no reading of its own, so its single attempt was handed implement attempt 1's pair and printed its finding verbatim. Observed live: `the branch head moved during this attempt ed073bfb` appearing identically under both nodes.

This is not cosmetic. Branch head movement is the routing signal in ADR 038 decision 1, and the same pairing feeds the `gated` attempt state.

Observations are now passed in by the caller, which knows the workflow shape, rather than rediscovered per node. A node with no readings of its own gets none by construction, so the misattribution cannot be reintroduced silently.

## "started 0s ago" was a serialization gap, not a clock

`_iso` passed any non-datetime through untouched, `Date.parse` returned NaN on the far side, and `fmtDur`'s `Number(seconds) || 0` turned that into a confident zero printed beside a real `attempt 1 · 2m`. `_iso` now emits a timestamp or nothing, trusting strings only if they parse; the formatters return `null` for absent or non-finite input.

## `fmtCost` had one falsy answer for two different facts

Now `null` when there is no figure and `""` when the figure is a measured zero. That single conflation is why a run with no spend printed the fragment `of $50.00 budget`. Callers can omit a clause instead of emitting half of one.

## One call site needed care

`RunView` interpolated a duration into a template literal, where `null` renders as the literal text `"null"`, which would have been a louder fabrication than the `0s` being removed. It goes through a small `withDur` helper that drops the clause; the phrase layer generalises that in the next PR.

## Verification

New tests confirmed executed by name, not inferred:

```
view_test.py::test_review_does_not_inherit_the_implement_lane_head_reads PASSED
view_test.py::test_unserializable_timestamp_is_absent_not_passed_through PASSED
```

`view_test` 12 to 14 tests, frontend `Tests 586 passed (586)` up from 584.

## Still to come against #4625

Phrase layer and labelled workflow id; sidebar split, designed collapsed rail, kind row and breadcrumb; evidence register and the terminal-claim conflict rule; dark tokens and copy migration.