### PR TITLE
feat(embervm): add a 1gi brick class for the conformance dev fleet

### DIFF
--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1114,6 +1114,34 @@ bricks:
   # EMBERVM_NODED_DAEMON_RESERVE_MIB default; this single source renders both.
   daemonReserveMib: 512
   classes:
+    # THE SMALLEST CLASS THAT CAN HOST ANYTHING, and the arithmetic is the
+    # reason rather than a preference: daemonReserveMib (512) is subtracted from
+    # the class limit to get guest-schedulable capacity, so 1Gi yields 512Mi for
+    # guests (four 128Mi microVMs) and a 512Mi class would yield ZERO. Do not add
+    # a class at or below daemonReserveMib; it renders a brick that can never
+    # admit a VM, and nothing validates that today.
+    #
+    # Exists for the conformance work (#4762): checking a spec invariant needs
+    # LIFECYCLE EVENTS per unit of memory, not compute, so many tiny VMs beat few
+    # large ones, and tiny VMs are cheap enough to destroy deliberately, which is
+    # what fault injection requires.
+    #
+    # Rendering a class does NOT create a brick: replicas reads
+    # `desiredReplicas[class] | default 0` (brick-deployment.yaml), and an
+    # unlisted class also reads maxReplicas max(desired, min) = 0, so the
+    # BrickController cannot scale it either. Production lists no 1gi desired
+    # replicas, so this adds an empty Deployment and no pods. The dev
+    # environment opts in by listing it.
+    - name: 1gi
+      resources:
+        requests:
+          # Same as 2gi. A guest still pays full boot cost regardless of its
+          # memory footprint, so starving CPU would slow the very lifecycle
+          # transitions this class exists to produce.
+          cpu: "1"
+          memory: 1Gi
+        limits:
+          memory: 1Gi
     - name: 2gi
       resources:
         requests:


### PR DESCRIPTION
Groundwork for #4762. **Inert in production**: adds an empty Deployment and no
pods.

## Why 1Gi and not 512Mi

Arithmetic, not preference. `daemonReserveMib` (512) is subtracted from the
class limit to get guest-schedulable capacity:

```
1Gi   ->  512Mi for guests  ->  four 128Mi microVMs
512Mi ->  0Mi               ->  a brick that can never admit a VM
```

Nothing validates that today, so a future 512Mi class would render a brick that
silently admits nothing. The values comment now says so.

## Why a tiny class exists at all

The scarce resource for conformance checking is **lifecycle events per unit of
memory**, not compute. Every invariant worth checking is about transitions
(prime, assign, adopt, bank, relight, destroy), so many tiny VMs beat few large
ones. Tiny VMs are also cheap enough to **destroy deliberately**, which is what
fault injection needs.

Production's catalog is all far too heavy for this: `claude-runtime` alone
carries 4GiB bases, and #4290 already shows base images filling the masters'
35GiB scratch.

## Why this is safe to land in production values now

Declaring a class and running a class are cleanly separated:

```
replicas: {{ index .Values.bricks.desiredReplicas $class.name | default 0 }}
```

and an unlisted class reads `maxReplicas` as `max(desired, min)` = 0, so the
BrickController cannot scale it either.

Verified by rendering against production values:

```
embervm-embervm-noded-brick-1gi     replicas=0  mem=1Gi   <- new, empty
embervm-embervm-noded-brick-2gi     replicas=1  mem=2Gi
embervm-embervm-noded-brick-4gi     replicas=0  mem=4Gi
embervm-embervm-noded-brick-8gi     replicas=0  mem=8Gi
embervm-embervm-noded-brick-16gi    replicas=1  mem=16Gi
... node-pinned bricks unchanged
```

Same inert-landing shape the brick programme already used for its canary
(`bricks.enabled=false`), which is why the mechanism was there to reuse. Dev
opts in with one line in its own values.

## On the 512Mi reserve, measured rather than inherited

Worth recording, since it affects how dev should be tuned. Live noded container
memory ranges from 10Mi to 1135Mi across the fleet, but **that metric includes
the microVMs noded hosts**, because Firecracker runs in the same cgroup. It is
the same reason #4563 found noded admits on *observed* cgroup memory rather than
declared `memMib`. A 1135Mi reading on a 2Gi brick would otherwise mean the
design was already broken.

So the daemon's own idle floor is the low end, tens of MiB, and 512 is headroom
rather than a requirement. Left unchanged here because it costs nothing on
2Gi-and-up production bricks. The dev install can lower it (`bricks.daemonReserveMib`
is a values key, global per install) and get more guests per brick:

```
reserve 512  ->  1Gi brick = 512Mi guests
reserve 192  ->  1Gi brick = 832Mi guests
```

Caveat recorded honestly: this measures the daemon's idle floor, not its peak,
since the metric conflates daemon and guests. Base builds and snapshot handling
are the plausible spikes, so dev's reserve should be lowered deliberately and
watched, not set to the floor.

## Verification

- `helm template` against production values: the render above.
- `ci test`: **1212 tests, 0 failures, 6 skipped**, `Executed 2 out of 707`
  (the template tests exercised the change).
- `ci lint` clean. No em-dashes. No `Chart.yaml` version or `targetRevision` edit.

Refs #4759, #4762.