### PR TITLE
fix(ci): build the runfiles tree so the image push can find its layout

### DIFF
--- a/bazel/images/push/push-changed.sh
+++ b/bazel/images/push/push-changed.sh
@@ -157,20 +157,35 @@ PUSH_COUNT=$(grep -c . "$TO_PUSH" || true)
 echo ""
 echo "==> $PUSH_COUNT image(s) to push, $SKIPPED already published"
 
-# --remote_download_outputs=all overrides the --remote_download_minimal that
-# --config=ci sets, and only for the pushes. `bazel run` materialises the
-# generated push script but leaves the oci_image layout DIRECTORY at rest in
-# CAS, so push.sh.tpl's first jq reads a path that is not on disk:
+# --build_runfile_links, and NOT a download-mode override. preset.bazelrc sets
+# `common --nobuild_runfile_links` repo-wide, and its own comment says a binary
+# that is going to be EXECUTED has to ask for the tree back. apko_push.sh.tpl
+# resolves everything through rlocation, and with no tree rlocation falls back
+# to RUNFILES_MANIFEST_FILE, which is where this breaks.
 #
-#   jq: error: Could not open file projects/monolith/frontend/image/index.json
+# 57c2dd16c reached for --remote_download_outputs=all instead and changed
+# nothing: BuildBuddy recorded the flag on the argv and bazel exited SUCCESS
+# while the push still died on the same jq line. Building the tree is what
+# materialises the layout, because bazel needs real files to symlink; measured
+# on a runner, --build_runfile_links ALONE is sufficient and the download
+# override is pure BuildBuddy egress for no benefit. Do not add it back.
 #
-# `toplevel` is what the manifest build above uses and is not enough here: crane
-# uploads every blob in that layout, so the whole tree has to be local rather
-# than just the run target's own output.
+# WHY CHARTS PUBLISHED FINE THROUGHOUT. push.sh.tpl has the identical runfiles
+# preamble and the identical rlocation calls, and chart pushes never broke. The
+# difference is what each resolves: CHART_TGZ is a regular FILE and IMAGE_DIR is
+# a DIRECTORY. A runfiles manifest maps individual files, so a .tgz lookup
+# succeeds and a tree artifact, which has no entry of its own, does not. That
+# asymmetry is why the failure reads as an image-only problem and why the
+# deploy could keep writing chart versions back while publishing no images.
 #
-# This is the one place in the deploy that genuinely needs the bytes, which is
-# why the flag is on this line and not in BAZEL_ARGS. The skip decision above is
-# what bounds the cost: only the images whose content actually changed, which is
+# Verified on a real BuildBuddy Linux runner before landing, via
+# `bazel run ... --run_under` to list the tree without invoking crane:
+#
+#   PROBE_LAYOUT_NODL=blobs  index.json  oci-layout
+#
+# The flag stays on this line rather than in BAZEL_ARGS: this is the only
+# command in the deploy that executes a bazel-built binary, and the skip
+# decision above bounds it to the images whose content actually changed,
 # normally one or two rather than all 24.
 #
 # The branch had never executed until 2026-08-11 (#4685). Every deploy for weeks
@@ -180,7 +195,7 @@ while IFS= read -r label || [ -n "$label" ]; do
 	[ -n "$label" ] || continue
 	echo ""
 	echo "==> push $label"
-	"$BAZEL" run "$label" "${BAZEL_ARGS[@]}" --remote_download_outputs=all
+	"$BAZEL" run "$label" "${BAZEL_ARGS[@]}" --build_runfile_links
 done <"$TO_PUSH"
 
 # Charts LAST, and in their own multirun. Ordering is load-bearing now in a way

--- a/bazel/images/push/push-changed_test.sh
+++ b/bazel/images/push/push-changed_test.sh
@@ -230,13 +230,14 @@ else
 fi
 teardown
 
-# 9. An image push must ask for its layout to be materialised. --config=ci sets
-#    --remote_download_minimal, which leaves the oci_image layout directory in
-#    CAS, while push.sh.tpl reads index.json off local disk. Without the flag
-#    every push dies on `jq: Could not open file .../image/index.json` (#4685).
+# 9. An image push must build its runfiles tree. preset.bazelrc sets
+#    `common --nobuild_runfile_links` repo-wide, and apko_push.sh.tpl resolves
+#    IMAGE_DIR through rlocation, which without a tree falls back to the
+#    manifest and cannot resolve a DIRECTORY. Without the flag every push dies
+#    on `jq: Could not open file .../image/index.json` (#4685).
 #
-#    Pinned as a command line rather than as behaviour because the failure is a
-#    bazel download mode on a remote runner, which no local test can reproduce.
+#    Pinned as a command line rather than as behaviour because the failure needs
+#    a bazel-built binary on a remote runner, which no local test reproduces.
 #    The reason it needs pinning at all is that this branch does not run when
 #    every image is content-identical, so a regression here stays invisible
 #    until the next commit that genuinely publishes something.
@@ -244,11 +245,27 @@ setup "$MANIFEST_3" ""
 OUT=$(run_script)
 IMAGE_ARGV=$(grep "alpha:image.push" "$STUB_ARGV_LOG" || true)
 if [ -z "$IMAGE_ARGV" ]; then
-	fail "image push materialises the image layout" "no image push was recorded"
-elif grep -q -- "--remote_download_outputs=all" <<<"$IMAGE_ARGV"; then
-	pass "image push materialises the image layout"
+	fail "image push builds its runfiles tree" "no image push was recorded"
+elif grep -q -- "--build_runfile_links" <<<"$IMAGE_ARGV"; then
+	pass "image push builds its runfiles tree"
 else
