### PR TITLE
feat(embervm): emit :primed from the paths production actually takes

### DIFF
--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -719,7 +719,7 @@ defmodule Embervm.Application do
     [queue_depth_cap: queue_depth_cap(), op_log: op_log_mod(), op_log_mod: op_log_mod()] ++ share_fraction_opt()
   end
 
-  defp pool_opts, do: []
+  defp pool_opts, do: [op_log: op_log_mod(), op_log_mod: op_log_mod()]
 
   # Extra opts threaded into every Embervm.Session the SessionManager starts. Empty
   # in production (the session process uses its real NodeChannel/SessionAssign

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -98,7 +98,7 @@ defmodule Embervm.Dispatcher do
   require OpenTelemetry.Tracer, as: Tracer
 
   alias Embervm.{Brick, NodeCapacity, WorkloadCatalog}
-  alias Embervm.OpLog.Op
+  alias Embervm.PrimedOp
   alias Embervm.Scheduler
   alias Embervm.Scheduler.Request
 
@@ -1027,13 +1027,7 @@ defmodule Embervm.Dispatcher do
     if ctx.op_log == nil do
       :ok
     else
-      op = %Op{
-        kind: :primed,
-        tenant: ctx.tenant,
-        workload: ctx.workload,
-        ts: ctx.wall_clock.(),
-        payload: %{vm_id: vm_id, node_id: node_id, workload: ctx.workload, lane: :task}
-      }
+      op = PrimedOp.build(ctx.tenant, ctx.workload, vm_id, node_id, :task)
 
       ctx.op_log_mod.append(ctx.op_log, op)
     end

--- a/projects/embervm/control/lib/embervm/pool_manager.ex
+++ b/projects/embervm/control/lib/embervm/pool_manager.ex
@@ -71,6 +71,7 @@ defmodule Embervm.PoolManager do
   require Logger
 
   alias Embervm.{NodeCapacity, WorkloadCatalog}
+  alias Embervm.PrimedOp
   alias Embervm.Scheduler
   alias Embervm.Scheduler.Request
   alias Embervm.Node.V1.{PrimeRequest, PrimeResponse, Trace}
@@ -121,6 +122,9 @@ defmodule Embervm.PoolManager do
       invalidate_fun: Keyword.get(opts, :invalidate_fun, &Embervm.NodeChannel.invalidate/2),
       prime_fun: Keyword.get(opts, :prime_fun, &default_prime/2),
       deposit_fun: Keyword.get(opts, :deposit_fun, &Embervm.Dispatcher.deposit/4),
+      op_log: Keyword.get(opts, :op_log, nil),
+      op_log_mod: Keyword.get(opts, :op_log_mod, Embervm.OpLog.SQLite),
+      tenant: Keyword.get(opts, :tenant, "homelab"),
       status_writer: Keyword.get(opts, :status_writer, &Embervm.K8s.patch_workload_status/3),
       refill_interval_ms: Keyword.get(opts, :refill_interval_ms, @refill_interval_ms),
       max_concurrent_primes: Keyword.get(opts, :max_concurrent_primes, @max_concurrent_primes),
@@ -169,6 +173,7 @@ defmodule Embervm.PoolManager do
 
         case result do
           {:ok, %PrimeResponse{vm_id: vm_id}} when is_binary(vm_id) and vm_id != "" ->
+            _ = safe(fn -> append_primed(state, wl, vm_id, node_id) end)
             _ = safe(fn -> state.deposit_fun.(state.dispatcher, node_id, wl, vm_id) end)
 
           {:error, reason} ->
@@ -592,6 +597,13 @@ defmodule Embervm.PoolManager do
     catch
       _, _ -> :error
     end
+  end
+
+  defp append_primed(%{op_log: nil}, _workload, _vm_id, _node_id), do: :ok
+
+  defp append_primed(state, workload, vm_id, node_id) do
+    op = PrimedOp.build(state.tenant, workload, vm_id, node_id, :task)
+    state.op_log_mod.append(state.op_log, op)
   end
 
   defp default_mono, do: System.monotonic_time(:millisecond)

