### PR TITLE
feat(monolith): serve dev on its own hostname behind authentik

### DIFF
--- a/projects/monolith/chart/chart_env_identity_test.py
+++ b/projects/monolith/chart/chart_env_identity_test.py
@@ -179,26 +179,69 @@ def test_dev_claims_no_cluster_scoped_object_production_owns(renders):
     assert prod, "production rendered no cluster-scoped objects; this test is inert"
 
 
-def test_dev_claims_no_hostname(renders):
-    """The ingress collision. Dev must claim nothing on the shared Gateway."""
-    dev_hosts = set()
-    for kind, _name, doc in _docs(renders["dev"]):
-        if kind == "HTTPRoute":
-            dev_hosts.update(_HOSTNAME.findall(doc))
-    assert not dev_hosts, (
-        f"dev renders HTTPRoutes claiming {sorted(dev_hosts)}. Every route "
-        "attaches to the one cloudflare-ingress Gateway, and Gateway API merges "
-        "routes claiming the same hostname, so production traffic could be "
-        "served by dev. Dev needs a hostname of its own before ingress is "
-        "enabled there."
+def test_dev_claims_no_hostname_production_claims(renders):
+    """The ingress collision, generalised now that dev has a hostname.
+
+    This began as "dev claims NO hostname", which was right while dev had none
+    of its own. Once dev.jomcgi.dev exists that phrasing would have to be
+    deleted to let dev work, and deleting it would silently remove the check
+    that caught dev claiming private.jomcgi.dev and ships.jomcgi.dev.
+
+    So it asserts the property that was always the real one: the environments
+    claim DISJOINT hostnames. Every HTTPRoute attaches to the one
+    cloudflare-ingress Gateway, and Gateway API merges routes claiming the same
+    hostname, so an overlap is production traffic reaching a dev build.
+    """
+
+    def hosts(env):
+        out = set()
+        for kind, _name, doc in _docs(renders[env]):
+            if kind == "HTTPRoute":
+                out.update(_HOSTNAME.findall(doc))
+        return out
+
+    shared = hosts("prod") & hosts("dev")
+    assert not shared, (
+        f"dev and production both claim {sorted(shared)}. Routes attaching to "
+        "one Gateway for one hostname are MERGED, so production traffic could "
+        "be served by a dev build running against a copy of production's data."
     )
-    # Guard the guard, as above: production must actually claim hostnames, or
-    # an empty dev set proves nothing about the mechanism.
-    prod_hosts = set()
-    for kind, _name, doc in _docs(renders["prod"]):
-        if kind == "HTTPRoute":
-            prod_hosts.update(_HOSTNAME.findall(doc))
-    assert prod_hosts, "production claimed no hostnames; this test is inert"
+    # Both halves must be non-empty or disjointness is vacuous: if dev stopped
+    # rendering ingress, or production did, this would pass while proving
+    # nothing about the mechanism.
+    assert hosts("prod"), "production claimed no hostname; this test is inert"
+    assert hosts("dev"), (
+        "dev claimed no hostname; this test is inert. If dev ingress was "
+        "deliberately disabled, assert that explicitly rather than leaving "
+        "this passing on an empty set."
+    )
+
+
+def test_dev_exposes_no_unauthenticated_path(renders):
+    """Everything on dev's hostname sits behind authentik.
+
+    The github-webhook route carries NO SecurityPolicy by design: GitHub
+    bypasses Cloudflare Access at the edge and sends no JWT, so a policy there
+    would reject every real delivery, and HMAC in the handler is its gate.
+
+    Correct for production, a hole anywhere else: an unauthenticated route on a
+    host that is otherwise gated, which GitHub is not even delivering to.
+    """
+    dev_routes = {
+        name for kind, name, _ in _docs(renders["dev"]) if kind == "HTTPRoute"
+    }
+    assert not any("github-webhook" in n for n in dev_routes), (
+        f"dev renders an ungated webhook route: {sorted(dev_routes)}. That "
+        "route intentionally has no SecurityPolicy, so on dev's hostname it is "
+        "an open endpoint."
+    )
+    prod_routes = {
+        name for kind, name, _ in _docs(renders["prod"]) if kind == "HTTPRoute"
+    }
+    assert any("github-webhook" in n for n in prod_routes), (
+        "production stopped rendering the webhook route; this test is inert "
+        "and GitHub deliveries are probably broken."
+    )
 
 
 def test_dev_claims_no_resource_pinned_outside_its_namespace(renders):

--- a/projects/monolith/chart/templates/httproute-private.yaml
+++ b/projects/monolith/chart/templates/httproute-private.yaml
@@ -92,12 +92,137 @@ spec:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.cfIngress.private.servicePort | int }}
 ---