-	fail "image push materialises the image layout" "$IMAGE_ARGV"
+	fail "image push builds its runfiles tree" "$IMAGE_ARGV"
+fi
+teardown
+
+# 10. And it must NOT carry a download-mode override. 57c2dd16c added
+#     --remote_download_outputs=all on the theory that the layout was stranded
+#     in CAS. It was not the cause and it did not fix anything, but it does pull
+#     every layer of every changed image to the runner, which is exactly the
+#     BuildBuddy egress push-changed.sh exists to cut (PR #4586, 488 GB/day).
+#     Measured on a runner: --build_runfile_links alone materialises the layout.
+setup "$MANIFEST_3" ""
+OUT=$(run_script)
+IMAGE_ARGV=$(grep "alpha:image.push" "$STUB_ARGV_LOG" || true)
+if grep -q -- "--remote_download_outputs" <<<"$IMAGE_ARGV"; then
+	fail "image push does not pay for a download-mode override" "$IMAGE_ARGV"
+else
+	pass "image push does not pay for a download-mode override"
 fi
 teardown
 

--- a/bazel/tools/oci/apko_push.sh.tpl
+++ b/bazel/tools/oci/apko_push.sh.tpl
@@ -27,6 +27,26 @@ readonly IMAGE_DIR="$(rlocation "{{IMAGE_DIR}}")"
 readonly REPOSITORY_FILE="$(rlocation "{{REPOSITORY_FILE}}")"
 readonly TAGS_FILE="$(rlocation "{{TAGS_FILE}}")"
 
+# rlocation hands back the path it was given when it cannot resolve, so an
+# unbuilt runfiles tree arrives at jq below as a workspace-relative path and
+# reads as a missing FILE rather than as a failed lookup:
+#
+#   jq: error: Could not open file projects/monolith/frontend/image/index.json
+#
+# That sentence cost #4685 a wrong fix, because it looks like the layout was
+# never downloaded when in fact it was never named. IMAGE_DIR is a directory,
+# which is precisely the case a runfiles MANIFEST cannot answer, so this fires
+# exactly when the caller forgot --build_runfile_links. preset.bazelrc sets
+# --nobuild_runfile_links repo-wide, which makes forgetting it the default.
+if [[ ! -d "${IMAGE_DIR}" ]]; then
+  echo >&2 "ERROR: the image layout did not resolve through runfiles."
+  echo >&2 "       IMAGE_DIR=${IMAGE_DIR}"
+  echo >&2 "       Run this target with --build_runfile_links. rlocation cannot"
+  echo >&2 "       resolve a DIRECTORY from RUNFILES_MANIFEST_FILE alone, and"
+  echo >&2 "       preset.bazelrc disables the runfiles tree repo-wide."
+  exit 1
+fi
+
 # Read repository
 REPOSITORY=$(cat "${REPOSITORY_FILE}")
 


### PR DESCRIPTION
#4694 claimed to fix #4685 and did not. Main's next deploy failed with the
byte-identical error, and BuildBuddy recorded why:

```
EXPLICIT_COMMAND_LINE: ["run","//projects/monolith/frontend:image.push",
                        "--config=ci","--stamp","--remote_download_outputs=all"]
bazelExitCode: SUCCESS
```

The flag applied. Bazel succeeded. The push still died on `jq`. **The download
mode was never the cause.**

## What it actually is

`bazel/tools/preset.bazelrc:15` sets `common --nobuild_runfile_links` repo-wide,
and its own comment says a binary that is going to be executed has to ask for
the tree back. `apko_push.sh.tpl` resolves `IMAGE_DIR` through `rlocation`,
which without a tree falls back to `RUNFILES_MANIFEST_FILE`. A manifest maps
individual files, so it cannot answer a **directory** at all.

## Why charts published fine the whole time

`push.sh.tpl` has the identical runfiles preamble and the identical `rlocation`
calls, and chart pushes never broke. The difference is what each resolves:

| | Resolves | Manifest lookup |
|---|---|---|
| `push.sh.tpl` | `CHART_TGZ`, a regular file | succeeds |
| `apko_push.sh.tpl` | `IMAGE_DIR`, a tree artifact | fails |

That asymmetry is why the deploy could keep writing chart versions back while
publishing no images at all, and it is what made the failure look image-specific
rather than runfiles-specific.

## Measured, not reasoned

Both probes ran on a real BuildBuddy Linux runner using `--run_under` to list
the tree without invoking crane, so nothing was published to test this:

```
--build_runfile_links --remote_download_outputs=all
  PROBE_LAYOUT=blobs  index.json  oci-layout

--build_runfile_links alone
  PROBE_LAYOUT_NODL=blobs  index.json  oci-layout
```

So the download override is **replaced, not supplemented**. Building the tree
materialises the layout by itself, because bazel needs real files to symlink.
Keeping the override would pull every layer of every changed image to the runner
for no benefit, which is the exact BuildBuddy egress `push-changed.sh` exists to
cut (PR #4586, 488 GB/day). **Case 10 pins that it stays gone.**

## The error message that caused the wrong fix

`rlocation` returns its input unchanged when it cannot resolve, so an unresolved
**name** reached `jq` disguised as a missing **file**:

```
jq: error: Could not open file projects/monolith/frontend/image/index.json
```

That reads as "the layout was never downloaded" when it means "the layout was
never named". `apko_push.sh.tpl` now checks and fails with the cause and the
remedy instead of passing the unresolved path along.

## Tests

Case 9 pins the flag, verified to fail without it:

```
FAIL: image push builds its runfiles tree
```

Case 10 pins the absence of the download override.

`ci test`: 703 tests pass.

Refs #4685