### PR TITLE
fix(ci): enforce the two helm invariants that fail silently

### DIFF
--- a/bazel/tools/format/fast-format.sh
+++ b/bazel/tools/format/fast-format.sh
@@ -121,9 +121,12 @@ if $STAGED; then
 		esac
 	done
 
-	# Sync homelab-library dependency versions (local-only: needs the helm CLI,
-	# which is not in the CI format runner; charts have their own version gates)
-	./bazel/tools/format/sync-helm-deps.sh 2>/dev/null &
+	# Sync vendored chart dependencies, by CONTENT as well as version (local-only:
+	# needs the helm CLI, which the CI format runner does not have; CI enforces the
+	# same invariant read-only via check_helm_deps.py). stderr is kept: it used to
+	# be discarded, so a sync that could not run looked identical to one with
+	# nothing to do, which is the failure mode issue #4682 was about.
+	./bazel/tools/format/sync-helm-deps.sh &
 	PIDS+=($!)
 
 	for pid in "${PIDS[@]}"; do wait "$pid" 2>/dev/null || true; done
@@ -180,9 +183,12 @@ PIDS+=($!)
 (./bazel/tools/format/run-generators.sh 2>/dev/null || true) &
 PIDS+=($!)
 
-# Sync homelab-library dependency versions (local-only: needs the helm CLI, which
-# is not in the CI format runner; charts have their own version gates)
-./bazel/tools/format/sync-helm-deps.sh 2>/dev/null &
+# Sync vendored chart dependencies, by CONTENT as well as version (local-only:
+# needs the helm CLI, which the CI format runner does not have; CI enforces the
+# same invariant read-only via check_helm_deps.py). stderr is kept: it used to be
+# discarded, so a sync that could not run looked identical to one with nothing to
+# do, which is the failure mode issue #4682 was about.
+./bazel/tools/format/sync-helm-deps.sh &
 PIDS+=($!)
 
 # Atlas migration checksums

--- a/bazel/tools/format/helm_deps/BUILD
+++ b/bazel/tools/format/helm_deps/BUILD
@@ -1,0 +1,24 @@
+# Hand-managed targets (same convention as bazel/tools/format/readme_structure):
+# the checker is invoked as plain python3 from the CI "Format check" step against
+# the full working tree (a sandboxed bazel test cannot list projects/* on RBE),
+# so only the pure-logic contract is pinned by a bazel test here.
+# gazelle:exclude check_helm_deps.py
+# gazelle:exclude check_helm_deps_test.py
+
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("//bazel/tools/pytest:defs.bzl", "py_test")
+
+py_library(
+    name = "check_helm_deps_lib",
+    srcs = ["check_helm_deps.py"],
+    imports = ["."],
+)
+
+py_test(
+    name = "check_helm_deps_test",
+    srcs = ["check_helm_deps_test.py"],
+    deps = [
+        ":check_helm_deps_lib",
+        "@pip//pytest",
+    ],
+)

