### PR TITLE
fix(monolith): apply the approved grimoire copy review

### DIFF
--- a/projects/monolith/frontend/src/lib/public/grimoire/chat/stream.js
+++ b/projects/monolith/frontend/src/lib/public/grimoire/chat/stream.js
@@ -176,16 +176,13 @@ export function applyFrame(state, frame) {
 // before any SSE starts) to a human message. The soft, retryable shed arrives
 // in-stream as a 200 `busy` frame; these are the terminal pre-stream cases.
 function messageForError(status, detail) {
-  if (detail && typeof detail.message === "string" && detail.message) {
-    return detail.message;
-  }
   switch (status) {
     case 400:
       return `That message is too long (max ${CHARACTER_LIMIT} characters). Please shorten it.`;
     case 404:
       return "Your chat session expired. Reload the page to start a new one.";
     case 429:
-      return "This chat session has reached its limit. Reload the page to start a new one.";
+      return "This conversation has reached its length limit. Reload the page to start a new one.";
     default:
       return FALLBACK_ERROR;
   }

--- a/projects/monolith/frontend/src/lib/public/grimoire/chat/stream.test.js
+++ b/projects/monolith/frontend/src/lib/public/grimoire/chat/stream.test.js
@@ -193,7 +193,9 @@ describe("streamChatMessage", () => {
     expect(frames).toHaveLength(1);
     expect(frames[0].type).toBe("error");
     expect(frames[0].data.code).toBe("max_turns");
-    expect(frames[0].data.message).toBe("limit");
+    expect(frames[0].data.message).toBe(
+      "This conversation has reached its length limit. Reload the page to start a new one.",
+    );
   });
 
   it("maps a 404 with no body to a friendly session-expired error", async () => {

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
@@ -151,8 +151,8 @@
 
   const COUNTS = [
     ["books", story.corpus.books],
-    ["chunks", story.corpus.chunks],
-    ["entities", story.corpus.entities],
+    ["passages", story.corpus.chunks],
+    ["characters, places and items", story.corpus.entities],
     ["relationships", story.corpus.edges],
   ];
   const topTypes = Object.entries(story.corpus.byType)
@@ -161,16 +161,16 @@
 
   const CAPTIONS = {
     layout: [
-      "1 / LAYOUT DETECTION",
-      "Marker reads the scanned page and finds its structure: headers, columns, asides, art.",
+      "1 / Reading the page.",
+      "The scan gets picked apart into headers, columns, asides and art.",
     ],
     chunks: [
-      "2 / STRUCTURAL CHUNKING",
-      "Blocks become chunks in reading order, keyed to the section they belong to.",
+      "2 / Broken into passages.",
+      "The page becomes readable passages in the right order, each tagged with the section it came from.",
     ],
     entities: [
-      "3 / ENTITY EXTRACTION",
-      "An LLM reads each chunk and emits typed entities, and how they relate. Click a node.",
+      "3 / Who and what is on the page.",
+      "Every character, place and item gets picked out, along with how they connect.",
     ],
   };
 
@@ -901,7 +901,7 @@
             >Who is the Black Spider?</span
           >
         </h1>
-        <p>Scroll to watch Grimoire extract the answer.</p>
+        <p>Scroll to watch Grimoire find the answer.</p>
         <div class="cue">SCROLL <span class="arrow">&darr;</span></div>
       </div>
 
@@ -982,7 +982,7 @@
             {/each}
           </ul>
           <div class="pfoot">
-            extracted from {popData.nMentions} mention{popData.nMentions === 1
+            found in {popData.nMentions} mention{popData.nMentions === 1
               ? ""
               : "s"} on this page
           </div>
@@ -994,9 +994,11 @@
           Unearthed from this page
         </div>
         <div class="this-page">
-          <span>{story.bboxes.length} blocks</span><span class="k">/</span>
-          <span>{story.chunks.length} chunks</span><span class="k">/</span>
-          <span>{story.entities.length} entities</span><span class="k">/</span>
+          <span>{story.bboxes.length} text blocks</span><span class="k">/</span>
+          <span>{story.chunks.length} passages</span><span class="k">/</span>
+          <span>{story.entities.length} characters, places and items</span><span
+            class="k">/</span
+          >
           <span>{graphEdges.length} relationships</span>
         </div>
         <div class="scale-head grim-title section-head compendium-head">
@@ -1023,14 +1025,13 @@
       <div class="chat-head" bind:this={chatHeadEl}>
         <div class="scale-head grim-title">Ask the Grimoire.</div>
         <div class="chat-sub">
-          Every claim cites the chunks and entities it came from. Click a
-          citation.
+          Every claim links back to the passage it came from. Click one.
         </div>
       </div>
 
       <div class="chat" bind:this={chatEl}>
         {#if isPlaceholder}
-          <div class="mock-note">mock transcript</div>
+          <div class="mock-note">example conversation</div>
         {/if}
         <div class="bubble-q">{transcript.question}</div>
         <div class="bubble-a">
@@ -1060,7 +1061,7 @@
         </div>
         <div class="ctas" bind:this={ctasEl}>
           <a class="cta primary" href={chatHref()}>Ask the Grimoire</a>
-          <a class="cta ghost" href={worldHref()}>Wander the graph</a>
+          <a class="cta ghost" href={worldHref()}>Explore the world</a>
           <a class="cta ghost" href={libraryHref()}>Browse the library</a>
         </div>
       </div>
@@ -1094,20 +1095,19 @@
     <section class="static-hero">
       <h1 class="grim-title">
         <span class="line">Grimoire.</span><span class="line accent"
-          >Who is the Black Spider, and what does he actually want?</span
+          >Who is the Black Spider?</span
         >
       </h1>
       <p>
         The answer is buried in this page of Lost Mine of Phandelver. Grimoire
-        digs it out below: layout, chunks, entities, a graph, and a grounded
-        answer.
+        digs it out below.
       </p>
     </section>
 
     <section class="static-scene">
       <p class="static-cap">
-        <b>1 / Layout detection.</b> Marker reads the scanned page and finds its structure:
-        headers, columns, asides, art.
+        <b>1 / Reading the page.</b> The scan gets picked apart into headers, columns,
+        asides and art.
       </p>
       <div class="static-page" style="aspect-ratio:{aspect}">
         <img
@@ -1134,8 +1134,8 @@
 
     <section class="static-scene">
       <p class="static-cap">
-        <b>2 / Structural chunking.</b> Blocks become chunks in reading order, keyed
-        to the section they belong to.
+        <b>2 / Broken into passages.</b> The page becomes readable passages in the
+        right order, each tagged with the section it came from.
       </p>
       <div class="static-cards">
         {#each cards as c (c.id)}
@@ -1149,8 +1149,8 @@
 
     <section class="static-scene">
       <p class="static-cap">
-        <b>3 / Entity extraction.</b> An LLM reads each chunk and emits typed entities
-        and how they relate.
+        <b>3 / Who and what is on the page.</b> Every character, place and item gets
+        picked out, along with how they connect.
       </p>
       <svg
         class="static-graph"
@@ -1188,8 +1188,7 @@
 
     <section class="static-scene">
       <p class="static-cap">
-        <b>4 / The entire compendium.</b> You just watched a single page unearthed.
-        Every book in the compendium gets the same treatment.
+        <b>4 / Every book.</b>
       </p>
       <div class="static-counters">
         {#each COUNTS as [label, value] (label)}
@@ -1211,12 +1210,12 @@
 
     <section class="static-scene">
       <p class="static-cap">
-        <b>5 / Grounded answers.</b> Every claim cites the chunks and entities it
-        came from.
+        <b>5 / Grounded answers.</b> Every claim links back to the passage it came
+        from. Click one.
       </p>
       <div class="chat static-chat">
         {#if isPlaceholder}
-          <div class="mock-note">mock transcript</div>
+          <div class="mock-note">example conversation</div>
         {/if}
         <div class="bubble-q">{transcript.question}</div>
         <div class="bubble-a">
@@ -1239,7 +1238,7 @@
         </div>
         <div class="ctas static-ctas">
           <a class="cta primary" href={chatHref()}>Ask the Grimoire</a>
-          <a class="cta ghost" href={worldHref()}>Wander the graph</a>
+          <a class="cta ghost" href={worldHref()}>Explore the world</a>
           <a class="cta ghost" href={libraryHref()}>Browse the library</a>
         </div>
       </div>

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/timeline.js
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/timeline.js
@@ -37,7 +37,7 @@ export const PHASES = [
     end: 0.26,
     hold: 0.2,
     rest: 0.22,
-    label: "LAYOUT",
+    label: "PAGE",
   },
   {
     id: "chunks",
@@ -49,7 +49,7 @@ export const PHASES = [
     end: 0.44,
     hold: 0.42,
     rest: 0.43,
-    label: "CHUNKS",
+    label: "PASSAGES",
   },
   {
     id: "entities",
@@ -57,7 +57,7 @@ export const PHASES = [
     end: 0.66,
     hold: 0.56,
     rest: 0.6,
-    label: "ENTITIES",
+    label: "WHO AND WHAT",
   },
   {
     id: "scale",
@@ -65,7 +65,7 @@ export const PHASES = [
     end: 0.82,
     hold: 0.76,
     rest: 0.79,
-    label: "COMPENDIUM",
+    label: "EVERYTHING",
   },
   { id: "chat", start: 0.82, end: 1.0, hold: 0.97, rest: 1.0, label: "ASK" },
 ];

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -99,7 +99,7 @@
     <title>Grimoire · jomcgi.dev</title>
     <meta
       name="description"
-      content="A read-only, link-shareable D&D sourcebook library: browse loaded books, read chunk by chunk, and look up creatures and lore."
+      content="Browse the D&D sourcebooks loaded here, read them page by page, and look up creatures, places and lore."
     />
     <meta name="robots" content="noindex, nofollow" />
   {/if}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
@@ -19,36 +19,39 @@
     {
       status: "Planned",
       title: "Evidence-grounded verification",
-      body: "A trailing job re-checks every extracted stat against its source passage, corrects it or nulls it.",
+      body: "Every stat gets re-checked against the passage it came from, and fixed or removed if it does not match.",
     },
     {
       status: "Planned",
       title: "Alias merge",
-      body: 'Split-name twins ("Gundren" and "Gundren Rockseeker") get merged into one entity, report-first with a human approving every pair.',
+      body: 'Split-name twins ("Gundren" and "Gundren Rockseeker") get merged into one, with a person approving every pair.',
     },
     {
       status: "Designed",
       title: "One search everywhere",
-      body: "A single omnibox blending instant name matches with semantic hits over lore chunks and related entities.",
+      body: "One search box that finds a name as you type, and also finds the passages that describe it.",
     },
     {
       status: "Designed",
       title: "Live-play tools",
-      body: "DM advice capture and a live session view for use mid-encounter.",
+      body: "Notes and a live view to run a session from.",
     },
     {
       status: "Long term",
       title: "Loom migration",
-      body: "The schema is deliberately kept compatible with a governed lakehouse system of record, with per-session hot-tier checkouts when it lands.",
+      body: "Move the library onto Loom, so campaign data lives in one place with a record of every change.",
     },
   ];
 </script>
 
 <svelte:head>
-  <title>Grimoire: a grant-scoped D&D campaign manager · jomcgi.dev</title>
+  <title
+    >Grimoire: a D&D campaign manager where each player sees only what the DM
+    shares · jomcgi.dev</title
+  >
   <meta
     name="description"
-    content="Scan a sourcebook, extract its entities and relationships, then ask it questions with grounded, cited answers. Every player sees only what their DM has granted."
+    content="Scan a sourcebook, then ask it questions and get answers with the page they came from. Every player sees only what their DM has shared."
   />
   <!-- Only this landing page is crawlable: every other route under
        /public/app/grimoire stays noindex (see the layout's svelte:head). -->
@@ -64,9 +67,9 @@
       <span class="kn">demo</span>
     </div>
     <p class="block-lede">
-      The same entity renders differently for each player character, depending
-      on the scope their DM has granted. The creature below is invented for this
-      demo; the real corpus works the same way.
+      Each player sees the same creature differently, depending on how much
+      their DM has shared. The creature below is made up for this demo; real
+      ones work the same way.
     </p>
     <div class="grant-row">
       <article class="grant-card">
@@ -104,10 +107,6 @@
         </p>
       </article>
     </div>
-    <p class="block-note">
-      One visibility predicate covers entity lookups, search results, and the
-      reader's "entities on this page" chips.
-    </p>
   </section>
 
   <section class="block">

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/adventure/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/adventure/[id]/+page.svelte
@@ -25,6 +25,7 @@
     try {
       adventure = await apiFetch(`/adventures/${encodeURIComponent(id)}`);
     } catch (e) {
+      console.error("Could not load adventure", e);
       const msg = String(e.message);
       if (msg.includes("404") || msg.toLowerCase().includes("not found")) {
         notFound = true;
@@ -57,10 +58,12 @@
   {:else if notFound}
     <div class="empty">
       <p class="grim-title empty-lead">Not found.</p>
-      <p class="empty-help">This adventure isn't in the loaded corpus.</p>
+      <p class="empty-help">Nothing by that name in the books loaded here.</p>
     </div>
   {:else if error}
-    <p class="status-error">{error}</p>
+    <p class="status-error">
+      Could not load this right now. Try again in a moment.
+    </p>
   {:else if adventure}
     <a class="eyebrow back-link" href={bookHref(adventure.book_id)}
       >&larr; {adventure.book_display_name.toUpperCase()}</a
@@ -91,7 +94,7 @@
       </section>
     {:else}
       <p class="empty-help roster-empty">
-        No entities extracted in this range yet.
+        No characters or places recorded for this adventure yet.
       </p>
     {/if}
   {/if}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/chat/+page.svelte
@@ -343,8 +343,8 @@
           <div class="chat-gate">
             <p class="eyebrow chat-gate-eyebrow">START CHATTING</p>
             <p class="chat-gate-copy">
-              Solve the challenge once to open a session. Every answer is
-              grounded in the loaded sourcebooks, cited, and never invented.
+              Solve the puzzle once to start. Every answer quotes the sourcebook
+              page it came from.
             </p>
             <TurnstileGate
               siteKey={data.turnstileSiteKey}
@@ -363,7 +363,7 @@
             <p class="empty-sub">
               Rules, spells, monsters, magic items, lore, adventures. A sage
               reads the loaded sourcebooks and answers, citing what it drew on.
-              No tools, no cloud, no telemetry.
+              Nothing leaves this machine.
             </p>
             <div class="chat-examples">
               {#each EXAMPLES as ex}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/chat/s/[id]/+page@.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/chat/s/[id]/+page@.svelte
@@ -170,9 +170,8 @@
         <p class="fork-eyebrow">CONTINUE THIS CHAT</p>
         <p class="fork-copy">
           Solve the challenge to pick up this conversation in a fresh session.
-          The transcript above is carried over and you can keep asking the
-          Grimoire from there. No sign-in, no tracking beyond what keeps the
-          bots out.
+          The transcript above is carried over. No sign-in, no tracking beyond
+          what keeps the bots out.
         </p>
         <TurnstileGate
           siteKey={data.turnstileSiteKey}
@@ -184,8 +183,8 @@
 
     <div class="share-foot">
       <p class="share-foot-copy">
-        This is a read-only snapshot of a conversation with the Grimoire, a sage
-        grounded in the D&D sourcebooks loaded on my homelab cluster.
+        A saved copy of a conversation with the Grimoire, a sage that answers
+        from my D&D sourcebooks.
       </p>
       <a class="share-cta" href="/app/grimoire/chat">Ask the Grimoire &rarr;</a>
     </div>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/entity/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/entity/[id]/+page.svelte
@@ -29,6 +29,7 @@
     try {
       entity = await apiFetch(`/entities/${encodeURIComponent(id)}`);
     } catch (e) {
+      console.error("Could not load entity", e);
       const msg = String(e.message);
       if (msg.includes("404") || msg.toLowerCase().includes("not found")) {
         notFound = true;
@@ -56,10 +57,12 @@
   {:else if notFound}
     <div class="empty">
       <p class="grim-title empty-lead">Not found.</p>
-      <p class="empty-help">This entity isn't in the loaded corpus.</p>
+      <p class="empty-help">Nothing by that name in the books loaded here.</p>
     </div>
   {:else if error}
-    <p class="status-error">{error}</p>
+    <p class="status-error">
+      Could not load this right now. Try again in a moment.
+    </p>
   {:else if entity}
     <EntityDetail {entity} />
 

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/library/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/library/+page.svelte
@@ -25,6 +25,7 @@
     try {
       books = await apiFetch("/books");
     } catch (e) {
+      console.error("Could not load library", e);
       error = e.message;
     } finally {
       loading = false;
@@ -168,10 +169,12 @@
     <p class="summary">
       {totals.books.toLocaleString()}
       {totals.books === 1 ? "book" : "books"}, {totals.chunks.toLocaleString()}
-      pages of lore, {totals.entities.toLocaleString()} entities, synced {totals.synced}
+      pages of lore, {totals.entities.toLocaleString()} characters, places and items,
+      updated {totals.synced}
     </p>
     <p class="legend">
-      Open-licensed books are readable in full. Others are listed for reference.
+      Some books are free to read here in full. The rest are listed so you can
+      see what is loaded.
     </p>
     {#if readableCount > 0 && readableCount < totals.books}
       <div class="filter" role="tablist" aria-label="Filter books">
@@ -204,11 +207,13 @@
       {/each}
     </div>
   {:else if error}
-    <p class="status-error">{error}</p>
+    <p class="status-error">
+      Could not load this right now. Try again in a moment.
+    </p>
   {:else if books.length === 0}
     <div class="empty">
-      <p class="grim-title empty-lead">Nothing loaded yet.</p>
-      <p class="empty-help">Check back once a sourcebook has been uploaded.</p>
+      <p class="grim-title empty-lead">No books here yet.</p>
+      <p class="empty-help">Check back soon.</p>
     </div>
   {:else}
     {#each grouped as group (group.kind)}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/world/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/world/+page.svelte
@@ -250,6 +250,7 @@
         applyEgo(id, res);
       } catch (e) {
         if (requestId !== egoRequestSeq) return;
+        console.error("Could not load world", e);
         loadError = e.message;
         ego = { nodes: [], edges: [] };
       } finally {
@@ -362,7 +363,9 @@
           <div class="skeleton"></div>
         </div>
       {:else if loadError && displayGraph.nodes.length === 0}
-        <p class="status-error">{loadError}</p>
+        <p class="status-error">
+          Could not load this right now. Try again in a moment.
+        </p>
       {:else if displayGraph.nodes.length === 0}
         <div class="empty">
           <p class="grim-title empty-lead">Nothing to show.</p>
@@ -379,7 +382,7 @@
         />
         {#if fellBackToFullEgo}
           <p class="fallback-note">
-            No neighbors in this scope/lens; showing the full world instead.
+            Nothing connects to this here. Showing the whole world instead.
           </p>
         {/if}
         {#if legendTypes.length}


### PR DESCRIPTION
First of four per-surface PRs applying the accepted public-copy review (97 of 98 findings accepted in triage). This one covers grimoire: findings G1-G13, G15-G22 and S1-S15.

What changed: pipeline vocabulary translated for lay readers across the landing page, ScrollStory, reader, world, library, entity and adventure pages; the four raw `{error}` renders replaced with a fixed line (originals go to console); empty states restated in plain words; `stream.js` no longer passes backend `detail.message` through verbatim (known statuses map to friendly text, everything else gets the fallback), with its test updated.

Two notes:
- G14 (the "Bots? Get outta here!" gate) was denied in triage and is untouched.
- One deviation from the accepted text: S7's proposed caption "Every book, not just this page." contains "not just", which is on docs/writing.md's own checklist, so it landed as "4 / Every book." Shout if you want the longer form anyway.

`ci test`: Executed 2 out of 705 tests, 705 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)