### PR TITLE
feat(monolith): let a deployment turn off every leader singleton at once

### DIFF
--- a/projects/monolith/framework/core.py
+++ b/projects/monolith/framework/core.py
@@ -420,7 +420,31 @@ def build_private_lifespan(profile: Profile, modules: Sequence[Module]):
         # bots/streams. Followers just serve HTTP. See app/leadership.py.
         app.state.elector = None
         elector_task = None
-        if profile.leader_singletons and any(m.leader_start for m in modules):
+        # A second deployment fed by a copy of prod's database (the standing dev
+        # environment) must start NONE of these. Two of them act on queue state
+        # the copy brings with it: the chat outbox drain would post prod's
+        # queued messages to Discord a second time, and DBOS recovers pending
+        # workflows on launch, so dev would resume prod's in-flight agent runs.
+        #
+        # The gate stops the elector being CONSTRUCTED rather than stopping its
+        # callbacks. The lease is scoped by profile.leader_lease_key, not by
+        # database, so a dev instance that takes the lease benches prod's
+        # leader: the mute would cause the outage it exists to prevent.
+        #
+        # Unset and unrecognised both mean enabled, so a typo cannot silently
+        # stop prod's bot while every probe still reports healthy.
+        leader_singletons_config = os.environ.get("MONOLITH_LEADER_SINGLETONS")
+        leader_singletons_enabled = leader_singletons_config is None or (
+            leader_singletons_config.strip().lower() not in {"false", "0", "no"}
+        )
+        leader_singletons_available = profile.leader_singletons and any(
+            m.leader_start for m in modules
+        )
+        if leader_singletons_available and not leader_singletons_enabled:
+            logger.info(
+                "Monolith started (leader singletons disabled by configuration)"
+            )
+        elif leader_singletons_available:
             from core.leadership import LeaderElector
 
             elector = LeaderElector(lease_key=profile.leader_lease_key)

--- a/projects/monolith/framework/core_test.py
+++ b/projects/monolith/framework/core_test.py
@@ -11,6 +11,7 @@ import asyncio
 import dataclasses
 import logging
 
+import core.leadership as leadership
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -330,6 +331,35 @@ def _leader_module(name: str, log: list[str]) -> Module:
     return Module(name=name, leader_start=leader_start, leader_stop=leader_stop)
 
 
+class _FakeLeaderElector:
+    constructed = 0
+
+    def __init__(self, lease_key: str) -> None:
+        type(self).constructed += 1
+        self.lease_key = lease_key
+
+    async def run(self, on_acquire, on_resign) -> None:
+        await on_acquire()
+        await asyncio.Event().wait()
+
+
+def _patch_fake_elector(monkeypatch):
+    _FakeLeaderElector.constructed = 0
+    monkeypatch.setattr(leadership, "LeaderElector", _FakeLeaderElector)
+
+
+async def _run_private_lifespan(monkeypatch, modules, env_name, env_value=None):
+    _patch_fake_elector(monkeypatch)
+    if env_value is None:
+        monkeypatch.delenv(env_name, raising=False)
+    else:
+        monkeypatch.setenv(env_name, env_value)
+    app = FastAPI()
+    async with build_private_lifespan(_PLAIN_PRIVATE, modules)(app):
+        await asyncio.sleep(0)
+    return app
+
+
 @pytest.mark.asyncio
 async def test_start_and_stop_leader_singletons_compose_across_modules():
     log: list[str] = []
@@ -392,3 +422,66 @@ async def test_private_lifespan_runs_startup_hooks_and_skips_elector_without_lea
         # No module declares leader hooks, so no elector was created; the
         # attribute still exists (None) so readers never AttributeError.
         assert app.state.elector is None