--- a/bazel/tools/format/helm_deps/check_helm_deps.py
+++ b/bazel/tools/format/helm_deps/check_helm_deps.py
@@ -1,0 +1,274 @@
+"""Guard the two Helm invariants that fail silently and deploy the wrong thing.
+
+Both were live bugs on 2026-08-11, and neither is caught by a linter, a bazel
+test, or `helm lint`.
+
+STALE TARBALL. A consuming chart vendors its `file://` dependencies as committed
+`charts/*.tgz`, and `helm_chart` globs `**/*`, so the committed tarball is what
+Bazel packages and ships. `sync-helm-deps.sh` rebuilds it only when the library
+*version* changes, never on content. Editing a library template without bumping
+the library version therefore leaves the fix in the source while the stale
+tarball deploys: clean diff, green CI, nothing rolls.
+
+BARE TAG. `helm_images_values` injects `repository`, `tag` and `digest` for
+every image in a `helm_chart(images = {...})` map. The tag is build-timestamped
+so it moves on every commit to main, while `push-changed.sh` skips pushing an
+image whose content digest is already published. A chart rendering
+`repository:tag` therefore pins a tag that was frequently never created, which
+is an ImagePullBackOff. That wedged monolith-public for ~11h (PR #4680) and was
+latent in two more charts (PR #4681).
+
+Runs against the full working tree from the CI format step, because a sandboxed
+bazel test cannot list projects/* on RBE. The pure logic is pinned by
+check_helm_deps_test.py. Deliberately no `helm` dependency: the CI format runner
+does not have the helm CLI, which is why sync-helm-deps.sh is local-only and
+why this check has to compare tarballs by hand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import re
+import sys
+import tarfile
+from pathlib import Path
+
+# Files inside a packaged chart whose drift changes what deploys.
+#
+# Chart.yaml is compared separately, on `version:` alone, because `helm package`
+# RE-SERIALISES it: keys come back alphabetised, strings unquoted, and list
+# indentation changed. Byte-comparing it reports every chart as stale forever.
+# Chart.lock is excluded entirely: it records a resolution timestamp, so it
+# differs on every rebuild without meaning anything.
+_MEANINGFUL = re.compile(r"^[^/]+/(templates/.*|values\.yaml)$")
+_VERSION = re.compile(r"^version:\s*(\S+)", re.MULTILINE)
+
+# `image: "{{ .Values.<path>.repository }}:{{ ... }}"` with no `@` anywhere in
+# the rendered string. The `@` test is what lets `repo:tag@digest` through: the
+# digest still decides which bytes run (embervm tokenBroker renders that way).
+_IMAGE_LINE = re.compile(r'image:\s*"([^"]*\{\{[^"]*)"')
+_REPOSITORY_REF = re.compile(r"\.Values\.([A-Za-z0-9_.]+)\.repository")
+
+
+def declared_version(text: str) -> str | None:
+    """The top-level `version:` of a Chart.yaml, whatever the key order."""
+    match = _VERSION.search(text)
+    return match.group(1).strip("\"'") if match else None
+
+
+def tarball_entries(raw: bytes) -> tuple[dict[str, bytes], str | None]:
+    """The deploy-meaningful members of a .tgz, plus its declared version."""
+    entries: dict[str, bytes] = {}
+    version = None
+    with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tar:
+        for member in tar.getmembers():
+            if not member.isfile():
+                continue
+            handle = tar.extractfile(member)
+            if handle is None:
+                continue
+            if member.name.count("/") == 1 and member.name.endswith("/Chart.yaml"):
+                version = declared_version(handle.read().decode())
+            elif _MEANINGFUL.match(member.name):
+                entries[member.name] = handle.read()
+    return entries, version
+
+
+def chart_name(chart_dir: Path) -> str:
+    """The chart's declared name, which is what `helm package` keys members by.
+
+    NOT the directory name. `homelab-library` lives in `.../homelab-library/chart`
+    and `cf-ingress` in `.../cf-ingress-library`, so keying on the directory makes
+    every member look both added and removed, and every chart look stale.
+    """
+    match = re.search(
+        r"^name:\s*(\S+)", (chart_dir / "Chart.yaml").read_text(), re.MULTILINE
+    )
+    return match.group(1) if match else chart_dir.name
+
+
+def source_entries(chart_dir: Path) -> dict[str, bytes]:
+    """The same view of an unpacked source chart, keyed the same way."""
+    entries: dict[str, bytes] = {}
+    name = chart_name(chart_dir)
+    for path in sorted(chart_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        member = f"{name}/{path.relative_to(chart_dir).as_posix()}"
+        if _MEANINGFUL.match(member):
+            entries[member] = path.read_bytes()
+    return entries
+
+
+def diff_entries(packaged: dict[str, bytes], source: dict[str, bytes]) -> list[str]:
+    """Names that differ between a packaged chart and its source, sorted."""
+    return sorted(
+        set(packaged)
+        .symmetric_difference(source)
+        .union(k for k in set(packaged) & set(source) if packaged[k] != source[k])
+    )
+
+
+def bare_tag_refs(template_text: str, managed_paths: set[str]) -> list[str]:
+    """Image renders that pin a bazel-managed image by tag with no digest.
+
+    Only paths in the chart's `helm_chart(images = ...)` map are managed, so an
+    upstream image pinned by tag (cloudflare-gateway's envoy, embervm's
+    servingEnvoy) is correctly ignored: nothing injects a digest for it and
+    nothing skips pushing it.
+    """
+    offenders = []
+    for line in template_text.splitlines():
+        match = _IMAGE_LINE.search(line)
+        if not match:
+            continue
+        rendered = match.group(1)
+        if "@" in rendered:
+            continue
+        for path in _REPOSITORY_REF.findall(rendered):
+            if path in managed_paths:
+                offenders.append(f"{path}: {line.strip()}")
+    return offenders
+
+
+def parse_managed_paths(build_text: str) -> set[str]:
+    """The yaml paths in every `helm_chart(images = {...})` in one BUILD file.
+
+    A path here is a promise that helm_images_values will inject a digest at
+    that key, which is exactly the set that must not deploy by tag.
+    """
+    paths: set[str] = set()
+    for block in re.findall(r"images\s*=\s*\{(.*?)\}", build_text, re.DOTALL):
+        paths.update(re.findall(r'"([^"]+)"\s*:', block))
+    return paths
+
+
+def _dependency_dirs(chart_yaml: Path) -> list[tuple[str, Path]]:
+    """(name, resolved source dir) for each `file://` dependency of a chart."""
+    deps = []
+    text = chart_yaml.read_text()
+    for name, repo in re.findall(
+        r"-\s*name:\s*(\S+)\s*\n\s*version:.*\n\s*repository:\s*\"?(file://[^\"\s]+)",
+        text,
+    ):
+        deps.append((name, (chart_yaml.parent / repo[len("file://") :]).resolve()))
+    return deps
+
+
+def check_repo(root: Path) -> list[str]:
+    """Every violation in the tree, as human-readable lines."""
+    problems: list[str] = []
+
+    for chart_yaml in sorted(root.glob("projects/**/Chart.yaml")):
+        for name, source_dir in _dependency_dirs(chart_yaml):
+            if not source_dir.is_dir():
+                problems.append(
+                    f"{chart_yaml}: file:// dependency {name} -> {source_dir} is missing"
+                )
+                continue
+            tarballs = sorted((chart_yaml.parent / "charts").glob(f"{name}-*.tgz"))
+            if not tarballs:
+                problems.append(
+                    f"{chart_yaml.parent}/charts: no {name}-*.tgz committed; "
+                    f"bazel globs charts/**, so the dependency would not ship. "
+                    f"Run ./bazel/tools/format/sync-helm-deps.sh"
+                )
+                continue
+            if len(tarballs) > 1:
+                problems.append(
+                    f"{chart_yaml.parent}/charts: {len(tarballs)} {name}-*.tgz committed "
+                    f"({', '.join(t.name for t in tarballs)}); a partial sync left a stale one behind"
+                )
+                continue
+            packaged, packaged_version = tarball_entries(tarballs[0].read_bytes())
+            drift = diff_entries(packaged, source_entries(source_dir))
+            if drift:
+                problems.append(
+                    f"{tarballs[0]} is STALE against {source_dir}: {', '.join(drift)}. "
+                    f"The committed tarball is what ships, so this change would not deploy. "
+                    f"Run ./bazel/tools/format/sync-helm-deps.sh"
+                )
+            source_version = declared_version((source_dir / "Chart.yaml").read_text())
+            if packaged_version != source_version:
+                problems.append(
+                    f"{tarballs[0]} declares version {packaged_version} but "
+                    f"{source_dir}/Chart.yaml says {source_version}. "
+                    f"Run ./bazel/tools/format/sync-helm-deps.sh"
+                )
+
+    for build in sorted(root.glob("projects/**/BUILD")):
+        managed = parse_managed_paths(build.read_text())
+        if not managed:
+            continue
+        for template in sorted(build.parent.rglob("templates/*")):
+            if (
+                template.suffix not in (".yaml", ".yml", ".tpl")
+                or not template.is_file()
+            ):
+                continue
+            for offender in bare_tag_refs(template.read_text(), managed):
+                problems.append(
+                    f"{template}: deploys a bazel-managed image by tag, not digest. "
+                    f"The build-timestamped tag is often never pushed "
+                    f"(push-changed.sh skips content-identical images), so this is an "
+                    f"ImagePullBackOff waiting to happen. {offender}"
+                )
+
+    return problems
+
+
+def stale_chart_dirs(root: Path) -> list[Path]:
+    """Consumer chart directories whose vendored tarballs need rebuilding.
+
+    sync-helm-deps.sh drives `helm dependency update` off this rather than
+    reimplementing the comparison in bash, so there is one definition of "stale"
+    and it is the one pinned by check_helm_deps_test.py.
+    """
+    stale: list[Path] = []
+    for chart_yaml in sorted(root.glob("projects/**/Chart.yaml")):
+        for name, source_dir in _dependency_dirs(chart_yaml):
+            if not source_dir.is_dir():
+                continue
+            tarballs = sorted((chart_yaml.parent / "charts").glob(f"{name}-*.tgz"))
+            if len(tarballs) != 1:
+                stale.append(chart_yaml.parent)
+                break
+            packaged, packaged_version = tarball_entries(tarballs[0].read_bytes())
+            if diff_entries(
+                packaged, source_entries(source_dir)
+            ) or packaged_version != declared_version(
+                (source_dir / "Chart.yaml").read_text()
+            ):
+                stale.append(chart_yaml.parent)
+                break
+    return stale
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="repository root to check")
+    parser.add_argument(
+        "--list-stale",
+        action="store_true",
+        help="print chart dirs needing `helm dependency update`, one per line, and exit 0",
+    )
+    args = parser.parse_args()
+
+    if args.list_stale:
+        for chart_dir in stale_chart_dirs(Path(args.root).resolve()):
+            print(chart_dir)
+        return 0
+
+    problems = check_repo(Path(args.root).resolve())
+    if problems:
+        print("Helm dependency/image check FAILED:\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}\n", file=sys.stderr)
+        return 1
+    print("Helm dependency/image check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bazel/tools/format/helm_deps/check_helm_deps_test.py
+++ b/bazel/tools/format/helm_deps/check_helm_deps_test.py
@@ -1,0 +1,159 @@
+"""Pin the pure logic of check_helm_deps.py.
+
+The checker itself runs as plain python3 against the full working tree from the
+CI format step (a sandboxed bazel test cannot list projects/* on RBE), so what
+is pinned here is the decision logic, not the walk.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+from check_helm_deps import (
+    bare_tag_refs,
+    declared_version,
+    diff_entries,
+    parse_managed_paths,
+    source_entries,
+    tarball_entries,
+)
+
+
+def _tgz(members: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, text in members.items():
+            raw = text.encode()
+            info = tarfile.TarInfo(name)
+            info.size = len(raw)
+            tar.addfile(info, io.BytesIO(raw))
+    return buf.getvalue()
+
+
+# --- tarball freshness -----------------------------------------------------
+
+
+def test_identical_templates_are_not_stale():
+    packaged, _ = tarball_entries(
+        _tgz({"lib/templates/_a.tpl": "x", "lib/Chart.yaml": "version: 1.0.0"})
+    )
+    assert diff_entries(packaged, {"lib/templates/_a.tpl": b"x"}) == []
+
+
+def test_changed_template_is_stale():
+    packaged, _ = tarball_entries(_tgz({"lib/templates/_a.tpl": "old"}))
+    assert diff_entries(packaged, {"lib/templates/_a.tpl": b"new"}) == [
+        "lib/templates/_a.tpl"
+    ]
+
+
+def test_added_and_removed_templates_are_both_stale():
+    packaged, _ = tarball_entries(_tgz({"lib/templates/_a.tpl": "x"}))
+    assert diff_entries(packaged, {"lib/templates/_b.tpl": b"x"}) == [
+        "lib/templates/_a.tpl",
+        "lib/templates/_b.tpl",
+    ]
+
+
+def test_chart_yaml_reserialisation_is_not_drift():
+    """`helm package` alphabetises keys and unquotes strings.
+
+    This is the false positive that would have made the check useless: every
+    chart would read as permanently stale. Chart.yaml is compared on version
+    alone, so it must not appear in the byte-compared entry set.
+    """
+    packaged, version = tarball_entries(
+        _tgz({"lib/Chart.yaml": "annotations:\n  a: b\nname: lib\nversion: 0.6.0\n"})
+    )
+    assert packaged == {}
+    assert version == "0.6.0"
+
+
+def test_version_is_read_regardless_of_key_order_and_quoting():
+    assert declared_version('name: lib\nversion: "0.6.0"\n') == "0.6.0"
+    assert declared_version("version: 0.6.0\nname: lib\n") == "0.6.0"
+    assert declared_version("name: lib\n") is None
+
+
+def test_chart_lock_is_ignored():
+    """Chart.lock carries a resolution timestamp, so it always differs."""
+    packaged, _ = tarball_entries(
+        _tgz({"lib/Chart.lock": "generated: 2026-01-01", "lib/templates/_a.tpl": "x"})
+    )
+    assert set(packaged) == {"lib/templates/_a.tpl"}
+
+
+def test_source_entries_key_on_chart_name_not_directory(tmp_path):
+    """homelab-library lives in `.../homelab-library/chart`, cf-ingress in
+    `.../cf-ingress-library`. Keying on the directory makes every member look
+    both added and removed, i.e. every chart permanently stale."""
+    chart_dir = tmp_path / "chart"
+    (chart_dir / "templates").mkdir(parents=True)
+    (chart_dir / "Chart.yaml").write_text("name: homelab-library\nversion: 0.6.0\n")
+    (chart_dir / "templates" / "_a.tpl").write_text("x")
+    assert set(source_entries(chart_dir)) == {"homelab-library/templates/_a.tpl"}
+
+
+# --- digest-not-tag --------------------------------------------------------
+
+_MANAGED = {"web.image", "controllerManager.image"}
+
+
+def test_bare_tag_on_a_managed_image_is_flagged():
+    line = 'image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"'
+    assert bare_tag_refs(line, _MANAGED)
+
+
+def test_digest_render_is_accepted():
+    line = 'image: "{{ .Values.web.image.repository }}@{{ .Values.web.image.digest }}"'
+    assert bare_tag_refs(line, _MANAGED) == []
+
+
+def test_tag_plus_digest_is_accepted():
+    """embervm tokenBroker renders `repo:tag@digest`; the digest still decides."""
+    line = 'image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}@{{ .Values.web.image.digest }}"'
+    assert bare_tag_refs(line, _MANAGED) == []
+
+
+def test_unmanaged_upstream_image_is_ignored():
+    """Nothing injects a digest for an upstream image and nothing skips pushing
+    it, so a bare tag there is correct (cloudflare-gateway envoy, embervm
+    servingEnvoy)."""
+    line = 'image: "{{ .Values.servingEnvoy.image.repository }}:{{ .Values.servingEnvoy.image.tag }}"'
+    assert bare_tag_refs(line, _MANAGED) == []
+
+
+def test_tag_behind_a_helper_include_is_still_flagged():
+    """dashboard-sidecar hid its tag behind `include "....imageTag"`, which is
+    why matching on the whole rendered string matters, not just `.tag`."""
+    line = 'image: "{{ .Values.controllerManager.image.repository }}:{{ include "x.imageTag" . }}"'
+    assert bare_tag_refs(line, _MANAGED)
+
+
+def test_non_image_lines_are_ignored():
+    assert (
+        bare_tag_refs('  repository: "{{ .Values.web.image.repository }}"', _MANAGED)
+        == []
+    )
+
+
+# --- managed path extraction ----------------------------------------------
+
+
+def test_managed_paths_parsed_from_helm_chart():
+    build = """
+helm_chart(
+    name = "chart",
+    images = {
+        "web.image": "//projects/monolith:image_public.info",
+        "frontend.image": "//projects/monolith/frontend:image_public.info",
+    },
+    publish = True,
+)
+"""
+    assert parse_managed_paths(build) == {"web.image", "frontend.image"}
+
+
+def test_chart_without_images_map_manages_nothing():
+    assert parse_managed_paths('helm_chart(\n    name = "chart",\n)\n') == set()

--- a/bazel/tools/format/sync-helm-deps.sh
+++ b/bazel/tools/format/sync-helm-deps.sh
@@ -48,30 +48,56 @@ while IFS= read -r chart_file; do
 	fi
 done < <(grep -rl 'name: homelab-library' --include='Chart.yaml' projects/ 2>/dev/null || true)
 
-if [[ ${#MISMATCHED[@]} -eq 0 ]]; then
+if $CHECK_ONLY; then
+	if [[ ${#MISMATCHED[@]} -gt 0 ]]; then
+		err "homelab-library is $LIBRARY_VERSION but these charts reference an older version:"
+		for f in "${MISMATCHED[@]}"; do
+			err "  $f"
+		done
+		exit 1
+	fi
+	# Content drift is the other half, and the half a version comparison cannot
+	# see. check_helm_deps.py is the authority on both, and is what CI runs.
+	exec python3 ./bazel/tools/format/helm_deps/check_helm_deps.py --root .
+fi
+
+if [[ ${#MISMATCHED[@]} -gt 0 ]]; then
+	log "Syncing homelab-library $LIBRARY_VERSION to ${#MISMATCHED[@]} chart(s)..."
+
+	for chart_file in "${MISMATCHED[@]}"; do
+		# Update the version in Chart.yaml (line after "name: homelab-library")
+		sed -i '' "/name: homelab-library/{n;s/version: \"[^\"]*\"/version: \"$LIBRARY_VERSION\"/;}" "$chart_file"
+		log "  Updated $chart_file"
+	done
+fi
+
+# CONTENT drift, not just version drift. This used to rebuild only when a
+# declared dependency version differed from the library's, which meant editing a
+# library template WITHOUT bumping its version left the fix in the source while
+# the stale committed tarball kept deploying: `helm_chart` globs `**/*`, so the
+# tarball is what Bazel ships. Clean diff, green CI, nothing rolls. That trap
+# nearly swallowed PR #4680's fix (issue #4682).
+#
+# The comparison lives in check_helm_deps.py rather than here so there is ONE
+# definition of stale, it is unit tested, and CI can enforce it without helm.
+if ! command -v helm &>/dev/null; then
+	# Local-only by design: the CI format runner has no helm CLI. CI enforces
+	# the same invariant read-only via check_helm_deps.py, so a missing helm
+	# here means "cannot fix", never "nothing was wrong".
 	exit 0
 fi
 
-if $CHECK_ONLY; then
-	err "homelab-library is $LIBRARY_VERSION but these charts reference an older version:"
-	for f in "${MISMATCHED[@]}"; do
-		err "  $f"
-	done
-	exit 1
+STALE=()
+while IFS= read -r chart_dir; do
+	[[ -n "$chart_dir" ]] && STALE+=("$chart_dir")
+done < <(python3 ./bazel/tools/format/helm_deps/check_helm_deps.py --root . --list-stale 2>/dev/null || true)
+
+if [[ ${#STALE[@]} -eq 0 ]]; then
+	exit 0
 fi
 
-log "Syncing homelab-library $LIBRARY_VERSION to ${#MISMATCHED[@]} chart(s)..."
-
-for chart_file in "${MISMATCHED[@]}"; do
-	chart_dir=$(dirname "$chart_file")
-
-	# Update the version in Chart.yaml (line after "name: homelab-library")
-	sed -i '' "/name: homelab-library/{n;s/version: \"[^\"]*\"/version: \"$LIBRARY_VERSION\"/;}" "$chart_file"
-
-	# Rebuild dependency archive
-	if command -v helm &>/dev/null; then
-		helm dependency update "$chart_dir" >/dev/null 2>&1 || true
-	fi
-
-	log "  Updated $chart_file"
+log "Rebuilding ${#STALE[@]} chart(s) whose vendored tarballs drifted from source..."
+for chart_dir in "${STALE[@]}"; do
+	helm dependency update "$chart_dir" >/dev/null 2>&1 || true
+	log "  Rebuilt $chart_dir"
 done

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -149,6 +149,17 @@ actions:
             # --depth=1, so a history lookup reads the graft boundary.
             python3 ./bazel/tools/format/doc_links/check_doc_links.py
 
+            # Two Helm invariants that fail silently and deploy the wrong
+            # thing: a vendored charts/*.tgz gone stale against its file://
+            # source (the tarball is what bazel ships, so the source fix never
+            # deploys), and a chart pinning a bazel-built image by its
+            # build-timestamped tag (push-changed.sh skips content-identical
+            # images, so that tag is often never pushed: ImagePullBackOff).
+            # Read-only here on purpose: sync-helm-deps.sh needs the helm CLI,
+            # which this runner does not have, so CI reports and the human
+            # fixes locally. Pure logic pinned by a bazel test.
+            python3 ./bazel/tools/format/helm_deps/check_helm_deps.py
+
             if git diff --exit-code; then
               echo "All files formatted correctly"
             else
@@ -338,6 +349,17 @@ actions:
             ./bazel/tools/hooks/validate-hooks-executable.sh
             python3 ./bazel/tools/format/readme_structure/check_readme_structure.py
             python3 ./bazel/tools/format/doc_links/check_doc_links.py
+
+            # Two Helm invariants that fail silently and deploy the wrong
+            # thing: a vendored charts/*.tgz gone stale against its file://
+            # source (the tarball is what bazel ships, so the source fix never
+            # deploys), and a chart pinning a bazel-built image by its
+            # build-timestamped tag (push-changed.sh skips content-identical
+            # images, so that tag is often never pushed: ImagePullBackOff).
+            # Read-only here on purpose: sync-helm-deps.sh needs the helm CLI,
+            # which this runner does not have, so CI reports and the human
+            # fixes locally. Pure logic pinned by a bazel test.
+            python3 ./bazel/tools/format/helm_deps/check_helm_deps.py
 
             if ! git diff --exit-code; then
               echo "ERROR: Code not formatted or BUILD files out of sync."


### PR DESCRIPTION
Closes #4682.

## Why

`sync-helm-deps.sh` decided whether to rebuild a consumer's committed `charts/*.tgz` by comparing the library's declared version against the consumer's. It never compared content. `helm_chart` globs `**/*`, so the committed tarball is what Bazel packages and ships.

Consequence: **editing a library template without bumping the library version left the fix in the source while the stale tarball kept deploying.** Clean diff, green CI, nothing rolls. PR #4680 only shipped because the version bump happened to be a deliberate manual step; nothing required it.

## What

**1. The rebuild decision is content-based**, and lives in `check_helm_deps.py` rather than bash, so there is one definition of "stale", it is unit tested, and `sync-helm-deps.sh` just drives `helm dependency update` off `--list-stale`.

**2. That checker is now a fatal CI format step**, and while it is walking the tree it enforces a second invariant: no chart may deploy a bazel-managed image by its build-timestamped tag. That is the #4680 / #4681 bug. Only paths in a `helm_chart(images = {...})` map count as managed, so upstream images pinned by tag are correctly ignored, and `repo:tag@digest` passes because the digest still decides.

Read-only in CI on purpose: the format runner has no helm CLI, which is exactly why `sync-helm-deps.sh` is local-only. CI reports, the human fixes locally. Same shape as `check_readme_structure.py` and `check_doc_links.py`, including the pure logic being pinned by a bazel test.

**3. `fast-format.sh` no longer discards the sync's stderr.** A sync that could not run looked identical to one with nothing to do, which is the same class of silent failure this issue is about.

## Verification

Each claim exercised, not asserted:

- Appending a comment to a library template **without** bumping its version, i.e. exactly the hole this closes, is now caught: 2 charts reported stale. `sync-helm-deps.sh` then repairs both and the recheck is clean.
- The bare-tag half independently rediscovers exactly `oci-model-cache` and `dashboard-sidecar` on pre-#4686 main, and **nothing else**. After rebasing onto merged #4686 it reports `passed`, so the check and the fix agree.
- No false positive on `cloudflare-gateway`, `renovate`, or embervm `servingEnvoy` (unmanaged upstream images), nor on embervm `tokenBroker` (`repo:tag@digest`).
- `ci test`: `Executed 1 out of 703 tests: 703 tests pass` (the new target).

## Two false positives found while building it

Both would have made the check useless, and both are pinned by a named test:

1. `helm package` **re-serialises** `Chart.yaml`: keys alphabetised, strings unquoted, list indentation changed. Byte-comparing it marks every chart permanently stale. It is now compared on `version:` alone.
2. Packaged members are keyed by the chart's **declared name**, not its directory. `homelab-library` lives in `.../homelab-library/chart` and `cf-ingress` in `.../cf-ingress-library`, so directory-keying makes every member look both added and removed.

`Chart.lock` is excluded entirely: it carries a resolution timestamp and differs on every rebuild without meaning anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)