### PR TITLE
fix(helm): deploy the last two tag-pinned charts by digest

### DIFF
--- a/bazel/images/push/push-changed.sh
+++ b/bazel/images/push/push-changed.sh
@@ -16,9 +16,22 @@
 # guard already relies on. So an image whose manifest digest is already in the
 # registry has nothing to publish. The only thing a push would add is one more
 # build-timestamped tag over identical bytes, and nothing reads those tags:
-# every chart here deploys `repository@digest`. The two tag-only image
-# references in the repo (embervm servingEnvoy, context-forge toolRefresh) are
-# upstream images this never pushes.
+# every chart here deploys `repository@digest`.
+#
+# THAT LAST SENTENCE IS A LOAD-BEARING INVARIANT, NOT AN OBSERVATION, and it was
+# false for eight months. A chart rendering `repository:tag` pins the very tag
+# this script decided not to create, which is an ImagePullBackOff on the next
+# content-identical commit. monolith-public deployed that way and wedged for
+# ~11h on 2026-08-11 while this script printed "0 image(s) to push" and the
+# action stayed green. Fixed in PR #4680 (homelab-library) and #4681
+# (oci-model-cache, signoz dashboard-sidecar). Before relying on the skip again,
+# check that no chart template renders a bare tag over an image we push:
+#
+#   grep -rn 'image.repository }}:{{' projects/*/chart/templates projects/*/*/chart/templates
+#
+# Legitimate hits are upstream images this never pushes (embervm servingEnvoy,
+# context-forge toolRefresh, cloudflare-gateway, renovate). embervm tokenBroker
+# renders `repo:tag@digest`, where the digest still decides.
 #
 # FAIL CLOSED. An image is pushed whenever we cannot prove it is unnecessary:
 # no manifest entry, a blank repository or digest, or any registry lookup that

--- a/projects/operators/oci-model-cache/helm/oci-model-cache-operator/templates/_helpers.tpl
+++ b/projects/operators/oci-model-cache/helm/oci-model-cache-operator/templates/_helpers.tpl
@@ -56,3 +56,26 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- default "default" .Values.syncServiceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Container image reference. Prefers the content-addressed digest, falling back to
+the tag when no digest is set.
+
+WHY THE DIGEST WINS. helm_images_values emits repository, tag AND digest, and
+the tag is build-timestamped: it moves on every commit to main even when the
+image bytes are identical. push-changed.sh skips pushing an image whose content
+digest is already in the registry, so that new tag is frequently never created,
+and deploying it is an ImagePullBackOff. That wedged monolith-public on
+2026-08-11 (PR #4680 fixed the shared homelab-library the same way; this chart
+does not use that library, so it needed its own).
+
+The tag fallback keeps the chart renderable when no digest is present, e.g. a
+plain `helm template` from source values.
+*/}}
+{{- define "oci-model-cache-operator.imageRef" -}}
+{{- if .Values.controllerManager.image.digest -}}
+{{ .Values.controllerManager.image.repository }}@{{ .Values.controllerManager.image.digest }}
+{{- else -}}
+{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag | default .Chart.AppVersion }}
+{{- end -}}
+{{- end }}

--- a/projects/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
+++ b/projects/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         {{- if ne .Values.controllerManager.metrics.bindAddress "0" }}
         - --metrics-bind-address={{ .Values.controllerManager.metrics.bindAddress }}
         {{- end }}
-        image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "oci-model-cache-operator.imageRef" . }}"
         imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}
         name: manager
         securityContext:

--- a/projects/platform/signoz-addons/dashboard-sidecar/templates/_helpers.tpl
+++ b/projects/platform/signoz-addons/dashboard-sidecar/templates/_helpers.tpl
@@ -65,3 +65,26 @@ Get the image tag
 {{- define "signoz-dashboard-sidecar.imageTag" -}}
 {{- .Values.image.tag | default .Chart.AppVersion }}
 {{- end }}