+
+
+@pytest.mark.asyncio
+async def test_private_lifespan_leader_singletons_default_to_enabled(monkeypatch):
+    log: list[str] = []
+    app = await _run_private_lifespan(
+        monkeypatch, [_leader_module("a", log)], "MONOLITH_LEADER_SINGLETONS"
+    )
+
+    assert _FakeLeaderElector.constructed == 1
+    assert log == ["a:start", "a:stop"]
+    assert app.state.elector is not None
+
+
+@pytest.mark.asyncio
+async def test_private_lifespan_false_disables_leader_singletons(monkeypatch):
+    log: list[str] = []
+    app = await _run_private_lifespan(
+        monkeypatch, [_leader_module("a", log)], "MONOLITH_LEADER_SINGLETONS", "false"
+    )
+
+    assert _FakeLeaderElector.constructed == 0
+    assert app.state.elector is None
+    assert "a:start" not in log
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", ["FALSE", " false "])
+async def test_private_lifespan_false_is_case_and_whitespace_insensitive(
+    monkeypatch, value
+):
+    log: list[str] = []
+    app = await _run_private_lifespan(
+        monkeypatch, [_leader_module("a", log)], "MONOLITH_LEADER_SINGLETONS", value
+    )
+
+    assert _FakeLeaderElector.constructed == 0
+    assert app.state.elector is None
+    assert "a:start" not in log
+
+
+@pytest.mark.asyncio
+async def test_private_lifespan_unrecognized_value_fails_safe(monkeypatch):
+    log: list[str] = []
+    app = await _run_private_lifespan(
+        monkeypatch, [_leader_module("a", log)], "MONOLITH_LEADER_SINGLETONS", "maybe"
+    )
+
+    assert _FakeLeaderElector.constructed == 1
+    assert app.state.elector is not None
+    assert log == ["a:start", "a:stop"]
+
+
+@pytest.mark.asyncio
+async def test_private_lifespan_true_enables_leader_singletons(monkeypatch):
+    log: list[str] = []
+    app = await _run_private_lifespan(
+        monkeypatch, [_leader_module("a", log)], "MONOLITH_LEADER_SINGLETONS", "true"
+    )
+
+    assert _FakeLeaderElector.constructed == 1
+    assert app.state.elector is not None
+    assert log == ["a:start", "a:stop"]


### PR DESCRIPTION
Groundwork for a standing `dev` environment fed by a nightly copy of
production's database. Such a deployment must start **none** of the
leader-elected singletons, and there was no way to arrange that.

## Why this is load-bearing rather than hygiene

Two of the five singletons act on queue state that the nightly copy brings with
it, so the refresh actively arms them:

- `chat/leader.py` runs the Discord bot and "the outbox drain that posts rows
  enqueued by any replica or Argo job". Dev would post production's queued
  messages to Discord a second time.
- `swarm/module.py` calls `swarm.runtime.launch()`, which launches DBOS. DBOS
  recovers pending workflows on launch, so dev would resume production's
  in-flight agent runs and spawn real sessions and VMs.

`profile.leader_singletons` is a compile-time constant on `PRIVATE_PROFILE`, so
a deployment could not opt out. `MONOLITH_LEADER_SINGLETONS` is an additional
gate on top of it: both must be true for singletons to start.

## Two design points worth review

**It prevents the elector being constructed, not just its callbacks firing.**
The lease is scoped by `profile.leader_lease_key`, not by database, so a dev
instance that merely skipped the callbacks would still take the lease and
**bench production's leader**. The mute would then cause the outage it exists to
prevent.

**Unset and unrecognised both mean enabled.** Production sets nothing and
behaves exactly as it does today. A typo (`flase`) leaves prod electing a
leader rather than silently stopping the bot and the outbox drain while every
probe still reports healthy. Only an explicit `false`, `0`, or `no`, case
insensitive and whitespace trimmed, disables.

A third distinct INFO line is logged for the disabled-by-configuration case, so
an operator can tell it apart from "this replica is a follower".

## Tests

Five cases in `framework/core_test.py`: unset, `false`, `FALSE` and `" false "`,
`maybe` (fails safe toward production), and `true`. The fake elector counts
constructions, which is what pins the no-lease property rather than just the
no-callback one.

`ci test`: Executed 376 out of 703 tests, 703 pass.

## Not in this PR

The dev deployment that sets the variable, the dev CNPG cluster, and the
nightly refresh. Nothing here changes production behaviour.