### PR TITLE
chore(authentik): run the 2026.8.0 release candidate to try token exchange

### DIFF
--- a/projects/platform/authentik/values.yaml
+++ b/projects/platform/authentik/values.yaml
@@ -18,6 +18,20 @@ authentik:
       user: authentik
       port: 5432
   global:
+    # Pinned to the 2026.8.0 release candidate to try RFC 8693 token exchange,
+    # which lands in 2026.8 and does not exist in 2026.5.6 (verified: that
+    # tag's providers/oauth2/views/token.py has no GRANT_TYPE_TOKEN_EXCHANGE).
+    # It is set here rather than as a Chart.yaml dependency bump because
+    # charts.goauthentik.io publishes no 2026.8.0 chart at all, RC or
+    # otherwise: the newest chart is 2026.5.6. So this runs the new image on
+    # the old chart, which the release notes permit ("This release does not
+    # introduce any new requirements"). The chart dependency and Chart.lock
+    # deliberately stay at 2026.5.6.
+    #
+    # Once enabled, token exchange is off by default per provider and has to
+    # be turned on under the provider's Grant Types setting.
+    image:
+      tag: "2026.8.0-rc7"
     # authentik.existingSecret replaces the chart-generated configuration
     # secret, so the PostgreSQL connection settings must be supplied here too.
     # Without these values authentik falls back to localhost:5432.


### PR DESCRIPTION
## What

Pins the authentik image to `2026.8.0-rc7` to try RFC 8693 token exchange.

## Why the image and not a chart bump

`charts.goauthentik.io` publishes **no 2026.8.0 chart at all**, RC or otherwise. The newest chart there is 2026.5.6, the one we already run. So this sets `authentik.global.image.tag` and runs the new image on the existing chart. The release notes permit it: "This release does not introduce any new requirements." The chart dependency and `Chart.lock` deliberately stay at 2026.5.6.

## Evidence the feature is actually there

Checked the source at each tag rather than trusting the changelog:

- `2026.5.6` `providers/oauth2/views/token.py` (fetched, 200, 35KB): **zero** occurrences of `GRANT_TYPE_TOKEN_EXCHANGE`.
- `2026.8.0-rc1` and `2026.8.0-rc7`: present, implemented at `views/token.py:336` against RFC 8693 section 2.2.1, issuing on the `audience` target provider and carrying an `actor`.
- No `enterprise` or `license` reference in that file, so unlike DCR it is not license-gated.

Note this is **generic RFC 8693, not ID-JAG**. `id-jag` and `id_jag` return zero hits across the authentik repo, so the MCP enterprise-managed-authorization spec is still not implementable. What this unlocks is the audience-restricted token that #4569's `aud` workaround exists to compensate for.

## Verification

This chart is `lint = False` and no test covers it, so rendering is the verification:

- `helm template` diff is exactly the two `image:` lines plus the `app.kubernetes.io/version` labels. Nothing structural.
- Both server and worker render `ghcr.io/goauthentik/server:2026.8.0-rc7`.
- Tag resolves in GHCR to `sha256:9d30c53c17a6`.

## Risks, accepted deliberately

- `projects/platform` deploys at `targetRevision: HEAD`, so this goes live on merge with no chart-version gate.
- `authentik-pg` is a single-instance CNPG cluster with `spec.backup` empty and no `Backup` or `ScheduledBackup` objects anywhere, so the schema migration this triggers has no restore path.
- This is a release candidate serving as the cluster's IdP, fronting `mcp.jomcgi.dev` and the `friends.jomcgi.dev/preview/` lane.

Breaking changes in 2026.8 are the `hash_password` CLI dropping positional args and the WebAuthn "prevent duplicate device" removal. Neither applies here.

## Not in this PR

Token exchange is off by default per provider and still has to be enabled under the provider's Grant Types setting. That is a blueprint change and lands separately, after the RC is confirmed healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CRurfuZqpzdZM3moMfEQ4