### PR TITLE
fix(monolith): stop a dev environment 503ing the public health endpoint

### DIFF
--- a/projects/monolith/cluster/cd_health.py
+++ b/projects/monolith/cluster/cd_health.py
@@ -83,10 +83,38 @@ async def _argocd_fault(grace_s: float) -> str | None:
     return await _argocd_fault_real(apps, grace_s)
 
 
-async def _argocd_fault_real(apps: list[dict], grace_s: float) -> str | None:
-    """Return a description of the unhealthy apps, or None if all are fine."""
+def _non_prod_apps() -> frozenset[str]:
+    """ArgoCD apps whose health is reported but does NOT fault this component.
+
+    This check was written when every ArgoCD app WAS production, so "any app
+    unhealthy" and "production unhealthy" were the same predicate. Introducing
+    monolith-dev broke that equivalence silently, and the check kept evaluating
+    the old one: a dev environment with a stuck Atlas migration took
+    jomcgi.dev/health to 503 while production was entirely fine.
+
+    These are still worth reporting. A dev environment that cannot sync is a
+    real signal and often an early one, since it runs the same chart production
+    is about to. It is just not a reason to tell the outside world that this
+    site is down.
+    """
+    raw = os.environ.get("CD_HEALTH_NON_PROD_APPS", "monolith-dev")
+    return frozenset(n.strip() for n in raw.split(",") if n.strip())
+
+
+async def _argocd_fault_real(
+    apps: list[dict], grace_s: float, non_prod: frozenset[str] | None = None
+) -> tuple[str | None, str | None]:
+    """Split unhealthy apps into (production faults, non-production notes).
+
+    Returns a pair so the caller can decide differently about each. Only the
+    first makes /api/health 503; the second rides along in the detail string so
+    the signal is kept rather than discarded.
+    """
+    if non_prod is None:
+        non_prod = _non_prod_apps()
     now = datetime.now(timezone.utc)
-    faults = []
+    faults: list[str] = []
+    notes: list[str] = []
     for app in apps:
         if app.get("sync") == "Synced" and app.get("health") == "Healthy":
             continue
@@ -98,11 +126,15 @@ async def _argocd_fault_real(apps: list[dict], grace_s: float) -> str | None:
             continue
         age_s = (now - finished).total_seconds()
         if age_s > grace_s:
-            faults.append(
+            line = (
                 f"{app['name']} is {app.get('sync')}/{app.get('health')} "
                 f"for {age_s / 60:.0f}m"
             )
-    return "; ".join(sorted(faults)) if faults else None
+            (notes if app.get("name") in non_prod else faults).append(line)
+    return (
+        "; ".join(sorted(faults)) if faults else None,
+        "; ".join(sorted(notes)) if notes else None,
+    )
 
 
 async def _ci_fault(red_window_s: float) -> str | None:
@@ -213,9 +245,15 @@ async def cd_health() -> dict:
         logger.warning("cd health: argocd check failed: %s", exc)
         details.append(f"argocd check unavailable ({exc})")
     else:
-        if argocd:
+        argocd_fault, argocd_note = argocd
+        if argocd_fault:
             ok = False
-            details.append(argocd)
+            details.append(argocd_fault)
+        if argocd_note:
+            # Reported, deliberately NOT faulting. See _non_prod_apps: a dev
+            # environment failing to sync is worth surfacing and is not a
+            # reason to tell the outside world this site is down.
+            details.append(f"non-prod: {argocd_note}")
 
     if not os.environ.get("GITHUB_API_TOKEN", ""):
         details.append("ci check disabled: no GITHUB_API_TOKEN")

--- a/projects/monolith/cluster/cd_health_test.py
+++ b/projects/monolith/cluster/cd_health_test.py
@@ -34,7 +34,7 @@ async def test_all_apps_synced_healthy_is_ok():
     apps = [
         {"name": "monolith", "sync": "Synced", "health": "Healthy", "finished_at": None}
     ]
-    assert await mod._argocd_fault_real(apps, 900.0) is None
+    assert (await mod._argocd_fault_real(apps, 900.0))[0] is None
 
 
 @pytest.mark.asyncio
@@ -43,7 +43,7 @@ async def test_app_stuck_unsynced_past_grace_trips():
     apps = [
         {"name": "monolith", "sync": "Unknown", "health": "Healthy", "finished_at": old}
     ]
-    fault = await mod._argocd_fault_real(apps, 900.0)
+    fault, _note = await mod._argocd_fault_real(apps, 900.0)
     assert fault is not None
     assert "monolith is Unknown/Healthy" in fault
 
@@ -59,7 +59,7 @@ async def test_app_mid_rollout_inside_grace_does_not_trip():
             "finished_at": recent,
         }
     ]
-    assert await mod._argocd_fault_real(apps, 900.0) is None
+    assert (await mod._argocd_fault_real(apps, 900.0))[0] is None
 
 
 @pytest.mark.asyncio
@@ -77,7 +77,7 @@ async def test_app_with_no_finish_time_does_not_trip():
             "finished_at": None,
         }
     ]
-    assert await mod._argocd_fault_real(apps, 900.0) is None
+    assert (await mod._argocd_fault_real(apps, 900.0))[0] is None
 
 
 # --------------------------------------------------------------------------
