### PR TITLE
fix(monolith): resolve wc2026 swing team names through the code map

### DIFF
--- a/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
@@ -541,8 +541,9 @@
               <div class="swing-head">
                 <span class="fixture">
                   <span class="rank">{String(i + 1).padStart(2, "0")}</span>
-                  {m.home_name} <span class="v">v</span>
-                  {m.away_name}
+                  {codeToName[m.home_code] ?? m.home_code}
+                  <span class="v">v</span>
+                  {codeToName[m.away_code] ?? m.away_code}
                   {#if m.is_own_match}
                     <span class="badge own">{countryName}</span>
                   {/if}
@@ -581,7 +582,9 @@
                   class="out {deltaClass(m.p_qualify_home_win)}"
                   class:best={pctNum(m.p_qualify_home_win) === best}
                 >
-                  <span class="out-label">If {m.home_name} win</span>
+                  <span class="out-label"
+                    >If {codeToName[m.home_code] ?? m.home_code} win</span
+                  >
                   <span class="out-num">{pct(m.p_qualify_home_win)}</span>
                   {#if deltaAbs(m.p_qualify_home_win) > 0}
                     <span class="out-delta"
@@ -609,7 +612,9 @@
                   class="out {deltaClass(m.p_qualify_away_win)}"
                   class:best={pctNum(m.p_qualify_away_win) === best}
                 >
-                  <span class="out-label">If {m.away_name} win</span>
+                  <span class="out-label"
+                    >If {codeToName[m.away_code] ?? m.away_code} win</span
+                  >
                   <span class="out-num">{pct(m.p_qualify_away_win)}</span>
                   {#if deltaAbs(m.p_qualify_away_win) > 0}
                     <span class="out-delta"


### PR DESCRIPTION
Hotfix for a regression PR #4734 shipped: the swing cards were switched from `m.home_code` to `m.home_name`, a field the swings API never emits (`_serialize_swing` sends codes only), so "Matches that could change it" rendered blank team names in production. The cards now resolve codes through the existing `codeToName` map with the raw code as fallback, which also delivers the full-name display A14 wanted.

Found by the post-deploy verification review. Remaining (non-breaking) verification findings land separately.

`ci test`: Executed 2 out of 707 tests, 707 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)