### PR TITLE
feat(monolith): turn on Postgres backups, and keep dev out of the catalogue

### DIFF
--- a/projects/monolith/chart/chart_env_identity_test.py
+++ b/projects/monolith/chart/chart_env_identity_test.py
@@ -134,6 +134,23 @@ def _docs(rendered: str):
             yield kind.group(1), name.group(1), doc
 
 
+_DESTINATION = re.compile(r"^\s*destinationPath:\s*(\S+)\s*$", re.M)
+
+
+def _write_forced_backup() -> Path:
+    """Values that force backups on, to prove the collision is real.
+
+    Used only by the positive control in
+    test_dev_does_not_write_to_productions_backup_store.
+    """
+    path = Path(tempfile.gettempdir()) / "monolith_forced_backup.yaml"
+    path.write_text("postgres:\n  backup:\n    enabled: true\n")
+    return path
+
+
+_FORCED_BACKUP = _write_forced_backup()
+
+
 _RELEASE_NAME = re.compile(r"^\s*releaseName:\s*(\S+)\s*$", re.M)
 
 
@@ -346,4 +363,64 @@ def test_refresh_job_does_not_run_the_extension_image(renders):
         f"the refresh job runs {ext.group(1)}, the declarative extension image. "
         "That artifact has no shell and the workflow cannot start. Use a "
         "postgres RUNTIME image carrying pg_dump, pg_restore and psql."
+    )
+
+
+def test_dev_does_not_write_to_productions_backup_store(renders):
+    """The backup destination is an identity too, and a destructive one.
+
+    postgres.backup.destinationPath is a fixed string in the chart's values
+    (s3://monolith-pg-backups/monolith-pg), not derived from the release. So
+    inheriting `enabled: true` does not give dev its own catalogue, it aims dev
+    at production's: two CNPG clusters writing one barman object store, where
+    dev's retentionPolicy prunes production's base backups and WALs. The
+    mechanism protecting production's data becomes the one deleting it, and
+    nothing errors at render time.
+
+    Same shape as the CronWorkflow case: a name that reads descriptive and is
+    already somebody's identity.
+    """
+
+    def destinations(env):
+        return {m.strip("\"'") for m in _DESTINATION.findall(renders[env])}
+
+    prod_dest = destinations("prod")
+    dev_dest = destinations("dev")
+
+    shared = prod_dest & dev_dest
+    assert not shared, (
+        f"dev and production both back up to {sorted(shared)}. One barman "
+        "catalogue with two clusters writing it: dev's retentionPolicy prunes "
+        "production's backups. Keep postgres.backup.enabled false in dev's "
+        "overlay, or give dev a release-scoped destinationPath."
+    )
+    # Guard the guard. Disjointness is vacuous if production stopped rendering a
+    # backup destination, which is exactly the state #4714 was filed about: the
+    # whole block sat behind `enabled: false` and every render was empty.
+    assert prod_dest, (
+        "production renders no backup destinationPath, so it has no backups at "
+        "all and this comparison proves nothing. Check "
+        "postgres.backup.enabled in projects/monolith/deploy/values.yaml."
+    )
+
+    # Positive control: dev is safe only because its overlay says so. Force
+    # backups on for dev and it lands on production's exact path. If this ever
+    # stops holding, the path became release-scoped and the assertion above can
+    # be relaxed; until then it is the only thing standing between the two.
+    chart = _chart_dir()
+    forced_dev = _render(
+        _release_name(Path(os.environ["DEV_APPLICATION"])),
+        [
+            chart / "values.yaml",
+            Path(os.environ["DEPLOY_VALUES"]),
+            Path(os.environ["DEV_VALUES"]),
+            _FORCED_BACKUP,
+        ],
+    )
+    forced_dest = {m.strip("\"'") for m in _DESTINATION.findall(forced_dev)}
+    assert forced_dest & prod_dest, (
+        "forcing backups on for dev no longer collides with production "
+        f"({sorted(forced_dest)} vs {sorted(prod_dest)}), so this test is no "
+        "longer guarding a live hazard. Either the path became release-scoped "
+        "(good, say so here) or the render broke."
     )

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -43,6 +43,21 @@ postgres:
     enabled: true
   storage:
     size: 50Gi
+  # Barman base backups plus continuous WAL archiving to the SeaweedFS object
+  # store. Written into the chart months ago and left inert, so production has
+  # never had a working backup (#4714). Enabled here rather than in the chart so
+  # a bare `helm template` still writes to nobody's S3.
+  #
+  # The monolith-pg-backups bucket was pre-created out of band and must stay
+  # that way: letting the SeaweedFS chart's bucket hook create it flips the
+  # whole cluster's S3 to auth-enforced.
+  #
+  # Scope, so nobody mistakes this for DR: SeaweedFS is backed by the same
+  # Longhorn layer as the Postgres PVCs, so this covers logical loss (a bad
+  # migration, a dropped table, corruption of the Pg volumes) and NOT the loss
+  # of the cluster. Off-cluster DR is a separate follow-up.
+  backup:
+    enabled: true
 
 onepassword:
   enabled: true

