### PR TITLE
feat(monolith): make terminal claims carry the evidence that contradicts them

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
@@ -23,6 +23,7 @@
   import PaneHeader from "./PaneHeader.svelte";
   import { crumbTrail } from "./lineage.js";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
+  import { claimStatus } from "./claims.js";
   let {
     run,
     view,
@@ -87,13 +88,16 @@
       {/each}
     </div>
   {:else}
+    {@const claim = claimStatus(run, view.now)}
     <PaneHeader
       kind={P.labels.run}
       crumbs={crumbTrail({ kind: "run", runTitle: firstLine(run.task.text) })}
       {onCrumb}
     >
       {#snippet chips()}
-        <span class={`state-chip s-${run.state}`}
+        <span
+          class={`state-chip s-${run.state}`}
+          class:unconfirmed={claim.unconfirmed}
           >{P.stateWords[run.state] || run.state}</span
         >
       {/snippet}
@@ -132,13 +136,32 @@
           )}{/if}
       {/if}
     </div>
-    {#if run.stranded}<div class="banner">
-        {P.labels.strandedBanner}
-        {P.labels.buildWord}
-        {run.app_version}
-        {P.punct.dot}
-        {P.labels.serverBuildWord}
-        {run.server_app_version}
+    {#if run.stranded}<div class="banner" data-register="belief">
+        <span class="register-tag">{P.labels.engineBelief}</span>
+        {joinMeta(
+          P.labels.strandedBanner,
+          run.app_version == null
+            ? null
+            : `${P.labels.buildWord} ${run.app_version}`,
+          run.server_app_version == null
+            ? null
+            : `${P.labels.serverBuildWord} ${run.server_app_version}`,
+        )}
+      </div>{/if}
+    {#if claim.terminal && claim.observation}<div
+        class="obs-line"
+        data-register="fact"
+      >
+        <span class="lbl">{P.labels.lastActivity}</span>
+        <span
+          >{joinMeta(
+            ago(claim.observation.observedAt),
+            claim.observation.nodeLabel,
+          )}</span
+        >
+      </div>{/if}
+    {#if claim.unconfirmed}<div class="conflict" data-register="belief">
+        {P.labels.stateConflict}
       </div>{/if}
     <div class="rv-actions">
       {#if active}<button
@@ -172,8 +195,11 @@
     </div>
     {#if run.deviations?.length}<div class="deviations" data-register="fact">
         <div class="stage-head">{P.labels.deviations}</div>
-        {#each run.deviations as deviation}<div class="deviation-text mono">
-            {deviation.text}
+        {#each run.deviations as deviation}<div class="deviation-text">
+            <span class="dev-chip"
+              >{P.deviationCodes[deviation.code] ?? deviation.code}</span
+            >
+            <span>{deviation.text}</span>
           </div>{/each}
       </div>{/if}
     <div
@@ -261,37 +287,46 @@
             >{/if}{/each}
       </div>{/if}
     {#each node.attempts ?? [] as attempt}
+      {@const attemptLine = attempt.ended_at
+        ? attemptMeta(
+            attempt.n,
+            null,
+            relSeconds(attempt.started_at, attempt.ended_at),
+            attempt.cost_usd,
+          )
+        : attemptMeta(
+            attempt.n,
+            P.stateWords.running,
+            since(attempt.started_at),
+            attempt.cost_usd,
+          )}
       <div>
+        <!-- The accessible name carries the attempt line as well as the
+             affordance. A bare aria-label of "open session" would replace the
+             name rather than add to it, so a screen reader would hear which
+             control this is but never which attempt it opens. -->
         <button
           class="log-entry"
           type="button"
+          aria-label={joinMeta(attemptLine, P.labels.openSession)}
           onclick={() =>
             attempt.session_id && onSelectSession(attempt.session_id)}
-          ><span class="entry-meta"
-            >{attempt.ended_at
-              ? attemptMeta(
-                  attempt.n,
-                  null,
-                  relSeconds(attempt.started_at, attempt.ended_at),
-                  attempt.cost_usd,
-                )
-              : attemptMeta(
-                  attempt.n,
-                  P.stateWords.running,
-                  since(attempt.started_at),
-                  attempt.cost_usd,
-                )}</span
-          >{#if attempt.state === "running" && attempt.live?.activity}<span
-              class="live-line"
-              ><span class="live-dot"></span><span class="live-act"
-                >{attempt.live.activity}</span
-              ><span class="live-when">{ago(attempt.live.observed_at)}</span
-              ></span
-            >{/if}{#if attempt.finding}<span class="finding"
-              >{attempt.finding.text}
-              {attempt.finding.observed_head ?? ""}</span
-            >{/if}</button
+          ><span class="entry-meta">{attemptLine}</span></button
         >
+        {#if attempt.state === "running" && attempt.live?.activity}<div
+            class="live-line"
+          >
+            <span class="live-dot" aria-hidden="true"></span>
+            <code class="act-cmd">{attempt.live.activity}</code>
+            <span class="act-when">{ago(attempt.live.observed_at)}</span>
+          </div>{/if}
+        {#if attempt.finding}<div class="evidence" data-register="fact">
+            <span class="ev-tag">{attempt.finding.code}</span>
+            <span>{attempt.finding.text}</span>
+            {#if attempt.finding.observed_head}<span class="sha"
+                >{attempt.finding.observed_head}</span
+              >{/if}
+          </div>{/if}
         {#if attempt.rationale?.parse_status === "parsed" || attempt.rationale?.parse_status === "unparseable"}
           <div class="testimony" data-register="testimony">
             <div class="testimony-attribution">
@@ -333,10 +368,11 @@
             >{shortSha(node.verdict.commit_sha)}</a
           >{/if}
       </div>{/if}
-    {#if node.evidence}<div class="log-entry">
-        <span class="entry-meta"
-          >{P.labels.evidence} {node.evidence.summary}</span
+    {#if node.evidence}<div class="evidence" data-register="fact">
+        <span class="ev-tag"
+          >{joinMeta(P.labels.evidence, node.evidence.kind)}</span
         >
+        <span>{node.evidence.summary}</span>
       </div>{/if}
     {#if node.blocked_on?.kind === "human"}<div class="rv-actions">
         <button class="btn-quiet btn-approve" type="button"

--- a/projects/monolith/frontend/src/routes/private/agents/claims.js
+++ b/projects/monolith/frontend/src/routes/private/agents/claims.js
@@ -1,0 +1,63 @@
+// A run state is terminal when the engine is claiming no further work will
+// happen. The complement of the live set means a later state defaults to
+// terminal, so disagreement is treated as unconfirmed.
+export const LIVE_STATES = new Set([
+  "queued",
+  "running",
+  "reviewing",
+  "escalated",
+  "blocked",
+]);
+
+export function isTerminalState(state) {
+  return !LIVE_STATES.has(state);
+}
+
+// Five minutes is longer than a single step's reporting gap and shorter than
+// the idle time of a genuinely stranded run.
+export const TERMINAL_QUIET_SECONDS = 300;
+
+function parsedTime(value) {
+  const time = Date.parse(value);
+  return Number.isFinite(time) ? time : null;
+}
+
+export function freshestActivity(run) {
+  let freshest = null;
+  for (const node of run?.nodes ?? []) {
+    for (const attempt of node.attempts ?? []) {
+      const live = attempt.live;
+      const observedAt = parsedTime(live?.observed_at);
+      if (observedAt == null) continue;
+      if (freshest == null || observedAt > freshest.time) {
+        freshest = {
+          time: observedAt,
+          observedAt: live.observed_at,
+          nodeLabel: node.label,
+          activity: live.activity,
+        };
+      }
+    }
+  }
+  if (freshest == null) return null;
+  const { time, ...observation } = freshest;
+  return observation;
+}
+
+export function claimStatus(run, now) {
+  const terminal = isTerminalState(run?.state) || run?.stranded === true;
+  const observation = freshestActivity(run);
+  let unconfirmed = false;
+  if (terminal && observation) {
+    const observedAt = parsedTime(observation.observedAt);
+    const completedAt = parsedTime(run?.completed_at);
+    const nowTime = parsedTime(now);
+    if (completedAt != null) {
+      unconfirmed = observedAt > completedAt;
+    } else if (nowTime != null) {
+      const ageSeconds = (nowTime - observedAt) / 1000;
+      unconfirmed = ageSeconds >= 0 && ageSeconds <= TERMINAL_QUIET_SECONDS;
+    }
+  }
+  return { terminal, observation, unconfirmed };
+}

--- a/projects/monolith/frontend/src/routes/private/agents/claims.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/claims.test.js
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "vitest";
+import {
+  claimStatus,
+  freshestActivity,
+  TERMINAL_QUIET_SECONDS,
+} from "./claims.js";
+
+const now = "2026-08-11T12:00:00Z";
+const activity = (
+  observed_at,
+  nodeLabel = "implement",
+  text = "git status",
+) => ({
+  label: nodeLabel,
+  attempts: [{ live: { observed_at, activity: text } }],
+});
+const run = (state, options = {}) => ({ state, nodes: [], ...options });
+
+describe("claimStatus", () => {
+  test("does not unconfirm a terminal run without an observation", () => {
+    expect(claimStatus(run("failed"), now)).toEqual({
+      terminal: true,
+      observation: null,
+      unconfirmed: false,
+    });
+  });
+
+  test("does not unconfirm activity before completion", () => {
+    const result = claimStatus(
+      run("failed", {
+        completed_at: "2026-08-11T11:00:00Z",
+        nodes: [activity("2026-08-11T10:59:00Z")],
+      }),
+      now,
+    );
+    expect(result.unconfirmed).toBe(false);
+  });
+
+  test("unconfirms activity after completion", () => {
+    const result = claimStatus(
+      run("failed", {
+        completed_at: "2026-08-11T11:00:00Z",
+        nodes: [activity("2026-08-11T11:00:01Z")],
+      }),
+      now,
+    );
+    expect(result.unconfirmed).toBe(true);
+  });
+
+  test("uses the quiet window for stranded runs", () => {
+    expect(
+      claimStatus(
+        run("failed", {
+          stranded: true,
+          nodes: [activity("2026-08-11T11:59:55Z")],
+        }),
+        now,
+      ).unconfirmed,
+    ).toBe(true);
+    expect(
+      claimStatus(
+        run("failed", {
+          stranded: true,
+          nodes: [
+            activity(
+              new Date(
+                Date.parse(now) - (TERMINAL_QUIET_SECONDS + 1) * 1000,
+              ).toISOString(),
+            ),
+          ],
+        }),
+        now,
+      ).unconfirmed,
+    ).toBe(false);
+  });
+
+  // The clause that motivates the feature. A run stranded by a deploy can
+  // still report a live state, since `stranded` and `state` come from
+  // different sources, and that contradiction is exactly what the console has
+  // to render as a disagreement rather than as two confident facts.
+  test("treats a stranded run as terminal even in a live state", () => {
+    const result = claimStatus(
+      run("running", {
+        stranded: true,
+        nodes: [activity("2026-08-11T11:59:55Z")],
+      }),
+      now,
+    );
+    expect(result.terminal).toBe(true);
+    expect(result.unconfirmed).toBe(true);
+  });
+
+  test("never unconfirms a running run", () => {
+    expect(
+      claimStatus(
+        run("running", { nodes: [activity("2026-08-11T11:59:55Z")] }),
+        now,
+      ).unconfirmed,
+    ).toBe(false);
+  });
+});
+
+test("freshestActivity picks the newest observation across nodes", () => {
+  const result = freshestActivity({
+    nodes: [
+      activity("2026-08-11T11:58:00Z", "planner", "old command"),
+      activity("2026-08-11T11:59:00Z", "implement", "new command"),
+    ],
+  });
+  expect(result).toEqual({
+    observedAt: "2026-08-11T11:59:00Z",
+    nodeLabel: "implement",
+    activity: "new command",
+  });
+});

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -70,6 +70,13 @@ export const RUN_LEXICON = {
     parallel: "in parallel",
     byWord: "by",
     evidence: "evidence",
+    lastActivity: "last activity",
+    stateConflict:
+      "live activity disagrees with this state; treating it as unconfirmed",
+    engineBelief: "engine belief",
+    evidenceWord: "evidence",
+    testimonyWord: "testimony",
+    openSession: "open session",
     deviationWord: "deviation",
     approve: "approve",
     deny: "deny",
@@ -104,6 +111,13 @@ export const RUN_LEXICON = {
     noneYet: "none yet",
   },
   punct: { dot: "·", arrow: "→", colon: ":" },
+  deviationCodes: {
+    retry_taken: "retry taken",
+    budget_exceeded: "budget exceeded",
+    attempts_exhausted: "attempts exhausted",
+    model_mismatch: "model mismatch",
+    verdict_not_approve: "verdict",
+  },
   units: { s: "s", m: "m", h: "h", d: "d" },
   ordinals: { 1: "1st", 2: "2nd", 3: "3rd", other: "th" },
 };

--- a/projects/monolith/frontend/src/routes/private/agents/run-view.css
+++ b/projects/monolith/frontend/src/routes/private/agents/run-view.css
@@ -109,6 +109,10 @@
   padding: 1px 7px;
   font: var(--size-meta) var(--font-mono);
 }
+.state-chip.unconfirmed {
+  border-style: dashed;
+  background: transparent;
+}
 .s-running,
 .s-reviewing {
   color: var(--ok);
@@ -208,6 +212,9 @@
   padding-top: 10px;
 }
 .deviation-text {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
   color: var(--text-soft);
   margin-top: 4px;
 }
@@ -319,7 +326,6 @@
   font-size: 13px;
   color: var(--text-soft);
 }
-.finding,
 .verdict-excerpt {
   display: block;
   margin-top: 3px;
@@ -328,6 +334,7 @@
   display: flex;
   gap: 7px;
   align-items: baseline;
+  margin-top: 4px;
 }
 .live-dot {
   width: 7px;
@@ -336,28 +343,65 @@
   background: var(--ok);
   flex: none;
 }
-.live-act {
+.act-cmd {
+  min-width: 0;
+  overflow-x: auto;
+  white-space: nowrap;
   font: var(--size-body-mono) var(--font-mono);
 }
 /* The observation time is its own element, never text trailing the command.
    Written as an adjacent text node it produced "... | head -405s ago". */
-.live-when {
+.act-when {
   margin-left: auto;
   flex: none;
   color: var(--muted);
   font: var(--size-meta) var(--font-mono);
 }
-/* A label introducing a sentence, so the gap is CSS. Rendered as a bare word
-   before the text it produced "deviation Vite runtime validation was ...",
-   where the label read as the sentence's first word. */
+.evidence {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-top: 4px;
+}
+/* Labels that introduce a sentence, so the gap is CSS on a flex parent and no
+   template whitespace can be trimmed away and glue them to the text. Rendered
+   as a bare word before its sentence, the deviation label produced "deviation
+   Vite runtime validation was ...", where it read as the first word. */
+.ev-tag,
+.sha,
 .dev-chip {
-  margin-right: 7px;
   padding: 0 5px;
   border: 1px solid var(--line-strong);
   border-radius: 3px;
   color: var(--muted);
   font: var(--size-meta) var(--font-mono);
   white-space: nowrap;
+}
+.sha {
+  color: var(--text-soft);
+}
+.obs-line {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  margin-top: 6px;
+}
+.lbl {
+  color: var(--muted);
+  font: var(--size-meta) var(--font-mono);
+}
+.conflict {
+  margin-top: 5px;
+  color: var(--attn);
+  font-size: 13px;
+}
+.register-tag {
+  display: inline-block;
+  margin-right: 7px;
+  padding: 0 5px;
+  border: 1px solid var(--attn);
+  border-radius: 3px;
+  font: var(--size-meta) var(--font-mono);
 }
 .copy-id {
   margin-left: 7px;


### PR DESCRIPTION
## What

The console already sorts what it shows into fact, belief, and testimony via
`data-register`, and already hides beliefs when the engine snapshot is stale.
Three surfaces sat outside that system and read as unsourced assertions:

- a finding was one span of text plus a bare sha, so the same observation
  attributed to two nodes appeared as mysterious repetition rather than as
  one citation used twice;
- the live activity line put a raw shell command at headline register;
- the stranded banner was an engine inference styled as a fact, with no
  observation beside it.

So a terminal banner and five-second-old activity could stack as two
confident facts.

## The rule this installs

Any terminal claim renders with the freshest observed activity beside it, and
when the two disagree the claim demotes itself: the state chip goes hollow
(dashed, colour kept, because the point is "not confirmed" and not "changed")
and a conflict line names which register to trust.

```
RUN  [stranded]              RUN  [stranded]   <- dashed
engine belief  stranded by…  engine belief  stranded by…
last activity  4h ago · implement
                             last activity  5s ago · implement
                             live activity disagrees with this state;
                             treating it as unconfirmed
```

`claims.js` owns that judgement so no component re-derives it.
`TERMINAL_QUIET_SECONDS` is exported rather than inlined, so the number and
the assertions about it cannot drift apart.

Terminal is defined as the complement of the live set, so a state added later
defaults to terminal. When a claim and fresh activity disagree, calling it
unconfirmed is the honest answer for an unknown state too.

The backend attribution bug is being fixed separately. This is the
presentation rule, which has to hold whether or not the data is ever wrong
again.

## Also here

- Findings render as labeled evidence: finding code chip, the sentence, sha
  chip. The sha is omitted when absent rather than printing `?? ""`, which
  left a trailing space where a sha would be.
- The live command scrolls in its own `overflow-x` container with the
  timestamp as a separate element. Both it and the evidence row move out of
  the attempt button, where a chip row was both bad semantics and a
  hit-target problem.
- Deviations get lexicon-mapped code chips before the server's verbatim text,
  and lose `mono`: prose is not mono, the chip is. An unmapped code falls
  back to the raw code, so a new server code stays visible.

## Three things found in review, fixed here

**The attempt button lost its accessible name.** A bare
`aria-label="open session"` replaces the name rather than adding to it, so a
screen reader would hear which control it is but never which attempt it
opens. The name now carries both.

**The attempt line was promoted out of meta register**, from 11.5px mono
muted to 13px sans, when its `.entry-meta` wrapper was dropped. That
contradicts the change's own thesis, so the wrapper is back.

**Two comments recording earlier defects were deleted** with the rules they
explained: why the observation time must be its own element (`"| head -405s
ago"`) and why a label's gap is CSS (`"deviation Vite runtime validation
was…"`). Restored against the new class names. Those comments are the only
record of why the markup is shaped that way.

One test was added for the clause that motivates the whole feature: a run
stranded by a deploy can still report a live state, because `stranded` and
`state` come from different sources, and nothing exercised that path.

## Verification

- `ci lint`: clean.
- `//projects/monolith/frontend:test`: `Executed 1 out of 1 test: 1 test
  passes.`, 608 tests up from 601.
- `//projects/monolith/frontend:build`: `Build completed successfully, 73
  total actions`.

## Note

This will merge but will not deploy: main's deploy is broken for every image
push, tracked in #4685.