### PR TITLE
feat(platform): authenticate the Kargo UI with authentik, no new credential

### DIFF
--- a/projects/platform/authentik/blueprints/kargo-auth.yaml
+++ b/projects/platform/authentik/blueprints/kargo-auth.yaml
@@ -1,0 +1,120 @@
+version: 1
+metadata:
+  name: homelab - kargo promotion UI auth
+  labels:
+    blueprints.goauthentik.io/description: |
+      OAuth2 provider and application for the Kargo UI at
+      private.jomcgi.dev/app/kargo. Kargo runs the OIDC flow itself rather than
+      Envoy Gateway doing it, so unlike the dev and preview lanes there is no
+      SecurityPolicy involved and no client secret anywhere.
+entries:
+  # ── 1. The provider Kargo authenticates against ──────────────────────────
+  # PUBLIC, not confidential, and this is the whole reason this lane costs
+  # nothing to run. Kargo uses the Authorization Code flow with PKCE, which
+  # exists so browser apps that cannot hide a secret can still authenticate
+  # safely: the client proves possession of a one-time verifier instead of a
+  # static credential.
+  #
+  # So there is NO client_secret here, no `!Env` lookup, and no 1Password item.
+  # dev-auth.yaml needs all three because Envoy Gateway runs that flow as a
+  # confidential client; Kargo runs its own and does not.
+  #
+  # That also sidesteps the `!Env [KEY]` trap those lanes document: a
+  # one-element sequence raises IndexError inside authentik's tag constructor,
+  # which blueprints_find() does not catch, aborting discovery for the ENTIRE
+  # /blueprints tree including the other lanes. Nothing here uses !Env at all.
+  - model: authentik_providers_oauth2.oauth2provider
+    id: kargo-provider
+    identifiers:
+      name: kargo
+    attrs:
+      client_type: public
+      # Pinned rather than generated: it is not a secret (public clients have
+      # none) and projects/platform/kargo/values.yaml must name the same value.
+      client_id: kargo
+      # Both required when a provider is created from a blueprint. grant_types
+      # defaults to an EMPTY list on the model and both the authorize and token
+      # views reject anything absent from it, so omitting this yields a provider
+      # supporting no grant at all, failing on the first hop.
+      grant_types:
+        - authorization_code
+        - refresh_token
+      # Without a signing_key authentik falls back to HS256 signed with the
+      # client secret, and a public client has no secret to sign with. Kargo
+      # validates ID tokens against the JWKS endpoint, which would be empty.
+      # Invisible to a discovery check: .well-known still answers 200.
+      signing_key:
+        !Find [
+          authentik_crypto.certificatekeypair,
+          [name, authentik Self-signed Certificate],
+        ]
+      # Kargo's operator guide: for an IDP supporting OIDC and PKCE the UI
+      # callback is https://<api server hostname>/login. With
+      # api.basePath: /app/kargo the server's own base URL is
+      # https://private.jomcgi.dev/app/kargo, and the UI composes auth
+      # redirects through withBasePath(), so /login sits under the prefix.
+      #
+      # strict matching, so if Kargo turns out to redirect somewhere else this
+      # fails LOUDLY at the callback rather than silently accepting a URL
+      # nobody intended.
+      redirect_uris:
+        - matching_mode: strict
+          url: https://private.jomcgi.dev/app/kargo/login
+      authorization_flow:
+        !Find [
+          authentik_flows.flow,
+          [slug, default-provider-authorization-implicit-consent],
+        ]
+      invalidation_flow:
+        !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # The three managed defaults, restated. Binding REPLACES the list rather
+      # than appending. `email` is load-bearing here beyond the usual reason:
+      # api.oidc.usernameClaim defaults to `email`, so dropping it leaves Kargo
+      # unable to name the logged-in user.
+      property_mappings:
+        - !Find [
+            authentik_providers_oauth2.scopemapping,
+            [managed, goauthentik.io/providers/oauth2/scope-openid],
+          ]
+        - !Find [
+            authentik_providers_oauth2.scopemapping,
+            [managed, goauthentik.io/providers/oauth2/scope-email],
+          ]
+        - !Find [
+            authentik_providers_oauth2.scopemapping,
+            [managed, goauthentik.io/providers/oauth2/scope-profile],
+          ]
+
+  # ── 2. The application, whose SLUG is the issuer URL ─────────────────────
+  # authentik derives the OIDC issuer from the APPLICATION slug, not the
+  # provider name: https://auth.jomcgi.dev/application/o/<slug>/. Kargo's
+  # api.oidc.issuerURL is built from this same slug, so renaming the
+  # application silently breaks token validation.
+  - model: authentik_core.application
+    id: kargo-app
+    identifiers:
+      slug: kargo
+    attrs:
+      name: Kargo
+      provider: !KeyOf kargo-provider
+      meta_description: Promotion controller UI for the monolith's dev and production stages.
+
+  # ── 3. Gate it ───────────────────────────────────────────────────────────
+  # Without a policy binding authentik lets EVERY authenticated account
+  # authorize the application. Bound to homelab-admin, and this one is not a
+  # judgement call: the Kargo UI can promote Freight to PRODUCTION, so its
+  # audience is exactly the operator.
+  #
+  # This gate and Kargo's own are separate. authentik decides who may obtain a
+  # token; api.oidc.admins.claims decides what a token holder may do inside
+  # Kargo. Both name homelab-admin on purpose, so neither alone is what grants
+  # production promotion rights.
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf kargo-app
+      group: !Find [authentik_core.group, [name, homelab-admin]]
+      order: 0
+    attrs:
+      enabled: true
+      negate: false
+      timeout: 30