+
+{{/*
+Container image reference. Prefers the content-addressed digest, falling back to
+the tag when no digest is set.
+
+WHY THE DIGEST WINS. helm_images_values emits repository, tag AND digest, and
+the tag is build-timestamped: it moves on every commit to main even when the
+image bytes are identical. push-changed.sh skips pushing an image whose content
+digest is already in the registry, so that new tag is frequently never created,
+and deploying it is an ImagePullBackOff. That wedged monolith-public on
+2026-08-11 (PR #4680 fixed the shared homelab-library the same way; this chart
+does not use that library, so it needed its own).
+
+The tag fallback keeps the chart renderable when no digest is present, e.g. a
+plain `helm template` from source values.
+*/}}
+{{- define "signoz-dashboard-sidecar.imageRef" -}}
+{{- if .Values.image.digest -}}
+{{ .Values.image.repository }}@{{ .Values.image.digest }}
+{{- else -}}
+{{ .Values.image.repository }}:{{ include "signoz-dashboard-sidecar.imageTag" . }}
+{{- end -}}
+{{- end }}

--- a/projects/platform/signoz-addons/dashboard-sidecar/templates/deployment.yaml
+++ b/projects/platform/signoz-addons/dashboard-sidecar/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ include "signoz-dashboard-sidecar.imageTag" . }}"
+          image: "{{ include "signoz-dashboard-sidecar.imageRef" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}


### PR DESCRIPTION
Closes #4681.

## Why

PR #4680 fixed the shared `homelab-library` after it wedged `monolith-public` in `ImagePullBackOff` for ~11h. Two charts do not use that library and carried the identical bug:

- `projects/operators/oci-model-cache/.../templates/deployment.yaml`
- `projects/platform/signoz-addons/dashboard-sidecar/templates/deployment.yaml`

Both rendered `repository:tag`. That tag is build-timestamped so it moves on every commit to main, while `push-changed.sh` skips pushing an image whose content digest is already in the registry. The tag a chart pins is therefore frequently never created, and deploying it is an `ImagePullBackOff` with the deploy still printing `0 image(s) to push` and exiting green.

Neither had failed yet, purely because no chart publish had landed on a commit where its image content happened to be unchanged. This is a latent prod bug, not a cleanup.

## The prerequisite I checked first

Both charts declare a `helm_chart(images = {...})` map, so `helm_images_values` injects a digest. Confirmed in the currently published charts rather than assumed:

```
oci-model-cache-operator 0.2.13  digest: sha256:1ce40e076e8f...
signoz-dashboard-sidecar 0.3.3   digest: sha256:923f58199db1...
```

Had either lacked a digest, the fix would have been to wire it into `helm_images_values` first, not to change the template.

## What

Each chart gets its own `imageRef` helper, since neither depends on `homelab-library` and there is no shared place to put one. Digest first, tag as fallback. The fallback keeps `helm template` from source values renderable and preserves the existing `| default .Chart.AppVersion` semantics.

Verified both branches on both charts:

| chart | no digest | with digest |
|---|---|---|
| `dashboard-sidecar` | `...dashboard-sidecar/cmd:0.1.0` | `...dashboard-sidecar/cmd@sha256:923f5819...` |
| `oci-model-cache` | `...oci-model-cache:latest` | `...oci-model-cache@sha256:1ce40e07...` |

## The comment that caused this

`push-changed.sh` stated *"nothing reads those tags: every chart here deploys `repository@digest`"* as an observation. It is actually the invariant the entire skip optimisation rests on, and it was false for months. The header now says that explicitly and records the grep that checks it, so the next person to trust the skip has a way to verify it instead of a claim to believe.

Enforcing that invariant mechanically is #4682, next.

## Verification

- `ci lint` clean.
- `ci test`: `Executed 5 out of 702 tests: 702 tests pass`.

No `Chart.yaml` `version:` or `targetRevision:` touched. `dashboard-sidecar` is OCI-pinned at `0.3.3` with only its values on `HEAD`, so it deploys via the normal chart bump rather than instantly on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)