### PR TITLE
revert(kyverno): restore the clone rules the cluster accepts

### DIFF
--- a/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
+++ b/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
@@ -153,42 +153,7 @@ spec:
         clone:
           namespace: monolith
           name: goosecracker
-    # RENAMED, and the rename is the fix rather than cosmetics.
-    #
-    # These rules previously matched on the target Namespace. Changing that in
-    # place was rejected by Kyverno's own admission webhook:
-    #
-    #   changes of immutable fields of a rule spec in a generate rule is
-    #   disallowed (retried 5 times)
-    #
-    # A generate rule's match block is IMMUTABLE. The policy was refused whole,
-    # so the old rules stayed live, kyverno sat OutOfSync with a failing sync,
-    # and cd_health correctly reported it, taking jomcgi.dev/health to 503.
-    # Nothing looked broken in the diff: the file was right and the cluster had
-    # rejected it.
-    #
-    # A renamed rule is a NEW rule, so it is created rather than mutated, and
-    # the old one is removed. Any future change to these match blocks needs the
-    # same treatment.
-    # TRIGGERED BY THE SOURCE SECRET, not by the target namespace, unlike the
-    # rules above. That difference is load-bearing and was learned the hard way.
-    #
-    # Kyverno pins a generated resource to its source by UID
-    # (generate.kyverno.io/source-uid). A namespace-triggered rule fires once,
-    # when the namespace appears, and `synchronize: true` then propagates
-    # CONTENT changes to that one source UID. It does not re-evaluate when the
-    # source is DELETED AND RECREATED, because the target namespace produces no
-    # new event to trigger on.
-    #
-    # That is not hypothetical: monolith-workflows held a monolith-dev-pg-app
-    # cloned from the dev cluster's PREVIOUS credential, labelled
-    # cnpg.io/cluster: monolith-pg, after the dev release was renamed and CNPG
-    # issued a new one. The clone was stuck on a dead password permanently, and
-    # nothing reported a problem: the policy said Ready and the secret existed.
-    #
-    # Matching the source Secret means CNPG creating or replacing the credential
-    # IS the trigger, so a rotation or a cluster rebuild re-clones by itself.
-    - name: clone-pg-dump-reader-from-source
+    - name: clone-pg-dump-reader-to-monolith-workflows
       # Kyverno 1.13 defaults this server-side; declare it so ArgoCD desired
       # state matches live and the app does not sit permanently OutOfSync.
       skipBackgroundRequests: true
@@ -196,11 +161,9 @@ spec:
         any:
           - resources:
               kinds:
-                - Secret
-              namespaces:
-                - monolith
+                - Namespace
               names:
-                - monolith-pg-dump-reader
+                - monolith-workflows
       generate:
         apiVersion: v1
         kind: Secret
@@ -211,9 +174,7 @@ spec:
         clone:
           namespace: monolith
           name: monolith-pg-dump-reader
-    # Source-triggered for the reason documented on the rule above, and this is
-    # the rule that demonstrated the failure.
-    - name: clone-dev-pg-app-from-source
+    - name: clone-dev-pg-app-to-monolith-workflows
       # Kyverno 1.13 defaults this server-side; declare it so ArgoCD desired
       # state matches live and the app does not sit permanently OutOfSync.
       skipBackgroundRequests: true
@@ -221,11 +182,9 @@ spec:
         any:
           - resources:
               kinds:
-                - Secret
-              namespaces:
-                - monolith-dev
+                - Namespace
               names:
-                - monolith-dev-pg-app
+                - monolith-workflows
       generate:
         apiVersion: v1
         kind: Secret


### PR DESCRIPTION
Reverts #4713's match-block change and #4721's rename. **Both were rejected by
Kyverno's admission webhook**, so the old rules stayed live while the kyverno
Application sat `OutOfSync` with a failing sync, and `cd_health` correctly
reported it, holding `jomcgi.dev/health` at **503**.

```
admission webhook "validate-policy.kyverno.svc" denied the request:
changes of immutable fields of a rule spec in a generate rule is disallowed
```

## Why the rename didn't work

It was supposed to sidestep immutability by making these **new** rules rather
than mutated ones. It didn't. The renamed file reached the synced revision:

```
$ git show aadc396fe:.../clone-monolith-pg-secret-policy.yaml | grep -c from-source
2
```

and the webhook refused it anyway. So ArgoCD is patching the rules array rather
than replacing it, and Kyverno still sees existing rules changing shape.

**I am not guessing a third time with production's health endpoint down.** This
restores the file to `0845d2e72`, byte-identical to what the cluster is running,
so the sync succeeds and the fault clears.

## What is lost

Only robustness, not function. The namespace-triggered rules clone correctly
today. They go stale only if a source secret is **deleted and recreated**, which
is the bug #4713 was written for, and which I have already repaired by hand:

```
monolith-dev         df99d8941972e962
monolith-workflows   df99d8941972e962
```

## Follow-up

Tracked with the mechanism that should actually work: **remove** the rules in one
merge, **add** source-triggered ones in the next, so Kyverno never observes a
rule changing shape. Worth confirming against Kyverno's docs first rather than a
third attempt in production.