### PR TITLE
feat(embervm): make the modeled op kinds observable in the op-log

### DIFF
--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -716,7 +716,7 @@ defmodule Embervm.Application do
   # set, caps each principal at that fraction of a workload's cap; unset (the
   # default) means the dynamic cap/active-principals split.
   defp dispatcher_opts do
-    [queue_depth_cap: queue_depth_cap()] ++ share_fraction_opt()
+    [queue_depth_cap: queue_depth_cap(), op_log: op_log_mod(), op_log_mod: op_log_mod()] ++ share_fraction_opt()
   end
 
   defp pool_opts, do: []

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -98,6 +98,7 @@ defmodule Embervm.Dispatcher do
   require OpenTelemetry.Tracer, as: Tracer
 
   alias Embervm.{Brick, NodeCapacity, WorkloadCatalog}
+  alias Embervm.OpLog.Op
   alias Embervm.Scheduler
   alias Embervm.Scheduler.Request
 
@@ -232,6 +233,13 @@ defmodule Embervm.Dispatcher do
 
     state = %{
       task_store: task_store,
+      op_log: Keyword.get(opts, :op_log, nil),
+      op_log_mod: Keyword.get(opts, :op_log_mod, nil),
+      # `%Op{}` enforces :tenant, and the dispatcher otherwise has no concept of
+      # one: priming is workload-scoped (PrimeRequest carries the workload, no
+      # principal), so there is no per-task tenant to inherit here. Same default
+      # as Embervm.Metering, which faces the same problem for its audit ops.
+      tenant: Keyword.get(opts, :tenant, "homelab"),
       capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
       catalog_table: Keyword.get(opts, :catalog_table, WorkloadCatalog.table()),
       depth_table: Keyword.get(opts, :depth_table, @depth_table),
@@ -527,8 +535,8 @@ defmodule Embervm.Dispatcher do
     # sees the write in flight. nil for a miss (its vm_id is minted in the worker);
     # inert under the gate off. The ETS FSM advance and the queued-race guard here
     # are unchanged (Option A): only the durable append moves off the hot path.
-    with {:ok, {:ok, _}} <- safe_call(fn -> Embervm.TaskStore.assign(state.task_store, task_id, vm_id) end),
-         {:ok, {:ok, _}} <- safe_call(fn -> Embervm.TaskStore.start(state.task_store, task_id, vm_id) end) do
+    with {:ok, {:ok, _}} <- safe_call(fn -> Embervm.TaskStore.assign(state.task_store, task_id, vm_id, node_id) end),
+         {:ok, {:ok, _}} <- safe_call(fn -> Embervm.TaskStore.start(state.task_store, task_id, vm_id, node_id) end) do
       # Task left the queue: release its depth reservation and dedupe slot.
       release_depth(state, wl, pr)
 
@@ -733,10 +741,17 @@ defmodule Embervm.Dispatcher do
     assign_fun = state.assign_fun
     prime_fun = state.prime_fun
     get_request_fun = state.get_request_fun
+    op_log = state.op_log
+    op_log_mod = state.op_log_mod
+    wall_clock = state.wall_clock
     wall = state.wall_clock.()
 
     ctx = %{
       task_id: task_id,
+      op_log: op_log,
+      op_log_mod: op_log_mod,
+      wall_clock: wall_clock,
+      tenant: state.tenant,
       workload: wl,
       principal: pr,
       node_id: node_id,
@@ -958,6 +973,10 @@ defmodule Embervm.Dispatcher do
 
     case Embervm.Scheduler.Retry.run(ctx.candidates, attempt_fun) do
       {:ok, {vm_id, node_id, channel}} ->
+        # Instrumentation covers task-lane priming only. Session, serving, and
+        # stateful lane priming is not yet instrumented. Append once, after the
+        # retry policy has selected the successful prime attempt.
+        _ = safe_call(fn -> append_primed(ctx, vm_id, node_id) end)
         {:ok, vm_id, node_id, channel}
 
       {:error, {:prime_failed, reason}} ->
@@ -1001,6 +1020,22 @@ defmodule Embervm.Dispatcher do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  defp append_primed(ctx, vm_id, node_id) do
+    if ctx.op_log == nil do
+      :ok
+    else
+      op = %Op{
+        kind: :primed,
+        tenant: ctx.tenant,
+        workload: ctx.workload,
+        ts: ctx.wall_clock.(),
+        payload: %{vm_id: vm_id, node_id: node_id, workload: ctx.workload, lane: :task}
+      }
+
+      ctx.op_log_mod.append(ctx.op_log, op)
     end
   end
 

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -1070,6 +1070,7 @@ defmodule Embervm.SessionManager do
       expires_at: state.clock.() + entry.session.max_lifetime_seconds * 1000
     }
 
+    # node_id is the K8s node where the VM primed/started; SessionStore carries it into session_created.
     case SessionStore.create(state.session_store, attrs) do
       {:ok, %{session_id: session_id} = created} ->
         case start_session_process(state, session_id, workload, principal, entry, node_id, vm_id, dial_id) do
@@ -2186,6 +2187,7 @@ defmodule Embervm.SessionManager do
       {:ok, node_id, vm_id, relight_ms, dial_id} ->
         session = get_session!(state, session_id)
 
+        # node_id is the K8s node where the VM primed/started; SessionStore carries it into session_relit.
         # The wake hot-path durable append (session_relit): deferred to AsyncWriter
         # under EMBERVM_ASYNC_LIFECYCLE_WRITES (ADR embervm/014 decision 2), so the
         # woken session's durable write is off the wake path; the ETS row advances
@@ -2197,7 +2199,8 @@ defmodule Embervm.SessionManager do
             session_id,
             :relight_ready,
             :session_relit,
-            %{snapshot_ref: session.snapshot_ref, generation: session.generation, relight_ms: relight_ms},
+            %{snapshot_ref: session.snapshot_ref, generation: session.generation, relight_ms: relight_ms,
+              node_id: node_id, vm_id: vm_id},
             %{node_id: node_id, vm_id: vm_id},
             vm_id
           )

