### PR TITLE
fix(frontend): stop home links throwing you back to production

### DIFF
--- a/projects/monolith/frontend/src/lib/public/components/Nav.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Nav.svelte
@@ -12,7 +12,7 @@
   // DOCS is reference material (repo docs + ADRs), a peer of ENGINEERING, not an
   // interactive app, so it sits in the top row rather than the APPS dropdown.
   const publicItems = [
-    { slug: "home", label: "HOME", href: "https://jomcgi.dev/" },
+    { slug: "home", label: "HOME", href: "/" },
     { slug: "engineering", label: "ENGINEERING", href: "/engineering" },
     { slug: "docs", label: "DOCS", href: "/docs" },
     { slug: "cv", label: "CV", href: "/cv" },

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -770,7 +770,7 @@
   <div class="map" bind:this={mapContainer}></div>
 
   <nav class="map-chip" aria-label="Breadcrumb">
-    <a class="chip-home" href="https://jomcgi.dev/"
+    <a class="chip-home" href="/"
       >jomcgi.dev<span class="chip-home-arrow" aria-hidden="true">↗</span></a
     >
     <span class="chip-sep">/</span>

--- a/projects/monolith/frontend/src/routes/+error.svelte
+++ b/projects/monolith/frontend/src/routes/+error.svelte
@@ -147,7 +147,11 @@
     {/if}
 
     <div class="nf-cta">
-      <a href="https://jomcgi.dev/" class="btn btn-primary">
+      <!-- Relative, NOT https://jomcgi.dev/. This page renders on every host
+           that serves the bundle (private.jomcgi.dev, dev.jomcgi.dev), and an
+           absolute production URL sent people off the environment they were
+           actually using. `/` redirects to /public/. -->
+      <a href="/" class="btn btn-primary">
         <span class="btn-arr">←</span>&nbsp;BACK TO SOLID GROUND
       </a>
       <a href="/app/notes" class="btn btn-secondary">TALK TO MY NOTES</a>

--- a/projects/monolith/frontend/src/routes/+page.ts
+++ b/projects/monolith/frontend/src/routes/+page.ts
@@ -1,0 +1,16 @@
+import { redirect } from "@sveltejs/kit";
+
+// There is no page at `/`. The route tree starts at /public and /private, so a
+// bare root has always 404'd, and nobody noticed because nothing served the
+// root: jomcgi.dev is monolith-public and private.jomcgi.dev is entered at a
+// deep link.
+//
+// dev.jomcgi.dev is the first host where the root IS the entry point, and
+// landing on the 404 page there is a poor first impression of an environment
+// whose whole job is to look like production.
+//
+// 307 rather than 301: a permanent redirect would be cached by the browser and
+// would outlive any future decision to serve something real at `/`.
+export const load = () => {
+  redirect(307, "/public/");
+};

--- a/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
@@ -299,7 +299,7 @@
   <!-- Top-left crumb / title card. -->
   <div class="crumb-card">
     <nav class="crumb" aria-label="Breadcrumb">
-      <a class="crumb-home" href="https://jomcgi.dev/"
+      <a class="crumb-home" href="/"
         >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
         ></a
       >

--- a/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.svelte
@@ -151,7 +151,7 @@
     <header class="board-head">
       <div class="crumb-row">
         <nav class="crumb" aria-label="Breadcrumb">
-          <a class="crumb-home" href="https://jomcgi.dev/"
+          <a class="crumb-home" href="/"
             >jomcgi.dev<span class="crumb-arrow" aria-hidden="true"
               >&nearr;</span
             ></a

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/chat/s/[id]/+page@.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/chat/s/[id]/+page@.svelte
@@ -87,7 +87,7 @@
 <main class="share-app grimoire">
   <header class="app-header">
     <nav class="crumb" aria-label="Breadcrumb">
-      <a class="crumb-home" href="https://jomcgi.dev/"
+      <a class="crumb-home" href="/"
         >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
         ></a
       >

--- a/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
@@ -312,7 +312,7 @@
     <div class="panel control-head">
       <div class="crumb-row">
         <nav class="crumb" aria-label="Breadcrumb">
-          <a class="crumb-home" href="https://jomcgi.dev/"
+          <a class="crumb-home" href="/"
             >jomcgi.dev<span class="crumb-arrow" aria-hidden="true"
               >&nearr;</span
             ></a

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
@@ -451,7 +451,7 @@
        popover that overlays downward so it never shoves the layout. -->
   <header class="app-header">
     <nav class="crumb" aria-label="Breadcrumb">
-      <a class="crumb-home" href="https://jomcgi.dev/"
+      <a class="crumb-home" href="/"
         >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
         ></a
       >

--- a/projects/monolith/frontend/src/routes/public/app/notes/s/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/s/[id]/+page.svelte
@@ -60,7 +60,7 @@
 <main class="share-app">
   <header class="app-header">
     <nav class="crumb" aria-label="Breadcrumb">
-      <a class="crumb-home" href="https://jomcgi.dev/"
+      <a class="crumb-home" href="/"
         >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
         ></a
       >

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -275,7 +275,7 @@
     <div class="panel control-head">
       <div class="crumb-row">
         <nav class="crumb" aria-label="Breadcrumb">
-          <a class="crumb-home" href="https://jomcgi.dev/"
+          <a class="crumb-home" href="/"
             >jomcgi.dev<span class="crumb-arrow" aria-hidden="true"
               >&nearr;</span
             ></a

--- a/projects/monolith/frontend/src/routes/public/app/trips/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/+page.svelte
@@ -17,7 +17,7 @@
 <div class="page">
   <header class="head">
     <nav class="crumb" aria-label="Breadcrumb">
-      <a class="crumb-home" href="https://jomcgi.dev/"
+      <a class="crumb-home" href="/"
         >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
         ></a
       >

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/+page.svelte
@@ -107,7 +107,7 @@ ${trkpts}
 <div class="page">
   <header class="head">
     <nav class="crumb" aria-label="Breadcrumb">
-      <a class="crumb-home" href="https://jomcgi.dev/"
+      <a class="crumb-home" href="/"
         >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
         ></a
       >

--- a/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
@@ -252,7 +252,7 @@
     <header class="board-head">
       <div class="crumb-row">
         <nav class="crumb" aria-label="Breadcrumb">
-          <a class="crumb-home" href="https://jomcgi.dev/"
+          <a class="crumb-home" href="/"
             >jomcgi.dev<span class="crumb-arrow" aria-hidden="true"
               >&nearr;</span
             ></a

--- a/projects/monolith/frontend/src/routes/public/docs/DocsShell.svelte
+++ b/projects/monolith/frontend/src/routes/public/docs/DocsShell.svelte
@@ -149,7 +149,7 @@
 
 <header class="docs-topbar">
   <div class="docs-topbar-inner">
-    <a class="docs-back" href="https://jomcgi.dev/">
+    <a class="docs-back" href="/">
       <span class="docs-back-arrow" aria-hidden="true">&larr;</span>
       <span class="docs-back-label">jomcgi.dev</span>
     </a>


### PR DESCRIPTION
Three things, all found by actually using `dev.jomcgi.dev`.

## 1. `/` had no page

The route tree starts at `/public` and `/private`, so a bare root has **always**
404'd. Nobody noticed because nothing served the root: `jomcgi.dev` is
`monolith-public`, and `private.jomcgi.dev` is entered at a deep link.

`dev.jomcgi.dev` is the first host where the root **is** the entry point. It now
redirects to `/public/`. **307, not 301**, so a future decision to serve
something real at `/` is not fought by a cached permanent redirect.

## 2. The 404 page sent you to production

```html
<a href="https://jomcgi.dev/" class="btn btn-primary">← BACK TO SOLID GROUND</a>
```

That page renders on **every** host serving the bundle, so hitting a 404 on dev
threw you off the environment you were debugging.

## 3. Thirteen more home links did the same

The HOME nav item, the ships map chip, and `crumb-home` on wc2026, stars, hikes,
notes, dr-jobs, trips, campsites, grimoire chat, and the docs shell. All relative
now.

## Deliberately not changed

**`seo.js` `PUBLIC_BASE`** feeds canonical URLs and OG tags, which must be
absolute production URLs regardless of which host renders them.

**Two deep links in `engineering-data.js`** (`/app/ships`, `/app/stars`). This is
the honest choice, not an oversight: production's public build serves
`routes/public/*` at the **root**, while dev's private build serves the literal
tree. The same page is `/app/ships` on production and `/public/app/ships` on dev,
so a relative form would be correct on one and broken on the other.

## Known, not fixed here

That same divergence means the rest of the public nav (`ENGINEERING`, etc) **404s
on dev**, since those links are root-relative. Not introduced by this PR and not
fixed by it. It follows from dev preserving `/public/` and `/private/` paths, and
the fix is either giving dev the root-served public build production has, or
making the nav base-aware. Worth deciding deliberately rather than patching a
shared component at 7am.