@@ -166,7 +166,7 @@ async def test_missing_github_token_fails_open_but_says_so(monkeypatch):
     monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
 
     async def _no_argocd_fault(grace_s):
-        return None
+        return (None, None)
 
     monkeypatch.setattr(mod, "_argocd_fault", _no_argocd_fault)
     result = await mod.cd_health()
@@ -194,7 +194,7 @@ async def test_argocd_fault_makes_the_component_not_ok(monkeypatch):
     monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
 
     async def _fault(grace_s):
-        return "monolith is Unknown/Healthy for 40m"
+        return ("monolith is Unknown/Healthy for 40m", None)
 
     monkeypatch.setattr(mod, "_argocd_fault", _fault)
     result = await mod.cd_health()
@@ -210,9 +210,70 @@ async def test_result_is_cached(monkeypatch):
 
     async def _counting(grace_s):
         calls.append(1)
-        return None
+        return (None, None)
 
     monkeypatch.setattr(mod, "_argocd_fault", _counting)
     await mod.cd_health()
     await mod.cd_health()
     assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_non_prod_app_is_reported_but_does_not_fault():
+    """A dev environment must not 503 the public health endpoint.
+
+    This is the regression test for a real outage: monolith-dev sat
+    Synced/Degraded on a stuck Atlas migration and took jomcgi.dev/health to
+    503 while production was entirely healthy.
+    """
+    old = _iso(datetime.now(timezone.utc) - timedelta(minutes=40))
+    apps = [
+        {
+            "name": "monolith-dev",
+            "sync": "Synced",
+            "health": "Degraded",
+            "finished_at": old,
+        }
+    ]
+    fault, note = await mod._argocd_fault_real(
+        apps, 900.0, non_prod=frozenset({"monolith-dev"})
+    )
+    assert fault is None, "a non-production app must not fault the component"
+    assert note is not None and "monolith-dev is Synced/Degraded" in note, (
+        "it must still be REPORTED: a dev app failing to sync is an early "
+        "signal, since it runs the chart production is about to run"
+    )
+
+
+@pytest.mark.asyncio
+async def test_production_still_faults_alongside_a_non_prod_note():
+    """Scoping must not swallow the signal it was narrowed around."""
+    old = _iso(datetime.now(timezone.utc) - timedelta(minutes=40))
+    apps = [
+        {
+            "name": "monolith",
+            "sync": "Unknown",
+            "health": "Healthy",
+            "finished_at": old,
+        },
+        {
+            "name": "monolith-dev",
+            "sync": "Synced",
+            "health": "Degraded",
+            "finished_at": old,
+        },
+    ]
+    fault, note = await mod._argocd_fault_real(
+        apps, 900.0, non_prod=frozenset({"monolith-dev"})
+    )
+    assert fault is not None and "monolith is Unknown/Healthy" in fault
+    assert "monolith-dev" not in (fault or ""), "dev must not leak into the fault"
+    assert note is not None and "monolith-dev" in note
+
+
+@pytest.mark.asyncio
+async def test_non_prod_list_is_configurable_and_defaults_to_dev(monkeypatch):
+    monkeypatch.delenv("CD_HEALTH_NON_PROD_APPS", raising=False)
+    assert "monolith-dev" in mod._non_prod_apps()
+    monkeypatch.setenv("CD_HEALTH_NON_PROD_APPS", "a , b,")
+    assert mod._non_prod_apps() == frozenset({"a", "b"})


### PR DESCRIPTION
`monolith-dev` sat `Synced/Degraded` on a stuck Atlas migration and took
**`jomcgi.dev/health` to 503** while production was entirely healthy.

```
{"status":"unhealthy","backendStatus":503,"failing":["cd","ember_pages"]}
```

## Why the check was wrong without being buggy

It was written when every ArgoCD app **was** production, so "any app unhealthy"
and "production unhealthy" were the same predicate. Adding a second environment
broke that equivalence silently and the check kept evaluating the old one.

Nothing about `cd_health.py` was incorrect when written. **Its premise expired
underneath it**, and nothing signalled that.

## Scoped, not removed

Non-production apps are now reported but do not fault the component. Keeping the
signal matters: a dev environment that cannot sync is real information and often
*early*, since it runs the same chart production is about to run. It is just not
a reason to tell the outside world this site is down.

`_argocd_fault_real` now returns `(production faults, non-production notes)` so
the caller decides differently about each, rather than the filter being
invisible at the call site.

`CD_HEALTH_NON_PROD_APPS` defaults to `monolith-dev`, so no deployment config is
needed for the case that exists today.

## Tests

Both new tests fail without the scoping. One exists specifically to stop the
narrowing swallowing the signal it was narrowed around: **production must still
fault while a dev note rides alongside**, so this cannot quietly become "ignore
ArgoCD".

```
FAILED test_non_prod_app_is_reported_but_does_not_fault
FAILED test_production_still_faults_alongside_a_non_prod_note
2 failed, 14 passed
```

Existing mocks updated to the pair shape; 16 pass with the fix.

## Note

`ember_pages` was also failing and is unrelated to this change.