### PR TITLE
fix(monolith): apply the approved core-pages copy review

### DIFF
--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -84,7 +84,7 @@
 
 <Seo
   title="Joe McGinley · Senior Platform Engineer"
-  description="Platform Engineer @ Semgrep. Observability obsessed. Caremad about developer experience."
+  description="Joe McGinley's homelab: a four-node Kubernetes cluster running agents, maps, and a knowledge graph."
   path="/"
 />
 

--- a/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
+++ b/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
@@ -60,7 +60,7 @@
         <div class="callout featured">
           <div class="chead">
             <h3>{app.label.toUpperCase()}</h3>
-            <span class="where">FLAGSHIP</span>
+            <span class="where">NODE-4</span>
           </div>
           {#if app.slug === "grimoire"}
             <p>
@@ -73,10 +73,8 @@
             <p>
               Boot a workload once, freeze it, restore the snapshot for every
               request. The guest never holds a real secret; an egress proxy
-              swaps placeholder tokens for credentials at the network hop.
-              <b>EmberVM</b> runs this substrate today: one-shot tasks, stateful
-              sessions, and warm HTTP serving. Watch a microVM restore from disk
-              in <b>{sandboxRestoreMs}ms</b>.
+              swaps placeholder tokens for credentials at the network hop. Watch
+              a microVM restore from disk in <b>{sandboxRestoreMs}ms</b>.
               <a class="more" href="/ember/firecracker"
                 >watch it restore &rarr;</a
               >
@@ -108,9 +106,9 @@
           <span class="where">NODE-4</span>
         </div>
         <p>
-          vLLM serving a <b>35B sparse-MoE</b> (~3B active), int4-mixed weights
-          with an fp8 KV-cache, <b>~170 tok/s</b> single-stream decode. Chat, the
-          agents, and the knowledge graph's RAG all share the 4090.
+          A <b>35B model</b> holds a conversation at <b>~170 tokens a second</b>
+          on one consumer RTX 4090, squeezed in with int4 weights and an fp8 KV-cache.
+          Chat, the agents, and note search all share the card.
         </p>
       </div>
       <div class="callout">

--- a/projects/monolith/frontend/src/routes/public/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/chat/+page.svelte
@@ -17,7 +17,7 @@
 <main class="chat-shell">
   <h1>Chat</h1>
   {#if admitted}
-    <p>You're in. The chat experience lands in a later phase.</p>
+    <p>You're in. Chat isn't open yet, but your seat is saved.</p>
   {:else}
     <p>Solve the challenge to start chatting.</p>
     <TurnstileGate

--- a/projects/monolith/frontend/src/routes/public/cv/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/cv/+page.svelte
@@ -163,7 +163,7 @@
         <p class="cv-summary">{@render inline(summary)}</p>
       </div>
       <Sticker color="var(--accent)" rotate={-4} class="hero-sticker"
-        >Reliability-obsessed</Sticker
+        >BARE-METAL K3S</Sticker
       >
     </div>
   </header>

--- a/projects/monolith/frontend/src/routes/public/cv/cv-data.js
+++ b/projects/monolith/frontend/src/routes/public/cv/cv-data.js
@@ -31,7 +31,7 @@ export const tagline =
   "Senior Platform Engineer @ Semgrep · AWS / EKS · Kubernetes · eBPF";
 
 export const summary =
-  "Mostly I build infrastructure and abstractions so that other engineers don't have to think about it - Kubernetes, eBPF, and everything in between. Caremad about developer and user experience.";
+  "Mostly I build infrastructure and abstractions so that other engineers don't have to think about it: Kubernetes, eBPF, and the layers under them. Caremad about developer and user experience.";
 
 export const jobs = [
   // Current role stays deliberately scope-level: what the job is, not a
@@ -55,16 +55,15 @@ export const jobs = [
     title: "Senior Software Engineer / SSE2",
     dates: "Oct 2022 – May 2025",
     blurb:
-      "Pharma R&D SaaS. Spent three years making the hard infrastructure path the easy one for other engineers. Promoted to SSE2 within 12 months.",
+      "Pharma R&D SaaS. Three years building the infrastructure other engineers deployed on. Promoted to SSE2 within 12 months.",
     highlights: [
       {
         title: "Event-Driven Data Platform",
-        kicker: "From weeks to minutes; $644 down to $69 per 2.5M docs",
         intro:
           "BenchSci turns 25M+ scientific papers into structured biomedical knowledge through NER, LLM extraction, and knowledge-graph linking. Document processing was a weekly batch with pipeline-granularity caching: data freshness capped what the product team could ship, and unchanged work was reprocessed every cycle.",
         bullets: [
           "**Rebuilt it event-driven on GKE**: per-document events, per-document caching, scale-to-zero, so only changed documents reprocess. Processing went from weeks to minutes, cost dropped **from $644 to $69 per 2.5M docs (−89%)**, and the platform scaled to 100K+ concurrent documents with the full 25M+ corpus reprocessable on demand.",
-          "**Made it the path of least resistance**: for the ML researchers using it, adoption was a decorator and a Python function. The framework owned deployment, event semantics, the message log, and live data testing. **~200 engineers adopted it** as the data platform's foundation.",
+          "**Made it the default**: for the ML researchers using it, adoption was a decorator and a Python function. The framework owned deployment, event semantics, the message log, and live data testing. **~200 engineers adopted it** as the data platform's foundation.",
         ],
       },
       {
@@ -72,7 +71,7 @@ export const jobs = [
         bullets: [
           "**OpenTelemetry org-wide adoption**: every team was rolling their own logs, metrics, and tracing. I drove a company-wide OTel rollout that gave every service all three by default. Incident **time-to-identify dropped from 94 to 23 minutes (−75%)** and false-alert volume fell 15%.",
           "**GPU inference at cloud-quota limits**: ran in-pod L4 inference for ~50 in-house ML models (paper extraction, entity enrichment, vision ML) inside the same event-driven pipeline, autoscaling across regions against a **~25K L4-GPU quota** and bursting onto spot capacity when available. Each document's work stayed in one region to avoid cross-region transfer.",
-          "**RCA squad lead**: the post-incident process was bespoke per team. I wrote the company RCA playbook and led a cross-functional squad through it. **Time-to-resolution fell 40%** and the recurring SLA violations stopped.",
+          "**Fixed the post-incident process**: it was bespoke per team. I wrote the company RCA playbook and led a cross-functional squad through it. **Time-to-resolution fell 40%** and the recurring SLA violations stopped.",
         ],
       },
     ],

--- a/projects/monolith/frontend/src/routes/public/docs/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/docs/+page.svelte
@@ -16,10 +16,8 @@
     <p class="eyebrow">Homelab</p>
     <h1>Documentation</h1>
     <p class="lede">
-      Project READMEs and architecture decision records for the secure
-      Kubernetes homelab: how the platform is built, why the decisions were
-      made, and how the services fit together. Rendered straight from the
-      repository.
+      Project READMEs and architecture decision records for the homelab,
+      rendered straight from the repository.
     </p>
   </header>
 

--- a/projects/monolith/frontend/src/routes/public/engineering/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/engineering/+page.svelte
@@ -93,7 +93,7 @@
 </script>
 
 <svelte:head>
-  <title>Joe McGinley — Engineering</title>
+  <title>Joe McGinley · Engineering</title>
   <meta
     name="description"
     content="Engineering deep dives: agents, operators, data systems, and build tooling running on a bare-metal Kubernetes homelab."

--- a/projects/monolith/frontend/src/routes/public/engineering/engineering-data.js
+++ b/projects/monolith/frontend/src/routes/public/engineering/engineering-data.js
@@ -56,11 +56,11 @@ export const projects = [
     oneLiner:
       "Autonomous agents that do real platform work, each running in its own hardware-isolated Firecracker microVM, snapshotted to near-zero cost when idle and restored from memory in tens of milliseconds on the next turn.",
     motivation:
-      "The first version ran unattended Claude agents in sandboxed Kubernetes pods dispatched over NATS. When Claude's terms of service changed around unattended agent use, that dispatch model no longer held. Rather than retire the idea, I split the execution substrate apart from the model choice and rebuilt the substrate on Firecracker: every agent request gets its own hardware-isolated microVM instead of a shared pod, paused and snapshotted when idle so it costs nothing, and restored in tens of milliseconds when woken. The durable pieces from v1 carried over (on-cluster inference, the MCP gateway, the knowledge-graph surface); the sandbox underneath them got much stronger.",
+      "The first version ran unattended Claude agents in sandboxed Kubernetes pods. When Claude's terms of service changed around unattended agent use, that dispatch model no longer held. I split the execution substrate apart from the model choice and rebuilt the substrate on Firecracker: every agent request gets its own hardware-isolated microVM, paused and snapshotted when idle so it costs nothing, and restored in tens of milliseconds when woken. The durable pieces from v1 carried over: on-cluster inference, the MCP gateway, the knowledge-graph surface.",
     facts: [
       {
         k: "MicroVM per request",
-        v: "Every agent request runs in a fresh Firecracker microVM (kata-fc on a bare-metal node), not a shared container. For untrusted, agent-written code the isolation boundary is hardware-level, not a userspace kernel.",
+        v: "Every agent request gets its own microVM with its own kernel, so code an agent writes runs behind a hardware boundary.",
       },
       {
         k: "Snapshot / restore",
@@ -72,7 +72,7 @@ export const projects = [
       },
       {
         k: "Postgres control plane",
-        v: "High-churn idle-agent state lives in Postgres, not etcd, keeping thousands of waiting threads off the cluster control plane. The same registry backs the list and resume catalog exposed over MCP.",
+        v: "High-churn idle-agent state lives in Postgres, keeping thousands of waiting threads off the cluster control plane. The same registry backs the list and resume catalog exposed over MCP.",
       },
       {
         k: "Local inference",
@@ -93,15 +93,15 @@ export const projects = [
     oneLiner:
       "A Firecracker microVM orchestrator: an Elixir control plane and a Go node daemon run one-shot tasks, bankable stateful sessions, and warm HTTP serving on the same substrate.",
     motivation:
-      "fc-invoke proved the substrate but hardcoded one workload shape: a stateless invoke. EmberVM is the successor, built by forking the node daemon and putting a BEAM control plane in front of it. Semgrep scans already run on it, a public image renderer serves warm from it, and fc-invoke is frozen with the goose agent as its last tenant. The design goal: the control plane owns placement and policy but stays off every serving hit path.",
+      "fc-invoke proved the substrate but hardcoded one workload shape: a stateless invoke. EmberVM is the successor, built by forking the node daemon and putting a BEAM control plane in front of it. Semgrep scans already run on it, a public image renderer serves warm from it, and fc-invoke is frozen with the goose agent as its last tenant. The control plane owns placement and policy and stays off every serving hit path.",
     facts: [
       {
         k: "Workload classes",
-        v: "task (one-shot, vsock-only guest with no NIC), session (a stateful sandbox, banked to disk when idle and relit on the next invoke), and serving (a warm HTTP endpoint on a tap NIC).",
+        v: "task (one-shot, no network card, one channel to the host), session (a stateful sandbox, banked to disk when idle and relit on the next invoke), serving (a warm HTTP endpoint reachable from the edge).",
       },
       {
         k: "Serving data path",
-        v: "The control plane publishes endpoints over xDS to a per-node Envoy; the node's kernel DNATs each connection into the VM's tap network. Requests never touch the control plane or the Kubernetes apiserver.",
+        v: "Traffic goes straight from the edge into the VM. The control plane hands out the routes and then stays out of the way; no request touches it or Kubernetes.",
       },
       {
         k: "Quotas and metering",
@@ -113,7 +113,7 @@ export const projects = [
       },
       {
         k: "State",
-        v: "A Postgres op-log, not etcd: a 30-day journal with 7-day terminal-task retention. The current design is maintained in projects/embervm/ARCHITECTURE.md.",
+        v: "A Postgres op-log: a 30-day journal with 7-day terminal-task retention. The current design is maintained in projects/embervm/ARCHITECTURE.md.",
       },
     ],
     links: [
@@ -130,7 +130,7 @@ export const projects = [
     oneLiner:
       "An LLM pipeline that decomposes my notes into structured facts, embeds them, and serves semantic search, both to my agents and to this site's search bar.",
     motivation:
-      "Notes are only useful if they come back at the right moment. The knowledge pipeline turns markdown into a queryable graph: an on-cluster LLM decomposes each note into atomic facts, critiques its own extraction, and stores embeddings for semantic recall.",
+      "An on-cluster model breaks each of my notes into atomic facts and stores them so a question pulls back the right one. The knowledge pipeline turns markdown into a queryable graph, critiques its own extraction, and stores embeddings for semantic recall.",
     facts: [
       {
         k: "Decomposition",
@@ -169,7 +169,7 @@ export const projects = [
     oneLiner:
       "An open-source take on Palantir Foundry: a typed-object data platform with lineage and governance built in, on a Rust + DataFusion + DuckLake core.",
     motivation:
-      "Operating a governed data platform should scale sub-linearly with data and org size: a new dataset, domain, or transform should add no new system to run. Loom is a collaborative bet on that premise, with governance treated as a safety property (STPA hazard analysis, where unsafe means a governance violation, not a crash).",
+      "Loom is a collaborative bet on a governed data platform where a new dataset, domain, or transform adds no new system to run. It treats governance as a safety property: the STPA hazard analysis defines unsafe as a governance violation.",
     facts: [
       {
         k: "Status",
@@ -189,7 +189,7 @@ export const projects = [
       },
       {
         k: "Governance",
-        v: "OpenLineage events plus STPA-derived constraints. The ontology and ACLs live next to the data they govern, not in a bolt-on service.",
+        v: "OpenLineage events plus STPA-derived constraints. The ontology and ACLs live next to the data they govern.",
       },
     ],
     links: [],
@@ -216,8 +216,8 @@ export const projects = [
         v: "Streams HuggingFace models into OCI layers: HTTP response to tar to io.Pipe to registry push. Zero disk I/O. Safetensors and GGUF formats.",
       },
       {
-        k: "Smart naming",
-        v: "The HuggingFace baseModels API resolves derivative models to their base, so derivatives share OCI layers with the base repo for deduplication.",
+        k: "Deduplication",
+        v: "The HuggingFace baseModels API resolves derivative models to their base, so derivatives share OCI layers with the base repo.",
       },
     ],
     snippet: {
@@ -238,7 +238,7 @@ export const projects = [
     oneLiner:
       "A code generator that turns YAML state-machine specs into type-safe Go, so invalid operator state transitions become compile errors.",
     motivation:
-      "Kubernetes operators are state machines, but we write them as imperative reconciliation loops. Every operator I wrote had the same bugs: invalid state transitions, forgotten error handling, missing metrics. Sextant defines the state machine declaratively and generates the boilerplate.",
+      "Sextant defines Kubernetes operator state machines declaratively and generates the boilerplate for their reconciliation loops. Every operator I wrote had the same bugs: invalid state transitions, forgotten error handling, missing metrics.",
     facts: [
       {
         k: "Compile-time safety",
@@ -250,7 +250,7 @@ export const projects = [
       },
       {
         k: "Guard conditions",
-        v: "Go expressions embedded in the YAML, evaluated at transition time. Invalid expressions fail at code-generation time, not in production.",
+        v: "Go expressions embedded in the YAML, evaluated at transition time. Invalid expressions fail at code-generation time.",
       },
       {
         k: "CI drift guard",
@@ -323,15 +323,15 @@ export const projects = [
       },
       {
         k: "Store",
-        v: "Postgres is the source of truth for trip points; folding trips into the monolith retired the old NATS event store. Image bytes live content-addressed in SeaweedFS, so a re-POST of the same frame is idempotent.",
+        v: "Postgres is the source of truth for trip points; folding trips into the monolith retired the old NATS event store. Image bytes live content-addressed in SeaweedFS.",
       },
       {
         k: "Delivery",
-        v: "imgproxy resizes originals on the fly and Cloudflare caches at the edge. Content-addressed keys mean cache invalidation is never needed.",
+        v: "imgproxy resizes originals on the fly and Cloudflare caches at the edge.",
       },
       {
         k: "Display",
-        v: "A read-only, SSR tier renders the public pages from localhost in-pod and is CDN-cached: MapLibre vector tiles with terrain hillshade, day-by-day galleries, and an elevation-profile scrubber. No live socket, the public reads never touch the write path.",
+        v: "A read-only, SSR tier renders the public pages from localhost in-pod and is CDN-cached: MapLibre vector tiles with terrain hillshade, day-by-day galleries, and an elevation-profile scrubber. The public reads never touch the write path.",
       },
     ],
     links: [{ label: "Live trips", href: "/app/trips" }],
@@ -347,19 +347,19 @@ export const projects = [
     facts: [
       {
         k: "AIS ingest",
-        v: "A supervised background task inside the monolith holds a websocket to AISStream.io, filters to a Pacific Northwest bounding box, and batches position reports. NATS is gone: it writes straight to Postgres, and an AISStream hiccup can never crash the app.",
+        v: "A background task inside the app holds a websocket to AISStream.io, filters to a Pacific Northwest box, and writes position reports straight to Postgres.",
       },
       {
         k: "Storage",
-        v: "Postgres is the single source of truth. ships.positions is range-partitioned by day, so retention drops whole partitions with zero vacuum churn; a stateless persister reads affected vessels back, dedups, and upserts a latest-positions serving table.",
+        v: "Postgres is the single source of truth. ships.positions is range-partitioned by day. A stateless persister reads affected vessels back, dedups, and upserts a latest-positions serving table.",
       },
       {
         k: "Ships API",
-        v: "SSR-only REST reached from localhost in-pod: a snapshot endpoint for the initial render and a per-vessel track on click. Both are CDN-cached with ETag 304s, so they run a few times a minute regardless of how many browsers are watching.",
+        v: "SSR-only REST is reached from localhost in-pod: a snapshot endpoint for the initial render and a per-vessel track on click. Both are CDN-cached with ETag 304s.",
       },
       {
         k: "MapLibre UI",
-        v: "Vessels render as a GPU GeoJSON symbol layer, directional icons by heading, so panning stays smooth at scale. A separate WebGL layer maps distinct-vessel traffic density per ~500m cell.",
+        v: "Vessels render as a GPU GeoJSON symbol layer with directional icons by heading. A separate WebGL layer maps distinct-vessel traffic density per ~500m cell.",
       },
     ],
     links: [
@@ -380,7 +380,7 @@ export const projects = [
     facts: [
       {
         k: "Site grid",
-        v: "A light-pollution grid of ~14k road-accessible dark sites is built offline and uploaded to SeaweedFS; a scheduled job wholesale-replaces the stars.sites table from it, so the scorer always works off a current site list.",
+        v: "A light-pollution grid of ~14k road-accessible dark sites is built offline and uploaded to SeaweedFS. A scheduled job wholesale-replaces the stars.sites table.",
       },
       {
         k: "Forecast scoring",
@@ -388,7 +388,7 @@ export const projects = [
       },
       {
         k: "Metric",
-        v: "The unit is clear-dark hours, not a single composite score. Qualifying hours land in Postgres (stars.site_hours); an hourly prune drops hours once their clock hour has elapsed.",
+        v: "The unit is clear-dark hours. Qualifying hours land in Postgres (stars.site_hours); an hourly prune drops hours once their clock hour has elapsed.",
       },
       {
         k: "Delivery",


### PR DESCRIPTION
Second of four per-surface PRs from the accepted public-copy review. Covers the homepage, engineering, cv, docs and chat pages: findings C1-C18.

What changed: the nine antithesis constructions and seven trailing consequence clauses in engineering-data.js restated per docs/writing.md; the three thesis openers now open on what each project does; jargon translated in the EmberVM entries; the GPU card leads with capability but keeps the throughput and quantization numbers per the triage note; self-rating labels (FLAGSHIP, Reliability-obsessed, the homepage meta description) replaced with literal facts; the banned phrase in the cv blurb is gone.

Senior read caught and fixed two dispatch drifts before commit:
- The Loom rewrite inverted a negation: STPA "unsafe" is a governance violation, the original explicitly excluded crashes, and the draft said "or a crash".
- The renamed Deduplication fact ended by restating its own key.

`ci test`: Executed 2 out of 705 tests, 705 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)