--- a/projects/monolith/dev/deploy/values.yaml
+++ b/projects/monolith/dev/deploy/values.yaml
@@ -71,6 +71,18 @@ postgres:
   # Applications would fight over it on every sync.
   devRefresh:
     enabled: false
+  # Production owns the backups and dev must NOT take them. destinationPath is a
+  # fixed string in the chart's values (s3://monolith-pg-backups/monolith-pg),
+  # not derived from the release, so an inherited `true` would aim dev's
+  # monolith-dev-pg at production's barman catalogue: two clusters writing one
+  # object store, with dev's 14 day retention pruning production's base backups
+  # and WALs. The thing meant to protect production's data would be the thing
+  # deleting it.
+  #
+  # Dev is reseeded from production nightly, so it holds nothing a backup would
+  # protect. chart_env_identity_test asserts the two never share a destination.
+  backup:
+    enabled: false
 
 # The WhatsApp bridge holds a REAL external identity: it starts with
 # bot_number +12369923104, the production account, and a second bridge would


### PR DESCRIPTION
Closes the zero-backup gap on production Postgres (#4714). The database is
1545 MB and has never been successfully backed up.

## Why this was only a flag flip

The whole barman configuration was already written and inert. The issue listed
one blocking prerequisite: the `monolith-pg-backups` bucket must exist,
pre-created out of band, because letting the SeaweedFS chart's bucket hook run
flips the entire cluster's S3 to auth-enforced.

It already exists:

```
$ weed shell -c s3.bucket.list
  monolith-pg-backups	size:0	chunk:0
```

So the prerequisite is met and the hook stays untouched.

## The trap this PR is mostly about

Enabling it in `projects/monolith/deploy/values.yaml` alone would have been
actively destructive. The dev Application layers its overlay **on top of**
production's values file:

```yaml
valueFiles:
  - $values/projects/monolith/deploy/values.yaml
  - $values/projects/monolith/dev/deploy/values.yaml
```

and `destinationPath` is a fixed string, not release-derived:

```
s3://monolith-pg-backups/monolith-pg
```

So dev's `monolith-dev-pg` would have inherited `enabled: true` and written to
production's catalogue. Two CNPG clusters sharing one barman object store,
where dev's 14 day `retentionPolicy` prunes production's base backups and
WALs. The mechanism added to protect the data would be the one deleting it,
and it renders perfectly.

Dev therefore sets `postgres.backup.enabled: false` explicitly, and
`chart_env_identity_test` gains a guard with a positive control: it forces
backups on for dev and asserts that this lands on production's exact path, so
the test proves the hazard is live rather than passing on an empty set.
Deleting dev's override fails it by name:

```
AssertionError: dev and production both back up to
['s3://monolith-pg-backups/monolith-pg']. One barman catalogue with two
clusters writing it: dev's retentionPolicy prunes production's backups.
```

## What this is and is not

It covers **logical** loss: a bad migration, a dropped table, corruption of the
Postgres volumes. Backups land in SeaweedFS, a different volume set.

It is **not** DR. SeaweedFS is backed by the same Longhorn layer as the
Postgres PVCs, so losing the cluster loses both. Off-cluster DR stays a
separate follow-up, and the values comment says so in place rather than
leaving a reader to infer it.

## Security, stated rather than buried

SeaweedFS S3 currently has no identities configured at all:

```
$ weed shell -c "s3.configure -apply=false"
{ "identities": [], "accounts": [] }
```

and there is no NetworkPolicy in the `seaweedfs` namespace. So this puts a
complete production database, compressed but not encrypted, into a bucket any
pod that can route to the S3 gateway can read. That is a real new exposure and
it belongs to #4708 (default object store is anonymous, no SigV4), which this
does not fix. It is still the right trade: no backup at all is worse than a
readable one, and the alternative is leaving the database unrecoverable while
waiting for auth work.

## Rollout

Values-only, and the values source is `targetRevision: HEAD`, so this reaches
the cluster on merge with no chart version involved.

No Postgres restart: `archive_mode` is already `on` with CNPG's no-op
`/controller/manager wal-archive`, so enabling `spec.backup` changes what that
command does internally, not the server config. Verified on the live primary.

Capacity is not a question: 1545 MB database, gzip-compressed, 14 day
retention, against 1004 GB free on the node4b volume server.

## Verification, and what stays open

`Executed 3 out of 707 tests: 707 tests pass` locally, the 3 being the targets
whose inputs changed.

Merging this is not the same as having backups, so #4714 stays open until:

1. WAL archiving is confirmed running, objects appearing under the destination
   path within roughly 5 minutes (`archive_timeout` is 300s).
2. A `Backup` object reaches phase `completed`. The `ScheduledBackup` fires at
   02:00 UTC daily and carries no `immediate: true`, so the first base backup
   is tonight, not on merge.

Until step 2 there is a WAL stream with no base backup to replay onto, which is
not yet a recovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39