### PR TITLE
fix(monolith): give the dev deployment its own release name

### DIFF
--- a/projects/monolith/chart/BUILD
+++ b/projects/monolith/chart/BUILD
@@ -47,10 +47,10 @@ py_test(
         "Chart.yaml",
         "values.yaml",
         "//projects/monolith:module_configs",
-        "//projects/monolith/dev/deploy:application",
-        "//projects/monolith/dev/deploy:deploy_values",
         "//projects/monolith/deploy:application",
         "//projects/monolith/deploy:deploy_values",
+        "//projects/monolith/dev/deploy:application",
+        "//projects/monolith/dev/deploy:deploy_values",
         "@multitool//tools/helm",
     ] + glob([
         "templates/**/*",
@@ -93,6 +93,19 @@ py_test(
 semgrep_test(
     name = "chart_env_vars_test_semgrep_test",
     srcs = ["chart_env_vars_test.py"],
+    exclude_rules = [
+        "avoid-sqlalchemy-text",
+        "sqlmodel-datetime-without-factory",
+        "tainted-fastapi-http-request-httpx",
+        "tainted-path-traversal-pillow-fastapi",
+        "tainted-path-traversal-stdlib-fastapi",
+    ],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "chart_env_identity_test_semgrep_test",
+    srcs = ["chart_env_identity_test.py"],
     exclude_rules = [
         "avoid-sqlalchemy-text",
         "sqlmodel-datetime-without-factory",

--- a/projects/monolith/chart/BUILD
+++ b/projects/monolith/chart/BUILD
@@ -40,6 +40,35 @@ helm_chart(
 )
 
 py_test(
+    name = "chart_env_identity_test",
+    srcs = ["chart_env_identity_test.py"],
+    data = [
+        "Chart.lock",
+        "Chart.yaml",
+        "values.yaml",
+        "//projects/monolith:module_configs",
+        "//projects/monolith/dev/deploy:application",
+        "//projects/monolith/dev/deploy:deploy_values",
+        "//projects/monolith/deploy:application",
+        "//projects/monolith/deploy:deploy_values",
+        "@multitool//tools/helm",
+    ] + glob([
+        "templates/**/*",
+        "charts/**/*",
+        "migrations/**/*",
+    ]),
+    env = {
+        "HELM_BIN": "$(rootpath @multitool//tools/helm)",
+        "DEPLOY_VALUES": "$(rootpath //projects/monolith/deploy:deploy_values)",
+        "DEV_VALUES": "$(rootpath //projects/monolith/dev/deploy:deploy_values)",
+        # The Applications, so releaseName is read from where it is DECLARED.
+        "PROD_APPLICATION": "$(rootpath //projects/monolith/deploy:application)",
+        "DEV_APPLICATION": "$(rootpath //projects/monolith/dev/deploy:application)",
+    },
+    deps = ["@pip//pytest"],
+)
+
+py_test(
     name = "chart_env_vars_test",
     srcs = ["chart_env_vars_test.py"],
     data = [

--- a/projects/monolith/chart/chart_env_identity_test.py
+++ b/projects/monolith/chart/chart_env_identity_test.py
@@ -1,0 +1,171 @@
+"""The dev deployment must not claim any identity production owns.
+
+Dev renders this SAME chart with an overlay layered on production's values, so
+everything not explicitly overridden is inherited. That is the point, and it is
+also the hazard: inheriting is safe for settings describing how a workload
+BEHAVES, and unsafe for the ones describing WHO IT CLAIMS TO BE.
+
+Two of those slipped through in one evening, both silently:
+
+  1. Dev inherited cfIngress and claimed private.jomcgi.dev and
+     ships.jomcgi.dev. Every HTTPRoute attaches to the one cloudflare-ingress
+     Gateway, and Gateway API MERGES routes attaching to the same Gateway for
+     the same hostname, so production traffic could have been served by a dev
+     build running against a copy of production's data. Nothing errors.
+
+  2. Dev ran under releaseName `monolith`, so it rendered ClusterRole/monolith,
+     which is cluster-scoped and therefore the very object production owns.
+     ArgoCD's shared-resource protection caught that one:
+
+       ClusterRole/monolith is part of applications argocd/monolith-dev
+       and monolith
+
+Neither is reachable by a normal unit test, and neither shows up as a red
+render: both charts template perfectly. Only comparing the two rendered
+outputs against each other finds them, which is what this does.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Kinds with no namespace: two Applications rendering the same name means one
+# object with two owners, not two objects.
+CLUSTER_SCOPED = {
+    "ClusterRole",
+    "ClusterRoleBinding",
+    "CustomResourceDefinition",
+    "PriorityClass",
+    "StorageClass",
+    "ValidatingWebhookConfiguration",
+    "MutatingWebhookConfiguration",
+}
+
+_DOC_KIND = re.compile(r"^kind:\s*(\S+)\s*$", re.M)
+_DOC_NAME = re.compile(r"^\s{2}name:\s*(\S+)\s*$", re.M)
+_HOSTNAME = re.compile(r"^\s*-\s*[\"']?([a-z0-9.-]+\.jomcgi\.dev)[\"']?\s*$", re.M)
+
+
+def _chart_dir() -> Path:
+    here = Path(__file__).resolve().parent
+    if (here / "Chart.yaml").exists():
+        return here
+    raise RuntimeError("Could not find chart Chart.yaml")
+
+
+def _render(release: str, values: list[Path]) -> str:
+    helm_bin = os.environ.get("HELM_BIN", "helm")
+    argv = [helm_bin, "template", release, str(_chart_dir()), "--namespace", release]
+    for v in values:
+        argv += ["--values", str(v)]
+    result = subprocess.run(argv, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"helm template failed: {result.stderr}")
+    return result.stdout
+
+
+def _docs(rendered: str):
+    for doc in rendered.split("\n---"):
+        kind = _DOC_KIND.search(doc)
+        name = _DOC_NAME.search(doc)
+        if kind and name:
+            yield kind.group(1), name.group(1), doc
+
+
+_RELEASE_NAME = re.compile(r"^\s*releaseName:\s*(\S+)\s*$", re.M)
+
+
+def _release_name(application_yaml: Path) -> str:
+    """Read releaseName from the Application, NOT from this test.
+
+    Load-bearing. The defect this file exists to catch lived in
+    deploy/application.yaml, not in the chart: the chart renders disjoint names
+    perfectly well when handed two different release names. Hardcoding them here
+    would produce a test that passes while the Application says otherwise, which
+    is the exact shape of a guard that cannot fail.
+    """
+    match = _RELEASE_NAME.search(application_yaml.read_text())
+    assert match, f"no releaseName found in {application_yaml}"
+    return match.group(1)
+
+
+@pytest.fixture(scope="module")
+def renders():
+    chart = _chart_dir()
+    base = [chart / "values.yaml", Path(os.environ["DEPLOY_VALUES"])]
+    dev_overlay = Path(os.environ["DEV_VALUES"])
+    prod_release = _release_name(Path(os.environ["PROD_APPLICATION"]))
+    dev_release = _release_name(Path(os.environ["DEV_APPLICATION"]))
+    return {
+        "prod": _render(prod_release, base),
+        "dev": _render(dev_release, base + [dev_overlay]),
+    }
+
+
+def test_dev_claims_no_cluster_scoped_object_production_owns(renders):
+    """The releaseName collision. Cluster-scoped names must be disjoint."""
+    prod = {f"{k}/{n}" for k, n, _ in _docs(renders["prod"]) if k in CLUSTER_SCOPED}
+    dev = {f"{k}/{n}" for k, n, _ in _docs(renders["dev"]) if k in CLUSTER_SCOPED}
+    shared = prod & dev
+    assert not shared, (
+        f"dev and production both render {sorted(shared)}. These kinds have no "
+        "namespace, so that is ONE object with two ArgoCD owners, both with "
+        "selfHeal. Give the dev Application a distinct releaseName."
+    )
+    # Guard the guard: if production stops rendering cluster-scoped objects
+    # entirely, the disjointness above passes for the wrong reason.
+    assert prod, "production rendered no cluster-scoped objects; this test is inert"
+
+
+def test_dev_claims_no_hostname(renders):
+    """The ingress collision. Dev must claim nothing on the shared Gateway."""
+    dev_hosts = set()
+    for kind, _name, doc in _docs(renders["dev"]):
+        if kind == "HTTPRoute":
+            dev_hosts.update(_HOSTNAME.findall(doc))
+    assert not dev_hosts, (
+        f"dev renders HTTPRoutes claiming {sorted(dev_hosts)}. Every route "
+        "attaches to the one cloudflare-ingress Gateway, and Gateway API merges "
+        "routes claiming the same hostname, so production traffic could be "
+        "served by dev. Dev needs a hostname of its own before ingress is "
+        "enabled there."
+    )
+    # Guard the guard, as above: production must actually claim hostnames, or
+    # an empty dev set proves nothing about the mechanism.
+    prod_hosts = set()
+    for kind, _name, doc in _docs(renders["prod"]):
+        if kind == "HTTPRoute":
+            prod_hosts.update(_HOSTNAME.findall(doc))
+    assert prod_hosts, "production claimed no hostnames; this test is inert"
+
+
+def test_dev_does_not_render_the_refresh_workflow(renders):
+    """Production owns the refresh.
+
+    It renders into jobs.workflowNamespace rather than the release namespace, so
+    two deployments rendering it would put two identically-named CronWorkflows
+    into monolith-workflows and the Applications would fight every sync.
+    """
+    assert "cnpg-dev-refresh" in renders["prod"]
+    assert "cnpg-dev-refresh" not in renders["dev"]
+
+
+def test_dev_mutes_leader_singletons_and_production_does_not(renders):
+    """The side-effect mute, asserted in BOTH directions.
+
+    Asserting only that dev is false would pass if the value stopped rendering
+    at all, which is the failure mode `| default true` would have produced.
+    """
+    assert (
+        'name: MONOLITH_LEADER_SINGLETONS\n              value: "false"'
+        in renders["dev"]
+    )
+    assert (
+        'name: MONOLITH_LEADER_SINGLETONS\n              value: "true"'
+        in renders["prod"]
+    )

--- a/projects/monolith/chart/templates/cnpg-dev-refresh-cronworkflow.yaml
+++ b/projects/monolith/chart/templates/cnpg-dev-refresh-cronworkflow.yaml
@@ -77,13 +77,13 @@ spec:
           env:
             - name: PROD_PGHOST
               value: monolith-pg-ro.monolith.svc.cluster.local
-            # monolith-pg-rw, NOT monolith-dev-pg-rw. The dev Application uses
-            # releaseName `monolith` deliberately, so its resources carry the
-            # same names as production's and only the NAMESPACE differs. The
-            # namespace is therefore the only thing distinguishing these two
-            # hosts, which is exactly what the guard above checks for.
+            # monolith-dev-pg-rw: the dev Application runs this chart under
+            # releaseName `monolith-dev`, which it must, because the chart also
+            # renders cluster-scoped RBAC that two Applications cannot both own.
+            # So dev's resources carry a distinct prefix AND live in a distinct
+            # namespace, and the guard above checks the host for `monolith-dev`.
             - name: DEV_PGHOST
-              value: monolith-pg-rw.monolith-dev.svc.cluster.local
+              value: monolith-dev-pg-rw.monolith-dev.svc.cluster.local
             - name: DUMP_ROLE
               value: {{ .Values.postgres.devRefresh.role | quote }}
             - name: DUMP_PASSWORD

--- a/projects/monolith/deploy/BUILD
+++ b/projects/monolith/deploy/BUILD
@@ -3,3 +3,9 @@ filegroup(
     srcs = ["values.yaml"],
     visibility = ["//projects/monolith:__subpackages__"],
 )
+
+filegroup(
+    name = "application",
+    srcs = ["application.yaml"],
+    visibility = ["//projects/monolith:__subpackages__"],
+)

--- a/projects/monolith/dev/deploy/BUILD
+++ b/projects/monolith/dev/deploy/BUILD
@@ -3,3 +3,9 @@ filegroup(
     srcs = ["values.yaml"],
     visibility = ["//projects/monolith:__subpackages__"],
 )
+
+filegroup(
+    name = "application",
+    srcs = ["application.yaml"],
+    visibility = ["//projects/monolith:__subpackages__"],
+)

--- a/projects/monolith/dev/deploy/application.yaml
+++ b/projects/monolith/dev/deploy/application.yaml
@@ -20,13 +20,27 @@ spec:
       chart: monolith
       targetRevision: 0.288.3
       helm:
-        # releaseName matches production ON PURPOSE. Helm prepends the release
-        # name to every resource, so an identical name means dev renders
-        # byte-identical object names and any diff between environments is
-        # purely values. A distinct release name would also silently rewrite
-        # every in-cluster service DNS name, which is the failure mode
-        # CLAUDE.md warns about. The namespace is what separates the two.
-        releaseName: monolith
+        # releaseName MUST differ from production's. It briefly did not, and
+        # ArgoCD refused the sync with:
+        #
+        #   ClusterRole/monolith is part of applications argocd/monolith-dev
+        #   and monolith
+        #
+        # The reasoning for matching it was that identical names make dev a pure
+        # values diff against prod. That holds only for NAMESPACED objects. This
+        # chart also renders ClusterRole and ClusterRoleBinding, which are
+        # cluster-scoped, so an identical release name is not a neutral choice
+        # there, it is the same object claimed by two Applications with selfHeal
+        # on. ArgoCD's shared-resource protection caught it and left production
+        # owning them, which is the only reason this was a degraded dev app
+        # rather than an outage.
+        #
+        # The cost this was avoiding is real but small: a distinct release name
+        # rewrites every in-cluster DNS name (monolith-dev-pg-rw, not
+        # monolith-pg-rw). Nothing in deploy/values.yaml hardcodes a service URL
+        # (grep returns 0), and the one consumer that cares, the refresh
+        # CronWorkflow, addresses dev explicitly.
+        releaseName: monolith-dev
         # ORDER IS LOAD-BEARING. Production's values first, dev's overrides
         # second, because Helm lets later files win. This is what makes dev the
         # same configuration as prod minus a deliberate, reviewable diff, rather

--- a/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
+++ b/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
@@ -188,19 +188,17 @@ spec:
       generate:
         apiVersion: v1
         kind: Secret
-        # RENAMED on clone. The dev Application runs the monolith chart with
-        # releaseName `monolith`, so CNPG names its credential `monolith-pg-app`
-        # in monolith-dev, exactly as production names its own in monolith.
-        # Cloning both into monolith-workflows under their source names would
-        # collide, so dev's lands under a distinct target name and the refresh
-        # workflow reads that.
+        # Source and target names match here, unlike the rule above, because the
+        # dev Application runs under releaseName `monolith-dev`, so CNPG already
+        # names its credential `monolith-dev-pg-app`. No collision to design
+        # around.
         name: monolith-dev-pg-app
         namespace: monolith-workflows
         synchronize: true
         generateExisting: true
         clone:
           namespace: monolith-dev
-          name: monolith-pg-app
+          name: monolith-dev-pg-app
 ---
 # Kyverno 3.x restricts both controllers' Secret access by default. The
 # BACKGROUND controller does the actual clone (needs get/list/watch on the


### PR DESCRIPTION
Dev deployed with `releaseName: monolith`, so it rendered `ClusterRole/monolith`
and `ClusterRoleBinding/monolith`: cluster-scoped objects, and therefore the very
ones production owns.

```
ClusterRole/monolith is part of applications argocd/monolith-dev and monolith
```

**Production was never at risk**, and only because ArgoCD's shared-resource
protection declined the sync instead of reconciling. Two Applications with
`selfHeal: true` both claiming one object would otherwise have flapped
production's RBAC between them. Live state while broken: `monolith`
Synced/Healthy, `monolith-dev` OutOfSync/Degraded, dev's CNPG cluster healthy.

## Why the original reasoning was wrong

Matching the release name was meant to make dev a pure values diff against prod:
identical object names, only the namespace differing. That holds for
**namespaced** objects and quietly assumes everything is namespaced. It is not.
A shared name across namespaces is not two objects, it is **one object with two
owners**.

## The pattern, since this is the second one

Dev inheriting `cfIngress` and claiming `private.jomcgi.dev` was the first. Both
come from the property that makes "same chart, thin overlay" worth having:
everything not overridden is **inherited**.

> Inheriting is safe for settings describing how a workload **behaves**, and
> unsafe for the ones describing **who it claims to be**.

## The guard

`chart_env_identity_test.py` renders both environments and compares them:

- cluster-scoped names must be disjoint
- dev must claim no hostname
- dev must not render the refresh CronWorkflow
- the leader-singleton mute is asserted in **both** directions

It reads `releaseName` from `deploy/application.yaml` rather than hardcoding it.
That is load-bearing: the defect lived in the Application, not the chart, and the
chart renders disjoint names perfectly well when handed two different release
names. **My first version hardcoded them and passed with the bug present.**

Verified by reintroducing each bug:

```
AssertionError: dev and production both render
['ClusterRole/monolith', 'ClusterRoleBinding/monolith']. These kinds have no
namespace, so that is ONE object with two ArgoCD owners, both with selfHeal.

AssertionError: dev renders HTTPRoutes claiming ['private.jomcgi.dev'].
```

Both tests also guard themselves: if production ever stops rendering
cluster-scoped objects or hostnames, the disjointness assertions fail loudly
rather than passing vacuously forever.

## Knock-ons, both handled

- dev's database is `monolith-dev-pg-rw` again, which the refresh workflow targets
- dev's CNPG credential is `monolith-dev-pg-app`, so the Kyverno rule no longer
  renames it on clone

`ci test`: Executed 4 out of 704, 704 pass.