### PR TITLE
fix(kyverno): trigger the workflow-secret clones on their source, not a namespace

### DIFF
--- a/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
+++ b/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
@@ -153,6 +153,24 @@ spec:
         clone:
           namespace: monolith
           name: goosecracker
+    # TRIGGERED BY THE SOURCE SECRET, not by the target namespace, unlike the
+    # rules above. That difference is load-bearing and was learned the hard way.
+    #
+    # Kyverno pins a generated resource to its source by UID
+    # (generate.kyverno.io/source-uid). A namespace-triggered rule fires once,
+    # when the namespace appears, and `synchronize: true` then propagates
+    # CONTENT changes to that one source UID. It does not re-evaluate when the
+    # source is DELETED AND RECREATED, because the target namespace produces no
+    # new event to trigger on.
+    #
+    # That is not hypothetical: monolith-workflows held a monolith-dev-pg-app
+    # cloned from the dev cluster's PREVIOUS credential, labelled
+    # cnpg.io/cluster: monolith-pg, after the dev release was renamed and CNPG
+    # issued a new one. The clone was stuck on a dead password permanently, and
+    # nothing reported a problem: the policy said Ready and the secret existed.
+    #
+    # Matching the source Secret means CNPG creating or replacing the credential
+    # IS the trigger, so a rotation or a cluster rebuild re-clones by itself.
     - name: clone-pg-dump-reader-to-monolith-workflows
       # Kyverno 1.13 defaults this server-side; declare it so ArgoCD desired
       # state matches live and the app does not sit permanently OutOfSync.
@@ -161,9 +179,11 @@ spec:
         any:
           - resources:
               kinds:
-                - Namespace
+                - Secret
+              namespaces:
+                - monolith
               names:
-                - monolith-workflows
+                - monolith-pg-dump-reader
       generate:
         apiVersion: v1
         kind: Secret
@@ -174,6 +194,8 @@ spec:
         clone:
           namespace: monolith
           name: monolith-pg-dump-reader
+    # Source-triggered for the reason documented on the rule above, and this is
+    # the rule that demonstrated the failure.
     - name: clone-dev-pg-app-to-monolith-workflows
       # Kyverno 1.13 defaults this server-side; declare it so ArgoCD desired
       # state matches live and the app does not sit permanently OutOfSync.
@@ -182,9 +204,11 @@ spec:
         any:
           - resources:
               kinds:
-                - Namespace
+                - Secret
+              namespaces:
+                - monolith-dev
               names:
-                - monolith-workflows
+                - monolith-dev-pg-app
       generate:
         apiVersion: v1
         kind: Secret


### PR DESCRIPTION
`monolith-workflows` held a `monolith-dev-pg-app` cloned from the dev cluster's
**previous** credential, after the dev release was renamed and CNPG issued a new
one. The clone's own labels give it away:

```
cnpg.io/cluster: monolith-pg                    <- the DELETED cluster
generate.kyverno.io/source-uid: 280d3404-...    <- a Secret that no longer exists
generate.kyverno.io/trigger-kind: Namespace
```

Source and clone hash differently, so the nightly refresh would have failed to
authenticate against the new dev database. **Nothing reported a problem**: the
policy said `Ready`, the secret existed, and both Applications were healthy.

## Why `synchronize: true` did not save it

Kyverno pins a generated resource to its source by **UID**. A namespace-triggered
rule fires once, when the namespace appears, and `synchronize: true` then
propagates **content** changes for that one UID. It does not re-evaluate when the
source is **deleted and recreated**, because the target namespace produces no new
event to trigger on. The old UID was gone, so the clone was stuck permanently and
would never self-heal.

## The fix

Match the **source Secret**. CNPG creating or replacing the credential is then
the trigger itself, so a rotation or a cluster rebuild re-clones without help.

```diff
           - resources:
               kinds:
-                - Namespace
+                - Secret
+              namespaces:
+                - monolith-dev
               names:
-                - monolith-workflows
+                - monolith-dev-pg-app
```

## Scope

The two rules added for the dev environment. The pre-existing `monolith-pg-app`
and clickhouse rules carry the same latent fragility (their clones would go stale
if those sources were ever recreated rather than updated in place), but their
sources are stable and rewriting them is not this PR's job. Worth an issue.

## After merge

The stale target needs deleting once so Kyverno regenerates it from the correct
source. Verify with:

```sh
for ns in monolith-dev monolith-workflows; do
  kubectl get secret monolith-dev-pg-app -n $ns -o jsonpath='{.data.password}' | shasum
done
```

The two hashes must match.