--- a/projects/platform/kargo/values.yaml
+++ b/projects/platform/kargo/values.yaml
@@ -1,15 +1,56 @@
-# Kargo, scoped to ONE job: owning the dev environment's chart version.
+# Kargo, owning the monolith's chart version in dev and production.
 #
 # Everything not needed for that is off, because each enabled integration
 # widens the controller's RBAC and the chart's own docs say explicitly
 # disabling is preferable to leaving an integration on and unused.
 kargo:
   api:
-    # No UI or CLI surface for v1. It would need TLS, an ingress, and an auth
-    # decision (Dex or an admin account), none of which promotion requires:
-    # the CONTROLLER reconciles Warehouses, Stages and Promotions on its own.
-    # Kargo state is readable with kubectl until there is a reason to expose it.
-    enabled: false
+    # The UI at private.jomcgi.dev/app/kargo. Off until now because it needed
+    # TLS, an ingress and an auth decision; all three are answered below and
+    # none of them cost a new credential.
+    enabled: true
+    host: private.jomcgi.dev
+    # Requires >= v1.11.0. The API server ALWAYS serves at the root, so the
+    # gateway strips this prefix before forwarding; basePath only tells the
+    # server what to put in issued URLs and what to inject as
+    # window.__KARGO_BASE_PATH__ for the UI to compose absolute links with.
+    basePath: /app/kargo
+    tls:
+      # Plain HTTP in-cluster: Cloudflare terminates TLS at the edge and the
+      # gateway talks to a Service, so a self-signed cert here would only give
+      # the gateway something it has to be told to distrust.
+      enabled: false
+      # LOAD-BEARING, and the one setting in this block still honoured when
+      # tls.enabled is false. Without it every URL the server issues is
+      # http://, including ADMIN_ACCOUNT_TOKEN_ISSUER and the OIDC redirect,
+      # while the browser arrives over https://. That mismatch presents as a
+      # login redirect loop or a rejected token, with nothing anywhere
+      # mentioning a protocol.
+      terminatedUpstream: true
+    adminAccount:
+      # No local password. authentik is the identity provider, so a second
+      # credential here would be one more thing to hold, rotate and leak.
+      enabled: false
+    oidc:
+      enabled: true
+      # authentik derives the issuer from the APPLICATION slug, not the
+      # provider name. Must match blueprints/kargo-auth.yaml's `slug: kargo`.
+      issuerURL: https://auth.jomcgi.dev/application/o/kargo/
+      clientID: kargo
+      admins:
+        # authentik emits `groups` in the default profile scope, which the
+        # blueprint's property_mappings include. This is Kargo's OWN authz,
+        # separate from authentik's policy binding: authentik decides who may
+        # obtain a token, this decides what a token holder may do. Both name
+        # homelab-admin so neither alone grants production promotion rights.
+        claims:
+          groups:
+            - homelab-admin
+      dex:
+        # Kargo bundles Dex to adapt IDPs that cannot do PKCE. authentik can,
+        # so Kargo talks to it directly and this stays off: Dex would be a
+        # second identity hop and a second thing to upgrade.
+        enabled: false
     rollouts:
       integrationEnabled: false
 