--- a/projects/embervm/control/lib/embervm/primed_op.ex
+++ b/projects/embervm/control/lib/embervm/primed_op.ex
@@ -1,0 +1,42 @@
+defmodule Embervm.PrimedOp do
+  @moduledoc """
+  Builds the `:primed` op, shared by every lane that primes a VM.
+
+  ONE builder on purpose. There are three append sites (the dispatcher's
+  cold-miss path, the PoolManager's warm-pool refill, and the SessionManager's
+  session prime), and a conformance checker joins `:primed` to `:assigned` on
+  `(vm_id, node_id)`. Three hand-written payloads drift: an earlier version of
+  this instrumentation had one site recording the brick `dial_id` as the node
+  while another recorded `node_id`, which silently breaks that join.
+
+  TIMESTAMPS ARE TAKEN HERE, and the caller may NOT inject a clock. That is a
+  deliberate restriction, not an oversight, because the obvious injection is a
+  trap: the two calling modules use the name `clock` for opposite things.
+
+      SessionManager  clock            -> System.system_time    (WALL)
+      SessionManager  monotonic_clock  -> System.monotonic_time  (MONOTONIC)
+      PoolManager     clock            -> System.monotonic_time  (MONOTONIC)
+
+  `System.monotonic_time/1` has an arbitrary origin and is not a Unix epoch
+  value, so passing the wrong one writes a nonsense `ts` into the durable
+  op-log. It still appends, so nothing fails: the trace validator simply orders
+  events by a garbage field. Taking the wall clock here makes that unreachable.
+
+  Tests that need a deterministic timestamp should assert on the payload and
+  treat `ts` as opaque, or freeze time at the boundary rather than threading a
+  clock through this call.
+  """
+
+  alias Embervm.OpLog.Op
+
+  @spec build(String.t(), String.t(), String.t(), String.t(), atom()) :: Op.t()
+  def build(tenant, workload, vm_id, node_id, lane) do
+    %Op{
+      kind: :primed,
+      tenant: tenant,
+      workload: workload,
+      ts: System.system_time(:millisecond),
+      payload: %{lane: lane, workload: workload, vm_id: vm_id, node_id: node_id}
+    }
+  end
+end

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -57,6 +57,7 @@ defmodule Embervm.SessionManager do
   alias Embervm.{Brick, NodeCapacity, SessionState, SessionStore, SessionTrace, WakeInstance, WorkloadCatalog}
   alias Embervm.Scheduler.Request
   alias Embervm.Scheduler
