### PR TITLE
fix(monolith): point dev at the chart that contains its own route

### DIFF
--- a/projects/monolith/dev/deploy/application.yaml
+++ b/projects/monolith/dev/deploy/application.yaml
@@ -32,7 +32,7 @@ spec:
     # PRODUCTION's pin is left alone.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.291.0
+      targetRevision: 0.293.0
       helm:
         # releaseName MUST differ from production's. It briefly did not, and
         # ArgoCD refused the sync with:


### PR DESCRIPTION
Dev sat at `0.291.0` while production reached `0.293.0`. #4723 added the
authentik SecurityPolicy template that `dev.jomcgi.dev` needs, and **templates
live in the OCI chart**, so merging it gave dev nothing. The hostname kept 404ing
because no route existed to claim it.

## Second time tonight

In #4710 the same stale pin left a **safety gate inert**: the overlay set
`cfIngress.shipsRedirect.enabled: false` against a chart version with no `if` to
read it, so dev claimed `ships.jomcgi.dev` alongside production on the shared
Gateway. Here it withheld a feature instead.

## Why it is silent

| Change type | Source | Reaches dev |
| --- | --- | --- |
| values | `$values` git ref at HEAD | **immediately** |
| templates | the OCI chart at the pinned version | only when this line moves |

So one PR can be **half-applied** to dev, values live and templates absent, with
nothing OutOfSync and both Applications reporting Healthy.

## Verified before pinning

I did not assume the version that published after the merge is the one carrying
the change:

```
$ helm template ... oci://.../charts/monolith --version 0.293.0 -f prod -f dev
  HTTPRoute/monolith-dev-private
  SecurityPolicy/monolith-dev-private-authentik
  oidc block present: True
  bearer extraction present: True
```

## Follow-up

Tracked as #4728. Kargo owning this line is the fix; this is the interim, and it
will need doing again after the next template change dev depends on.