### PR TITLE
fix(platform): make Kargo actually promote, and survive a cold install

### DIFF
--- a/projects/platform/kargo/templates/monolith-dev-promotion.yaml
+++ b/projects/platform/kargo/templates/monolith-dev-promotion.yaml
@@ -20,6 +20,44 @@ apiVersion: kargo.akuity.io/v1alpha1
 kind: Project
 metadata:
   name: {{ .Values.devPromotion.project }}
+  annotations:
+    # Wave 0: this Project CREATES the namespace the Warehouse and Stage live
+    # in, so it must be admitted before they are applied. Without waves ArgoCD
+    # applies all three in one pass and the other two fail with
+    # `namespaces "kargo-monolith" not found`, which is what happened on the
+    # first install.
+    argocd.argoproj.io/sync-wave: "0"
+
+---
+{{- /*
+AUTO-PROMOTION. Without this the Warehouse discovers Freight, the Stage reports
+"Stage has no current Freight", and NOTHING promotes: autoPromotionEnabled
+defaults to false, so a fresh install looks fully wired and silently does
+nothing. That is exactly what the first install did.
+
+It lives on ProjectConfig, not Project: in Kargo 1.9 the Project spec is empty
+and promotionPolicies moved here.
+
+stageSelector rather than the `stage` field, which the CRD marks deprecated.
+The selector takes a name directly, so this needs no labels on the Stage.
+
+Auto-promotion is right for THIS stage specifically: the schema notes it is
+"commonly set to true for Stages that subscribe to Warehouses instead of other,
+upstream Stages". Dev subscribes to a Warehouse and has no upstream to gate on.
+A production stage would not want this.
+*/}}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: {{ .Values.devPromotion.project }}
+  namespace: {{ .Values.devPromotion.project }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  promotionPolicies:
+    - stageSelector:
+        name: dev
+      autoPromotionEnabled: true
 ---
 {{- /*
 Subscribes to the chart repository, not to images. Images are already pinned by
@@ -32,6 +70,12 @@ repoURL alone (no chart name field), unlike Helm which wants both.
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Warehouse
 metadata:
+  annotations:
+    # Wave 1: after the Project's namespace exists. Namespace creation is
+    # asynchronous (Kargo's management controller does it once the Project is
+    # admitted), so ArgoCD may still need one retry here. The wave removes the
+    # guaranteed failure; the retry covers the remaining race.
+    argocd.argoproj.io/sync-wave: "1"
   name: monolith-chart
   namespace: {{ .Values.devPromotion.project }}
 spec:
@@ -66,6 +110,12 @@ is not in this repo.
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
+  annotations:
+    # Wave 1: after the Project's namespace exists. Namespace creation is
+    # asynchronous (Kargo's management controller does it once the Project is
+    # admitted), so ArgoCD may still need one retry here. The wave removes the
+    # guaranteed failure; the retry covers the remaining race.
+    argocd.argoproj.io/sync-wave: "1"
   name: dev
   namespace: {{ .Values.devPromotion.project }}
 spec:


### PR DESCRIPTION
Two defects, both of which leave Kargo looking fully wired while doing nothing.

## 1. Nothing would ever promote

`autoPromotionEnabled` **defaults to false**. Without it the Project exists, the
Warehouse discovers Freight, the Stage reports `Fulfilled`, the controller runs
clean, and **no promotion ever happens**.

Observed live: Freight found chart `0.293.5` while dev stayed pinned at
`0.293.0` — the exact bug Kargo was built to fix, now with a controller in front
of it making it look solved.

It lives on **`ProjectConfig`**, not `Project`: in Kargo 1.9 the Project spec is
empty and `promotionPolicies` moved. Uses `stageSelector` (which takes a name
directly) rather than the `stage` field the CRD marks deprecated.

Auto-promotion is correct for *this* stage specifically. The schema notes it is
"commonly set to true for Stages that subscribe to Warehouses instead of other,
upstream Stages" — dev subscribes to a Warehouse and has no upstream to gate on.
A production stage would not want it.

## 2. A cold install fails, then partially recovers

Worse than failing outright, because it looks self-healing when it is
order-dependent.

ArgoCD applies in one pass. The `Project` **creates** the namespace its
`Warehouse` and `Stage` live in:

```
one or more objects failed to apply, reason: namespaces "kargo-monolith" not found
```

Compounded on a cold cluster by Kargo's admission webhook, served by a pod from
**this same Application**, so there is a window where the CRD exists, the webhook
is registered, and nothing is listening:

```
failed calling webhook "project.kargo.akuity.io": failed to call webhook
```

Retries produced the Project and Warehouse. After four attempts the **Stage was
still missing**, so nothing could promote even had (1) been fixed.

| Resource | Wave |
| --- | --- |
| `Project` | 0 |
| `ProjectConfig`, `Warehouse`, `Stage` | 1 |

Namespace creation is asynchronous, so one retry may still be needed. The wave
removes the guaranteed ordering bug; the retry covers the remaining race.

## Why both were invisible

Every component reported success for its own step. The app was `Healthy`, pods
`Running`, Freight discovered. Only the **effect** disagreed: `targetRevision`
did not move. Same discipline as judging a test run by `Executed N out of M`
rather than its exit code.