### PR TITLE
fix(embervm): split :session_relit, a rejoin is not a memory relight

### DIFF
--- a/projects/embervm/control/lib/embervm/op_log.ex
+++ b/projects/embervm/control/lib/embervm/op_log.ex
@@ -99,7 +99,19 @@ defmodule Embervm.OpLog do
     :session_banked,
     :session_parked,
     :session_parking,
+    # NOTE: Pre-split history ambiguity. Before this change, :session_relit was
+    # also emitted by the rejoin path (filesystem lineage restore, no generation
+    # pairing). Production has about 59 such rows, distinguishable by the
+    # absence of `generation` in the payload. Any consumer reading historical
+    # :session_relit rows must treat absence of `generation` as a rejoin
+    # (filesystem restore) rather than a relight (memory snapshot restore). This
+    # payload-based discriminator is self-describing and correct forever,
+    # unlike a time-based watermark that would break on restore.
     :session_relit,
+    # Rejoin restores a filesystem lineage volume (ADR 027 memory:false),
+    # participates in no generation pairing, and is distinct from
+    # :session_relit (memory snapshot with generation).
+    :session_rejoined,
     :session_expired,
     :session_evicted,
     # session_destroying is the durable destroy INTENT (ADR embervm/014 decision 5):

--- a/projects/embervm/control/lib/embervm/op_log/postgres.ex
+++ b/projects/embervm/control/lib/embervm/op_log/postgres.ex
@@ -779,6 +779,9 @@ defmodule Embervm.OpLog.Postgres do
     )
   end
 
+  defp project(conn, %Op{kind: :session_rejoined} = op, _seq),
+    do: project(conn, %{op | kind: :session_relit}, nil)
+
   # session_destroying: the durable destroy INTENT (ADR embervm/014 decision 5).
   # A non-terminal state marker appended BEFORE the teardown, so a CP crash
   # mid-destroy rebuilds as destroying and re-drives it rather than forgetting.

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -973,6 +973,9 @@ defmodule Embervm.OpLog.SQLite do
     end
   end
 
+  defp project(conn, %Op{kind: :session_rejoined} = op, _seq),
+    do: project(conn, %{op | kind: :session_relit}, nil)
+
   # session_destroying: the durable destroy INTENT (ADR embervm/014 decision 5).
   # A non-terminal state marker appended BEFORE the node-confirmed teardown RPC, so
   # a CP crash mid-destroy rebuilds as destroying and re-drives the destroy rather

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -1825,7 +1825,7 @@ defmodule Embervm.SessionManager do
     case start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id,
            dial_id, [rejoin_failure_fun: failure_fun]) do
       {:ok, pid} ->
-        case SessionStore.transition(state.session_store, session_id, :rejoin_ready, :session_relit,
+        case SessionStore.transition(state.session_store, session_id, :rejoin_ready, :session_rejoined,
                %{volume_node_id: session.volume_node_id}, %{node_id: node_id, vm_id: vm_id}) do
           {:ok, _} -> drain_relight_into_process(state, session_id, pid)
           {:error, reason} ->

--- a/projects/embervm/control/test/embervm/op_log/session_projection_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/session_projection_test.exs
@@ -113,6 +113,28 @@ defmodule Embervm.OpLog.SessionProjectionTest do
     :ok = GenServer.stop(server)
   end
 
+  test "session_rejoined projects a parked filesystem lineage session as running", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("s-rejoin", "p1", 100))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :session_rejoined,
+        tenant: "t1",
+        principal: "p1",
+        workload: "sandbox-session",
+        session_id: "s-rejoin",
+        ts: 200,
+        payload: %{volume_node_id: "node-9"}
+      })
+
+    s = session_by_id(server)["s-rejoin"]
+    assert s.state == "running"
+
+    :ok = GenServer.stop(server)
+  end
+
   test "a session_created op with an explicit lineage_id in its payload projects it verbatim, not defaulted", %{path: path} do
     server = start_server(path)
 

--- a/projects/embervm/control/test/embervm/op_log_payloads_test.exs
+++ b/projects/embervm/control/test/embervm/op_log_payloads_test.exs
@@ -102,6 +102,89 @@ defmodule Embervm.OpLogPayloadsTest do
     assert op.payload["relight_ms"] == 27
   end
 
