### PR TITLE
fix(monolith): stop dev dialling production's WhatsApp account

### DIFF
--- a/projects/monolith/dev/deploy/values.yaml
+++ b/projects/monolith/dev/deploy/values.yaml
@@ -56,3 +56,18 @@ postgres:
   # Applications would fight over it on every sync.
   devRefresh:
     enabled: false
+
+# The WhatsApp bridge holds a REAL external identity: it starts with
+# bot_number +12369923104, the production account, and a second bridge would
+# contend for that one WhatsApp session.
+#
+# This is off for the same reason leaderSingletons is, and it is here because
+# that switch does NOT cover it. The five leader-elected singletons are one
+# mechanism; this is a separate Deployment that inherited straight through. The
+# rule is not "disable the leader singletons", it is "disable anything holding
+# an external identity", and that set spans more than one mechanism.
+#
+# Not an exception to keeping dev identical to prod: an external account is
+# identity, and dev must not claim production's.
+whatsapp:
+  enabled: false


### PR DESCRIPTION
Dev's WhatsApp bridge was in CrashLoopBackOff, and the crash was the lucky part:

```
"msg":"whatsapp gateway starting","bot_number":"+12369923104"
"msg":"whatsapp gateway exited with error","err":"open whatsmeow sqlstore:
  failed to create version table: ERROR: no schema has been selected"
```

It starts with the **production account number**. A second bridge contends for
that one WhatsApp session. The crash is incidental (a fresh database with no
schema for whatsmeow's sqlstore); had the schema existed it would have
connected.

## The gap this exposes

`leaderSingletons: false` covers the five **leader-elected** singletons. The
WhatsApp bridge is a separate Deployment, outside that mechanism, so it
inherited straight through.

> The rule is not "disable the leader singletons", it is "disable anything
> holding an external identity", and that set spans more than one mechanism.

This is not an exception to keeping dev identical to production. An external
account is identity, and dev must not claim production's, exactly as with
hostnames and cluster-scoped names.

Verified: production still renders the bridge (4 refs), dev renders none, and
chart_env_identity_test still passes.