### PR TITLE
feat(monolith): make every agents pane state its kind and lineage

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -21,8 +21,10 @@
   import MasterView from "./MasterView.svelte";
   import StateIcon from "./StateIcon.svelte";
   import { nodeIconKey, nodeStateClass } from "./dag.js";
-  import { fmtCost, joinMeta } from "./run-format.js";
+  import { firstLine, fmtCost, joinMeta } from "./run-format.js";
+  import { crumbTrail, sessionLineage } from "./lineage.js";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
+  import PaneHeader from "./PaneHeader.svelte";
 
   const MOBILE_MEDIA_QUERY = "(max-width: 760px)";
 
@@ -171,6 +173,21 @@
       firstLine(detail?.pending_queue?.[0]?.prompt) ||
       sessionTitle(selectedSession),
   );
+  const crumbRunTitle = $derived(
+    selectedRunId ? firstLine(runDetail?.run?.task?.text) : "",
+  );
+  const crumbLineage = $derived(
+    selectedRunId ? sessionLineage(runDetail?.run, selectedId) : null,
+  );
+  const sessionCrumbs = $derived(
+    crumbTrail({
+      kind: "session",
+      runTitle: crumbRunTitle,
+      nodeLabel: crumbLineage?.nodeLabel,
+      attemptN: crumbLineage?.attemptN,
+      sessionTitle: headerTitle,
+    }),
+  );
 
   function isActive(session) {
     return session?.status === "running" || Number(session?.pending_count) > 0;
@@ -212,12 +229,6 @@
     const months = Math.floor(days / 30);
     if (months < 12) return `${months}mo`;
     return `${Math.floor(months / 12)}y`;
-  }
-
-  function firstLine(value) {
-    return String(value || "")
-      .trim()
-      .split("\n")[0];
   }
 
   function shortId(session) {
@@ -596,6 +607,11 @@
 
   function returnToRun() {
     navigateTo(backToRun($page.url.searchParams));
+  }
+
+  function paneCrumb(to) {
+    if (to === "home") selectRuns();
+    else if (to === "run") returnToRun();
   }
 
   function closeNewPanel() {
@@ -1093,44 +1109,58 @@
         view={fixture.view}
         sessions={fixture.sessions}
         onSelectSession={selectSession}
+        onCrumb={paneCrumb}
       />
     {:else if selectedId && selectedSession}
       <header class="transcript-head">
-        <div class="head-main">
-          {#if selectedRunId}
-            <button class="back-to-run" type="button" onclick={returnToRun}>
-              ← back to run
-            </button>
-          {/if}
-          <h1
-            class="session-title"
-            title={headerTitle}
-            tabindex="-1"
-            bind:this={titleEl}
-          >
-            {headerTitle}
-          </h1>
-          <div class="session-context mono">
-            {formatRepoContext(selectedSession)} · {selectedSession.model ||
-              "luna"} · {shortId(selectedSession)}
-          </div>
-        </div>
-        <div class="head-actions">
-          <span
-            class={`vm-chip vm-${vmState(selectedSession, vms)}`}
-            title={vms[selectedSession.ember_session_id]?.cp_state
-              ? `control plane: ${vms[selectedSession.ember_session_id].cp_state}`
-              : "no live microVM; the next prompt boots fresh"}
-            >vm {vmState(selectedSession, vms)}</span
-          >
-          {#if statusClass(selectedSession) !== "completed"}
-            <span class={`session-state ${statusClass(selectedSession)}`}
-              >{statusLabel(selectedSession)}</span
+        <PaneHeader
+          kind={P.labels.sessionWord}
+          crumbs={sessionCrumbs}
+          onCrumb={paneCrumb}
+        >
+          {#snippet chips()}
+            <span
+              class={`vm-chip vm-${vmState(selectedSession, vms)}`}
+              title={vms[selectedSession.ember_session_id]?.cp_state
+                ? `control plane: ${vms[selectedSession.ember_session_id].cp_state}`
+                : "no live microVM; the next prompt boots fresh"}
+              >vm {vmState(selectedSession, vms)}</span
             >
-          {/if}
-          <button class="destroy-button" type="button" onclick={destroySession}
-            >destroy</button
-          >
+            {#if statusClass(selectedSession) !== "completed"}
+              <span class={`session-state ${statusClass(selectedSession)}`}
+                >{statusLabel(selectedSession)}</span
+              >
+            {/if}
+            <!-- One right-hand group whether or not the session came from a
+                 run. Pushing only the back link would leave destroy sitting
+                 against the state chip on a standalone session, so the
+                 button a mis-click destroys a VM with moves under the
+                 cursor depending on how you arrived. -->
+            <span class="push head-right">
+              {#if selectedRunId}
+                <button class="back-to-run" type="button" onclick={returnToRun}
+                  >{P.labels.backToRun}</button
+                >
+              {/if}
+              <button
+                class="destroy-button"
+                type="button"
+                onclick={destroySession}>destroy</button
+              >
+            </span>
+          {/snippet}
+        </PaneHeader>
+        <h1
+          class="session-title"
+          title={headerTitle}
+          tabindex="-1"
+          bind:this={titleEl}
+        >
+          {headerTitle}
+        </h1>
+        <div class="session-context mono">
+          {formatRepoContext(selectedSession)} · {selectedSession.model ||
+            "luna"} · {shortId(selectedSession)}
         </div>
       </header>
       <div class="turns" bind:this={turnsEl}>
@@ -1298,7 +1328,10 @@
       <!-- ?session= for a row absent from the server-rendered list. Without
            this branch the pane falls through to the master view and swaps
            once loadDetail resolves. -->
-      <div class="empty blank-state">Loading session…</div>
+      <div class="loading-session">
+        <PaneHeader kind={P.labels.sessionWord} />
+        <div class="empty blank-state">Loading session…</div>
+      </div>
     {:else if selectedRunId}
       {#if runDetail?.run}
         <RunView
@@ -1307,6 +1340,7 @@
           sessions={runDetail.sessions}
           onSelectSession={selectSession}
           onCancel={() => cancelRun(selectedRunId)}
+          onCrumb={paneCrumb}
         />
         <!-- loadRunDetail's catch leaves runDetail set with run: null and the
              tier marked absent. Without this branch that state is
@@ -1632,10 +1666,8 @@
     gap: 8px;
   }
   .side-head,
-  .transcript-head,
   .composer-actions,
-  .new-actions,
-  .head-actions {
+  .new-actions {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -1913,11 +1945,14 @@
     background: var(--panel-bg);
   }
   .transcript-head {
+    display: block;
     padding: 14px 28px;
     border-bottom: 1px solid var(--line);
   }
-  .head-main {
-    min-width: 0;
+  .head-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
   .session-title {
     margin: 0;
@@ -2396,11 +2431,7 @@
       background: transparent;
     }
     .transcript-head {
-      justify-content: flex-start;
-      flex-wrap: wrap;
-    }
-    .transcript-head .head-main {
-      flex: 1;
+      padding: 12px 16px;
     }
     .new-panel-scrim {
       display: block;

--- a/projects/monolith/frontend/src/routes/private/agents/MasterView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/MasterView.svelte
@@ -1,6 +1,7 @@
 <script>
   import { fmtCost, fmtDur } from "./run-format.js";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
+  import PaneHeader from "./PaneHeader.svelte";
   let {
     master,
     onSelectRun = () => {},
@@ -16,11 +17,11 @@
   class:tier-stale={view.engine_tier === "stale"}
   class="runview master-view"
 >
-  <div class="rv-eyebrow">
-    <span class="eyebrow-label">{P.labels.masterEyebrow}</span><span
-      class="rv-id">{master.runs.length} {P.labels.inFlight}</span
-    >
-  </div>
+  <PaneHeader kind={P.labels.masterEyebrow}>
+    {#snippet chips()}
+      <span class="rv-id">{master.runs.length} {P.labels.inFlight}</span>
+    {/snippet}
+  </PaneHeader>
   {#if view.engine_tier === "absent"}
     <div class="m-quiet">{P.labels.absentNotice}</div>
   {:else}

--- a/projects/monolith/frontend/src/routes/private/agents/PaneHeader.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/PaneHeader.svelte
@@ -1,0 +1,25 @@
+<script>
+  let { kind, crumbs = [], onCrumb = () => {}, chips } = $props();
+</script>
+
+{#if crumbs.length}
+  <nav class="crumbs" aria-label="Location">
+    {#each crumbs as crumb, i}
+      {#if crumb.to}
+        <button
+          class="crumb-link"
+          type="button"
+          onclick={() => onCrumb(crumb.to)}>{crumb.label}</button
+        >
+      {:else}<span class="crumb-current" aria-current="page">{crumb.label}</span
+        >{/if}
+      {#if i < crumbs.length - 1}<span class="crumb-sep" aria-hidden="true"
+          >/</span
+        >{/if}
+    {/each}
+  </nav>
+{/if}
+<div class="kind-row">
+  <span class="kind">{kind}</span>
+  {@render chips?.()}
+</div>

--- a/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
@@ -18,7 +18,10 @@
     relSeconds,
     spendOfBudget,
     startedAgo,
+    firstLine,
   } from "./run-format.js";
+  import PaneHeader from "./PaneHeader.svelte";
+  import { crumbTrail } from "./lineage.js";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
   let {
     run,
@@ -26,6 +29,7 @@
     sessions = [],
     onSelectSession = () => {},
     onCancel = () => {},
+    onCrumb = () => {},
   } = $props();
   const active = $derived(
     run?.dbos_status === "PENDING" || run?.dbos_status === "ENQUEUED",
@@ -54,11 +58,11 @@
 
 <div class:tier-stale={view.engine_tier === "stale"} class="runview">
   {#if !run || view.engine_tier === "absent"}
-    <div class="rv-eyebrow">
-      <span class="eyebrow-label">{P.labels.run}</span><span class="state-chip"
-        >{P.labels.sessionsOnly}</span
-      >
-    </div>
+    <PaneHeader kind={P.labels.run} {onCrumb}>
+      {#snippet chips()}
+        <span class="state-chip">{P.labels.sessionsOnly}</span>
+      {/snippet}
+    </PaneHeader>
     <div class="absent-note">{P.labels.absentNotice}</div>
     <div class="sess-list">
       {#each sessions as session, i}
@@ -83,11 +87,17 @@
       {/each}
     </div>
   {:else}
-    <div class="rv-eyebrow">
-      <span class={`state-chip s-${run.state}`}
-        >{P.stateWords[run.state] || run.state}</span
-      >
-    </div>
+    <PaneHeader
+      kind={P.labels.run}
+      crumbs={crumbTrail({ kind: "run", runTitle: firstLine(run.task.text) })}
+      {onCrumb}
+    >
+      {#snippet chips()}
+        <span class={`state-chip s-${run.state}`}
+          >{P.stateWords[run.state] || run.state}</span
+        >
+      {/snippet}
+    </PaneHeader>
     <h2 class="rv-title">{run.task.text}</h2>
     <div class="rv-meta">
       {joinMeta(

--- a/projects/monolith/frontend/src/routes/private/agents/lineage.js
+++ b/projects/monolith/frontend/src/routes/private/agents/lineage.js
@@ -1,0 +1,56 @@
+import { joinMeta } from "./run-format.js";
+import { RUN_LEXICON } from "./run-lexicon.js";
+
+export function sessionLineage(run, sessionId) {
+  // Both guards exist because the comparison is stringified: the URL carries
+  // ?session= as a string while the payload carries a number, so a strict ===
+  // would never match. Without them String(null) === String(null) holds, and
+  // ?run= with no session would claim the lineage of the first attempt that
+  // never got a session: a fabricated answer, not an absent one.
+  if (sessionId == null) return null;
+  for (const node of run?.nodes ?? []) {
+    for (const attempt of node.attempts ?? []) {
+      if (attempt.session_id == null) continue;
+      if (String(attempt.session_id) === String(sessionId)) {
+        return {
+          nodeKey: node.key,
+          nodeLabel: node.label,
+          attemptN: attempt.n,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+export function crumbTrail({
+  kind,
+  runTitle,
+  nodeLabel,
+  attemptN,
+  sessionTitle,
+}) {
+  runTitle = String(runTitle ?? "").trim();
+  nodeLabel = String(nodeLabel ?? "").trim();
+  sessionTitle = String(sessionTitle ?? "").trim();
+  if (kind === "run") {
+    return runTitle
+      ? [
+          { label: RUN_LEXICON.labels.runsWord, to: "home" },
+          { label: runTitle, to: null },
+        ]
+      : [{ label: RUN_LEXICON.labels.runsWord, to: "home" }];
+  }
+  if (kind !== "session" || !runTitle) return [];
+
+  const leaf =
+    joinMeta(
+      nodeLabel,
+      attemptN != null ? `${RUN_LEXICON.labels.attempt} ${attemptN}` : null,
+    ) || sessionTitle;
+  return [
+    { label: RUN_LEXICON.labels.runsWord, to: "home" },
+    { label: runTitle, to: "run" },
+    ...(leaf ? [{ label: leaf, to: null }] : []),
+  ];
+}

--- a/projects/monolith/frontend/src/routes/private/agents/lineage.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/lineage.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+import { crumbTrail, sessionLineage } from "./lineage.js";
+
+describe("sessionLineage", () => {
+  const run = {
+    nodes: [
+      {
+        key: "implement",
+        label: "implement",
+        attempts: [{ session_id: 42, n: 2 }],
+      },
+    ],
+  };
+
+  test("matches numeric payload ids to string URL ids", () => {
+    expect(sessionLineage(run, "42")).toEqual({
+      nodeKey: "implement",
+      nodeLabel: "implement",
+      attemptN: 2,
+    });
+  });
+  test("returns null for empty nodes", () => {
+    expect(sessionLineage({ nodes: [] }, "42")).toBe(null);
+  });
+  test("returns null for a nullish run", () => {
+    expect(sessionLineage(null, "42")).toBe(null);
+  });
+  test("returns null when no attempt matches", () => {
+    expect(sessionLineage(run, "43")).toBe(null);
+  });
+  // ?run= with no ?session= derives lineage too. Stringified comparison makes
+  // "null" equal "null", so without the guards an attempt that never got a
+  // session would answer for the session nobody asked about.
+  test("does not match an attempt with no session against no session", () => {
+    const unstarted = {
+      nodes: [{ key: "review", label: "review", attempts: [{ n: 1 }] }],
+    };
+    expect(sessionLineage(unstarted, null)).toBe(null);
+    expect(sessionLineage(unstarted, undefined)).toBe(null);
+  });
+});
+
+describe("crumbTrail", () => {
+  test("renders a run trail", () => {
+    expect(crumbTrail({ kind: "run", runTitle: "Fixture" })).toEqual([
+      { label: "runs", to: "home" },
+      { label: "Fixture", to: null },
+    ]);
+  });
+  test("shortens a blank run trail", () => {
+    expect(crumbTrail({ kind: "run", runTitle: " " })).toEqual([
+      { label: "runs", to: "home" },
+    ]);
+  });
+  test("renders session lineage", () => {
+    expect(
+      crumbTrail({
+        kind: "session",
+        runTitle: "Fixture",
+        nodeLabel: "implement",
+        attemptN: 2,
+      }),
+    ).toEqual([
+      { label: "runs", to: "home" },
+      { label: "Fixture", to: "run" },
+      { label: "implement · attempt 2", to: null },
+    ]);
+  });
+  test("falls back to the session title without lineage", () => {
+    expect(
+      crumbTrail({
+        kind: "session",
+        runTitle: "Fixture",
+        sessionTitle: "Chat",
+      }),
+    ).toEqual([
+      { label: "runs", to: "home" },
+      { label: "Fixture", to: "run" },
+      { label: "Chat", to: null },
+    ]);
+    expect(crumbTrail({ kind: "session", runTitle: "Fixture" })).toEqual([
+      { label: "runs", to: "home" },
+      { label: "Fixture", to: "run" },
+    ]);
+  });
+  test("has no trail for standalone sessions or home", () => {
+    expect(crumbTrail({ kind: "session" })).toEqual([]);
+    expect(crumbTrail({ kind: "home" })).toEqual([]);
+  });
+});

--- a/projects/monolith/frontend/src/routes/private/agents/run-format.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-format.js
@@ -1,5 +1,11 @@
 import { RUN_LEXICON } from "./run-lexicon.js";
 
+export function firstLine(value) {
+  return String(value ?? "")
+    .trim()
+    .split("\n")[0];
+}
+
 // A console for a durable workflow engine has to keep three things apart that
 // these formatters used to collapse into one: a measured zero, a value not
 // observed yet, and a value that failed to parse. Only the first is a fact.

--- a/projects/monolith/frontend/src/routes/private/agents/run-format.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-format.test.js
@@ -4,6 +4,7 @@ import {
   engineStale,
   fmtCost,
   fmtDur,
+  firstLine,
   joinMeta,
   ordinal,
   relSeconds,
@@ -12,6 +13,12 @@ import {
 } from "./run-format.js";
 
 describe("run formatting", () => {
+  test("returns the trimmed first line", () => {
+    expect(firstLine("  first line\nsecond line  ")).toBe("first line");
+    expect(firstLine("\n  \n")).toBe("");
+    expect(firstLine(null)).toBe("");
+    expect(firstLine(undefined)).toBe("");
+  });
   test("formats durations using the contract units", () => {
     expect(fmtDur(12)).toBe("12s");
     expect(fmtDur(90)).toBe("1m");

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -78,6 +78,8 @@ export const RUN_LEXICON = {
     gateWord: "gate",
     budgetWord: "budget",
     sessionMode: "session",
+    sessionWord: "session",
+    backToRun: "back to run",
     runMode: "run",
     newSession: "new session",
     newRun: "new run",

--- a/projects/monolith/frontend/src/routes/private/agents/run-view.css
+++ b/projects/monolith/frontend/src/routes/private/agents/run-view.css
@@ -10,18 +10,42 @@
   line-height: 1.45;
   overflow-wrap: anywhere;
 }
-.rv-eyebrow {
+.crumbs {
+  margin-bottom: 8px;
+  overflow: hidden;
+  color: var(--muted);
+  font: var(--size-meta) var(--font-mono);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.crumb-link {
+  padding: 0;
+  border: 0;
+  color: var(--info);
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+.crumb-link:hover {
+  text-decoration: underline;
+}
+.crumb-sep {
+  margin: 0 6px;
+}
+.kind-row {
   display: flex;
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
 }
-.eyebrow-label,
-.rv-eyebrow-label {
+.kind {
   color: var(--muted);
   font: var(--size-meta) var(--font-mono);
   letter-spacing: 0.13em;
   text-transform: uppercase;
+}
+.kind-row .push {
+  margin-left: auto;
 }
 .rv-id,
 .rv-meta,


### PR DESCRIPTION
## What

Master, run, and session views shared one region with no persistent kind
marker, so a session opened from a run looked identical to a standalone one.
The URL contract already told them apart (`?run=`, `?session=`,
`?run=&session=`); nothing rendered it.

Every pane now opens with a kind row, and a session reached through a run
carries a breadcrumb back up it:

```
runs / Fixture running run / implement · attempt 2
SESSION  [running]  [vm awake]                     back to run  destroy
Fixture running run
```

- `PaneHeader.svelte` owns that header once. Three call sites
  (`MasterView`, `RunView`, the session transcript) render through it, so
  the pane header cannot drift into three shapes again.
- `lineage.js` owns the question of which node and attempt a session
  belongs to. No component re-derives it, and the crumb trail is a truth
  table rather than a chain of ternaries in markup.
- The crumb separator is its own element with a CSS margin, not template
  whitespace. Svelte trims whitespace at block boundaries, which is why the
  spacing defects earlier in this series could not survive where they were
  written.

## Two things found in review, fixed here

**`sessionLineage` could answer a question nobody asked.** The lookup
compares stringified ids, because the URL carries `?session=` as a string
while the payload carries a number. That also makes `String(null)` equal
`String(null)`, so a `?run=` with no session would have matched the first
attempt that never got one and reported its lineage as fact. `?run=` derives
lineage on every render, so this was live, not theoretical. Guarded at both
ends with a test that pins it.

**The destroy button moved depending on how you arrived.** Pushing only the
back-to-run link right would leave `destroy` against the state chip on a
standalone session. Both now sit in one right-hand group, so the control
that destroys a VM does not shift under the cursor.

## Left behind deliberately

`.rv-eyebrow`, `.eyebrow-label`, `.head-main`, and `.head-actions` are
deleted rather than left dormant: a second way to write a pane header is how
the first drift happened. Grepped to confirm no remaining users.

## Verification

- `ci lint`: clean.
- `//projects/monolith/frontend:test`: `Executed 1 out of 1 test: 1 test
  passes.`, 601 tests up from 590 (+10 in `lineage.test.js`, +1 in
  `run-format.test.js`).
- `//projects/monolith/frontend:build`: `Build completed successfully, 72
  total actions`. This is the load-bearing check here: vitest never imports
  `+page.svelte`, so the test target would stay green through a dangling
  import or a broken snippet reference.