### PR TITLE
fix(platform): write Kargo durations in the normalized form the API server stores

### DIFF
--- a/projects/platform/kargo/values.yaml
+++ b/projects/platform/kargo/values.yaml
@@ -131,7 +131,15 @@ promotion:
   # progressDeadlineSeconds trips the Application to Degraded first, and
   # argocd-wait fails fast on that transition, so this only catches a workload
   # that never reaches a terminal state at all.
-  waitTimeout: 10m
+  # WRITTEN AS 10m0s, NOT 10m, and that is not a style choice. The API server
+  # normalizes these duration strings to the Go `0s`-suffixed form, so a chart
+  # rendering `10m` against a stored `10m0s` is a diff ArgoCD can never close.
+  # Same reasoning as warehouseInterval below, and the same failure it caused:
+  # selfHeal syncs only the DRIFTED resources, so one unconvergeable resource
+  # emits a continuous stream of targeted single-resource syncs that preempt the
+  # full sync and starve every other resource in the Application, green the
+  # whole time.
+  waitTimeout: 10m0s
   # Order is the pipeline. `upstream` is what makes it one rather than two
   # independent subscribers: prod can only receive Freight that dev has already
   # taken, so a chart reaches production having run somewhere first.
@@ -172,7 +180,8 @@ promotion:
       #
       # Dev has no soak: nothing is upstream of it, and a delay there would only
       # postpone the environment that exists to find problems first.
-      requiredSoakTime: 2m
+      # 2m0s, not 2m: the API server stores the normalized form. See waitTimeout.
+      requiredSoakTime: 2m0s
       autoPromotion: true
 
 # Private-tier ingress: https://private.jomcgi.dev/app/kargo


### PR DESCRIPTION
Follow-up to #4755, fixing drift that PR introduced. Caught by verifying the
rollout rather than stopping at MERGED.

## What broke

#4755 rendered `requiredSoakTime: 2m` and `retry.timeout: 10m`. The API server
normalizes both to the Go `0s`-suffixed form:

```
chart renders : requiredSoakTime: 2m     retry.timeout: 10m
API server has: requiredSoakTime: 2m0s   retry.timeout: 10m0s
```

So the chart could never converge, and both Stages went OutOfSync the moment it
deployed:

```
SecurityPolicy kargo-private-cf-access -> OutOfSync   (pre-existing, #4752)
HTTPRoute      kargo-private           -> OutOfSync   (pre-existing, #4752)
Stage          dev                     -> OutOfSync   (mine)
Stage          prod                    -> OutOfSync   (mine)
```

## Why it matters more than a cosmetic diff

This chart already documents this exact failure twice for the Warehouse, and
`warehouseInterval` is written `5m0s` in the same file for this reason. I added
two fields without following the precedent sitting eight lines above them.

`selfHeal` syncs only the DRIFTED resources, so an unconvergeable resource
emits a continuous stream of targeted single-resource syncs, each preempting
the full sync. On the original install that left `Stage/prod` planned but never
applied while the Application reported Succeeded throughout. Two permanently
drifting Stages is the same starvation source, now inside the resource that
owns production's promotions.

## Fix

Write both durations in the stored form. Verified by rendering and diffing
against the live Stage rather than against the CRD pattern, which accepts both
forms and would have told me nothing:

```
rendered: requiredSoakTime: 2m0s | retry.timeout: 10m0s
live    : requiredSoakTime: 2m0s | retry.timeout: 10m0s
```

The comment now says why the form is load-bearing, so the next person adding a
duration here does not repeat it.

Refs #4755, #4752.