### PR TITLE
fix(monolith): authorize Kargo to promote the dev Application

### DIFF
--- a/projects/monolith/dev/deploy/application.yaml
+++ b/projects/monolith/dev/deploy/application.yaml
@@ -3,6 +3,20 @@ kind: Application
 metadata:
   name: monolith-dev
   namespace: argocd
+  annotations:
+    # Kargo will not touch an Application that has not opted in. Without this
+    # the promotion fails with:
+    #
+    #   Argo CD Application "monolith-dev" in namespace "argocd" is not authorized
+    #
+    # That is a deliberate guard, not an obstacle: it means installing Kargo
+    # cannot silently give it write access to every Application in the cluster,
+    # and production's Application is protected by simply never carrying this.
+    #
+    # Format is <kargo project>:<stage>. The project is kargo-monolith rather
+    # than monolith because a Kargo Project OWNS a namespace of its own name and
+    # both monolith and monolith-dev already exist.
+    kargo.akuity.io/authorized-stage: kargo-monolith:dev
 spec:
   project: default
   sources:


### PR DESCRIPTION
The first promotion fired and errored:

```
Argo CD Application "monolith-dev" in namespace "argocd" is not authorized
```

Kargo will not touch an Application that has not **opted in**. That is a
deliberate guard rather than an obstacle: installing Kargo cannot silently hand
it write access to every Application in the cluster, and **production's
Application is protected by simply never carrying this annotation**.

```yaml
kargo.akuity.io/authorized-stage: kargo-monolith:dev
```

The project is `kargo-monolith`, not `monolith`, because a Kargo Project **owns a
namespace of its own name** and both `monolith` and `monolith-dev` already exist
with live workloads.

## Everything upstream is verified working

| | |
| --- | --- |
| Controller | 4 pods running, 9 CRDs |
| Warehouse | discovered 3 Freight: `0.293.5`, `0.294.0`, `0.294.1` |
| Auto-promotion | enabled via `ProjectConfig` |
| Promotion | created, reached its `argocd-update` step |
| Failure point | the authorization check — **the correct place to fail** |

This is the last piece. `dev` is pinned at `0.293.0` with `0.294.1` available, so
there is a real promotion waiting.

## Verification after merge

Not "the Promotion succeeded":

```sh
kubectl get application monolith-dev -n argocd -o jsonpath='{.spec.sources[0].targetRevision}'
```

must move off `0.293.0` **and still be moved a few minutes later** — the second
check is what proves the `canada` ignoreDifferences exception is holding, since
without it the promotion succeeds and is silently reverted.