### PR TITLE
fix(monolith): apply the approved app-pages copy review and fix four page bugs

### DIFF
--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -812,7 +812,7 @@
     </div>
   {:else}
     <div class="legend">
-      <p class="eyebrow legend-title">Vessels / cell · all time</p>
+      <p class="eyebrow legend-title">Ships seen per map square</p>
       <ul class="heat-scale">
         {#each heatBreaks.slice(0, HEAT_COLORS.length) as br, i (br)}
           <li>
@@ -832,11 +832,13 @@
         aria-label="Close vessel panel">&times;</button
       >
       <h2 class="panel-name">
-        {selected.name || selected.ship_name || `MMSI ${selected.mmsi}`}
+        {selected.name ||
+          selected.ship_name ||
+          `MMSI ${selected.mmsi} (ship radio id)`}
       </h2>
       <dl class="panel-rows">
         <div>
-          <dt>MMSI</dt>
+          <dt title="a ship's radio id">MMSI</dt>
           <dd>{selected.mmsi}</dd>
         </div>
         <div>

--- a/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
@@ -198,7 +198,7 @@
   }
 
   function daysLabel(n) {
-    return n === 1 ? "1 clear day" : `${n} clear days`;
+    return n === 1 ? "1 clear night" : `${n} clear nights`;
   }
 
   // Clicking a row selects (and pans the map via the bindable); clicking the
