### PR TITLE
fix(ci): stop the crane build flipping --stamp mid-deploy

### DIFF
--- a/bazel/images/push/push-changed.sh
+++ b/bazel/images/push/push-changed.sh
@@ -71,8 +71,14 @@ if [ ! -s "$MANIFEST" ]; then
 	exit 1
 fi
 
+# "${BAZEL_ARGS[@]}", not a bare --config=ci, even though crane is a prebuilt
+# binary that --stamp cannot affect. Bazel discards the whole analysis cache
+# whenever --stamp flips, so building this one target unstamped between two
+# stamped ones cost TWO re-analyses per deploy: observed 2026-08-11 at 05:26:02
+# and again at 05:26:16, the second re-configuring 19,282 targets in 21s. Keep
+# every bazel command in this script on the same value.
 echo "==> Building crane"
-"$BAZEL" build @multitool//tools/crane --config=ci
+"$BAZEL" build @multitool//tools/crane "${BAZEL_ARGS[@]}"
 # `|| true` because pipefail turns a find that cannot read the tree into an
 # abort with no explanation, instead of the message below.
 CRANE="${CRANE:-$(find -L "$BAZEL_BIN/external" -name "crane" -type f -perm /111 2>/dev/null | head -1 || true)}"


### PR DESCRIPTION
Follow-up to #4669, found by reading its first real deploy (`a435f1f4c`).

That run logged **four** `--stamp has changed, discarding analysis cache`
warnings where the old layout logged two:

```
05:25:31  bazel build push_all --stamp         <- pre-existing (after unstamped `bazel test`)
05:26:02  bazel build @multitool//tools/crane  <- introduced by #4669
05:26:16  bazel run push_charts --stamp        <- introduced by #4669, flipping back
05:26:43  bazel run format                     <- pre-existing
```

`push-changed.sh` built crane with a bare `--config=ci`, sandwiched between two
stamped commands, so bazel dropped the analysis cache going in and again coming
out. The second re-configured 19,282 targets and took 21s.

crane is a prebuilt multitool binary that `--stamp` cannot affect, which is
exactly why it looked safe to leave off. The flag value matters to bazel whether
or not the target uses it. Fixed by passing `"${BAZEL_ARGS[@]}"` like every
other bazel call in the script.

This is wall time on the deploy path, not bytes, so it does not move the
BuildBuddy numbers. It runs ~38 times a day and was a regression introduced one
commit earlier, so it is worth the one-line fix.

## Testing

`push-changed_test.sh` passes (the stubs are indifferent to bazel flags, so this
is unit-test-invisible by construction). The real signal is the next deploy's
log: it should show two `--stamp has changed` warnings, not four. I will check
after merge and report.

No chart bump: CI tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)