### PR TITLE
fix(ci): materialise the image layout so main's deploy can push

### DIFF
--- a/bazel/images/push/push-changed.sh
+++ b/bazel/images/push/push-changed.sh
@@ -157,11 +157,30 @@ PUSH_COUNT=$(grep -c . "$TO_PUSH" || true)
 echo ""
 echo "==> $PUSH_COUNT image(s) to push, $SKIPPED already published"
 
+# --remote_download_outputs=all overrides the --remote_download_minimal that
+# --config=ci sets, and only for the pushes. `bazel run` materialises the
+# generated push script but leaves the oci_image layout DIRECTORY at rest in
+# CAS, so push.sh.tpl's first jq reads a path that is not on disk:
+#
+#   jq: error: Could not open file projects/monolith/frontend/image/index.json
+#
+# `toplevel` is what the manifest build above uses and is not enough here: crane
+# uploads every blob in that layout, so the whole tree has to be local rather
+# than just the run target's own output.
+#
+# This is the one place in the deploy that genuinely needs the bytes, which is
+# why the flag is on this line and not in BAZEL_ARGS. The skip decision above is
+# what bounds the cost: only the images whose content actually changed, which is
+# normally one or two rather than all 24.
+#
+# The branch had never executed until 2026-08-11 (#4685). Every deploy for weeks
+# found all 24 images content-identical and took the skip path, so the first
+# commit that really needed a push turned main's deploy red.
 while IFS= read -r label || [ -n "$label" ]; do
 	[ -n "$label" ] || continue
 	echo ""
 	echo "==> push $label"
-	"$BAZEL" run "$label" "${BAZEL_ARGS[@]}"
+	"$BAZEL" run "$label" "${BAZEL_ARGS[@]}" --remote_download_outputs=all
 done <"$TO_PUSH"
 
 # Charts LAST, and in their own multirun. Ordering is load-bearing now in a way

--- a/bazel/images/push/push-changed_test.sh
+++ b/bazel/images/push/push-changed_test.sh
@@ -66,9 +66,15 @@ BUILD
 	printf '%s' "$manifest" >"$WORK/bazel-bin/bazel/images/digests/manifest.txt"
 
 	# Stub bazel: `run` appends its label to run.log, everything else is a no-op.
+	# argv.log keeps the WHOLE command line as well. The two are separate on
+	# purpose: most cases assert on labels alone and compare them exactly, so
+	# widening run.log would break them, while the flags are what case 9 needs.
 	cat >"$WORK/bin/bazel" <<'STUB'
 #!/usr/bin/env bash
-if [ "${1:-}" = "run" ]; then echo "$2" >>"$STUB_RUN_LOG"; fi
+if [ "${1:-}" = "run" ]; then
+	echo "$2" >>"$STUB_RUN_LOG"
+	echo "$*" >>"$STUB_ARGV_LOG"
+fi
 exit 0
 STUB
 
@@ -84,7 +90,9 @@ STUB
 
 	chmod +x "$WORK/bin/bazel" "$WORK/bin/crane"
 	export STUB_RUN_LOG="$WORK/run.log"
+	export STUB_ARGV_LOG="$WORK/argv.log"
 	: >"$STUB_RUN_LOG"
+	: >"$STUB_ARGV_LOG"
 }
 
 teardown() { rm -rf "$WORK"; }
@@ -219,6 +227,28 @@ if run_script >/dev/null 2>&1; then
 	fail "fails loudly on an empty manifest" "expected a non-zero exit"
 else
 	pass "fails loudly on an empty manifest"
+fi
+teardown
+
+# 9. An image push must ask for its layout to be materialised. --config=ci sets
+#    --remote_download_minimal, which leaves the oci_image layout directory in
+#    CAS, while push.sh.tpl reads index.json off local disk. Without the flag
+#    every push dies on `jq: Could not open file .../image/index.json` (#4685).
+#
+#    Pinned as a command line rather than as behaviour because the failure is a
+#    bazel download mode on a remote runner, which no local test can reproduce.
+#    The reason it needs pinning at all is that this branch does not run when
+#    every image is content-identical, so a regression here stays invisible
+#    until the next commit that genuinely publishes something.
+setup "$MANIFEST_3" ""
+OUT=$(run_script)
+IMAGE_ARGV=$(grep "alpha:image.push" "$STUB_ARGV_LOG" || true)
+if [ -z "$IMAGE_ARGV" ]; then
+	fail "image push materialises the image layout" "no image push was recorded"
+elif grep -q -- "--remote_download_outputs=all" <<<"$IMAGE_ARGV"; then
+	pass "image push materialises the image layout"
+else
+	fail "image push materialises the image layout" "$IMAGE_ARGV"
 fi
 teardown
 


### PR DESCRIPTION
Main's deploy has been red since 2026-08-11. Every run dies in the same place:

```
==> 2 image(s) to push, 24 already published
==> push //projects/monolith/frontend:image.push
  Build completed successfully, 3 total actions
  jq: error: Could not open file projects/monolith/frontend/image/index.json: No such file or directory
  Action failed: exit status 2
```

`--config=ci` sets `--remote_download_minimal`, so `bazel run <image>.push` builds
the image remotely and leaves the OCI layout directory at rest in CAS. The
generated `push.sh.tpl` reads `index.json` off local disk, and `jq` is the first
thing to touch it. `Build completed successfully` is true and says nothing about
whether a single byte reached the runner.

## Blast radius

Wider than the images. The failure lands before the `==> Publishing charts`
step, so no chart publishes either, which is why no `chart-version-bot`
write-back has landed since and four merged PRs are sitting on main without
reaching the cluster.

## Why `all` and not `toplevel`

`toplevel` is what the manifest build above already uses, and it is not enough
here. It materialises the run target's own output, which is the generated push
script. crane uploads every blob in the layout, so the whole tree has to be
local.

The flag is on the push line rather than in `BAZEL_ARGS` because this is the one
place in the deploy that genuinely needs the bytes. The skip decision above
bounds the cost to images whose content actually changed, normally one or two
rather than all 24, so the BuildBuddy volume this script was written to cut
(PR #4586, 488 GB/day) is not given back.

## Why it hid for so long

The push branch had never executed. Every deploy for weeks found all 24 images
content-identical and took the skip path, so the optimisation that cut download
volume also removed the only thing that would have exercised the broken code.
The first commit that genuinely needed a push turned main red.

## Test

Case 9 in `push-changed_test.sh` pins the flag on the push command line. It is a
command-line assertion rather than a behavioural one because the failure is a
bazel download mode on a remote runner, which no local test reproduces. Verified
it fails without the fix:

```
FAIL: image push materialises the image layout
      run //projects/alpha:image.push --config=ci --stamp
```

The bazel stub now records full argv to a second log, leaving `run.log` label-only
so the seven cases that compare labels exactly are untouched.

`ci test`: 703 tests pass.

Closes #4685