### PR TITLE
fix(kyverno): rename the clone rules so the policy can actually apply

### DIFF
--- a/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
+++ b/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
@@ -153,6 +153,23 @@ spec:
         clone:
           namespace: monolith
           name: goosecracker
+    # RENAMED, and the rename is the fix rather than cosmetics.
+    #
+    # These rules previously matched on the target Namespace. Changing that in
+    # place was rejected by Kyverno's own admission webhook:
+    #
+    #   changes of immutable fields of a rule spec in a generate rule is
+    #   disallowed (retried 5 times)
+    #
+    # A generate rule's match block is IMMUTABLE. The policy was refused whole,
+    # so the old rules stayed live, kyverno sat OutOfSync with a failing sync,
+    # and cd_health correctly reported it, taking jomcgi.dev/health to 503.
+    # Nothing looked broken in the diff: the file was right and the cluster had
+    # rejected it.
+    #
+    # A renamed rule is a NEW rule, so it is created rather than mutated, and
+    # the old one is removed. Any future change to these match blocks needs the
+    # same treatment.
     # TRIGGERED BY THE SOURCE SECRET, not by the target namespace, unlike the
     # rules above. That difference is load-bearing and was learned the hard way.
     #
@@ -171,7 +188,7 @@ spec:
     #
     # Matching the source Secret means CNPG creating or replacing the credential
     # IS the trigger, so a rotation or a cluster rebuild re-clones by itself.
-    - name: clone-pg-dump-reader-to-monolith-workflows
+    - name: clone-pg-dump-reader-from-source
       # Kyverno 1.13 defaults this server-side; declare it so ArgoCD desired
       # state matches live and the app does not sit permanently OutOfSync.
       skipBackgroundRequests: true
@@ -196,7 +213,7 @@ spec:
           name: monolith-pg-dump-reader
     # Source-triggered for the reason documented on the rule above, and this is
     # the rule that demonstrated the failure.
-    - name: clone-dev-pg-app-to-monolith-workflows
+    - name: clone-dev-pg-app-from-source
       # Kyverno 1.13 defaults this server-side; declare it so ArgoCD desired
       # state matches live and the app does not sit permanently OutOfSync.
       skipBackgroundRequests: true


### PR DESCRIPTION
#4713 changed these rules' `match` block in place, from the target Namespace to
the source Secret. Kyverno's admission webhook refused it:

```
Failed sync attempt to d9beb6c18: admission webhook "validate-policy.kyverno.svc"
denied the request: changes of immutable fields of a rule spec in a generate rule
is disallowed (retried 5 times)
```

**A generate rule's match block is immutable.** The policy was rejected whole, so
the old rules stayed live, kyverno has been `OutOfSync` with a failing sync since
05:17, and `cd_health` correctly reported it, taking `jomcgi.dev/health` to 503.

## The part worth keeping

The diff was right and the cluster rejected it. I observed the live policy still
reading `kinds=['Namespace']` after #4713 merged, and called it sync lag.

> The merge succeeded and the apply did not.

Same mistake as trusting a green deploy earlier tonight: I checked that my change
had landed in git rather than that it had landed in the cluster.

## Fix

A renamed rule is a **new** rule, so it is created rather than mutated and the
old one is removed:

```diff
-    - name: clone-pg-dump-reader-to-monolith-workflows
+    - name: clone-pg-dump-reader-from-source
-    - name: clone-dev-pg-app-to-monolith-workflows
+    - name: clone-dev-pg-app-from-source
```

Any future change to these match blocks needs the same treatment, which the
comment now states so the next person does not spend an hour on it.

## Verification after merge

`kubectl get clusterpolicy clone-monolith-pg-app` must show the two new rules
with `kinds: [Secret]`, and the kyverno Application must return to Synced.