### PR TITLE
fix(monolith): date a cd health fault from the health transition, not the sync

### DIFF
--- a/projects/monolith/cluster/cd_health.py
+++ b/projects/monolith/cluster/cd_health.py
@@ -14,6 +14,12 @@ component holds no state and needs no prober or latch table:
    Covers the unreachable-chart case above, a failed sync, and a degraded
    workload, without needing registry credentials: an app pinned to a chart
    that was never published does not reach Synced.
+
+   The two faults are dated from different clocks, which took an incident to
+   get right. A degraded app is dated by ``.status.health``'s
+   lastTransitionTime; a merely OutOfSync one by the last sync operation,
+   because ``.status.sync`` carries no transition time. Dating a health fault
+   from the last SYNC meant a settled app got no grace at all.
 2. main's CI: the most recent commit WITH A COMPLETED STATUS is red and older
    than the red window, or there were commits inside that window and none of
    them completed at all.
@@ -118,13 +124,31 @@ async def _argocd_fault_real(
     for app in apps:
         if app.get("sync") == "Synced" and app.get("health") == "Healthy":
             continue
-        finished = _parse_ts(app.get("finished_at"))
-        # No finish time means we cannot date the fault. Treat it as in-flight
-        # rather than page: a genuinely stuck app acquires one on its next
-        # attempt, and guessing here would page on every fresh rollout.
-        if finished is None:
+        # Date the fault by whatever actually went wrong, because the two
+        # faults have different clocks.
+        #
+        # A degraded app is dated by its health transition. Using the last SYNC
+        # time here was a defect: embervm last synced 622 minutes before it went
+        # Progressing, so the 15 minute grace was not shortened, it was skipped,
+        # and jomcgi.dev/health 503'd on the first bad tick. The inversion is
+        # the tell, since a settled app has the stalest finished_at and so got
+        # the least grace, which is backwards.
+        #
+        # A merely OutOfSync app has no transition time of its own
+        # (`.status.sync` carries none), so the last sync attempt stands. That
+        # is a weaker signal in the other direction, since an app that retries
+        # forever keeps refreshing it, which is #4727 and not fixed here.
+        if app.get("health") != "Healthy":
+            since = _parse_ts(app.get("health_changed_at"))
+        else:
+            since = _parse_ts(app.get("finished_at"))
+        # Undateable means in-flight rather than page. A genuinely stuck app
+        # acquires a timestamp on its next transition, and guessing here would
+        # page on every fresh rollout. Deliberately NOT falling back to
+        # finished_at for a health fault: that fallback IS the bug above.
+        if since is None:
             continue
-        age_s = (now - finished).total_seconds()
+        age_s = (now - since).total_seconds()
         if age_s > grace_s:
             line = (
                 f"{app['name']} is {app.get('sync')}/{app.get('health')} "

--- a/projects/monolith/cluster/cd_health_test.py
+++ b/projects/monolith/cluster/cd_health_test.py
@@ -57,6 +57,7 @@ async def test_app_mid_rollout_inside_grace_does_not_trip():
             "sync": "Synced",
             "health": "Progressing",
             "finished_at": recent,
+            "health_changed_at": recent,
         }
     ]
     assert (await mod._argocd_fault_real(apps, 900.0))[0] is None
@@ -75,6 +76,101 @@ async def test_app_with_no_finish_time_does_not_trip():
             "sync": "OutOfSync",
             "health": "Missing",
             "finished_at": None,
