### PR TITLE
feat(monolith): give every joined line in the run view one author

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
@@ -7,7 +7,18 @@
     nodeStateClass,
     capacityPips,
   } from "./dag.js";
-  import { fmtCost, fmtDur, ordinal, relSeconds } from "./run-format.js";
+  import {
+    agoPhrase,
+    attemptMeta,
+    engineStale,
+    fmtCost,
+    joinMeta,
+    queuePosition,
+    queuedOnQueue,
+    relSeconds,
+    spendOfBudget,
+    startedAgo,
+  } from "./run-format.js";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
   let {
     run,
@@ -27,17 +38,18 @@
   // would silently override the server, which owns every string this page
   // shows.
   const shortSha = (sha) => String(sha || "").slice(0, 8);
-  const ago = (value) => fmtDur(relSeconds(value, view.now));
-
-  // "running 2m" when the elapsed time is known, bare "running" when it is
-  // not. Interpolating the duration directly would print the text "null" now
-  // that formatters report absence honestly, which is a louder fabrication
-  // than the "0s" it replaced. The phrase layer generalises this.
-  const withDur = (word, seconds) => {
-    const duration = fmtDur(seconds);
-    return duration ? `${word} ${duration}` : word;
-  };
+  const since = (value) => relSeconds(value, view.now);
+  const ago = (value) => agoPhrase(since(value));
+  // Ids are plumbing: needed for copy and correlation, never for scanning.
+  const shortId = (id) => String(id || "").slice(-12);
   const path = (i, suffix) => `run.nodes[${i}]${suffix}`;
+  let copied = $state(false);
+
+  function copyWorkflowId() {
+    navigator.clipboard?.writeText(run.workflow_id);
+    copied = true;
+    setTimeout(() => (copied = false), 1200);
+  }
 </script>
 
 <div class:tier-stale={view.engine_tier === "stale"} class="runview">
@@ -60,13 +72,12 @@
             aria-hidden="true"
           ></span>
           <span class="sess-title">{session.title}</span><span class="sess-meta"
-            >{session.status}
-            {P.punct.dot}
-            {session.model}
-            {fmtCost(session.total_cost_usd)}
-            {P.punct.dot}
-            {ago(session.last_turn_at)}
-            {P.labels.ago}</span
+            >{joinMeta(
+              session.status,
+              session.model,
+              fmtCost(session.total_cost_usd),
+              ago(session.last_turn_at),
+            )}</span
           >
         </button>
       {/each}
@@ -79,18 +90,11 @@
     </div>
     <h2 class="rv-title">{run.task.text}</h2>
     <div class="rv-meta">
-      {run.work_branch}
-      {P.punct.dot}
-      {P.labels.started}
-      {ago(run.created_at)}
-      {P.labels.ago}
-      {#if run.plan?.budget_usd != null}
-        {P.punct.dot}
-        {fmtCost(run.cost_usd)}
-        {P.labels.of}
-        {fmtCost(run.plan.budget_usd)}
-        {P.labels.budgetWord}
-      {:else if fmtCost(run.cost_usd)}{P.punct.dot} {fmtCost(run.cost_usd)}{/if}
+      {joinMeta(
+        run.work_branch,
+        startedAgo(since(run.created_at)),
+        spendOfBudget(run.cost_usd, run.plan?.budget_usd),
+      )}
     </div>
     <div class="rv-statusline" data-register="fact">
       {#if run.state === "running" && attempts && run.plan?.pinned}
@@ -106,16 +110,16 @@
           >{P.punct.dot} {P.labels.retriesRemain}</span
         >
       {:else if run.completed_at}
-        {P.stateWords[run.state] || run.state}
-        {#if run.cancelled_by}
-          {P.labels.byWord} {run.cancelled_by.actor}{/if}
-        {ago(run.completed_at)}
-        {P.labels.ago}
+        {joinMeta(
+          run.cancelled_by
+            ? `${P.stateWords[run.state] || run.state} ${P.labels.byWord} ${run.cancelled_by.actor}`
+            : P.stateWords[run.state] || run.state,
+          ago(run.completed_at),
+        )}
       {:else if run.state === "queued"}
-        {#if run.nodes.find((node) => node.queue)}{ordinal(
+        {#if run.nodes.find((node) => node.queue)}{queuePosition(
             run.nodes.find((node) => node.queue).queue.position,
-          )}
-          {P.labels.positionWord}{/if}
+          )}{/if}
       {/if}
     </div>
     {#if run.stranded}<div class="banner">
@@ -167,13 +171,18 @@
       class:stale={view.engine_tier === "stale"}
       data-register="fact"
     >
-      <span class="rv-id">{run.workflow_id}</span>
+      <span class="rv-id"
+        >{P.labels.workflowWord}
+        {shortId(run.workflow_id)}</span
+      ><button
+        class="copy-id"
+        type="button"
+        title={run.workflow_id}
+        onclick={copyWorkflowId}
+        >{copied ? P.labels.copied : P.labels.copyId}</button
+      >
       {#if view.engine_tier !== "live"}
-        {P.punct.dot}
-        {P.labels.engine}{P.punct.colon}
-        {P.labels.staleShowing}
-        {fmtDur(view.snapshot_age_seconds)}
-        {P.labels.staleOld}
+        <span>{engineStale(view.snapshot_age_seconds)}</span>
       {/if}
     </div>
   {/if}
@@ -207,10 +216,7 @@
       </div>{/if}
     {#if node.model}<div class="entry-meta">{node.model}</div>{/if}
     {#if node.queue}<div class="log-entry" data-register="fact">
-        {ordinal(node.queue.position)}
-        {P.labels.queuedOn}
-        {node.queue.name}
-        {P.labels.queueWord}
+        {queuedOnQueue(node.queue.position, node.queue.name)}
       </div>{/if}
     {#if node.decision}<div
         class="decision"
@@ -252,22 +258,25 @@
           onclick={() =>
             attempt.session_id && onSelectSession(attempt.session_id)}
           ><span class="entry-meta"
-            >{P.labels.attempt}
-            {attempt.n}
-            {P.punct.dot}
-            {attempt.ended_at
-              ? fmtDur(relSeconds(attempt.started_at, attempt.ended_at))
-              : withDur(
+            >{attempt.ended_at
+              ? attemptMeta(
+                  attempt.n,
+                  null,
+                  relSeconds(attempt.started_at, attempt.ended_at),
+                  attempt.cost_usd,
+                )
+              : attemptMeta(
+                  attempt.n,
                   P.stateWords.running,
-                  relSeconds(attempt.started_at, view.now),
-                )}{#if fmtCost(attempt.cost_usd)}
-              {P.punct.dot} {fmtCost(attempt.cost_usd)}{/if}</span
+                  since(attempt.started_at),
+                  attempt.cost_usd,
+                )}</span
           >{#if attempt.state === "running" && attempt.live?.activity}<span
               class="live-line"
               ><span class="live-dot"></span><span class="live-act"
                 >{attempt.live.activity}</span
-              >{ago(attempt.live.observed_at)}
-              {P.labels.ago}</span
+              ><span class="live-when">{ago(attempt.live.observed_at)}</span
+              ></span
             >{/if}{#if attempt.finding}<span class="finding"
               >{attempt.finding.text}
               {attempt.finding.observed_head ?? ""}</span
@@ -276,23 +285,26 @@
         {#if attempt.rationale?.parse_status === "parsed" || attempt.rationale?.parse_status === "unparseable"}
           <div class="testimony" data-register="testimony">
             <div class="testimony-attribution">
-              {node.label}
-              {P.punct.dot}
-              {P.labels.attempt}
-              {attempt.n}{#if attempt.model}
-                {P.punct.dot} {attempt.model}{/if}
+              {joinMeta(
+                node.label,
+                `${P.labels.attempt} ${attempt.n}`,
+                attempt.model,
+              )}
             </div>
             {#if attempt.rationale.parse_status === "parsed"}
               {#each attempt.rationale.areas as area}
                 <div class="testimony-line">
-                  {area.area}{#if area.why}
-                    {P.punct.dot} {area.why}{/if}
+                  {joinMeta(area.area, area.why)}
                 </div>
               {/each}
               {#each attempt.rationale.deviations as deviation}
                 <div class="testimony-line">
-                  {P.labels.deviationWord}
-                  {deviation}
+                  <!-- The label is a chip, not the sentence's first word.
+                       Its gap is CSS, so no template whitespace can be
+                       trimmed away and glue it to the text. -->
+                  <span class="dev-chip">{P.labels.deviationWord}</span><span
+                    >{deviation}</span
+                  >
                 </div>
               {/each}
             {:else}

--- a/projects/monolith/frontend/src/routes/private/agents/run-format.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-format.js
@@ -47,3 +47,101 @@ export function fmtCost(value) {
 export function ordinal(n) {
   return RUN_LEXICON.ordinals[String(n)] || `${n}${RUN_LEXICON.ordinals.other}`;
 }
+
+// ---------------------------------------------------------------------------
+// Phrases
+//
+// Every joined line is built here rather than assembled in markup, because
+// markup cannot hold spacing reliably. Svelte trims whitespace at block
+// boundaries, so a separator written as the first text inside an {#if} loses
+// the space before it, and a line break inside a tag produces no text node at
+// all. Both were observed live: "projects/monolith/local·why" and
+// "... | head -405s ago". Those read as copy bugs but are formatting
+// artifacts, invisible in review and reintroducible by prettier on any edit.
+//
+// A phrase owns its own separators and decides what to do when an operand is
+// absent: omit the clause, never emit half of one. Templates then render one
+// string per line and never place a separator next to a block tag.
+//
+// These live here rather than in run-lexicon.js as the review suggested,
+// because run-format.js already imports the lexicon and the reverse direction
+// would be an import cycle. The lexicon keeps the words; this keeps the joins.
+// ---------------------------------------------------------------------------
+
+const SEP = ` ${RUN_LEXICON.punct.dot} `;
+
+/** Join meta parts with the separator, dropping absent and empty ones. */
+export function joinMeta(...parts) {
+  const kept = parts.filter((part) => part != null && part !== "");
+  return kept.length ? kept.join(SEP) : null;
+}
+
+/**
+ * Spend, always whole or absent.
+ *
+ * fmtCost distinguishes a measured zero ("") from no figure at all (null), so
+ * a run that has not spent anything says so instead of leaving the observed
+ * headless fragment "of $50.00 budget".
+ */
+export function spendOfBudget(cost, budget) {
+  const spent = fmtCost(cost);
+  const cap = fmtCost(budget);
+  if (!cap) return spent || null;
+  if (spent === "") return RUN_LEXICON.labels.noSpendYet;
+  if (!spent) return null;
+  return `${spent} ${RUN_LEXICON.labels.of} ${cap} ${RUN_LEXICON.labels.budgetWord}`;
+}
+
+/** "2m ago", or nothing when the elapsed time was never measured. */
+export function agoPhrase(seconds) {
+  const duration = fmtDur(seconds);
+  return duration ? `${duration} ${RUN_LEXICON.labels.ago}` : null;
+}
+
+/** "started 2m ago", or nothing. */
+export function startedAgo(seconds) {
+  const phrase = agoPhrase(seconds);
+  return phrase ? `${RUN_LEXICON.labels.started} ${phrase}` : null;
+}
+
+/** "running 2m" when the duration is known, bare state word when it is not. */
+export function stateFor(word, seconds) {
+  const duration = fmtDur(seconds);
+  if (!word) return duration;
+  return duration ? `${word} ${duration}` : word;
+}
+
+/** "attempt 2 · running 20m · $0.12", omitting whichever parts are absent. */
+export function attemptMeta(n, word, seconds, cost) {
+  return joinMeta(
+    `${RUN_LEXICON.labels.attempt} ${n}`,
+    stateFor(word, seconds),
+    fmtCost(cost),
+  );
+}
+
+/** "2nd in line". */
+export function queuePosition(position) {
+  return `${ordinal(position)} ${RUN_LEXICON.labels.positionWord}`;
+}
+
+/** "2nd on the codex queue". */
+export function queuedOnQueue(position, name) {
+  return `${ordinal(position)} ${RUN_LEXICON.labels.queuedOn} ${name} ${RUN_LEXICON.labels.queueWord}`;
+}
+
+/**
+ * "engine: unreachable, showing 2m old state".
+ *
+ * Drops to the claim alone when the snapshot age was never measured, rather
+ * than asserting the state is "0s old", which would read as fresh.
+ */
+export function engineStale(seconds) {
+  const head = `${RUN_LEXICON.labels.engine}${RUN_LEXICON.punct.colon}`;
+  const age = fmtDur(seconds);
+  // staleShowing trails off into an age, so without one it would leave the
+  // sentence hanging: exactly the fragment this layer exists to prevent.
+  return age
+    ? `${head} ${RUN_LEXICON.labels.staleShowing} ${age} ${RUN_LEXICON.labels.staleOld}`
+    : `${head} ${RUN_LEXICON.labels.staleUnreachable}`;
+}

--- a/projects/monolith/frontend/src/routes/private/agents/run-format.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-format.test.js
@@ -1,5 +1,15 @@
 import { describe, expect, test } from "vitest";
-import { fmtCost, fmtDur, ordinal, relSeconds } from "./run-format.js";
+import {
+  attemptMeta,
+  engineStale,
+  fmtCost,
+  fmtDur,
+  joinMeta,
+  ordinal,
+  relSeconds,
+  spendOfBudget,
+  startedAgo,
+} from "./run-format.js";
 
 describe("run formatting", () => {
   test("formats durations using the contract units", () => {
@@ -39,5 +49,39 @@ describe("run formatting", () => {
     expect(fmtCost(0)).toBe("");
     expect(fmtCost(null)).toBe(null);
     expect(fmtCost(undefined)).toBe(null);
+  });
+});
+
+describe("phrases", () => {
+  test("joins with its own separator and drops absent parts", () => {
+    expect(joinMeta("a", "b")).toBe("a · b");
+    expect(joinMeta("a", null, "", undefined, "b")).toBe("a · b");
+    expect(joinMeta(null, undefined)).toBe(null);
+  });
+
+  test("spend is whole or absent, never a headless fragment", () => {
+    // The observed defect: a run with no spend yet printed "of $50.00 budget".
+    expect(spendOfBudget(0.2, 0.15)).toBe("$0.20 of $0.15 budget");
+    expect(spendOfBudget(0, 0.15)).toBe("nothing spent yet");
+    expect(spendOfBudget(null, 50)).toBe(null);
+    expect(spendOfBudget(0.2, null)).toBe("$0.20");
+    expect(spendOfBudget(null, null)).toBe(null);
+  });
+
+  test("attempt meta omits the parts it does not have", () => {
+    expect(attemptMeta(2, "running", 1200, 0.12)).toBe(
+      "attempt 2 · running 20m · $0.12",
+    );
+    expect(attemptMeta(1, null, 480, 0)).toBe("attempt 1 · 8m");
+    expect(attemptMeta(1, "running", null, null)).toBe("attempt 1 · running");
+  });
+
+  test("a claim survives without the measurement it would have carried", () => {
+    expect(startedAgo(120)).toBe("started 2m ago");
+    expect(startedAgo(null)).toBe(null);
+    // Dropping to the bare claim beats asserting the snapshot is "0s old",
+    // which would read as fresh.
+    expect(engineStale(120)).toBe("engine: unreachable, showing 2m old state");
+    expect(engineStale(null)).toBe("engine: unreachable");
   });
 });

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -91,6 +91,13 @@ export const RUN_LEXICON = {
     creating: "creating…",
     startingRun: "starting…",
     deviations: "deviations",
+    noSpendYet: "nothing spent yet",
+    workflowWord: "workflow",
+    copyId: "copy id",
+    copied: "copied",
+    // staleShowing trails off into an age ("unreachable, showing"), so it
+    // cannot stand alone when the age was never measured.
+    staleUnreachable: "unreachable",
   },
   punct: { dot: "·", arrow: "→", colon: ":" },
   units: { s: "s", m: "m", h: "h", d: "d" },

--- a/projects/monolith/frontend/src/routes/private/agents/run-view.css
+++ b/projects/monolith/frontend/src/routes/private/agents/run-view.css
@@ -315,6 +315,39 @@
 .live-act {
   font: var(--size-body-mono) var(--font-mono);
 }
+/* The observation time is its own element, never text trailing the command.
+   Written as an adjacent text node it produced "... | head -405s ago". */
+.live-when {
+  margin-left: auto;
+  flex: none;
+  color: var(--muted);
+  font: var(--size-meta) var(--font-mono);
+}
+/* A label introducing a sentence, so the gap is CSS. Rendered as a bare word
+   before the text it produced "deviation Vite runtime validation was ...",
+   where the label read as the sentence's first word. */
+.dev-chip {
+  margin-right: 7px;
+  padding: 0 5px;
+  border: 1px solid var(--line-strong);
+  border-radius: 3px;
+  color: var(--muted);
+  font: var(--size-meta) var(--font-mono);
+  white-space: nowrap;
+}
+.copy-id {
+  margin-left: 7px;
+  padding: 0 6px;
+  border: 1px solid var(--line-strong);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  font: var(--size-meta) var(--font-mono);
+  cursor: pointer;
+}
+.copy-id:hover {
+  color: var(--text-soft);
+}
 .decision {
   margin-top: 4px;
 }


### PR DESCRIPTION
Second of five from the UX review. Builds on #4674, which made the formatters able to express absence.

## The copy defects were not copy defects

They were markup holding spacing that markup cannot hold:

- Svelte trims whitespace at block boundaries, so a separator written as the first text inside an `{#if}` loses the space before it. That produced `projects/monolith/local·Provides a dependency-light...`
- A line break inside a tag produces no text node at all. That produced `... | head -405s ago`

Neither is visible in review, and prettier can reintroduce either on any edit. Fixing them where they appear would not hold.

## The fix

Joins move out of the template into phrases that own their separators and decide what to do when an operand is absent: omit the clause, never emit half of one.

`spendOfBudget`, `startedAgo`, `agoPhrase`, `attemptMeta`, `queuePosition`, `queuedOnQueue`, `engineStale`, plus a `joinMeta` helper that drops absent and empty parts. Templates now render one string per line.

They live in `run-format.js` rather than `run-lexicon.js` as the review proposed, because `run-format.js` already imports the lexicon and the reverse would be an import cycle. The lexicon keeps the words, this keeps the joins.

`spendOfBudget` is the one that needed #4674 first: `fmtCost` now separates a measured zero from no figure at all, so it can say `nothing spent yet` against a budget instead of the observed headless `of $50.00 budget`.

## Two labels stop being glued into prose

The deviation label becomes a chip whose gap is CSS, so no trimmed text node can turn it into the sentence's first word. The live activity timestamp becomes its own element rather than text trailing the command.

## The pane foot stops printing a bare UUID

Ids are plumbing: needed for copy and correlation, never for scanning. It renders as a labelled short id with a copy control, full value in `title`.

## Verification

`run-format.test.js` 5 to 9 tests, `Tests 590 passed (590)` up from 586.

Writing them caught `engineStale` emitting `engine: unreachable, showing` when the snapshot age was unmeasured, which is the same class of fragment this PR removes. It drops to `engine: unreachable` instead, and there is a test pinning that.

## Knowingly left

`RunView.svelte:110` still places a separator at the start of a span. It sits between two elements rather than inside a block boundary so it renders correctly, and the fact/belief register split requires the two elements. The stranded banner's separator is left for the register PR, which restructures that block.

Against #4625. Next: sidebar split, designed collapsed rail, kind row and breadcrumb.