+{{- if eq (.Values.cfIngress.private.auth | default "cloudflare") "authentik" }}
+{{- /*
+AUTHENTIK-GATED VARIANT of the private route's policy, for a deployment whose
+audience includes AGENTS rather than only a browser at a keyboard.
+
+Cloudflare Access cannot serve that audience: it consumes the Authorization
+header at the edge, so a bearer token never survives to reach Envoy. That is
+not a tuning problem, it is why this variant exists at all.
+
+The oidc and jwt blocks COMPOSE, they are not alternatives:
+
+  oidc  performs the browser redirect against authentik and stores the result
+        in a cookie. A bare jwt block cannot: it only validates a token already
+        present, so a browser arriving with none gets a 401 rather than a login
+        page.
+  jwt   validates what arrives, from EITHER that cookie or an Authorization
+        header, and projects a claim into a request header.
+
+extractFrom names BOTH sources, which is the whole point. Envoy's JWT filter
+defaults to the Authorization header, and naming any source REPLACES that
+default, so a cookies-only list (as the preview lane has) silently rejects every
+agent. Listing both keeps one policy serving both audiences.
+
+Modelled on projects/mcp/context-forge-gateway's preview lane, which proved this
+flow end to end; the deltas are the bearer source and the group.
+*/}}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "monolith.fullname" . }}-private-authentik
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "monolith.fullname" . }}-private
+  oidc:
+    provider:
+      issuer: {{ .Values.cfIngress.private.authentik.issuer | quote }}
+    clientID: {{ .Values.cfIngress.private.authentik.clientID | quote }}
+    clientSecret:
+      name: {{ .Values.cfIngress.private.authentik.clientSecretName | quote }}
+    redirectURL: {{ printf "https://%s/oauth2/callback" .Values.cfIngress.private.hostname | quote }}
+    logoutPath: /oauth2/logout
+    # Scoped to THIS host, never the apex. Envoy sets the cookie on the named
+    # domain AND its subdomains, and these cookies ARE the session. At the apex
+    # they would ride along to the public site, private, mcp and auth, so any
+    # header logging on any tier would capture a live session.
+    #
+    # Widening later is safe; narrowing is not. A stale wider-domain cookie
+    # shadows the narrower one and presents as a login LOOP rather than a
+    # rejection, fixable only by clearing browser cookies.
+    cookieDomain: {{ .Values.cfIngress.private.hostname | quote }}
+    # Named explicitly rather than defaulted, because the jwt block below
+    # extracts one of them BY NAME and a defaulted name is a silent coupling:
+    # if they drift, oidc logs the user in and jwt then rejects them, which
+    # presents as an infinite redirect rather than a 401.
+    cookieNames:
+      accessToken: dev-access-token
+      idToken: dev-id-token
+    scopes:
+      - email
+      - profile
+  jwt:
+    providers:
+      - name: authentik
+        issuer: {{ .Values.cfIngress.private.authentik.issuer | quote }}
+        remoteJWKS:
+          uri: {{ .Values.cfIngress.private.authentik.jwksUri | quote }}
+        extractFrom:
+          # The ID token, not the access token: OIDC REQUIRES the ID token to
+          # carry `email` when that scope is granted, whereas whether an access
+          # token does is provider-specific. This makes the projection below a
+          # spec guarantee rather than an authentik detail.
+          cookies:
+            - dev-id-token
+          # The agent path. Without this, naming cookies above would disable
+          # Envoy's default Authorization extraction entirely and every
+          # non-browser caller would 401.
+          headers:
+            - name: Authorization
+              valuePrefix: "Bearer "
+        claimToHeaders:
+          - claim: email
+            header: X-Auth-Email
+        recomputeRoute: true
+  # Authorization decides on the CLAIM, never the header projected above. A
+  # header can be sent by a caller; a claim sits inside a signature Envoy has
+  # just verified, so it cannot be forged at all.
+  #
+  # defaultAction Deny means a token that validates but carries no matching
+  # group is rejected rather than falling through to whatever the route would
+  # otherwise serve. That makes this a second, independent gate rather than a
+  # restatement of authentik's own application policy binding: authentik decides
+  # who may OBTAIN a token, this decides who may USE one here, and either
+  # misconfiguration fails closed on its own.
+  authorization:
+    defaultAction: Deny
+    rules:
+      - name: allow-dev-groups
+        action: Allow
+        principal:
+          jwt:
+            provider: authentik
+            claims:
+              - name: groups
+                valueType: StringArray
+                values:
+                  {{- range .Values.cfIngress.private.authentik.allowedGroups }}
+                  - {{ . | quote }}
+                  {{- end }}
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ .Values.cfIngress.private.authentik.clientSecretName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.cfIngress.private.authentik.onepassword.itemPath | quote }}
+{{- else }}
 {{- $spParams := dict
   "name" (printf "%s-private" (include "monolith.fullname" .))
   "team" .Values.cfIngress.private.team
 }}
 {{- include "cf-ingress.security-policy" $spParams }}