--- a/projects/embervm/control/lib/embervm/session_store.ex
+++ b/projects/embervm/control/lib/embervm/session_store.ex
@@ -479,6 +479,7 @@ defmodule Embervm.SessionStore do
           ts: state.clock.(),
           payload: %{
             node_id: session.node_id,
+            vm_id: session.vm_id,
             volume_node_id: session.volume_node_id,
             base_snapshot_ref: session.base_snapshot_ref,
             base_digest: session.base_digest,
@@ -567,6 +568,7 @@ defmodule Embervm.SessionStore do
 
     payload = %{
       node_id: Map.get(attrs, :node_id),
+      vm_id: Map.get(attrs, :vm_id),
       volume_node_id: Map.get(attrs, :volume_node_id),
       base_snapshot_ref: Map.get(attrs, :base_snapshot_ref),
       base_digest: Map.get(attrs, :base_digest),

--- a/projects/embervm/control/lib/embervm/task_store.ex
+++ b/projects/embervm/control/lib/embervm/task_store.ex
@@ -74,9 +74,13 @@ defmodule Embervm.TaskStore do
     GenServer.call(store, {:assign, task_id, nil})
   end
 
-  @spec assign(GenServer.server(), String.t(), binary() | nil) :: {:ok, map()} | {:error, term()}
+  @spec assign(GenServer.server(), String.t(), binary() | nil, binary() | nil) :: {:ok, map()} | {:error, term()}
+  def assign(store, task_id, vm_id, node_id) do
+    GenServer.call(store, {:assign, task_id, vm_id, node_id})
+  end
+
   def assign(store, task_id, vm_id) do
-    GenServer.call(store, {:assign, task_id, vm_id})
+    GenServer.call(store, {:assign, task_id, vm_id, nil})
   end
 
   @spec start(GenServer.server(), String.t()) :: {:ok, map()} | {:error, term()}
@@ -84,9 +88,13 @@ defmodule Embervm.TaskStore do
     GenServer.call(store, {:start, task_id, nil})
   end
 
-  @spec start(GenServer.server(), String.t(), binary() | nil) :: {:ok, map()} | {:error, term()}
+  @spec start(GenServer.server(), String.t(), binary() | nil, binary() | nil) :: {:ok, map()} | {:error, term()}
+  def start(store, task_id, vm_id, node_id) do
+    GenServer.call(store, {:start, task_id, vm_id, node_id})
+  end
+
   def start(store, task_id, vm_id) do
-    GenServer.call(store, {:start, task_id, vm_id})
+    GenServer.call(store, {:start, task_id, vm_id, nil})
   end
 
   @spec succeed(GenServer.server(), String.t(), map()) :: {:ok, map()} | {:error, term()}
@@ -436,12 +444,20 @@ defmodule Embervm.TaskStore do
     end
   end
 
+  def handle_call({:assign, task_id, vm_id, node_id}, _from, state) do
+    apply_lifecycle_transition(state, task_id, :assign, :assigned, vm_id, node_id)
+  end
+
   def handle_call({:assign, task_id, vm_id}, _from, state) do
-    apply_lifecycle_transition(state, task_id, :assign, :assigned, vm_id)
+    apply_lifecycle_transition(state, task_id, :assign, :assigned, vm_id, nil)
+  end
+
+  def handle_call({:start, task_id, vm_id, node_id}, _from, state) do
+    apply_lifecycle_transition(state, task_id, :start, :started, vm_id, node_id)
   end
 
   def handle_call({:start, task_id, vm_id}, _from, state) do
-    apply_lifecycle_transition(state, task_id, :start, :started, vm_id)
+    apply_lifecycle_transition(state, task_id, :start, :started, vm_id, nil)
   end
 
   def handle_call({:succeed, task_id, result, usage}, _from, state) do
@@ -456,7 +472,7 @@ defmodule Embervm.TaskStore do
       }
       |> maybe_put_usage(usage)
 
-    case apply_transition(state, task_id, :succeed, :succeeded, payload) do
+    case apply_payload_transition(state, task_id, :succeed, :succeeded, payload) do
       {:reply, {:ok, updated}, _state} = reply ->
         notify_metered(state, updated, usage)
         reply
@@ -690,12 +706,31 @@ defmodule Embervm.TaskStore do
 
   # -- transition helpers -----------------------------------------------------
 
-  # Shared path for the simple (state) x (event) x (op kind) transitions that
-  # don't need bespoke payload logic (assign, start, succeed): look up the
-  # task, ask the FSM for the next state, append, and on success update ETS.
-  defp apply_transition(state, task_id, event, op_kind, payload) do
+  defp apply_payload_transition(state, task_id, event, op_kind, payload) do
     with {:ok, task} <- fetch_task(state, task_id),
          {:ok, next} <- TaskState.transition(task.state, event) do
+      case append_and_update(state, task, op_kind, next, payload) do
+        {:ok, updated} -> {:reply, {:ok, updated}, state}
+        {:error, _reason} = error -> {:reply, error, state}
+      end
+    else
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
+  # Shared path for the dispatch lifecycle transitions (assign, start): look up
+  # the task, ask the FSM for the next state, append, and update ETS on success.
+  defp apply_transition(state, task_id, event, op_kind, vm_id, node_id) do
+    with {:ok, task} <- fetch_task(state, task_id),
+         {:ok, next} <- TaskState.transition(task.state, event) do
+      payload =
+        if op_kind in [:assigned, :started] do
+          # node_id is the K8s node where the VM primed/started.
+          %{epoch: task.attempt, vm_id: vm_id, node_id: node_id}
+        else
+          %{}
+        end
+
       case append_and_update(state, task, op_kind, next, payload) do
         {:ok, updated} -> {:reply, {:ok, updated}, state}
         {:error, _reason} = error -> {:reply, error, state}
@@ -716,15 +751,15 @@ defmodule Embervm.TaskStore do
   # reconcile-DESTROYED, so a lost task lifecycle write is self-healing without a
   # discriminator). vm_id is registered as a pending write anyway, for parity with
   # the session path and so a shared reconciler could consult it if ever needed.
-  defp apply_lifecycle_transition(state, task_id, event, op_kind, vm_id) do
+  defp apply_lifecycle_transition(state, task_id, event, op_kind, vm_id, node_id) do
     if state.async_lifecycle_writes do
-      apply_transition_async(state, task_id, event, op_kind, vm_id)
+      apply_transition_async(state, task_id, event, op_kind, vm_id, node_id)
     else
-      apply_transition(state, task_id, event, op_kind, %{})
+      apply_transition(state, task_id, event, op_kind, vm_id, node_id)
     end
   end
 
-  defp apply_transition_async(state, task_id, event, op_kind, vm_id) do
+  defp apply_transition_async(state, task_id, event, op_kind, vm_id, node_id) do
     with {:ok, task} <- fetch_task(state, task_id),
          {:ok, next} <- TaskState.transition(task.state, event) do
       ts = state.clock.()
@@ -746,7 +781,8 @@ defmodule Embervm.TaskStore do
         # `:retried` past this attempt, so a stale attempt-N :assigned/:started that
         # lands after a retry re-queued the task (attempt N+1) is dropped instead of
         # re-assigning a worker that no longer exists.
-        payload: %{epoch: task.attempt}
+        # node_id is the K8s node where the VM primed/started.
+        payload: %{epoch: task.attempt, vm_id: vm_id, node_id: node_id}
       }
 
       Embervm.AsyncWriter.enqueue(state.async_writer, %{

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -36,6 +36,13 @@ defmodule Embervm.DispatcherTest do
     {:ok, op_log} = SQLite.start_link(name: nil, path: path)
     {:ok, store} = TaskStore.start_link(name: nil, op_log: op_log, on_queued: fn t -> Dispatcher.enqueue(disp_name, t) end)
 
+    dispatcher_op_log_opts =
+      if Keyword.get(opts, :configure_op_log, false) do
+        [op_log: op_log, op_log_mod: SQLite]
+      else
+        []
+      end
+
     disp_opts =
       [
         name: disp_name,
@@ -49,7 +56,10 @@ defmodule Embervm.DispatcherTest do
         prime_fun: Keyword.get(opts, :prime_fun, fn _ch, _req -> {:ok, %PrimeResponse{vm_id: "vm-#{System.unique_integer([:positive])}"}} end),
         start_sweep: false
       ] ++
+        dispatcher_op_log_opts ++
         Keyword.take(opts, [
+          :op_log,
+          :op_log_mod,
           :queue_depth_cap,
           :share_fraction,
           :stale_after_ms,
@@ -57,12 +67,21 @@ defmodule Embervm.DispatcherTest do
           :quota_table,
           :wall_clock,
           :assign_watchdog_margin_ms,
-          :assign_watchdog_ms
+          :assign_watchdog_ms,
+          :tenant
         ])
 
     {:ok, disp} = Dispatcher.start_link(disp_opts)
 
-    %{disp: disp, name: disp_name, store: store, cap_table: cap_table, cat_table: cat_table, depth_table: depth_table}
+    %{
+      disp: disp,
+      name: disp_name,
+      store: store,
+      op_log: op_log,
+      cap_table: cap_table,
+      cat_table: cat_table,
+      depth_table: depth_table
+    }
   end
 
   defp success_resp(code \\ 200, body \\ "ok") do
@@ -308,6 +327,34 @@ defmodule Embervm.DispatcherTest do
     stats = Dispatcher.stats(ctx.name)
     assert stats.misses >= 1
     assert stats.warm_hits == 0
+  end
+
+  test "priming appends :primed op to op_log when configured" do
+    ctx =
+      start_stack(
+        configure_op_log: true,
+        tenant: "tenant-prime",
+        wall_clock: fn -> 123_456 end,
+        prime_fun: fn _ch, _req -> {:ok, %PrimeResponse{vm_id: "vm-prime-1"}} end
+      )
+
+    put_catalog(ctx, "wl-prime", cap: 10)
+    put_facts(ctx, "wl-prime", free: 0, live: 0, max: 8)
+    tid = submit(ctx, "wl-prime", "p1")
+
+    assert eventually(fn -> state_of(ctx, tid) == :succeeded end)
+    assert {:ok, ops} = SQLite.read_from(ctx.op_log, 0)
+
+    assert [%{kind: :primed} = op] = Enum.filter(ops, &(&1.kind == :primed))
+    assert op.tenant == "tenant-prime"
+    assert op.workload == "wl-prime"
+    assert op.ts == 123_456
+    assert op.payload == %{
+             "vm_id" => "vm-prime-1",
+             "node_id" => "node-4",
+             "workload" => "wl-prime",
+             "lane" => "task"
+           }
   end
 
   test "a miss commits and retries in Score.order order" do

--- a/projects/embervm/control/test/embervm/op_log_payloads_test.exs
+++ b/projects/embervm/control/test/embervm/op_log_payloads_test.exs
@@ -1,0 +1,103 @@
+defmodule Embervm.OpLogPayloadsTest do
+  use ExUnit.Case, async: true
+
+  alias Embervm.OpLog.SQLite
+  alias Embervm.SessionStore
+  alias Embervm.TaskStore
+
+  setup do
+    path = Path.join(System.tmp_dir!(), "embervm_op_payloads_#{System.unique_integer([:positive, :monotonic])}.db")
+    on_exit(fn -> File.rm_rf!(path) end)
+    %{path: path}
+  end
+
+  defp clock do
+    {:ok, agent} = Agent.start_link(fn -> 1_000 end)
+    fn -> Agent.get_and_update(agent, fn value -> {value, value + 1} end) end
+  end
+
+  defp read_kind(op_log, kind) do
+    {:ok, ops} = SQLite.read_from(op_log, 0)
+    Enum.find(ops, &(&1.kind == kind))
+  end
+
+  test "sync assigned and started payloads use the integer task attempt", %{path: path} do
+    {:ok, op_log} = SQLite.start_link(path: path, name: nil)
+
+    {:ok, store} =
+      TaskStore.start_link(
+        op_log: op_log,
+        name: nil,
+        clock: clock(),
+        on_queued: fn _ -> :ok end,
+        async_lifecycle_writes: false
+      )
+
+    {:ok, :created, task_id} = TaskStore.submit(store, %{tenant: "t", principal: "p", workload: "w"})
+    {:ok, _} = TaskStore.assign(store, task_id, "vm-1", "node-1")
+    {:ok, _} = TaskStore.start(store, task_id, "vm-1", "node-1")
+
+    for kind <- [:assigned, :started] do
+      op = read_kind(op_log, kind)
+      assert is_integer(op.payload["epoch"])
+      assert op.payload["vm_id"] == "vm-1"
+      assert op.payload["node_id"] == "node-1"
+      refute op.payload["epoch"] == :task_attempt
+    end
+  end
+
+  test "session_created payload contains vm_id and node_id", %{path: path} do
+    {:ok, op_log} = SQLite.start_link(path: path, name: nil)
+    {:ok, store} = SessionStore.start_link(op_log: op_log, name: nil, clock: clock(), async_lifecycle_writes: false)
+
+    {:ok, created} =
+      SessionStore.create(store, %{
+        tenant: "t",
+        principal: "p",
+        workload: "w",
+        vm_id: "vm-1",
+        node_id: "node-1"
+      })
+
+    op = read_kind(op_log, :session_created)
+    assert op.session_id == created.session_id
+    assert op.payload["vm_id"] == "vm-1"
+    assert op.payload["node_id"] == "node-1"
+  end
+
+  test "sync session_relit preserves residency and relight metadata", %{path: path} do
+    {:ok, op_log} = SQLite.start_link(path: path, name: nil)
+    {:ok, store} = SessionStore.start_link(op_log: op_log, name: nil, clock: clock(), async_lifecycle_writes: false)
+
+    {:ok, created} =
+      SessionStore.create(store, %{
+        tenant: "t",
+        principal: "p",
+        workload: "w",
+        vm_id: "vm-1",
+        node_id: "node-1"
+      })
+
+    {:ok, _} = SessionStore.mark(store, created.session_id, :bank)
+    {:ok, _} = SessionStore.transition(store, created.session_id, :bank_ready, :session_banked, %{snapshot_ref: "snap-1", generation: 3}, %{})
+    {:ok, _} = SessionStore.mark(store, created.session_id, :relight)
+
+    {:ok, _} =
+      SessionStore.transition_lifecycle(
+        store,
+        created.session_id,
+        :relight_ready,
+        :session_relit,
+        %{snapshot_ref: "snap-2", generation: 4, relight_ms: 27, vm_id: "vm-2", node_id: "node-2"},
+        %{snapshot_ref: "snap-2", generation: 4, vm_id: "vm-2", node_id: "node-2"},
+        "vm-2"
+      )
+
+    op = read_kind(op_log, :session_relit)
+    assert op.payload["vm_id"] == "vm-2"
+    assert op.payload["node_id"] == "node-2"
+    assert op.payload["snapshot_ref"] == "snap-2"
+    assert op.payload["generation"] == 4
+    assert op.payload["relight_ms"] == 27
+  end
+end

--- a/projects/embervm/control/test/embervm/spec_vocabulary_test.exs
+++ b/projects/embervm/control/test/embervm/spec_vocabulary_test.exs
@@ -128,4 +128,51 @@ defmodule Embervm.SpecVocabularyTest do
                "layer 1: the manifest must not claim to model what the specs do not)."
     end
   end
+
+  # Strip `#` comments and @doc/@moduledoc heredocs before looking for an atom.
+  # Both are why the naive greps failed: `:primed` appeared in a base_builder
+  # comment, and async_writer's @moduledoc names four kinds it does not append.
+  defp executable_source(path) do
+    path
+    |> File.read!()
+    |> then(&Regex.replace(~r/@(?:moduledoc|doc|typedoc)\s+"""(?:.|\n)*?"""/, &1, ""))
+    |> then(&Regex.replace(~r/@(?:moduledoc|doc|typedoc)\s+"(?:[^"\\]|\\.)*"/, &1, ""))
+    |> String.split("\n")
+    |> Enum.reject(&String.starts_with?(String.trim_leading(&1), "#"))
+    |> Enum.join("\n")
+  end
+
+  # Layer 1's #4756 guard: every MODELED op kind must be appended by the module
+  # vocabulary.exs names. See the op_kind_sites comment there for why this is a
+  # declared registry and not a grep (both greps were tried; one was vacuous,
+  # the other failed 8 kinds that are genuinely emitted).
+  test "every modeled op kind has a declared, real append site" do
+    lib_dir = Path.expand("../../lib", __DIR__)
+    {modeled, _excluded} = partition(:op_kinds)
+    sites = Map.fetch!(@vocabulary, :op_kind_sites)
+    declared = MapSet.new(Map.keys(sites))
+
+    # The registry must PARTITION the modeled kinds: a kind added to `modeled`
+    # with no declared site fails here rather than being silently unchecked.
+    assert MapSet.equal?(declared, modeled),
+           "op_kind_sites must name an append site for exactly the modeled op " <>
+             "kinds. Missing: #{inspect(MapSet.to_list(MapSet.difference(modeled, declared)))}. " <>
+             "Extra: #{inspect(MapSet.to_list(MapSet.difference(declared, modeled)))}."
+
+    for {kind, basename} <- sites do
+      matches = Path.wildcard(Path.join([lib_dir, "**", basename]))
+
+      assert matches != [],
+             "op_kind_sites names #{basename} as the append site for " <>
+               "#{inspect(kind)}, but no such file exists under #{lib_dir}."
+
+      source = Enum.map_join(matches, "\n", &executable_source/1)
+
+      assert Regex.match?(~r/:#{kind}\b/, source),
+             "modeled op kind #{inspect(kind)} is declared to be appended by " <>
+               "#{basename}, but that file never mentions it outside comments " <>
+               "and docs. Either add the append, or move the kind to `excluded` " <>
+               "in vocabulary.exs with a reason (see #4756)."
+    end
+  end
 end

--- a/projects/embervm/specs/vocabulary.exs
+++ b/projects/embervm/specs/vocabulary.exs
@@ -89,8 +89,8 @@
       # R0 task/VM lifecycle kinds the spec does NOT model as distinct actions.
       # vm_destroyed is the durable audit kind for a VM teardown; the spec models
       # the VM state reaching "destroyed" (Succeed / AbandonClaim / CrashNode) but
-      # not the log-emission verb as a named action, so the atom vm_destroyed is
-      # excluded (its string is absent from the spec by design). started collapses
+      # not the log-emission verb as a named action. Task-lane VMs are reclaimed by
+      # the node, not CP; there is no append site. started collapses
       # into assigned (the spec's taskState has no separate running state);
       # base_built pairs with the excluded BuildBase verb. denied remains excluded
       # because it covers auth-forbidden and per-principal queue-depth audit kinds;
@@ -140,5 +140,42 @@
         # R6 continuity (node drain + off-node artifact) kinds, out of scope.
         ~w(node_drain_started node_drain_finished artifact_exported
            artifact_restored artifact_evicted_remote)a
+  },
+  # -- append sites for every MODELED op kind (layer 1, the #4756 guard) -------
+  # Which control-plane module actually appends each modeled kind, declared
+  # rather than inferred. spec_vocabulary_test.exs asserts the keys exactly
+  # partition the modeled op kinds, the file exists, and the atom appears in it
+  # outside `#` comments and @doc/@moduledoc heredocs.
+  #
+  # WHY A DECLARED REGISTRY RATHER THAN A GREP. #4756: `:primed` and
+  # `:vm_destroyed` sat in the closed @kinds enum with NO append site, and layer
+  # 1 passed because it only checked enum against spec. Two greps were tried and
+  # both failed, which is why this is a manifest:
+  #
+  #   bare `:atom` anywhere in lib      -> too LOOSE. `:primed` matched a metrics
+  #     counter key in base_builder.ex (`Map.get(entry, :primed, 0)`) and a prose
+  #     comment, so it was green before any emission existed.
+  #   `kind: :atom` literal              -> too STRICT. Only `:primed` is built
+  #     literally; every other kind is threaded as a VARIABLE across a module
+  #     boundary (`%Op{kind: op_kind}` in task_store, `SessionStore.transition(
+  #     ..., :session_banked, ...)` in session_manager), so it failed 8 kinds
+  #     that are genuinely emitted.
+  #
+  # Naming the module is the part a grep cannot infer and a reviewer can check.
+  # A kind with no honest site cannot be given one here, which forces the
+  # decision the enum's closed-ness was supposed to force: emit it, or move it
+  # to `excluded` with a reason (as vm_destroyed now is, since task-lane VMs are
+  # reclaimed by the node and no CP-side teardown exists).
+  op_kind_sites: %{
+    submitted: "task_store.ex",
+    assigned: "task_store.ex",
+    succeeded: "task_store.ex",
+    primed: "dispatcher.ex",
+    quota_enforced: "metering.ex",
+    session_banked: "session_manager.ex",
+    session_relit: "session_manager.ex",
+    session_evicted: "session_manager.ex",
+    session_destroying: "session_manager.ex",
+    session_destroyed: "session_manager.ex"
   }
 }


### PR DESCRIPTION
Closes #4756. First implementation step of #4759, and the prerequisite for
ADR 006's layer 2 (#4760 records the design).

## The problem

Trace validation maps op-log events to TLA+ actions. It could not be built,
because the log cannot witness the invariants that matter:

- `:primed` and `:vm_destroyed` sat in the closed `@kinds` enum with **no
  append site anywhere**. Their only other occurrence is a `project/3` clause
  commented "Audit-only kinds", a handler for events nothing produces.
- `:assigned` / `:started` carried `%{epoch: task.attempt}` and **no vm_id**.

So `NoDoubleAssign`, `NoResurrection`, `NoReapLive` and `PrincipalIsolation`
were unobservable. Of adoption.tla's nine invariants, only the task FSM
ordering family could be checked, which is the least interesting one.

## Changes

**vm_id and node_id in the task lifecycle payloads, both paths.** The sync path
passed a literal `%{}` and discarded vm_id entirely, and **that is the path
production runs**: `EMBERVM_ASYNC_LIFECYCLE_WRITES` defaults off and is
rendered nowhere (#4758). Instrumenting only the async branch would have been
green in tests and dead in prod. `epoch` is preserved exactly, since the
projection's monotonic guard uses it to reject stale attempts.

**`:primed` emitted once, after the retry policy picks a winner.** Emitting
inside `prime_on/5` fires per attempt and used `ctx.node_id` rather than the
node actually primed on, so a retried prime could log several `:primed` events
for one VM against a node it never landed on. That corrupts precisely the
correlation the instrumentation exists to provide.

**`:vm_destroyed` deliberately NOT emitted**, and reclassified as `excluded`.
There is no CP-side task-lane teardown; those VMs are reclaimed by the node.
Emitting it would write untrue destructions into a durable log a checker treats
as ground truth, and `NoReapLive` would then fire against inventions. False
data is worse than missing data here.

**Session payloads** gain vm_id and node_id. `generation` and `snapshot_ref`
untouched, so bank/relight pairing is unaffected.

## The guard, which is the part that stops this recurring

`vocabulary.exs` gains `op_kind_sites`, naming the module that appends each
modeled kind, asserted to partition `modeled` exactly. **Two greps were tried
first and both failed**, which is why this is a declared manifest:

| attempt | rule | outcome |
| --- | --- | --- |
| bare `:atom` in lib | exclude `op_log/` | **vacuous.** `lib/embervm/op_log.ex` is not inside `lib/embervm/op_log/`, so every kind matched its own enum entry; `:primed` also matched a metrics counter key in `base_builder.ex`. Green before any emission existed |
| literal `kind: :atom` | construction site | **too strict.** Only `:primed` is built literally; the rest thread the atom as a variable across a module boundary, so it failed 8 genuinely-emitted kinds |
| declared registry | name the module | red on the bug, green after |

Whether a kind is emitted is a dataflow question a lexical test cannot answer,
so the manifest asks a human to assert what a grep cannot infer, and CI checks
the assertion is not obviously false.

**Red/green proven**, by replaying the guard's logic against pre-change main:

```
pre-change main  RED:   primed not appended by dispatcher.ex
this branch      GREEN: all sites real
```

That verification matters: the existing layer-1 guard is well written, cited in
three places, and passed on both #4756 and #4758. A guard nobody has watched go
red is indistinguishable from one that cannot.

## Safety

Instrumentation is non-critical by construction. `op_log` defaults to nil and
the append is wrapped in `safe_call`, so a missing or dead op-log can never
take down a dispatch worker. A **runtime test** asserts that with an op_log
configured a prime really does append, because an optional emission with no
test is indistinguishable from not having built it.

Consequence for the checker (noted on #4761): a downed op-log yields **missing**
events, not wrong ones, so the checker must distinguish "event absent" from
"invariant violated" or it will produce false positives.

## Verification

- `ci test`: **1208 tests, 0 failures, 6 skipped**, run independently rather
  than taken on report.
- `ci lint` clean. No em-dashes. No `Chart.yaml` or `targetRevision` edit.
- Payload additions need no DDL: ops rows store `payload_blob BYTEA`.

## What is still unobservable

`NoResurrection` and `AdoptIdempotent` depend on volatile control-plane state
(dispatcher inventory, health machine, streamer generations) that is unlogged
by design and should not enter the durable book-of-record. ADR 034 decides that
goes to a separate `protocol_events` table, which is follow-up work.

Refs #4756, #4759, #4758.