### PR DESCRIPTION
Enables Kargo's API server so there is a UI to reach, and points it at
authentik rather than a local admin account.

## No password, and no client secret either

Kargo uses the **Authorization Code flow with PKCE**, which exists so browser
apps that cannot hide a secret can authenticate by proving possession of a
one-time verifier instead of a static credential. So the provider is a
`client_type: public` one.

That means nothing in 1Password, no `!Env` lookup, and none of the two-item
secret arrangement `dev-auth.yaml` documents for Envoy Gateway's confidential
flow. It also sidesteps the `!Env [KEY]` sequence trap entirely, since this
blueprint uses no `!Env` at all.

I originally scoped this as "authentik costs an hour, a local password costs
ten minutes". That was backwards: the credential I was going to ask for does
not need to exist.

## Two gates, which look redundant and are not

| Gate | Decides |
| --- | --- |
| authentik policy binding -> `homelab-admin` | who may **obtain** a token |
| `api.oidc.admins.claims` -> `groups: [homelab-admin]` | what a token holder may **do** in Kargo |

Both name `homelab-admin`, so neither alone grants the right to promote Freight
to production.

## The line most likely to be omitted

```yaml
tls:
  enabled: false            # Cloudflare terminates; plain HTTP in-cluster
  terminatedUpstream: true  # but still issue https:// URLs
```

`terminatedUpstream` is the one setting in that block still honoured when
`tls.enabled` is false. Without it every URL the server issues is `http://`,
including `ADMIN_ACCOUNT_TOKEN_ISSUER` and the OIDC redirect, while the browser
arrives over `https://`. That presents as a login redirect loop or a rejected
token, with nothing anywhere mentioning a protocol.

## No route yet, on purpose

Kargo 1.11.1's own values say the API server always serves at the root and the
ingress **must strip** `basePath`. Its `server.go` on `main` shows
`wrapWithBasePath` doing `http.StripPrefix` **server-side**. Both cannot be
true, and they demand opposite gateway configs: forward `/app/kargo` intact, or
rewrite it to `/`. Double-stripping 404s everything.

With the API enabled and no route, it is reachable in-cluster only, which is
exactly where two `curl`s settle it. Guessing would ship a 404 that reads like
a broken ingress rather than a doubled strip. The route follows as a small PR
once the binary answers.

## Verification

Rendered rather than assumed:

```
OIDC_ISSUER_URL:     "https://auth.jomcgi.dev/application/o/kargo/"
OIDC_CLIENT_ID:      "kargo"
API_BASE_PATH:       "/app/kargo"
API_SERVER_BASE_URL: https://private.jomcgi.dev/app/kargo     <- https, via terminatedUpstream
Service kargo-api    port 80
rbac.kargo.akuity.io/claims: {"groups":["homelab-admin"]}
```

`blueprint_tags_test.py` passes (10 tests), which is the existing guard against
the `!Env [KEY]` form that aborts blueprint discovery for the whole tree.
`Executed 5 out of 707 tests: 707 tests pass`, format guards pass.

Note the issuer is derived from the **application slug**, not the provider
name, so renaming the application in the blueprint silently breaks token
validation. The values comment says so where someone would be tempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bakhr2iwPgQSxhhbwiE39