@@ -313,7 +313,7 @@
     </nav>
     <p class="crumb-note">
       {#if generatedAt}As of {fmtGeneratedAt(generatedAt)}.
-      {/if}Green = open AND clear skies.
+      {/if}Green means the site is open and the sky is forecast clear.
     </p>
   </div>
 
@@ -370,7 +370,7 @@
         </div>
         {#if activeDates.size === 0}
           <p class="nights-hint">
-            Pick the nights you can go to see matching parks.
+            Pick the nights you are free, and matching parks will appear.
           </p>
         {/if}
       </div>
@@ -388,7 +388,7 @@
           aria-expanded={listOpen}
           onclick={() => (listOpen = !listOpen)}
         >
-          {listOpen ? "Hide" : "List"}
+          {listOpen ? "Hide" : "Show"}
         </button>
       </div>
 
@@ -397,7 +397,7 @@
           <div class="sort-row">
             <span class="control-label">Sort</span>
             <div class="toggle" role="group" aria-label="Sort parks by">
-              {#each [["best_score", "Score"], ["good_days", "Days"], ["name", "Name"]] as [key, label] (key)}
+              {#each [["best_score", "Clear-sky score"], ["good_days", "Days"], ["name", "Name"]] as [key, label] (key)}
                 <button
                   type="button"
                   class="seg"
@@ -415,7 +415,7 @@
                 type="checkbox"
                 class="check-input"
                 bind:checked={clearOnly}
-                aria-label="Show only parks with at least one clear-sky day"
+                aria-label="show only sites with at least one clear night"
               />
               Clear nights only
             </label>
@@ -521,9 +521,10 @@
       </div>
 
       <p class="detail-legend">
-        Check = sites bookable. Color: green (clear) to grey (cloudy or closed).
-        Each cell shows max temp (&deg;) and rain (mm, blue when wet). Hover for
-        cloud cover.
+        A check means the site is bookable. Green fades to grey as forecast
+        cloud increases, and closed sites are grey. The clear-sky score runs 0
+        to 100, higher is clearer. Each cell shows max temp (&deg;) and rain
+        (mm, blue when wet).
       </p>
     </section>
   {/if}
@@ -1245,7 +1246,7 @@
       overflow: hidden;
     }
 
-    /* Hide the "As of HH:MM UTC. Green = open AND clear skies." note on mobile.
+    /* Hide the generated status note on mobile.
        The same context is available in the legend pop-out and on desktop. */
     .crumb-note {
       display: none;

--- a/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.svelte
@@ -71,9 +71,9 @@
   ];
 
   function fmtDate(iso) {
-    if (!iso) return "—";
+    if (!iso) return "n/a";
     const [y, m, d] = iso.split("-").map(Number);
-    if (!y || !m || !d) return "—";
+    if (!y || !m || !d) return "n/a";
     return `${d} ${MONTHS[m - 1]} ${y}`;
   }
 
@@ -189,7 +189,7 @@
             aria-pressed={view === "history"}
             onclick={() => (view = "history")}
           >
-            History ({historyJobs.length})
+            Past ({historyJobs.length})
           </button>
         </div>
 

--- a/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
@@ -371,6 +371,11 @@
           ></span>{/if}
         <span class="chev" aria-hidden="true">{filtersOpen ? "▴" : "▾"}</span>
       </button>
+      {#if filtered.length === 0}
+        <p class="geo-error">
+          No walks match these filters. Reset to see them all.
+        </p>
+      {/if}
     </div>
 
     {#if filtersOpen}

--- a/projects/monolith/frontend/src/routes/public/app/llm-leaderboard/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/llm-leaderboard/+page.svelte
@@ -41,6 +41,17 @@
   };
 
   const toolLabel = (t) => (t >= 0.999 ? "ok" : t > 0 ? "flaky" : "none");
+  const fmtDate = (iso) => {
+    if (!iso) return "n/a";
+    const date = new Date(`${iso}T12:00:00Z`);
+    if (Number.isNaN(date.getTime())) return "n/a";
+    return date.toLocaleDateString("en-GB", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+      timeZone: "UTC",
+    });
+  };
 </script>
 
 <svelte:head>
@@ -56,13 +67,11 @@
     <div class="hero-mark">MODEL-BENCH</div>
     <h1>LLM Leaderboard</h1>
     <p class="lede">
-      An <strong>agentic</strong> coding benchmark over this homelab's real
-      monolith. Each model is dropped into a snapshot of the repo with file
-      tools and has to make the change itself over multiple turns; it is then
-      graded by the repo's
-      <strong>own tests</strong>. Tasks are tiered: a model must clear every
-      <strong>easy + standard</strong> task to <strong>qualify</strong> as
-      viable, and the <strong>hard</strong> tasks plus cost and speed rank the ones
+      An agentic coding benchmark over this homelab's real monolith. Each model
+      is dropped into a snapshot of the repo with file tools and has to make the
+      change itself over multiple turns; it is then graded by the repo's own
+      tests. Tasks are tiered: a model must clear every easy + standard task to
+      qualify as viable, and the hard tasks plus cost and speed rank the ones
       that do.
     </p>
     <div class="meta">
@@ -74,7 +83,7 @@
       <span class="dot">·</span>
       <span>harness {lb.harness_version}</span>
       <span class="dot">·</span>
-      <span>{lb.generated_at}</span>
+      <span>{fmtDate(lb.generated_at)}</span>
     </div>
   </header>
 
@@ -193,16 +202,15 @@
     </div>
     <div class="legend">
       <span
-        ><b>Tokens / Turns / Wall-time</b> are the <b>mean per task</b> (not the median):
-        the tasks vary ~5x in size, so the mean keeps a blow-up on one hard task visible
-        instead of hiding it. Open a row for the per-task split.</span
+        >Tokens / Turns / Wall-time are the mean per task, so one task blowing
+        up stays visible. Open a row for the per-task split.</span
       >
       <span
-        ><b>Hard / Tokens / Turns / Tools</b> are model-intrinsic (the
-        <b>self-host lens</b>); <b>Wall-time / Cost / $-per-solve</b> are the
-        <b>cloud lens</b>: the real time and money to rent this model versus the
-        Claude
-        <b>anchor</b> rows you would be replacing. Wall-time is via OpenRouter.</span
+        >Two ways to read this table: what you can run on your own GPU, and what
+        you can call in the cloud. Hard, tokens, turns, and tools describe the
+        first view. Wall-time, cost, and $-per-solve describe the second,
+        including OpenRouter time and money compared with the Claude reference
+        rows.</span
       >
     </div>
   </section>
@@ -277,10 +285,7 @@
       OpenRouter at list price. Tasks carry a difficulty <em>tier</em>: easy +
       standard form the qualification floor (miss one and a model is
       disqualified as not yet viable), while the hard tasks and the cost and
-      speed columns rank the ones that clear it. Regenerate with
-      <code>python3 -m bench report --json-out</code>
-      in
-      <code>projects/model-bench</code>.
+      speed columns rank the ones that clear it.
     </p>
   </footer>
 </div>

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
@@ -233,7 +233,7 @@
     ...gpuItems,
     `CTX: ${fmtTokens(sessionTokens)} / ${CONTEXT_WINDOW / 1024}K`,
     `TOK/S: ${tokPerSec.toFixed(1)}`,
-    `KG: ${fmtCount(PUBLIC_NOTE_COUNT)} NOTES`,
+    `NOTES: ${fmtCount(PUBLIC_NOTE_COUNT)}`,
     "NO TOOLS / NO CLOUD / NO TELEMETRY",
   ]);
 
@@ -526,7 +526,7 @@
           <span class="panel-tag">PUBLIC CHAT</span>
           <span class="session" class:on={admitted}>
             <span class="led" class:on={admitted}></span>
-            {admitted ? "SESSION OPEN" : "LOCKED"}
+            {admitted ? "SESSION OPEN" : "NOT STARTED"}
           </span>
           <span class="panel-spacer"></span>
           {#if admitted && messages.length > 0}
@@ -629,9 +629,9 @@
                 ask my notes <span class="empty-hl">anything.</span>
               </h2>
               <p class="empty-sub">
-                There are {fmtCount(PUBLIC_NOTE_COUNT)} of them: coffee logs, ADRs,
-                dark-sky readings, half-finished side quests. An open model reads
-                the graph and answers. No tools, no cloud, no telemetry.
+                There are {fmtCount(PUBLIC_NOTE_COUNT)} of them: coffee logs, design
+                notes, dark-sky readings, half-finished side quests. A model running
+                on my own machines reads them and answers. Nothing leaves the house.
               </p>
               <div class="chat-examples">
                 {#each EXAMPLES as ex}
@@ -657,7 +657,7 @@
                   <div class="turn-md">{@html renderReply(m.content)}</div>
                   {#if m.touched && m.touched.length}
                     <div class="turn-touched">
-                      <span class="turn-touched-label">GROUNDED IN</span>
+                      <span class="turn-touched-label">BASED ON</span>
                       {#each m.touched as n}
                         <button
                           type="button"

--- a/projects/monolith/frontend/src/routes/public/app/notes/s/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/s/[id]/+page.svelte
@@ -83,7 +83,7 @@
           CONTINUE THIS CHAT
         </button>
       {/if}
-      <a class="bar-btn" href="/public/app/notes">START YOUR OWN CHAT</a>
+      <a class="bar-btn" href="/app/notes">START YOUR OWN CHAT</a>
     </div>
 
     <div class="chat-transcript">
@@ -100,11 +100,11 @@
               <p class="bot-label">{BOT_LABEL}</p>
               <div class="turn-md">{@html renderReply(m.content)}</div>
               {#if m.touched && m.touched.length}
-                <!-- The same GROUNDED IN set the live app shows, persisted on
+                <!-- The same BASED ON set the live app shows, persisted on
                      the assistant turn and carried into the snapshot. Static
                      labels here (read-only view: there is no graph to open). -->
                 <div class="turn-touched">
-                  <span class="turn-touched-label">GROUNDED IN</span>
+                  <span class="turn-touched-label">BASED ON</span>
                   {#each m.touched as n}
                     <span class="touched-chip"
                       >{n.title || "untitled note"}</span
@@ -123,8 +123,7 @@
         <p class="fork-eyebrow">CONTINUE THIS CHAT</p>
         <p class="fork-copy">
           Solve the challenge to pick up this conversation in a fresh session.
-          The transcript above is carried over and you can keep asking from
-          there. No sign-in, no tracking beyond what keeps the bots out.
+          No sign-in, no tracking beyond what keeps the bots out.
         </p>
         <TurnstileGate
           siteKey={data.turnstileSiteKey}
@@ -136,12 +135,9 @@
 
     <div class="share-foot">
       <p class="share-foot-copy">
-        This is a read-only snapshot of a conversation with an open model
-        running on my homelab cluster.
+        A frozen copy of a chat with a model running on my own machines.
       </p>
-      <a class="share-cta" href="/public/app/notes"
-        >Start your own chat &rarr;</a
-      >
+      <a class="share-cta" href="/app/notes">Start your own chat &rarr;</a>
     </div>
   </section>
 </main>
@@ -407,7 +403,7 @@
     letter-spacing: 0.06em;
   }
 
-  /* Grounding chips under a bot turn: same look as the live app's GROUNDED IN
+  /* Grounding chips under a bot turn: same look as the live app's BASED ON
      row, but static (no graph to open in a read-only snapshot). */
   .turn-touched {
     display: flex;

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -291,7 +291,7 @@
         {:else}
           <p class="stats">
             {count} dark-sky sites{#if topClearDark != null}
-              &middot; best {topClearDark} clear-dark hrs{/if}{#if agoLabel}
+              &middot; best {topClearDark} hrs of clear dark sky{/if}{#if agoLabel}
               &middot; updated {agoLabel} ago{/if}
           </p>
         {/if}
@@ -371,9 +371,9 @@
            twilight windows (down to -10 deg) and says so. -->
       {#if darkness === "none"}
         <div class="panel disclaimer" role="status">
-          No usable stargazing windows in Scotland this week: right now the
-          summer sky never gets dark enough, even for twilight. Astronomical
-          darkness returns by August.
+          The Scottish sky never gets properly dark at this time of year, so
+          there is nothing worth planning this week. Real darkness returns by
+          August.
         </div>
       {:else if darkness === "twilight"}
         <div class="panel disclaimer" role="status">
@@ -432,7 +432,7 @@
 
       {#if historyError}
         <div class="panel empty-state" role="status">
-          Historical data is unavailable right now. Try another month or check
+          Historical data is unavailable right now. Switch to Live, or check
           back shortly.
         </div>
       {:else if historyLoading && !histReady}
@@ -441,8 +441,7 @@
         </div>
       {:else if histReady && histCount === 0}
         <div class="panel empty-state" role="status">
-          No clear dark hours {historyScope}. The seasonal baseline comes from
-          the ERA5 reanalysis backfill.
+          No clear dark hours {historyScope}. Try another month.
         </div>
       {/if}
     {/if}

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
@@ -404,7 +404,7 @@
             {:else}
               <div class="cell r1">
                 <div class="label">TELEMETRY</div>
-                <div class="val sm">--</div>
+                <div class="val sm">no data for this photo</div>
               </div>
             {/if}
           </div>

--- a/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
@@ -350,7 +350,7 @@
       <div
         class="outcome-bar"
         role="img"
-        aria-label="Top-two finish {top2Pct}%, best third {thirdPct}%, eliminated {elimPct}%"
+        aria-label="Top-two finish {top2Pct}%, best third-place spot {thirdPct}%, eliminated {elimPct}%"
       >
         {#if top2Pct > 0}
           <div class="seg seg-top2" style="width:{top2Pct}%">
@@ -360,7 +360,7 @@
         {#if thirdPct > 0}
           <div class="seg seg-third" style="width:{thirdPct}%">
             <span class="seg-num">{thirdPct}%</span>
-            <span class="seg-label">Best third-placed route</span>
+            <span class="seg-label">Best third-place spot</span>
           </div>
         {/if}
         {#if elimPct > 0}
@@ -376,7 +376,7 @@
           <strong>{top2Pct}%</strong>
         </li>
         <li>
-          <span class="key key-third"></span>Best third
+          <span class="key key-third"></span>Best third-place spot
           <strong>{thirdPct}%</strong>
         </li>
         <li>
@@ -395,8 +395,8 @@
       <div class="explainer-body">
         <p>
           It's a Monte Carlo simulation. Every remaining group game is played
-          out {nSims} times, and Scotland's chance is the share of those runs where
-          they reach the Round of 32.
+          out {nSims} times, and {countryName}'s chance is the share of those
+          runs where they reach the Round of 32.
         </p>
         <ol class="explainer-steps">
           <li>
@@ -426,15 +426,10 @@
           </li>
           <li>
             <strong>Aggregate over the runs.</strong> Across all {nSims} runs, the
-            qualify chance, the top-two versus best-third split, and each match's
-            swing are all just counts from the same set of simulations.
+            qualify chance, the split between the top-two and third-place routes,
+            and each match's swing are all just counts from the same set of simulations.
           </li>
         </ol>
-        <p class="explainer-fine">
-          Matches are simulated independently, and the two lowest FIFA
-          tiebreakers (disciplinary record and world ranking) aren't modelled,
-          they're sampled as coin-flips.
-        </p>
       </div>
     </details>
 
@@ -518,7 +513,7 @@
       </div>
       <ul class="zone-legend">
         <li><span class="zone-key zone-top2"></span>1&ndash;2 qualify</li>
-        <li><span class="zone-key zone-third"></span>3rd: best-third route</li>
+        <li><span class="zone-key zone-third"></span>Best third-place spot</li>
         <li><span class="zone-key zone-out"></span>4th: out</li>
       </ul>
     </section>
@@ -528,8 +523,7 @@
       <h2 class="block-title">Matches that could change it</h2>
       <p class="block-sub">
         Each remaining match, ranked by how much its result moves {countryName}'s
-        qualify chance. The three figures are {countryName}'s qualify chance
-        after each outcome.
+        qualify chance.
       </p>
 
       {#if swings.length === 0}
@@ -547,8 +541,8 @@
               <div class="swing-head">
                 <span class="fixture">
                   <span class="rank">{String(i + 1).padStart(2, "0")}</span>
-                  {m.home_code} <span class="v">v</span>
-                  {m.away_code}
+                  {m.home_name} <span class="v">v</span>
+                  {m.away_name}
                   {#if m.is_own_match}
                     <span class="badge own">{countryName}</span>
                   {/if}
@@ -562,7 +556,7 @@
                     <span class="swing-fill" style="width:{swingBar(m.swing)}%"
                     ></span>
                   </span>
-                  &plusmn;{points(m.swing)}
+                  &plusmn;{points(m.swing)} pts
                 </span>
               </div>
               <p class="kickoff">{fmtKick(m.kickoff)}</p>
@@ -587,7 +581,7 @@
                   class="out {deltaClass(m.p_qualify_home_win)}"
                   class:best={pctNum(m.p_qualify_home_win) === best}
                 >
-                  <span class="out-label">If {m.home_code} win</span>
+                  <span class="out-label">If {m.home_name} win</span>
                   <span class="out-num">{pct(m.p_qualify_home_win)}</span>
                   {#if deltaAbs(m.p_qualify_home_win) > 0}
                     <span class="out-delta"
@@ -615,7 +609,7 @@
                   class="out {deltaClass(m.p_qualify_away_win)}"
                   class:best={pctNum(m.p_qualify_away_win) === best}
                 >
-                  <span class="out-label">If {m.away_code} win</span>
+                  <span class="out-label">If {m.away_name} win</span>
                   <span class="out-num">{pct(m.p_qualify_away_win)}</span>
                   {#if deltaAbs(m.p_qualify_away_win) > 0}
                     <span class="out-delta"


### PR DESCRIPTION
Last of four per-surface PRs from the accepted public-copy review. Covers the /app/* pages: findings A1-A34.

Copy: internal vocabulary translated (MMSI glossed inline, "clear-dark hrs" spelled out, self-host/cloud "lens" coinages replaced, the `python3 -m bench` maintainer command removed), empty and error states name a recovery that actually works, the notes HUD keeps its instrument look with readable labels, and the leaderboard lede loses its five bold spans.

Bugs fixed in the same pass: the wc2026 explainer hardcoded Scotland on a country-selectable page (A1); stars suggested "try another month" on an error where no month could have data (A4); hikes had no zero-results state, just a blank map (A5); two notes links pointed at the internal /public/app/notes path (A22).

Senior read caught two dispatch drifts before commit: the "Best third-place spot" UI label pasted into the explainer's running prose, and the campsites score note dropped into the legend without naming what it scores.

`ci test`: Executed 2 out of 705 tests, 705 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)