### PR TITLE
fix(monolith): correct why dev must not take backups

### DIFF
--- a/projects/monolith/chart/chart_env_identity_test.py
+++ b/projects/monolith/chart/chart_env_identity_test.py
@@ -366,47 +366,59 @@ def test_refresh_job_does_not_run_the_extension_image(renders):
     )
 
 
-def test_dev_does_not_write_to_productions_backup_store(renders):
-    """The backup destination is an identity too, and a destructive one.
+def test_dev_takes_no_backups(renders):
+    """Dev must take no backups, and its silence must be dev's doing.
 
-    postgres.backup.destinationPath is a fixed string in the chart's values
-    (s3://monolith-pg-backups/monolith-pg), not derived from the release. So
-    inheriting `enabled: true` does not give dev its own catalogue, it aims dev
-    at production's: two CNPG clusters writing one barman object store, where
-    dev's retentionPolicy prunes production's base backups and WALs. The
-    mechanism protecting production's data becomes the one deleting it, and
-    nothing errors at render time.
+    This shipped asserting something stronger and wrong: that the two
+    environments must never share a `destinationPath`, because a shared path
+    meant a shared barman catalogue and dev's 14 day retentionPolicy would
+    prune production's base backups and WALs.
 
-    Same shape as the CronWorkflow case: a name that reads descriptive and is
-    already somebody's identity.
+    The CRD refutes it in one line:
+
+        serverName: The server name on S3, the cluster name is used if this
+                    parameter is omitted
+
+    barman namespaces each cluster under the destination by serverName, so
+    production writes to <destinationPath>/monolith-pg/ and dev would have
+    written to <destinationPath>/monolith-dev-pg/. Separate catalogues,
+    separate retention, no cross-pruning. Visible in the live bucket, whose
+    real layout is /buckets/monolith-pg-backups/monolith-pg/monolith-pg/wals/,
+    the doubled segment being exactly that defaulted serverName.
+
+    What remains is smaller and still worth a guard. Dev is reseeded from
+    production nightly, so backing dev up stores a SECOND copy of production's
+    rows: roughly 1.5 GB of base backup a day, held 14 days, in a bucket with
+    no S3 identities configured and no NetworkPolicy in front of it (#4708).
+    Waste, and the same rows exposed twice.
+
+    So the invariant is just that dev takes no backups, plus a control proving
+    that is because of dev's override and not because the chart's barman
+    templates went away.
     """
 
     def destinations(env):
         return {m.strip("\"'") for m in _DESTINATION.findall(renders[env])}
 
-    prod_dest = destinations("prod")
     dev_dest = destinations("dev")
-
-    shared = prod_dest & dev_dest
-    assert not shared, (
-        f"dev and production both back up to {sorted(shared)}. One barman "
-        "catalogue with two clusters writing it: dev's retentionPolicy prunes "
-        "production's backups. Keep postgres.backup.enabled false in dev's "
-        "overlay, or give dev a release-scoped destinationPath."
+    assert not dev_dest, (
+        f"dev renders a backup object store ({sorted(dev_dest)}). Dev is a "
+        "nightly copy of production, so this stores production's rows a second "
+        "time in a bucket with no S3 auth in front of it (#4708). Keep "
+        "postgres.backup.enabled false in dev's overlay."
     )
-    # Guard the guard. Disjointness is vacuous if production stopped rendering a
-    # backup destination, which is exactly the state #4714 was filed about: the
-    # whole block sat behind `enabled: false` and every render was empty.
+
+    prod_dest = destinations("prod")
     assert prod_dest, (
         "production renders no backup destinationPath, so it has no backups at "
-        "all and this comparison proves nothing. Check "
-        "postgres.backup.enabled in projects/monolith/deploy/values.yaml."
+        "all and dev's emptiness above proves nothing. That was precisely the "
+        "state #4714 was filed about: the whole barman block sat behind "
+        "`enabled: false` and every render was empty."
     )
 
-    # Positive control: dev is safe only because its overlay says so. Force
-    # backups on for dev and it lands on production's exact path. If this ever
-    # stops holding, the path became release-scoped and the assertion above can
-    # be relaxed; until then it is the only thing standing between the two.
+    # Control. Dev is quiet because its overlay says so, not because the chart
+    # lost its backup templates. Without this, deleting the barman block from
+    # the chart entirely would leave this test green.
     chart = _chart_dir()
     forced_dev = _render(
         _release_name(Path(os.environ["DEV_APPLICATION"])),
@@ -417,10 +429,9 @@ def test_dev_does_not_write_to_productions_backup_store(renders):
             _FORCED_BACKUP,
         ],
     )
-    forced_dest = {m.strip("\"'") for m in _DESTINATION.findall(forced_dev)}
-    assert forced_dest & prod_dest, (
-        "forcing backups on for dev no longer collides with production "
-        f"({sorted(forced_dest)} vs {sorted(prod_dest)}), so this test is no "
-        "longer guarding a live hazard. Either the path became release-scoped "
-        "(good, say so here) or the render broke."
+    assert _DESTINATION.findall(forced_dev), (
+        "forcing postgres.backup.enabled=true renders dev no object store, so "
+        "dev's override is not what is keeping it quiet and the assertion "
+        "above passes for the wrong reason. Check the chart still has the "
+        "barman templates."
     )

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -52,6 +52,11 @@ postgres:
   # that way: letting the SeaweedFS chart's bucket hook create it flips the
   # whole cluster's S3 to auth-enforced.
   #
+  # The path in the bucket looks doubled and is not a typo. barman appends
+  # serverName, which defaults to the cluster name, so objects land under
+  # s3://monolith-pg-backups/monolith-pg/monolith-pg/wals/. destinationPath is
+  # a root that several clusters could share, not a path to one catalogue.
+  #
   # Scope, so nobody mistakes this for DR: SeaweedFS is backed by the same
   # Longhorn layer as the Postgres PVCs, so this covers logical loss (a bad
   # migration, a dropped table, corruption of the Pg volumes) and NOT the loss

--- a/projects/monolith/dev/deploy/values.yaml
+++ b/projects/monolith/dev/deploy/values.yaml
@@ -71,16 +71,20 @@ postgres:
   # Applications would fight over it on every sync.
   devRefresh:
     enabled: false
-  # Production owns the backups and dev must NOT take them. destinationPath is a
-  # fixed string in the chart's values (s3://monolith-pg-backups/monolith-pg),
-  # not derived from the release, so an inherited `true` would aim dev's
-  # monolith-dev-pg at production's barman catalogue: two clusters writing one
-  # object store, with dev's 14 day retention pruning production's base backups
-  # and WALs. The thing meant to protect production's data would be the thing
-  # deleting it.
+  # Dev takes no backups. Inherited as true from production's values otherwise,
+  # and nothing would error.
   #
-  # Dev is reseeded from production nightly, so it holds nothing a backup would
-  # protect. chart_env_identity_test asserts the two never share a destination.
+  # Not a correctness problem, despite an earlier version of this comment
+  # claiming dev's retention would prune production's backups. barman
+  # namespaces each cluster under destinationPath by serverName, which defaults
+  # to the cluster name, so dev would write to .../monolith-dev-pg/ rather than
+  # into production's catalogue.
+  #
+  # It is a waste and an exposure problem. Dev is reseeded from production
+  # nightly, so this would store a second copy of production's rows: roughly
+  # 1.5 GB of base backup a day, held 14 days, in a bucket with no S3
+  # identities configured and no NetworkPolicy in front of it (#4708).
+  # chart_env_identity_test asserts dev renders no object store.
   backup:
     enabled: false
 


### PR DESCRIPTION
#4740 landed the right change with the wrong reason. Comments and a test
docstring only, no behaviour change.

## The wrong claim

#4740 argued that dev inheriting `postgres.backup.enabled: true` would aim it
at production's barman catalogue, and that dev's 14 day `retentionPolicy`
would prune production's base backups and WALs.

The CRD refutes it in one line:

```
serverName: The server name on S3, the cluster name is used if this parameter is omitted
```

barman namespaces each cluster under the destination by `serverName`, so
production writes to `<destinationPath>/monolith-pg/` and dev would have
written to `<destinationPath>/monolith-dev-pg/`. Separate catalogues, separate
retention, no cross-pruning.

The live bucket shows the same thing, and the doubled segment is the defaulted
`serverName` rather than a typo:

```
/buckets/monolith-pg-backups/monolith-pg/monolith-pg/wals/00000003000000C7/
```

I read `destinationPath` as a path to a catalogue because of its name, instead
of reading the field description, which was one `kubectl get crd` away.

## What is actually true

Dev's override is still correct, for a smaller reason. Dev is reseeded from
production nightly, so backing it up stores a second copy of production's rows:
roughly 1.5 GB of base backup a day, held 14 days, in a bucket with no S3
identities configured and no NetworkPolicy in front of it (#4708). Waste, and
the same rows exposed twice.

## Changes

- `test_dev_does_not_write_to_productions_backup_store` becomes
  `test_dev_takes_no_backups`, which is what it asserts.
- The `destinationPath` disjointness assertion is **dropped**. Sharing a root
  is not a hazard, and asserting it would block a legitimate shared-bucket
  layout later (see the note on #4741, where one `s3://pg-backups/` root
  serving every cluster is now the obvious shape).
- The control is kept but re-aimed: forcing backups on for dev must render an
  object store, proving dev's silence comes from its override rather than from
  the chart having lost its barman templates. Without it, deleting the barman
  block from the chart entirely would leave the test green.
- Production's values comment gains a line explaining the doubled path, which
  otherwise reads as a bug to anyone looking in the bucket.

## Verification

Both assertions mutation-tested rather than trusted:

```
mutant 1, dev override deleted:
  AssertionError: dev renders a backup object store
  (['s3://monolith-pg-backups/monolith-pg']).

mutant 2, production backups turned back off:
  AssertionError: production renders no backup destinationPath, so it has no
  backups at all and dev's emptiness above proves nothing.
```

`Executed 3 out of 707 tests: 707 tests pass`, and the six CI format guards
pass locally.

## Unrelated but worth recording

On CNPG 1.30 neither status signal is usable for verifying archiving.
`ContinuousArchiving=True` on `monolith-pg` has a `lastTransitionTime` of
2026-07-21, three weeks before backups were enabled, because the no-op archiver
set it and nothing has transitioned it since. `lastSuccessfulArchiveTime` is
not populated at all. The object store is the only ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39