+  test "rejoin appends session_rejoined with filesystem lineage payload only", %{path: path} do
+    {:ok, op_log} = SQLite.start_link(path: path, name: nil)
+    {:ok, store} = SessionStore.start_link(op_log: op_log, name: nil, clock: clock(), async_lifecycle_writes: false)
+
+    {:ok, created} =
+      SessionStore.create(store, %{
+        tenant: "t",
+        principal: "p",
+        workload: "w",
+        vm_id: "vm-1",
+        node_id: "node-1"
+      })
+
+    {:ok, _} = SessionStore.transition(store, created.session_id, :park, :session_parking, %{volume_node_id: "node-1"}, %{})
+    {:ok, _} = SessionStore.transition(store, created.session_id, :park_complete, :session_parked, %{volume_node_id: "node-1"}, %{})
+    {:ok, _} = SessionStore.mark(store, created.session_id, :relight)
+
+    {:ok, _} =
+      SessionStore.transition(
+        store,
+        created.session_id,
+        :rejoin_ready,
+        :session_rejoined,
+        %{volume_node_id: "node-2"},
+        %{node_id: "node-2", vm_id: "vm-2"}
+      )
+
+    op = read_kind(op_log, :session_rejoined)
+    assert op.payload["volume_node_id"] == "node-2"
+    refute Map.has_key?(op.payload, "generation")
+    refute Map.has_key?(op.payload, "snapshot_ref")
+    refute read_kind(op_log, :session_relit)
+  end
+
+  # The POSITIVE half of the #4766 split. The rejoin test above proves a rejoin
+  # no longer masquerades as a relight; this proves a real memory relight still
+  # carries the pairing fields bank_relight.tla reads. Without it, dropping
+  # `generation` from the relight payload, or pointing the relight site at the
+  # rejoin kind, would leave the suite green and silently reopen #4766: the
+  # checker would see generation missing on every row and be unable to tell
+  # "wrong protocol" from "missing field", which is the exact ambiguity this
+  # split exists to remove.
+  test "memory relight appends session_relit WITH the pairing fields", %{path: path} do
+    {:ok, op_log} = SQLite.start_link(path: path, name: nil)
+    {:ok, store} = SessionStore.start_link(op_log: op_log, name: nil, clock: clock(), async_lifecycle_writes: false)
+
+    {:ok, created} =
+      SessionStore.create(store, %{
+        tenant: "t",
+        principal: "p",
+        workload: "w",
+        vm_id: "vm-1",
+        node_id: "node-1"
+      })
+
+    # running -> banking -> banked. `banking` is transient and ETS-only (no
+    # durable op), so it is a mark; the durable :session_banked lands on the
+    # bank_ready edge carrying the generation the pairing check reads.
+    {:ok, _} = SessionStore.mark(store, created.session_id, :bank)
+
+    {:ok, _} =
+      SessionStore.transition(store, created.session_id, :bank_ready, :session_banked,
+        %{generation: 7, snapshot_ref: "snap-7"}, %{})
+
+    {:ok, _} = SessionStore.mark(store, created.session_id, :relight)
+
+    {:ok, _} =
+      SessionStore.transition(
+        store,
+        created.session_id,
+        :relight_ready,
+        :session_relit,
+        %{snapshot_ref: "snap-7", generation: 7, relight_ms: 12},
+        %{node_id: "node-2", vm_id: "vm-2"}
+      )
+
+    op = read_kind(op_log, :session_relit)
+    assert op.payload["generation"] == 7
+    assert op.payload["snapshot_ref"] == "snap-7"
+    # The two kinds are distinct protocols and must never both fire for one wake.
+    refute read_kind(op_log, :session_rejoined)
+  end
+
   test "PrimedOp.build produces consistent payload shape across lanes" do
     task = PrimedOp.build("homelab", "wl", "vm-task", "node-4", :task)
     session = PrimedOp.build("homelab", "wl", "vm-session", "node-4", :session)

--- a/projects/embervm/specs/vocabulary.exs
+++ b/projects/embervm/specs/vocabulary.exs
@@ -80,6 +80,14 @@
         # protocol 2): bank/relight generation pairing + the ADR 014 node-confirmed
         # destroy carve-out (session_destroying intent -> node confirm ->
         # session_destroyed record).
