### PR TITLE
fix(monolith): give the dev refresh job an image it can actually start

### DIFF
--- a/projects/monolith/chart/chart_env_identity_test.py
+++ b/projects/monolith/chart/chart_env_identity_test.py
@@ -265,3 +265,42 @@ def test_dev_mutes_leader_singletons_and_production_does_not(renders):
         'name: MONOLITH_LEADER_SINGLETONS\n              value: "true"'
         in renders["prod"]
     )
+
+
+def test_refresh_job_does_not_run_the_extension_image(renders):
+    """The refresh job needs a RUNTIME image, not an extension artifact.
+
+    This shipped pointing at postgres.pgvector.image, which is the declarative
+    EXTENSION image for `vector` (cnpg-cluster.yaml's extensions block): a
+    minimal artifact carrying extension binaries and no shell. The workflow
+    could never start:
+
+        failed to find name in PATH: exec: "/bin/sh": no such file or directory
+
+    It failed only when submitted by hand. On its own schedule it would have
+    failed at 04:00 with an exit code nobody was watching, leaving dev with an
+    empty database indefinitely.
+
+    Helm cannot check whether an image contains a shell, so this pins the thing
+    it CAN check: that the job and the extension are not the same image.
+    """
+    import re as _re
+
+    ext = _re.search(r"^\s+reference:\s*(\S+)\s*$", renders["prod"], _re.M)
+    assert ext, "no declarative extension image rendered; this test is inert"
+
+    job_images = _re.findall(
+        r"^\s+image:\s*[\"']?(\S+?)[\"']?\s*$",
+        "\n".join(
+            doc
+            for kind, _n, doc in _docs(renders["prod"])
+            if kind == "CronWorkflow" and "cnpg-dev-refresh" in doc
+        ),
+        _re.M,
+    )
+    assert job_images, "the refresh CronWorkflow did not render; this test is inert"
+    assert ext.group(1) not in job_images, (
+        f"the refresh job runs {ext.group(1)}, the declarative extension image. "
+        "That artifact has no shell and the workflow cannot start. Use a "
+        "postgres RUNTIME image carrying pg_dump, pg_restore and psql."
+    )

--- a/projects/monolith/chart/templates/cnpg-dev-refresh-cronworkflow.yaml
+++ b/projects/monolith/chart/templates/cnpg-dev-refresh-cronworkflow.yaml
@@ -25,7 +25,7 @@ spec:
     templates:
       - name: refresh
         container:
-          image: {{ .Values.postgres.pgvector.image | quote }}
+          image: {{ .Values.postgres.devRefresh.refreshImage | quote }}
           command: ["/bin/sh", "-ceu"]
           args:
             - |

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -829,6 +829,21 @@ postgres:
     role: dump_reader
     # Argo CronWorkflow schedule, in UTC.
     cron: "0 4 * * *"
+    # The image the refresh JOB runs in. It needs a shell plus pg_dump,
+    # pg_restore and psql.
+    #
+    # NOT postgres.pgvector.image, which is what this first shipped as and could
+    # never work: that value is the declarative EXTENSION image for `vector`
+    # (see the extensions block above), a minimal artifact carrying extension
+    # binaries and no shell at all. The workflow died with
+    # `failed to find name in PATH: exec: "/bin/sh"`.
+    #
+    # Nor is it the cluster's own image: this chart never sets spec.imageName,
+    # so CNPG picks its operator default, and that default DIFFERS between
+    # clusters (production runs 18.1-system-trixie, dev 18.4). There is no
+    # in-chart value that names the running image, so pinning one here is the
+    # honest option rather than pretending to derive it.
+    refreshImage: ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie
     # kubernetes.io/basic-auth secret in monolith, created out-of-band because
     # CNPG's passwordSecret needs a type and a cnpg.io/reload label that the
     # 1Password operator cannot emit (see deploy/embervm-oplog-secret.md). This


### PR DESCRIPTION
The refresh CronWorkflow ran `postgres.pgvector.image`, which **can never work**:

```
failed to find name in PATH: exec: "/bin/sh": no such file or directory
```

That value is the declarative **extension** image for `vector` (see
`cnpg-cluster.yaml`'s `extensions` block), a minimal artifact carrying extension
binaries and no shell.

## Why I picked it, and why that reasoning was wrong

It is the only postgres-shaped image in the chart's values, and it reads like the
database's image. It is not. **This chart never sets `spec.imageName`**, so CNPG
picks its operator default, and that default differs per cluster:

```
production  ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie
dev         ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie
```

No in-chart value names the running image, so the job's image is now its own
pinned value rather than something pretending to be derived from one.

## How it surfaced

Only because the refresh was submitted **by hand**. On its own schedule it would
have failed at 04:00 with an exit code nobody was watching, and dev would have
sat with an empty database indefinitely, which is the exact failure this
environment exists to avoid.

## The guard

Helm cannot check whether an image contains a shell, so it pins what it can: the
job and the declarative extension must not be the same image. Verified by
pointing it back at the extension image:

```
FAILED test_refresh_job_does_not_run_the_extension_image
1 failed, 5 passed
```

Both halves also assert they are not inert, so if the extension block or the
CronWorkflow stops rendering the test fails loudly rather than passing on an
empty comparison.