+  alias Embervm.PrimedOp
 
   alias Embervm.Node.V1.{
     ArtifactRef,
@@ -796,7 +797,7 @@ defmodule Embervm.SessionManager do
       end
 
     with {:ok, restored} <- restore_session_workspace(state, dial_id, workload, restore_lineage),
-         {:ok, vm_id} <- prime(state, dial_id, snapshot_ref, entry, restore_lineage) do
+         {:ok, vm_id} <- prime(state, dial_id, workload, snapshot_ref, entry, restore_lineage) do
       {:ok, vm_id, restored}
     end
   end
@@ -951,7 +952,7 @@ defmodule Embervm.SessionManager do
   defp claim_or_prime(state, node_id, workload, snapshot_ref, entry, lineage_id) do
     if persistence_enabled_workload?(entry) do
       Tracer.set_attributes(%{"ember.pool_hit" => false})
-      prime(state, node_id, snapshot_ref, entry, lineage_id)
+      prime(state, node_id, workload, snapshot_ref, entry, lineage_id)
     else
       case state.claim_fun.(state.dispatcher, node_id, workload) do
         {:ok, vm_id} ->
@@ -962,7 +963,7 @@ defmodule Embervm.SessionManager do
 
         :miss ->
           Tracer.set_attributes(%{"ember.pool_hit" => false})
-          prime(state, node_id, snapshot_ref, entry, lineage_id)
+          prime(state, node_id, workload, snapshot_ref, entry, lineage_id)
       end
     end
   end
@@ -980,7 +981,7 @@ defmodule Embervm.SessionManager do
   defp normalize_restore_lineage(lineage) when is_binary(lineage) and lineage != "", do: lineage
   defp normalize_restore_lineage(_other), do: nil
 
-  defp prime(state, node_id, snapshot_ref, entry, lineage_id) do
+  defp prime(state, node_id, workload, snapshot_ref, entry, lineage_id) do
     # A prime failure is NOT a capacity problem, and reporting it as one cost a
     # whole debugging cycle: the persistence flip denied every create with
     # :no_capacity while the real reason (a rejected Prime) never left this
@@ -989,6 +990,7 @@ defmodule Embervm.SessionManager do
       {:ok, channel} ->
         case safe_prime(state, channel, snapshot_ref, entry, lineage_id) do
           {:ok, %PrimeResponse{vm_id: vm_id}} when is_binary(vm_id) and vm_id != "" ->
+            _ = safe(fn -> append_primed(state, workload, vm_id, node_id) end)
             {:ok, vm_id}
 
           other ->
@@ -1029,6 +1031,23 @@ defmodule Embervm.SessionManager do
     _ -> {:error, :prime_crashed}
   catch
     _, _ -> {:error, :prime_crashed}
+  end
+
+  defp append_primed(%{op_log: nil}, _workload, _vm_id, _node_id), do: :ok
+
+  defp append_primed(state, workload, vm_id, node_id) do
+    op = PrimedOp.build(state.tenant, workload, vm_id, node_id, :session)
+    state.op_log_mod.append(state.op_log, op)
+  end
+
+  defp safe(fun) do
+    try do
+      fun.()
+    rescue
+      _ -> :error
+    catch
+      _, _ -> :error
+    end
   end
 
   # Append session_created (mints id + token), then start the session process. The
@@ -1765,7 +1784,7 @@ defmodule Embervm.SessionManager do
          dial_id <- Brick.dial_id(brick),
          {:ok, _restored} <- restore_session_workspace(state, dial_id, workload, lineage_id),
          snapshot_ref <- get_in(brick, [:workloads, workload, :snapshot_ref]),
-         {:ok, vm_id} <- prime(state, dial_id, snapshot_ref, entry, lineage_id) do
+         {:ok, vm_id} <- prime(state, dial_id, workload, snapshot_ref, entry, lineage_id) do
       {:ok, vm_id, dial_id}
     else
       {:error, reason} -> {:error, reason}

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -348,7 +348,13 @@ defmodule Embervm.DispatcherTest do
     assert [%{kind: :primed} = op] = Enum.filter(ops, &(&1.kind == :primed))
     assert op.tenant == "tenant-prime"
     assert op.workload == "wl-prime"
-    assert op.ts == 123_456
+    # ts is taken inside Embervm.PrimedOp and is deliberately NOT injectable:
+    # this module's `wall_clock` is wall time but PoolManager's `clock` is
+    # monotonic, so a threaded clock silently stamps an arbitrary-origin value
+    # into the field a trace validator orders by. Assert the property instead.
+    assert is_integer(op.ts)
+    assert op.ts > 1_700_000_000_000
+    assert abs(System.system_time(:millisecond) - op.ts) < 60_000
     assert op.payload == %{
              "vm_id" => "vm-prime-1",
              "node_id" => "node-4",

--- a/projects/embervm/control/test/embervm/op_log_payloads_test.exs
+++ b/projects/embervm/control/test/embervm/op_log_payloads_test.exs
@@ -2,6 +2,7 @@ defmodule Embervm.OpLogPayloadsTest do
   use ExUnit.Case, async: true
 
   alias Embervm.OpLog.SQLite
+  alias Embervm.PrimedOp
   alias Embervm.SessionStore
   alias Embervm.TaskStore
 
@@ -99,5 +100,26 @@ defmodule Embervm.OpLogPayloadsTest do
     assert op.payload["snapshot_ref"] == "snap-2"
     assert op.payload["generation"] == 4
     assert op.payload["relight_ms"] == 27
+  end
+
+  test "PrimedOp.build produces consistent payload shape across lanes" do
+    task = PrimedOp.build("homelab", "wl", "vm-task", "node-4", :task)
+    session = PrimedOp.build("homelab", "wl", "vm-session", "node-4", :session)
+
+    assert MapSet.new(Map.keys(task.payload)) == MapSet.new(Map.keys(session.payload))
+    assert MapSet.new(Map.keys(task.payload)) == MapSet.new([:lane, :workload, :vm_id, :node_id])
+  end
+
+  # ts is taken inside the builder on purpose (see Embervm.PrimedOp), because
+  # the two calling modules spell a monotonic and a wall clock the same way.
+  # A monotonic value has an arbitrary origin, so this asserts the op carries a
+  # plausible epoch-millisecond timestamp rather than an interval counter.
+  test "PrimedOp.build stamps a wall-clock timestamp, not a monotonic one" do
+    op = PrimedOp.build("homelab", "wl", "vm-1", "node-4", :task)
+    now = System.system_time(:millisecond)
+
+    assert is_integer(op.ts)
+    assert op.ts > 1_700_000_000_000, "ts is not a plausible epoch millisecond"
+    assert abs(now - op.ts) < 60_000
   end
 end

--- a/projects/embervm/control/test/embervm/pool_manager_test.exs
+++ b/projects/embervm/control/test/embervm/pool_manager_test.exs
@@ -13,6 +13,13 @@ defmodule Embervm.PoolManagerTest do
   alias Embervm.{NodeCapacity, PoolManager, WorkloadCatalog}
   alias Embervm.Node.V1.{PrimeRequest, PrimeResponse, Trace}
 
+  defmodule OpLogRecorder do
+    def append(agent, op) do
+      Agent.update(agent, &[op | &1])
+      :ok
+    end
+  end
+
   defp start_pool(opts \\ []) do
     suffix = System.unique_integer([:positive])
     cap_table = :"pcap_#{suffix}"
@@ -52,6 +59,10 @@ defmodule Embervm.PoolManagerTest do
           invalidate_fun: invalidate_fun,
           prime_fun: prime_fun,
           deposit_fun: fn _srv, _node, _wl, _vm -> :ok end,
+          op_log: Keyword.get(opts, :op_log),
+          op_log_mod: Keyword.get(opts, :op_log_mod, Embervm.OpLog.SQLite),
+          tenant: Keyword.get(opts, :tenant, "homelab"),
+          monotonic_clock: Keyword.get(opts, :monotonic_clock, fn -> 2_000_000 end),
           status_writer: status_writer,
           max_concurrent_primes: Keyword.get(opts, :max_concurrent_primes, 100),
           start_refill: false
@@ -115,6 +126,24 @@ defmodule Embervm.PoolManagerTest do
     ctx.primes |> Agent.get(& &1) |> Enum.frequencies()
   end
 
+  defp eventually(fun, timeout \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_eventually(fun, deadline)
+  end
+
+  defp do_eventually(fun, deadline) do
+    if fun.() do
+      true
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        false
+      else
+        Process.sleep(10)
+        do_eventually(fun, deadline)
+      end
+    end
+  end
+
   test "a transport-dead Prime invalidates the channel so the next tick re-dials" do
     # Regression for the noded-pod-restart wedge: a Prime failing because the channel's
     # transport is dead (wrapped by the Mint adapter as an RPCError) must tear the
@@ -133,6 +162,22 @@ defmodule Embervm.PoolManagerTest do
     :ok = PoolManager.refill(ctx.pool)
 
     assert_receive {:invalidated, "node-4", :ch}, 1_000
+  end
+
+  test "records primed op on successful refill prime" do
+    {:ok, op_log} = Agent.start_link(fn -> [] end)
+    ctx = start_pool(op_log: op_log, op_log_mod: OpLogRecorder)
+    put_catalog(ctx, "wl-prime", 1)
+    put_facts(ctx, [{"wl-prime", 0}], max: 10)
+
+    :ok = PoolManager.refill(ctx.pool)
+
+    assert eventually(fn -> Agent.get(op_log, &length/1) == 1 end)
+    assert [%{kind: :primed, workload: "wl-prime", tenant: "homelab", payload: payload}] = Agent.get(op_log, & &1)
+    assert payload.lane == :task
+    assert payload.workload == "wl-prime"
+    assert payload.node_id == "node-4"
+    assert String.starts_with?(payload.vm_id, "vm-")
   end
 
   test "a server-status Prime failure leaves the channel up (no needless invalidate)" do

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -17,6 +17,13 @@ defmodule Embervm.SessionManagerTest do
   alias Embervm.OpLog.SQLite
   alias Embervm.Node.V1.{BankResponse, GuestResponse, PrimeResponse, RelightResponse, SessionAssignResponse, UsageStats}
 
+  defmodule OpLogRecorder do
+    def append(agent, op) do
+      Agent.update(agent, &[op | &1])
+      :ok
+    end
+  end
+
   # A stub op-log whose append/2 blocks until the test sends :go, so a test can hold
   # one async write "in flight" (pending) while it runs a reconcile pass, modelling
   # the writer-stalled-between-RPC-and-append window the adopt-and-backfill repair
@@ -51,6 +58,7 @@ defmodule Embervm.SessionManagerTest do
     on_exit(fn -> File.rm_rf!(path) end)
 
     {:ok, op_log} = SQLite.start_link(name: nil, path: path)
+    manager_op_log = Keyword.get(opts, :op_log, op_log)
 
     # A shared AsyncWriter (ADR embervm/014 decision 2), threaded into BOTH the store
     # and the manager so an async-gated stack defers appends through the same writer
@@ -109,7 +117,10 @@ defmodule Embervm.SessionManagerTest do
         delete_session_volume_fun: Keyword.get(opts, :delete_session_volume_fun, fn _ch, _req -> {:ok, %{}} end),
         session_opts: session_opts,
         async_writer: writer,
-        async_lifecycle_writes: async
+        async_lifecycle_writes: async,
+        op_log: manager_op_log,
+        op_log_mod: Keyword.get(opts, :op_log_mod, SQLite),
+        tenant: Keyword.get(opts, :tenant, "homelab")
       ] ++
         Keyword.take(opts, [
           :quota_config,
@@ -420,6 +431,24 @@ defmodule Embervm.SessionManagerTest do
     assert session.state == :running
     # A live session has a process registered under its id.
     assert [{_pid, _}] = Registry.lookup(ctx.registry, created.session_id)
+  end
+
+  test "records primed op on successful session create prime" do
+    {:ok, op_log} = Agent.start_link(fn -> [] end)
+
+    ctx =
+      start_stack(
+        op_log: op_log,
+        op_log_mod: OpLogRecorder,
+        claim_fun: fn _dispatcher, _node, _workload -> :miss end,
+        prime_fun: fake_prime_fun("vm-session-prime")
+      )
+
+    put_session_workload(ctx, "wl-session-prime")
+    assert {:ok, _created} = SessionManager.create(ctx.mgr, "wl-session-prime", "p1")
+
+    assert [%{kind: :primed, tenant: "homelab", workload: "wl-session-prime", payload: payload}] = Agent.get(op_log, & &1)
+    assert payload == %{lane: :session, workload: "wl-session-prime", vm_id: "vm-session-prime", node_id: "node-4"}
   end
 
   test "create denies unknown workload (404-shaped reason)" do

--- a/projects/embervm/specs/vocabulary.exs
+++ b/projects/embervm/specs/vocabulary.exs
@@ -170,7 +170,11 @@
     submitted: "task_store.ex",
     assigned: "task_store.ex",
     succeeded: "task_store.ex",
-    primed: "dispatcher.ex",
+    # :primed builder (Embervm.PrimedOp) is invoked from multiple sites
+    # (dispatcher, pool_manager, session_manager), so a shared builder centralizes
+    # the payload structure. The guard verifies the builder exists; runtime coverage
+    # is the checker's assertion (zero :primed alongside :assigned is vacuous, not passing).
+    primed: "primed_op.ex",
     quota_enforced: "metering.ex",
     session_banked: "session_manager.ex",
     session_relit: "session_manager.ex",


### PR DESCRIPTION
Closes #4765. Follow-up to #4764, fixing a gap that only production data
revealed.

## The gap

#4764 shipped `:primed`. Querying the live op-log 90 minutes later:

```
succeeded 36 | assigned 36 | started 36 | submitted 36 | primed 0
```

Task-lane VMs are single-use (ADR 001), so VMs were being primed constantly
with nothing recorded. The append sat on the dispatcher's **cold-miss** path;
real priming happens in `PoolManager`'s warm-pool refill and `SessionManager`'s
session prime, neither instrumented.

No test could have caught this. The code was correct, the tests passed, and the
layer-1 registry guard passed, because it proves a construction EXISTS and
cannot prove the path RUNS.

## Changes

- **PoolManager** gains op-log wiring (nil default, threaded from
  `application.ex`) and appends on a successful refill prime.
- **SessionManager** already held an op_log; appends on a successful session
  prime with `lane: :session`.
- **Dispatcher's** cold-miss append stays. It is correct, just rare.
- All three build through one `Embervm.PrimedOp`. Three sites spelling one
  event is how #4764's review found one recording the brick `dial_id` as node
  while another recorded `node_id`, silently breaking the `(vm_id, node_id)`
  join a checker depends on.

## The timestamp is deliberately not injectable

The obvious clock parameter is a trap, because these modules spell two
different clocks the same way:

```
SessionManager  clock            -> System.system_time     (WALL)
SessionManager  monotonic_clock  -> System.monotonic_time  (MONOTONIC)
PoolManager     clock            -> System.monotonic_time  (MONOTONIC)
```

An earlier revision threaded SessionManager's **monotonic** clock into the op.
`System.monotonic_time/1` has an arbitrary origin, so every session-lane
`:primed` would have carried a nonsense `ts` into the exact field a trace
validator orders events by. It still appends and nothing fails, so a green
1211-test suite proved nothing.

`PrimedOp` takes the wall clock itself, the moduledoc records that table so the
parameter is not re-added, and tests assert `ts` is a plausible epoch
millisecond rather than an injected constant. This is a case where removing
flexibility is the fix: a wrong `ts` is worse than no `ts`, because it yields a
confidently mis-ordered trace.

## Guard interaction, worth reading

The shared builder first landed under `lib/embervm/op_log/`, which the layer-1
construction-site guard **excludes** (backends consume kinds, they do not
originate them). The guard correctly went red. Moved to
`lib/embervm/primed_op.ex` and `op_kind_sites` updated, with a note recording
why the registry now names a builder rather than a call site:

> A static guard can prove a construction exists; it cannot prove the path
> runs. #4765 is precisely a construction that existed and never ran. The
> runtime half is the checker's coverage assertion, not a fourth grep.

Three guards have already failed trying to make a lexical test answer a
dataflow question. That reasoning is now in `vocabulary.exs` so a fourth is not
attempted.

## Tests

One per site, because the dispatcher path **already had a passing test** in
#4764 and still emitted nothing in production. A test proving "the append
works" is not a test proving "the append is where the work happens". Plus a
payload-shape test so a future site cannot introduce a differently-spelled
field.

## Verification

- `ci test`: **1212 tests, 0 failures, 6 skipped**, run independently.
- `ci lint` clean. No em-dashes. No `Chart.yaml` or `targetRevision` edit.
- Post-merge I will verify `:primed` rows actually appear in production across
  all three lanes with sane timestamps, since that check is what found this.

Refs #4759, #4764.