+        # NOTE: Pre-split history ambiguity. Before this change, :session_relit was
+        # also emitted by the rejoin path (filesystem lineage restore, no generation
+        # pairing). Production has about 59 such rows, distinguishable by the
+        # absence of `generation` in the payload. Any consumer reading historical
+        # :session_relit rows must treat absence of `generation` as a rejoin
+        # (filesystem restore) rather than a relight (memory snapshot restore). This
+        # payload-based discriminator is self-describing and correct forever,
+        # unlike a time-based watermark that would break on restore.
         ~w(session_banked session_relit session_evicted session_destroying
            session_destroyed)a ++
         # R0 quota gate protocol 3: quota.tla models the submit-time quota
@@ -101,7 +109,9 @@
       # outside the adoption pilot and outside bank_relight.tla's bank/relight
       # generation pairing (a parked session holds a filesystem lineage volume,
       # not a memory snapshot, so it pairs with no generation).
-      ~w(session_parking session_parked)a ++
+      # session_rejoined is not modeled by bank_relight.tla (filesystem lineage,
+      # no generation pairing).
+      ~w(session_parking session_parked session_rejoined)a ++
         ~w(started vm_destroyed base_built denied drain retried
            redrive dead_lettered failed)a ++
         # Remaining R2 session lifecycle kinds still out of scope. The bank/relight,


### PR DESCRIPTION
Closes #4766. Phase 0 of #4759.

## The defect

Two append sites shared one op kind while implementing **different protocols**:

```
session_manager.ex:1828   :rejoin_ready    %{volume_node_id: ...}
session_manager.ex:2219   :relight_ready   %{snapshot_ref:, generation:, relight_ms:}
```

A **rejoin** restores a filesystem lineage volume: the ADR 027 `memory:false`
quadrant, which `vocabulary.exs` already describes as pairing with no
generation. A **relight** restores a memory snapshot, where generation pairing
applies.

All 59 production rows are rejoins, verified from payload shape (33 bytes, no
`generation`). So a reader of `:session_relit` cannot tell whether memory state
was restored into the VM.

**This is a book-of-record defect on its own merits**, relevant to ADR
embervm/033's encryption-at-rest reasoning, not only to `bank_relight.tla`. It
is a good example of the line this programme is drawing: most spec-driven
pressure belongs in a separate trace (#4770), but here the spec work found a
genuine ambiguity in the durable log.

## Change

The rejoin site appends `:session_rejoined`, classified `excluded` in
`vocabulary.exs` (no generation pairing, outside `bank_relight.tla`).
`:session_relit` keeps the memory-snapshot path and stays `modeled`.

Both backends delegate the new kind to the existing `:session_relit`
projection, so sessions keep projecting identically. That clause takes `_seq`
and ignores it, so the delegation passing `nil` is inert (checked, not
assumed).

## The fix must not create the problem it removes

Existing `:session_relit` rows were written by the rejoin path, so **the kind
means different things either side of this commit**. Anyone asking "how often
do we relight?" next month would get 59 confident false positives from history.

Both `op_log.ex` and `vocabulary.exs` now record that a historical
`:session_relit` **without `generation`** is a rejoin.

The discriminator is payload-based rather than a seq or timestamp watermark on
purpose: it is self-describing, needs no maintenance, and stays correct through
a restore.

## Tests cover both directions

- **Negative**: a rejoin carries no `generation` or `snapshot_ref` and emits no
  `:session_relit`. This is what the bug looked like.
- **Positive**: a real memory relight still appends `:session_relit` **with**
  `generation` and `snapshot_ref`, and emits no `:session_rejoined`.
- Projection: `:session_rejoined` still advances a parked session to running.

The positive test is the one that stops recurrence. A negative-only suite is
satisfied by emitting the field nowhere at all, which is precisely the state
#4766 described.

## Scope note

An earlier revision of this branch also carried an inventory provenance tag on
the `:assigned` payload for #4768. **That was dropped deliberately.** Provenance
is evidence a conformance checker wants, not a business fact about the task, so
it belongs in the spec trace (#4770) rather than in a closed durable enum.
Widening the book of record for spec reasons is the mistake behind four of the
five defects found so far.

Interim, #4768 is handled without code: the checker reports "assigned with no
`:primed` within retention" as **UNPROVEN**, a distinct class from violation.

## Verification

- `ci test`: **1215 tests, 0 failures, 6 skipped**, run independently.
- A `NodeRegistryTest` expiry failure in an intermediate run did not reproduce;
  confirmed flaky rather than assumed.
- `ci lint` clean. No em-dashes. No `Chart.yaml` or `targetRevision` edit.

Refs #4759, #4768, #4770.