+{{- end }}
 ---
+{{- if .Values.cfIngress.private.githubWebhook.enabled }}
 # GitHub Semgrep webhook route — a SEPARATE HTTPRoute on the same private gateway
 # and hostname, carrying ONLY the webhook path and routed to the FastAPI backend
 # port. It is deliberately its own route so the cf-access SecurityPolicy above
@@ -133,4 +258,5 @@ spec:
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.service.apiPort | int }}
+{{- end }}
 {{- end }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1256,6 +1256,42 @@ cfIngress:
     enabled: true
   private:
     enabled: true
+    # Which gate gets attached to this route. `cloudflare` is production's
+    # Access policy. `authentik` is for a deployment whose audience includes
+    # AGENTS: Access consumes the Authorization header at the edge, so a bearer
+    # token cannot survive it, and no amount of configuration changes that.
+    auth: cloudflare
+    # The GitHub Semgrep webhook route carries NO SecurityPolicy by design:
+    # GitHub bypasses Cloudflare Access at the edge via an IP-allowlist Bypass
+    # policy and sends no Access JWT, so any policy on it would reject every
+    # real delivery. Its gate is the handler's HMAC verification.
+    #
+    # That is correct for production and WRONG anywhere the hostname is not
+    # production's: an unauthenticated path on another host is a hole, and
+    # GitHub is not delivering there anyway. True here, false in dev.
+    githubWebhook:
+      enabled: true
+    authentik:
+      # authentik derives the OIDC issuer from the APPLICATION SLUG, not the
+      # provider name, so these two must track the slug in
+      # projects/platform/authentik/blueprints/dev-auth.yaml. Renaming the
+      # application silently breaks token validation.
+      issuer: "https://auth.jomcgi.dev/application/o/dev/"
+      jwksUri: "https://auth.jomcgi.dev/application/o/dev/jwks/"
+      # Pinned in Git in the blueprint too, because it is not a secret and this
+      # policy has to name it.
+      clientID: dev-monolith
+      # The provider's secret reaches this namespace through its OWN 1Password
+      # item, deliberately not authentik's, so this namespace never receives
+      # authentik's secret key and bootstrap credentials to read one value.
+      clientSecretName: dev-oidc-client
+      onepassword:
+        itemPath: "vaults/k8s-homelab/items/dev-oidc"
+      # Group NAMES (not ids) from authentik's default profile scope mapping.
+      # Renaming a group in authentik stops matching here, and the symptom is a
+      # 403 after a completely successful login.
+      allowedGroups:
+        - homelab-admin
     tier: trusted
     hostname: private.jomcgi.dev
     servicePort: 3000

--- a/projects/monolith/dev/deploy/values.yaml
+++ b/projects/monolith/dev/deploy/values.yaml
@@ -24,24 +24,39 @@ backend:
   # truncates the outboxes, so the data holds nothing actionable either.
   leaderSingletons: false
 
-# INGRESS IS OFF, and this is the most safety-critical block in this file.
+# INGRESS: ONE hostname, both surfaces, authentik in front.
 #
-# Every HTTPRoute in this chart attaches to the ONE cloudflare-ingress Gateway
-# in envoy-gateway-system, and Gateway API MERGES routes that attach to the same
-# Gateway for the same hostname. Inheriting production's values unchanged would
-# have dev claim private.jomcgi.dev and ships.jomcgi.dev, and production traffic
-# could then be served by a dev build running against a copy of prod's data.
+# dev.jomcgi.dev is dev's OWN hostname, so this claims nothing production owns.
+# That is the only reason enabling it is safe: the guard in
+# chart/chart_env_identity_test.py checks the environments claim DISJOINT
+# hostnames, not that dev claims none, precisely so turning this on cannot
+# quietly disarm the check that caught dev claiming private.jomcgi.dev.
 #
-# Turning these off leaves dev reachable only in-cluster, which is correct until
-# it has a hostname of its OWN. That is deliberately not done here: the chart
-# emits a Cloudflare Access SecurityPolicy, and CF Access consumes the
-# Authorization header, so agents cannot authenticate through it. dev.jomcgi.dev
-# needs an authentik-gated variant (modelled on the working preview lane, with
-# extractFrom widened to accept bearer tokens), which is a chart addition rather
-# than a values change and lands separately.
+# One route serves BOTH surfaces. The private route has a `/` catch-all and the
+# chart applies no path rewrites anywhere, so /public/* and /private/* both
+# reach the app unmodified and the SvelteKit bundle carries both route groups.
+# Production splits them across two hostnames and two Applications only because
+# jomcgi.dev is a public origin; dev has no public audience to separate from.
+#
+# auth: authentik, NOT cloudflare, and this is the load-bearing line. Cloudflare
+# Access consumes the Authorization header at the edge, so an agent's bearer
+# token cannot survive it. Access would gate this fine for a browser and lock
+# every agent out, which is the opposite of what this environment is for.
+#
+# `tier: trusted` is inherited from production and left alone: it is the
+# cloudflared/gateway routing tier, not the auth mechanism.
 cfIngress:
   private:
-    enabled: false
+    enabled: true
+    hostname: dev.jomcgi.dev
+    auth: authentik
+    # No unauthenticated path on this host. GitHub delivers to production, and
+    # this route deliberately has no SecurityPolicy, so on dev it would be an
+    # open endpoint behind an otherwise authentik-gated hostname.
+    githubWebhook:
+      enabled: false
+  # Production's legacy ships.jomcgi.dev redirect. Nothing to do with dev, and
+  # claiming it would be a collision.
   shipsRedirect:
     enabled: false
 


### PR DESCRIPTION
One hostname, both surfaces, nothing public.

`dev.jomcgi.dev` carries the whole app. The private route has a `/` catch-all and
this chart applies **no path rewrites anywhere**, so `/public/*` and `/private/*`
both arrive unmodified and the SvelteKit bundle already contains both route
groups. Production splits them across two hostnames only because `jomcgi.dev` is
a public origin; dev has no public audience to separate from.

## authentik, not Cloudflare Access

The load-bearing choice. **Access consumes the `Authorization` header at the
edge**, so an agent's bearer token cannot survive it. Access would gate this
perfectly for a browser and lock out every agent, which is the opposite of what
this environment is for.

`oidc` and `jwt` compose rather than being alternatives: `oidc` performs the
browser redirect and stores a cookie, `jwt` validates what arrives from **either**
that cookie or an `Authorization` header.

```yaml
extractFrom:
  cookies:  [dev-id-token]
  headers:  [{name: Authorization, valuePrefix: "Bearer "}]
```

Naming both is deliberate. Envoy defaults to the Authorization header, and naming
*any* source **replaces** that default, so the preview lane's cookies-only list
would silently reject every agent. Copying it verbatim would have produced a lane
that works in a browser and fails at its actual purpose.

Authorization decides on the **claim**, not the projected header, with
`defaultAction: Deny`. authentik decides who may *obtain* a token; this decides
who may *use* one here. Either misconfiguration fails closed on its own.

## The webhook route is gated off in dev

`monolith-github-webhook` carries **no SecurityPolicy by design**: GitHub bypasses
Access at the edge and HMAC in the handler is its gate. Correct on production's
hostname, an **open path** on any other, and GitHub does not deliver to dev
anyway.

It came through the overlay as an inheritance nobody chose. That is the fifth
instance of that class tonight, after hostnames, cluster-scoped RBAC,
CronWorkflows and the WhatsApp account.

## The hostname guard generalised rather than being deleted

It asserted dev claims **no** hostname, which was true until dev had one of its
own. Letting dev work would have meant deleting the check that caught dev
claiming `private.jomcgi.dev`. It now asserts **disjointness**, which was always
the real property, and both halves assert they are not comparing empty sets.

A second guard asserts dev renders no ungated route.

Both fail on their own bug:

```
FAILED test_dev_claims_no_hostname_production_claims        (dev -> private.jomcgi.dev)
FAILED test_dev_exposes_no_unauthenticated_path             (webhook enabled in dev)
```

## Verification

- production: 2 cf-access references, **0** authentik, no stray OnePasswordItem
- dev: renders `monolith-dev-private` + `monolith-dev-private-authentik`, nothing else
- `ci test`: Executed 6 out of 705, 705 pass

## Still unverified, deliberately

That a **real bearer token** passes. A policy that renders correctly has been
worth very little tonight, so I want to exercise it against an actual token
before calling the agent half done.