+            "health_changed_at": None,
+        }
+    ]
+    assert (await mod._argocd_fault_real(apps, 900.0))[0] is None
+
+
+@pytest.mark.asyncio
+async def test_a_settled_app_going_unhealthy_gets_its_full_grace():
+    """The defect that 503'd jomcgi.dev, in its exact shape.
+
+    embervm had been Synced and untouched since 07:36. When a brick could not
+    be scheduled it went Progressing, and the check dated that fault from the
+    last SYNC, computed 622 minutes, and blew past a 15 minute grace on the
+    first bad tick.
+
+    The inversion is what makes it worth a test rather than a comment: the more
+    settled an app is, the staler its finished_at, so the LESS grace it got.
+    A healthy deployment history actively reduced the protection.
+    """
+    apps = [
+        {
+            "name": "embervm",
+            "sync": "Synced",
+            "health": "Progressing",
+            "finished_at": _iso(datetime.now(timezone.utc) - timedelta(minutes=622)),
+            "health_changed_at": _iso(
+                datetime.now(timezone.utc) - timedelta(minutes=2)
+            ),
+        }
+    ]
+    assert (await mod._argocd_fault_real(apps, 900.0))[0] is None
+
+
+@pytest.mark.asyncio
+async def test_a_genuinely_stuck_app_still_trips_and_reports_the_right_age():
+    """The other half: the grace must still expire, and say so honestly.
+
+    Asserting the minutes matters. The old message read "for 622m" while the
+    app had been unhealthy for two, so the number was not merely early, it
+    described a different event.
+    """
+    apps = [
+        {
+            "name": "embervm",
+            "sync": "Synced",
+            "health": "Progressing",
+            "finished_at": _iso(datetime.now(timezone.utc) - timedelta(minutes=622)),
+            "health_changed_at": _iso(
+                datetime.now(timezone.utc) - timedelta(minutes=40)
+            ),
+        }
+    ]
+    fault, _note = await mod._argocd_fault_real(apps, 900.0)
+    assert fault is not None
+    assert "embervm is Synced/Progressing for 40m" in fault, fault
+
+
+@pytest.mark.asyncio
+async def test_outofsync_but_healthy_is_still_dated_from_the_last_sync():
+    """Unchanged, and deliberately so.
+
+    `.status.sync` carries no transition time, so the last sync attempt is the
+    only clock available. That is a weaker signal in the opposite direction,
+    since an app retrying forever keeps refreshing it (#4727), which this
+    change does not attempt to fix.
+    """
+    apps = [
+        {
+            "name": "kyverno",
+            "sync": "OutOfSync",
+            "health": "Healthy",
+            "finished_at": _iso(datetime.now(timezone.utc) - timedelta(minutes=40)),
+            "health_changed_at": _iso(datetime.now(timezone.utc) - timedelta(days=3)),
+        }
+    ]
+    fault, _note = await mod._argocd_fault_real(apps, 900.0)
+    assert fault is not None
+    assert "kyverno is OutOfSync/Healthy for 40m" in fault, fault
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_app_with_no_health_transition_does_not_trip():
+    """No fallback to finished_at, because that fallback IS the bug.
+
+    ArgoCD always stamps health.lastTransitionTime, so this is defensive. If it
+    is ever missing the honest move is to treat the app as undateable rather
+    than reach for the timestamp that caused the incident.
+    """
+    apps = [
+        {
+            "name": "embervm",
+            "sync": "Synced",
+            "health": "Degraded",
+            "finished_at": _iso(datetime.now(timezone.utc) - timedelta(minutes=622)),
+            "health_changed_at": None,
         }
     ]
     assert (await mod._argocd_fault_real(apps, 900.0))[0] is None
@@ -233,6 +329,7 @@ async def test_non_prod_app_is_reported_but_does_not_fault():
             "sync": "Synced",
             "health": "Degraded",
             "finished_at": old,
+            "health_changed_at": old,
         }
     ]
     fault, note = await mod._argocd_fault_real(
@@ -261,6 +358,7 @@ async def test_production_still_faults_alongside_a_non_prod_note():
             "sync": "Synced",
             "health": "Degraded",
             "finished_at": old,
+            "health_changed_at": old,
         },
     ]
     fault, note = await mod._argocd_fault_real(

--- a/projects/monolith/cluster/kubernetes.py
+++ b/projects/monolith/cluster/kubernetes.py
@@ -120,12 +120,22 @@ class KubernetesClient:
         return len(result.get("items", []))
 
     async def list_argocd_app_health(self, namespace: str = "argocd") -> list[dict]:
-        """Return {name, sync, health, finished_at} for every ArgoCD Application.
+        """Return {name, sync, health, finished_at, health_changed_at} per app.
 
         One list call rather than N gets, because the cd health component reads
-        every app on each probe. `finished_at` is the last sync operation's
-        finish time, which is what dates a fault: an app that has been
-        not-Synced since a timestamp is distinguishable from one mid-rollout.
+        every app on each probe.
+
+        Two timestamps because the two faults are dated differently.
+        `finished_at` is the last sync operation's finish time, which is all
+        there is for a merely OutOfSync app: `.status.sync` carries no
+        transition time. `health_changed_at` is `.status.health`'s
+        lastTransitionTime, which is when the app's health ACTUALLY changed.
+
+        Reading finished_at for a health fault was a real defect: embervm last
+        synced 622 minutes before it went Progressing, so the 15 minute grace
+        was not shortened, it was skipped, and jomcgi.dev/health 503'd on the
+        first bad tick. The more settled an app is, the staler its finished_at,
+        so the less grace it got, which is exactly backwards.
         """
         api = await self._ensure_client()
         custom = client.CustomObjectsApi(api)
@@ -145,6 +155,9 @@ class KubernetesClient:
                     "health": (status.get("health") or {}).get("status"),
                     "finished_at": (status.get("operationState") or {}).get(
                         "finishedAt"
+                    ),
+                    "health_changed_at": (status.get("health") or {}).get(
+                        "lastTransitionTime"
                     ),
                 }
             )

--- a/projects/monolith/cluster/kubernetes_test.py
+++ b/projects/monolith/cluster/kubernetes_test.py
@@ -77,6 +77,62 @@ async def test_count_argocd_applications(k8s_client):
     assert count == 2
 
 
+@pytest.mark.asyncio
+async def test_list_argocd_app_health_reads_both_clocks(k8s_client):
+    """The extraction, which the cd_health judge tests cannot cover.
+
+    Those tests feed the judge a dict directly, so a wrong field name here
+    would leave every one of them green while the judge received None and
+    silently declined to page. The payload below is the real shape off a live
+    Application, including the nesting of lastTransitionTime UNDER health
+    rather than beside it, which is the part that is easy to get wrong.
+    """
+    mock_api = MagicMock()
+    mock_custom = MagicMock()
+    mock_custom.list_namespaced_custom_object = AsyncMock(
+        return_value={
+            "items": [
+                {
+                    "metadata": {"name": "embervm"},
+                    "status": {
+                        "sync": {"status": "Synced"},
+                        "health": {
+                            "status": "Progressing",
+                            "lastTransitionTime": "2026-08-12T17:55:00Z",
+                        },
+                        "operationState": {
+                            "finishedAt": "2026-08-12T07:36:24Z",
+                        },
+                    },
+                },
+                # An app ArgoCD has never synced: no operationState at all.
+                {
+                    "metadata": {"name": "fresh"},
+                    "status": {
+                        "sync": {"status": "OutOfSync"},
+                        "health": {"status": "Missing"},
+                    },
+                },
+            ]
+        }
+    )
+
+    with (
+        patch("cluster.kubernetes.config.load_incluster_config"),
+        patch("cluster.kubernetes.ApiClient", return_value=mock_api),
+        patch("cluster.kubernetes.client.CustomObjectsApi", return_value=mock_custom),
+    ):
+        apps = await k8s_client.list_argocd_app_health()
+
+    by_name = {a["name"]: a for a in apps}
+    assert by_name["embervm"]["health_changed_at"] == "2026-08-12T17:55:00Z"
+    assert by_name["embervm"]["finished_at"] == "2026-08-12T07:36:24Z", (
+        "both clocks must survive: the judge picks between them"
+    )
+    assert by_name["fresh"]["health_changed_at"] is None
+    assert by_name["fresh"]["finished_at"] is None
+
+
 def _node(name: str, allocatable: dict) -> MagicMock:
     node = MagicMock()
     node.metadata.name = name


### PR DESCRIPTION
## What happened

`jomcgi.dev/health` returned 503 tonight:

```
cd  ok=False  embervm is Synced/Progressing for 622m, down for 10m
```

`embervm` had been Progressing for about two minutes. The 622m was the age of
its last **sync** operation, `status.operationState.finishedAt`, which is the
timestamp the check used to date every fault.

The underlying cause was unrelated and has cleared on its own: fuzz Jobs were
submitted into `default`, where their ConfigMap does not exist, so six pods sat
in `Init:0/1` holding 2Gi each. Pods stuck in Init still hold their full
reservation, so 12Gi across three nodes became unavailable, node-2 hit 88% of
requestable memory, and an EmberVM 2Gi brick could not schedule. They were
resubmitted into `semgrekt`, where the ConfigMap exists, and are running fine.

This PR is about the reporting defect that turned ten minutes of internal
capacity pressure into a public 503.

## The defect

The 15 minute grace period is compared against that sync age, so **an app whose
last sync is older than the grace has no grace at all**. The first tick of
degraded health pages immediately.

The inversion is the part worth fixing rather than tuning: a settled app has the
stalest `finished_at` and therefore got the **least** protection. A clean
deployment history actively reduced the grace an app earned. `embervm` last
synced at 07:36, so by the evening it had none.

## The fix

ArgoCD already carries the right clock and it is on every Application:

```
$ kubectl get application embervm -n argocd -o jsonpath='{.status.health}'
{"lastTransitionTime":"2026-08-12T18:05:18Z","status":"Healthy"}
```

- Health faults are dated from `.status.health.lastTransitionTime`.
- Sync faults keep using the last sync operation, because `.status.sync`
  carries no transition time.

That leaves the opposite weakness on the sync side: an app retrying forever
keeps refreshing `finished_at` and never trips. That is #4727, deliberately not
touched here so this change stays reviewable.

There is **no fallback** to `finished_at` when `health_changed_at` is missing.
That fallback is the bug. An undateable app is treated as in-flight, which is
already what the check does when it cannot date a fault.

## Verification

Both halves mutation tested rather than assumed.

Reverting the judge reproduces the incident string exactly:

```
E  AssertionError: assert 'embervm is Synced/Progressing for 622m' is None
E  assert 'embervm is Synced/Progressing for 40m' in 'embervm is Synced/Progressing for 622m'
```

Pointing the extraction at the wrong parent object fails the new client test:

```
E  AssertionError: assert None == '2026-08-12T17:55:00Z'
```

That second test exists because the judge tests **structurally cannot** catch a
wrong field name: they feed `_argocd_fault_real` a dict directly, so a bad
extraction leaves all of them green while the judge receives `None` and quietly
declines to page. `list_argocd_app_health` had no test at all before this.

`Executed 216 out of 707 tests: 707 tests pass`, and the six CI format guards
pass locally.

## Rollout

Backend code, so it reaches the cluster on a chart publish and the post-merge
write-back rather than immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39