### PR TITLE
fix(monolith): apply the round-2 copy verification fixes

### DIFF
--- a/projects/monolith/frontend/src/lib/public/agentstory/AgentScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/agentstory/AgentScrollStory.svelte
@@ -340,7 +340,7 @@
         <p class="sub">Killed on idle, rebuilt from disk or S3 on resume.</p>
         <div class="stats">
           <span><b>2.5 ms</b> VM resume</span><span class="sep">·</span><span
-            ><b>20 s</b> idle, then the VM is destroyed</span
+            ><b>20 s</b> idle before the VM is destroyed</span
           ><span class="sep">·</span><span
             ><b>0</b> real credentials inside</span
           >

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -812,7 +812,7 @@
     </div>
   {:else}
     <div class="legend">
-      <p class="eyebrow legend-title">Ships seen per map square</p>
+      <p class="eyebrow legend-title">Ships seen per map square, all time</p>
       <ul class="heat-scale">
         {#each heatBreaks.slice(0, HEAT_COLORS.length) as br, i (br)}
           <li>

--- a/projects/monolith/frontend/src/lib/public/ember/ScanView.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/ScanView.svelte
@@ -459,7 +459,7 @@
     {#if sortedFindings.length === 0 && scanErrors.length === 0}
       <p class="empty-state">
         {#if result}
-          clean. no findings in this snippet. try another.
+          no findings in this snippet. try another.
         {:else}
           findings land on their lines as the scan passes them.
         {/if}

--- a/projects/monolith/frontend/src/lib/public/grimoire/ChaptersNav.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/ChaptersNav.svelte
@@ -174,7 +174,7 @@
       {:else if error}
         <p class="pub-chapters-status">{error}</p>
       {:else if tree.length === 0}
-        <p class="pub-chapters-status">This book has no chunks yet.</p>
+        <p class="pub-chapters-status">This book has no passages yet.</p>
       {:else}
         {@render branch(tree)}
       {/if}

--- a/projects/monolith/frontend/src/lib/public/grimoire/ConstellationDock.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/ConstellationDock.svelte
@@ -61,7 +61,7 @@
       <div
         class="dock-panel"
         role="dialog"
-        aria-label="Entities you've explored"
+        aria-label="People and places you've explored"
       >
         <div class="dock-panel-head">
           <span class="dock-panel-title">YOUR TRAIL</span>
@@ -96,7 +96,7 @@
       class="dock-pill"
       onclick={toggle}
       aria-expanded={expanded}
-      aria-label={`${state.nodes.length} entities in your trail, ${expanded ? "collapse" : "expand"}`}
+      aria-label={`${state.nodes.length} people and places in your trail, ${expanded ? "collapse" : "expand"}`}
     >
       <span class="dock-preview">
         <MiniConstellation

--- a/projects/monolith/frontend/src/lib/public/grimoire/chat/SourceDrawer.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/chat/SourceDrawer.svelte
@@ -94,7 +94,7 @@
     item?.kind === "entity" ? entityHref(item.id) : null,
   );
   const kindLabel = $derived(
-    item?.kind === "entity" ? item.entity_type || "entity" : "passage",
+    item?.kind === "entity" ? item.entity_type || "person or place" : "passage",
   );
   const headerLabel = $derived(
     item?.kind === "entity" && entity

--- a/projects/monolith/frontend/src/lib/public/grimoire/chat/stream.js
+++ b/projects/monolith/frontend/src/lib/public/grimoire/chat/stream.js
@@ -175,7 +175,7 @@ export function applyFrame(state, frame) {
 // Map a pre-stream HTTP error (the proxy relays the backend status + body
 // before any SSE starts) to a human message. The soft, retryable shed arrives
 // in-stream as a 200 `busy` frame; these are the terminal pre-stream cases.
-function messageForError(status, detail) {
+function messageForError(status) {
   switch (status) {
     case 400:
       return `That message is too long (max ${CHARACTER_LIMIT} characters). Please shorten it.`;
@@ -221,7 +221,7 @@ export async function streamChatMessage(
       type: "error",
       data: {
         code: detail.code ?? "error",
-        message: messageForError(resp.status, detail),
+        message: messageForError(resp.status),
       },
     });
     return;

--- a/projects/monolith/frontend/src/lib/public/grimoire/explore/ExploreCanvas.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/explore/ExploreCanvas.svelte
@@ -735,7 +735,7 @@
     bind:this={canvasEl}
     class:dragging
     role="application"
-    aria-label={`Entity relationship graph, ${nodes.length} entities, ${edges.length} relationships shown. Tap or click a node to open its detail, drag to pan, scroll or pinch to zoom.`}
+    aria-label={`People and places relationship graph, ${nodes.length} people and places, ${edges.length} relationships shown. Tap or click a node to open its detail, drag to pan, scroll or pinch to zoom.`}
   ></canvas>
 </div>
 

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
@@ -152,7 +152,7 @@
   const COUNTS = [
     ["books", story.corpus.books],
     ["passages", story.corpus.chunks],
-    ["characters, places and items", story.corpus.entities],
+    ["people and places", story.corpus.entities],
     ["relationships", story.corpus.edges],
   ];
   const topTypes = Object.entries(story.corpus.byType)
@@ -994,11 +994,9 @@
           Unearthed from this page
         </div>
         <div class="this-page">
-          <span>{story.bboxes.length} text blocks</span><span class="k">/</span>
-          <span>{story.chunks.length} passages</span><span class="k">/</span>
-          <span>{story.entities.length} characters, places and items</span><span
-            class="k">/</span
-          >
+          <span>{story.bboxes.length} text blocks /</span>
+          <span>{story.chunks.length} passages /</span>
+          <span>{story.entities.length} people and places /</span>
           <span>{graphEdges.length} relationships</span>
         </div>
         <div class="scale-head grim-title section-head compendium-head">
@@ -1025,7 +1023,7 @@
       <div class="chat-head" bind:this={chatHeadEl}>
         <div class="scale-head grim-title">Ask the Grimoire.</div>
         <div class="chat-sub">
-          Every claim links back to the passage it came from. Click one.
+          Every claim shows what it drew on. Click one to see it on the page.
         </div>
       </div>
 
@@ -1157,7 +1155,7 @@
         viewBox="0 0 100 100"
         preserveAspectRatio="xMidYMid meet"
         role="img"
-        aria-label="Relationship graph of the entities on this page"
+        aria-label="Relationship graph of the people and places on this page"
       >
         {#each graphEdges as e, i (i)}
           <line
@@ -1188,7 +1186,7 @@
 
     <section class="static-scene">
       <p class="static-cap">
-        <b>4 / Every book.</b>
+        <b>4 / Every book in the library gets the same treatment. In total:</b>
       </p>
       <div class="static-counters">
         {#each COUNTS as [label, value] (label)}
@@ -1210,8 +1208,7 @@
 
     <section class="static-scene">
       <p class="static-cap">
-        <b>5 / Grounded answers.</b> Every claim links back to the passage it came
-        from. Click one.
+        <b>5 / Grounded answers.</b> Every claim shows what it drew on.
       </p>
       <div class="chat static-chat">
         {#if isPlaceholder}

--- a/projects/monolith/frontend/src/lib/public/grimoire/world/EntitySearch.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/world/EntitySearch.svelte
@@ -191,7 +191,7 @@
       bind:this={inputEl}
       class="search-input"
       type="text"
-      placeholder="Search entities..."
+      placeholder="Search people and places..."
       autocomplete="off"
       role="combobox"
       aria-expanded={open}
@@ -200,7 +200,7 @@
         ? optionId(activeIdx)
         : null}
       aria-autocomplete="list"
-      aria-label="Search entities"
+      aria-label="Search people and places"
       bind:value={q}
       oninput={onInput}
       onfocus={onFocus}
@@ -247,7 +247,11 @@
     {/if}
   </div>
 
-  <div class="chips" role="group" aria-label="Filter search by entity type">
+  <div
+    class="chips"
+    role="group"
+    aria-label="Filter search by people and place type"
+  >
     {#each TYPE_CHIPS as t (t.value)}
       <button
         type="button"

--- a/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
+++ b/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
@@ -60,7 +60,9 @@
         <div class="callout featured">
           <div class="chead">
             <h3>{app.label.toUpperCase()}</h3>
-            <span class="where">NODE-4</span>
+            <span class="where"
+              >{app.slug === "grimoire" ? "NODE-2" : "NODE-4"}</span
+            >
           </div>
           {#if app.slug === "grimoire"}
             <p>
@@ -106,9 +108,10 @@
           <span class="where">NODE-4</span>
         </div>
         <p>
-          A <b>35B model</b> holds a conversation at <b>~170 tokens a second</b>
-          on one consumer RTX 4090, squeezed in with int4 weights and an fp8 KV-cache.
-          Chat, the agents, and note search all share the card.
+          A <b>35B model</b> with only 3B active at a time answers at
+          <b>~170 tokens a second</b> on one consumer RTX 4090. Int4 weights and an
+          fp8 KV-cache squeeze it into the card's 24 GB. Chat, the agents, and note
+          search all share it.
         </p>
       </div>
       <div class="callout">

--- a/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
@@ -397,7 +397,7 @@
           <div class="sort-row">
             <span class="control-label">Sort</span>
             <div class="toggle" role="group" aria-label="Sort parks by">
-              {#each [["best_score", "Clear-sky score"], ["good_days", "Days"], ["name", "Name"]] as [key, label] (key)}
+              {#each [["best_score", "Sky score"], ["good_days", "Nights"], ["name", "Name"]] as [key, label] (key)}
                 <button
                   type="button"
                   class="seg"
@@ -521,10 +521,10 @@
       </div>
 
       <p class="detail-legend">
-        A check means the site is bookable. Green fades to grey as forecast
-        cloud increases, and closed sites are grey. The clear-sky score runs 0
-        to 100, higher is clearer. Each cell shows max temp (&deg;) and rain
-        (mm, blue when wet).
+        A check means the site is bookable. Green fades to grey as the forecast
+        worsens, and closed sites are grey. The clear-sky score runs 0 to 100,
+        higher is clearer. Each cell shows max temp (&deg;) and rain (mm, blue
+        when wet).
       </p>
     </section>
   {/if}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -99,7 +99,7 @@
     <title>Grimoire · jomcgi.dev</title>
     <meta
       name="description"
-      content="Browse the D&D sourcebooks loaded here, read them page by page, and look up creatures, places and lore."
+      content="Browse the D&D sourcebooks loaded here, read them page by page, and look up the people, places and lore inside them."
     />
     <meta name="robots" content="noindex, nofollow" />
   {/if}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
@@ -45,10 +45,7 @@
 </script>
 
 <svelte:head>
-  <title
-    >Grimoire: a D&D campaign manager where each player sees only what the DM
-    shares · jomcgi.dev</title
-  >
+  <title>Grimoire: a D&D campaign manager · jomcgi.dev</title>
   <meta
     name="description"
     content="Scan a sourcebook, then ask it questions and get answers with the page they came from. Every player sees only what their DM has shared."
@@ -175,14 +172,6 @@
     max-width: 68ch;
     color: var(--grim-text-dim);
     font-size: 14px;
-    line-height: 1.6;
-  }
-
-  .block-note {
-    margin: 20px 8px 0;
-    max-width: 68ch;
-    color: var(--grim-text-faint);
-    font-size: 12.5px;
     line-height: 1.6;
   }
 

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/adventure/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/adventure/[id]/+page.svelte
@@ -94,7 +94,7 @@
       </section>
     {:else}
       <p class="empty-help roster-empty">
-        No characters or places recorded for this adventure yet.
+        No people or places recorded for this adventure yet.
       </p>
     {/if}
   {/if}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/+page.svelte
@@ -78,7 +78,9 @@
             {#if adv.summary}
               <p class="adventure-summary">{adv.summary}</p>
             {/if}
-            <span class="adventure-count">{adv.entity_count} ENTITIES</span>
+            <span class="adventure-count"
+              >{adv.entity_count} PEOPLE &amp; PLACES</span
+            >
           </a>
         </li>
       {/each}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/chat/+page.svelte
@@ -343,7 +343,7 @@
           <div class="chat-gate">
             <p class="eyebrow chat-gate-eyebrow">START CHATTING</p>
             <p class="chat-gate-copy">
-              Solve the puzzle once to start. Every answer quotes the sourcebook
+              Solve the puzzle once to start. Every answer shows the sourcebook
               page it came from.
             </p>
             <TurnstileGate
@@ -363,7 +363,7 @@
             <p class="empty-sub">
               Rules, spells, monsters, magic items, lore, adventures. A sage
               reads the loaded sourcebooks and answers, citing what it drew on.
-              Nothing leaves this machine.
+              Your questions never leave my homelab.
             </p>
             <div class="chat-examples">
               {#each EXAMPLES as ex}
@@ -404,7 +404,7 @@
                               ? n.entity_type
                               : 'class'}, currentColor)"
                           >
-                            {n.title || "untitled entity"}
+                            {n.title || "untitled"}
                           </a>
                         {:else}
                           <button
@@ -450,7 +450,7 @@
       {#if constellation.nodes.length > 0}
         <aside
           class="constellation"
-          aria-label="Entities this conversation has drawn on"
+          aria-label="People and places this conversation has drawn on"
         >
           <span class="constellation-cap">SESSION CONSTELLATION</span>
           <MiniConstellation

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/chat/s/[id]/+page@.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/chat/s/[id]/+page@.svelte
@@ -78,7 +78,7 @@
   <meta name="robots" content="noindex" />
   <meta
     name="description"
-    content="A read-only snapshot of a conversation with the Grimoire, a D&D sourcebook sage grounded in my loaded sourcebooks."
+    content="A saved copy of a conversation with the Grimoire, a sage that answers from my D&D sourcebooks."
   />
 </svelte:head>
 
@@ -148,7 +148,7 @@
                             ? n.entity_type
                             : 'class'}, currentColor)"
                         >
-                          {n.title || "untitled entity"}
+                          {n.title || "untitled"}
                         </a>
                       {:else}
                         <span class="touched-chip"
@@ -169,9 +169,9 @@
       <div class="fork-panel">
         <p class="fork-eyebrow">CONTINUE THIS CHAT</p>
         <p class="fork-copy">
-          Solve the challenge to pick up this conversation in a fresh session.
-          The transcript above is carried over. No sign-in, no tracking beyond
-          what keeps the bots out.
+          Solve the puzzle to pick up this conversation in a fresh session. The
+          transcript above is carried over. No sign-in, no tracking beyond what
+          keeps the bots out.
         </p>
         <TurnstileGate
           siteKey={data.turnstileSiteKey}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/library/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/library/+page.svelte
@@ -169,12 +169,11 @@
     <p class="summary">
       {totals.books.toLocaleString()}
       {totals.books === 1 ? "book" : "books"}, {totals.chunks.toLocaleString()}
-      pages of lore, {totals.entities.toLocaleString()} characters, places and items,
-      updated {totals.synced}
+      pages of lore, {totals.entities.toLocaleString()} people and places{#if totals.synced !== "never"},
+        updated {totals.synced}{/if}
     </p>
     <p class="legend">
-      Some books are free to read here in full. The rest are listed so you can
-      see what is loaded.
+      Some books are free to read here in full. The rest are reference only.
     </p>
     {#if readableCount > 0 && readableCount < totals.books}
       <div class="filter" role="tablist" aria-label="Filter books">
@@ -290,7 +289,7 @@
                 <span class="kind-label grim-smallcaps">{group.label}</span>
                 <span class="chips">
                   <span class="chip"
-                    >{book.entity_count.toLocaleString()} entities</span
+                    >{book.entity_count.toLocaleString()} people and places</span
                   >
                   <span class="chip"
                     >{book.image_count.toLocaleString()} images</span

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/world/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/world/+page.svelte
@@ -369,7 +369,9 @@
       {:else if displayGraph.nodes.length === 0}
         <div class="empty">
           <p class="grim-title empty-lead">Nothing to show.</p>
-          <p class="empty-help">Search for an entity to see its world.</p>
+          <p class="empty-help">
+            Search for a person or place to see their world.
+          </p>
         </div>
       {:else}
         <ExploreCanvas
@@ -382,7 +384,8 @@
         />
         {#if fellBackToFullEgo}
           <p class="fallback-note">
-            Nothing connects to this here. Showing the whole world instead.
+            Nothing connects to this in the chosen book and view. Showing the
+            whole world instead.
           </p>
         {/if}
         {#if legendTypes.length}

--- a/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
@@ -371,9 +371,10 @@
           ></span>{/if}
         <span class="chev" aria-hidden="true">{filtersOpen ? "▴" : "▾"}</span>
       </button>
-      {#if filtered.length === 0}
+      {#if walks.length > 0 && filtered.length === 0}
         <p class="geo-error">
-          No walks match these filters. Reset to see them all.
+          No walks match these filters. Open Filters and hit Reset to see them
+          all.
         </p>
       {/if}
     </div>

--- a/projects/monolith/frontend/src/routes/public/app/llm-leaderboard/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/llm-leaderboard/+page.svelte
@@ -206,11 +206,9 @@
         up stays visible. Open a row for the per-task split.</span
       >
       <span
-        >Two ways to read this table: what you can run on your own GPU, and what
-        you can call in the cloud. Hard, tokens, turns, and tools describe the
-        first view. Wall-time, cost, and $-per-solve describe the second,
-        including OpenRouter time and money compared with the Claude reference
-        rows.</span
+        >Hard, tokens, turns, and tools tell you how a model behaves on your own
+        GPU. Wall-time, cost, and $-per-solve tell you what it costs to rent,
+        timed through OpenRouter against the Claude reference rows.</span
       >
     </div>
   </section>

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
@@ -631,7 +631,8 @@
               <p class="empty-sub">
                 There are {fmtCount(PUBLIC_NOTE_COUNT)} of them: coffee logs, design
                 notes, dark-sky readings, half-finished side quests. A model running
-                on my own machines reads them and answers. Nothing leaves the house.
+                on my own machines reads them and answers. Your questions never go
+                to a model vendor.
               </p>
               <div class="chat-examples">
                 {#each EXAMPLES as ex}

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -441,7 +441,9 @@
         </div>
       {:else if histReady && histCount === 0}
         <div class="panel empty-state" role="status">
-          No clear dark hours {historyScope}. Try another month.
+          No clear dark hours {historyScope}{selectedMonth === ALL_YEAR
+            ? "."
+            : ". Try another month."}
         </div>
       {/if}
     {/if}

--- a/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
@@ -430,6 +430,10 @@
             and each match's swing are all just counts from the same set of simulations.
           </li>
         </ol>
+        <p class="explainer-fine">
+          The two lowest FIFA tiebreakers, discipline and world ranking, are
+          coin-flips here.
+        </p>
       </div>
     </details>
 
@@ -513,7 +517,9 @@
       </div>
       <ul class="zone-legend">
         <li><span class="zone-key zone-top2"></span>1&ndash;2 qualify</li>
-        <li><span class="zone-key zone-third"></span>Best third-place spot</li>
+        <li>
+          <span class="zone-key zone-third"></span>3rd: best third-place spot
+        </li>
         <li><span class="zone-key zone-out"></span>4th: out</li>
       </ul>
     </section>

--- a/projects/monolith/frontend/src/routes/public/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/chat/+page.svelte
@@ -17,7 +17,7 @@
 <main class="chat-shell">
   <h1>Chat</h1>
   {#if admitted}
-    <p>You're in. Chat isn't open yet, but your seat is saved.</p>
+    <p>You're in. The chat itself isn't open yet.</p>
   {:else}
     <p>Solve the challenge to start chatting.</p>
     <TurnstileGate

--- a/projects/monolith/frontend/src/routes/public/cv/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/cv/+page.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from "svelte";
-  import { Footer, Sticker, Marquee, Seo } from "$lib/public/components";
+  import { Footer, Marquee, Seo } from "$lib/public/components";
   import {
     contact,
     name,
@@ -162,9 +162,6 @@
         <span class="summary-tab mono">Profile</span>
         <p class="cv-summary">{@render inline(summary)}</p>
       </div>
-      <Sticker color="var(--accent)" rotate={-4} class="hero-sticker"
-        >BARE-METAL K3S</Sticker
-      >
     </div>
   </header>
 
@@ -199,9 +196,6 @@
               {#each job.highlights as highlight}
                 <div class="highlight">
                   <h4 class="highlight-title mono">{highlight.title}</h4>
-                  {#if highlight.kicker}
-                    <p class="highlight-kicker">{highlight.kicker}</p>
-                  {/if}
                   {#if highlight.intro}
                     <p class="highlight-intro">
                       {@render inline(highlight.intro)}
@@ -502,14 +496,6 @@
     background: var(--accent);
     border: 2px solid var(--ink);
     flex-shrink: 0;
-  }
-  .highlight-kicker {
-    font-family: var(--sans);
-    font-size: 15px;
-    font-weight: 600;
-    line-height: 1.45;
-    color: var(--ink);
-    margin: 0 0 8px;
   }
   .highlight-intro {
     font-family: var(--sans);

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -120,7 +120,7 @@
     {
       done: true,
       name: "R5 composite",
-      desc: "A scratch Kubernetes cluster as one composite workload: control plane and workers woke together on the first kubectl. The demo is since retired; the class awaits its next consumer.",
+      desc: "A scratch Kubernetes cluster as one composite workload: control plane and workers woke together on the first kubectl.",
     },
     {
       done: true,
@@ -140,7 +140,7 @@
     {
       done: false,
       name: "R9 packaging",
-      desc: "Ember becomes a standalone artifact somebody else could run: no dependency on the rest of this cluster, a project somebody else could clone and run.",
+      desc: "Ember becomes a standalone artifact somebody else could run: no dependency on the rest of this cluster.",
     },
     {
       done: false,
@@ -204,7 +204,7 @@
         <span class="sep">·</span>
         <span><b>~{vmRestore} ms</b> VM restore</span>
         <span class="sep">·</span>
-        <span>sleeping now</span>
+        <span>{stateWord ?? "asleep"} now</span>
         <span class="sep">·</span>
         <a
           class="src"
@@ -221,7 +221,7 @@
       <p class="body">
         Everything Ember runs is declared as a Kubernetes custom resource. There
         are five workload classes: task, session, serving, stateful, and
-        composite. What separates them is <b
+        composite. Three of them differ by <b
           >how much of the machine the guest is allowed to touch</b
         >. Stateful adds a disk that outlives the VM (the database below), and
         composite groups several VMs into one unit that wakes together.
@@ -493,14 +493,14 @@
         </p>
         <p>
           The task class has <b>no network device at all</b>. The guest can
-          reach exactly one thing: the daemon, over vsock.
+          reach exactly one thing: its channel to the host daemon.
         </p>
         <p>
-          <b>Quotas fail closed.</b> A principal with quota 0 is hard-stopped at submit.
+          <b>Quotas fail closed.</b> A customer with quota 0 is hard-stopped at submit.
         </p>
         <p>
-          If a node loses contact with the control plane it keeps running the
-          work and keeps its own tally.
+          The spend tally fails open: a node cut off from the control plane
+          keeps running the work and keeps its own tally.
         </p>
         <p>
           The one public route is scoped at <b>three independent layers</b>: the

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
@@ -425,8 +425,9 @@
     <header class="masthead">
       <h1><span class="ember-word">Ember</span> Bazel Skyframe Query</h1>
       <p class="lede">
-        Ask a question about a 514-target C++ build graph and get the answer in
-        under a second, from a build server that was frozen mid-thought.
+        Ask a question about a C++ build graph and get the answer in under a
+        second, from a build server that was frozen mid-thought. Computing that
+        graph from scratch takes 13.8 seconds.
       </p>
       <p class="subtitle">
         <a class="inline-link" href="https://github.com/abseil/abseil-cpp"

--- a/projects/monolith/frontend/src/routes/public/ember/semgrep/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/semgrep/+page.svelte
@@ -343,9 +343,9 @@ def probe():
 
     <h1><span class="ember-word">Ember</span> Semgrep</h1>
     <p class="lede">
-      The production security scanner behind this cluster's CI, pointed at your
-      own snippet. A <b>Semgrep Pro</b> engine loaded its 1,600 rules once, then
-      was frozen as a microVM snapshot. Every scan thaws its own fresh copy in
+      Point the production security scanner behind this cluster's CI at your own
+      snippet. A <b>Semgrep Pro</b> engine loaded its 1,600 rules once, then was
+      frozen as a microVM snapshot. Every scan thaws its own fresh copy in
       <b>21 ms</b>.
     </p>
 

--- a/projects/monolith/frontend/src/routes/public/engineering/engineering-data.js
+++ b/projects/monolith/frontend/src/routes/public/engineering/engineering-data.js
@@ -101,7 +101,7 @@ export const projects = [
       },
       {
         k: "Serving data path",
-        v: "Traffic goes straight from the edge into the VM. The control plane hands out the routes and then stays out of the way; no request touches it or Kubernetes.",
+        v: "The control plane hands out the routes; requests go from the edge into the VM without touching it or Kubernetes.",
       },
       {
         k: "Quotas and metering",
@@ -130,7 +130,7 @@ export const projects = [
     oneLiner:
       "An LLM pipeline that decomposes my notes into structured facts, embeds them, and serves semantic search, both to my agents and to this site's search bar.",
     motivation:
-      "An on-cluster model breaks each of my notes into atomic facts and stores them so a question pulls back the right one. The knowledge pipeline turns markdown into a queryable graph, critiques its own extraction, and stores embeddings for semantic recall.",
+      "An on-cluster model breaks each of my notes into atomic facts and stores them so a question pulls back the right one.",
     facts: [
       {
         k: "Decomposition",
@@ -238,7 +238,7 @@ export const projects = [
     oneLiner:
       "A code generator that turns YAML state-machine specs into type-safe Go, so invalid operator state transitions become compile errors.",
     motivation:
-      "Sextant defines Kubernetes operator state machines declaratively and generates the boilerplate for their reconciliation loops. Every operator I wrote had the same bugs: invalid state transitions, forgotten error handling, missing metrics.",
+      "Every operator I wrote had the same bugs: invalid state transitions, forgotten error handling, missing metrics. Sextant defines Kubernetes operator state machines declaratively and generates the boilerplate for their reconciliation loops.",
     facts: [
       {
         k: "Compile-time safety",
@@ -347,7 +347,7 @@ export const projects = [
     facts: [
       {
         k: "AIS ingest",
-        v: "A background task inside the app holds a websocket to AISStream.io, filters to a Pacific Northwest box, and writes position reports straight to Postgres.",
+        v: "A background task inside the monolith holds a websocket to AISStream.io, filters to a Pacific Northwest box, and writes position reports straight to Postgres.",
       },
       {
         k: "Storage",


### PR DESCRIPTION
The 45 accepted findings from the post-deploy verification review, in one PR (round-2 triage: 45 accept / 1 deny).

Factual corrections: per-app node labels on the homepage rack (grimoire is NODE-2), the sparse-MoE qualifier restored so the 170 tok/s claim is true again, the invented chat "seat" gone, the ember classes count truthful (five listed, three differ on machine access), the wc2026 tiebreaker caveat restored, and the static ScrollStory no longer tells reduced-motion readers to click inert elements.

Consistency: grimoire vocabulary converged on "people and places" / "passages" everywhere a reader or screen-reader meets it (including four components outside the original review scope that the sweep caught), one name for the Turnstile widget, the share-page meta matched to its visible copy.

Owner-steered variants applied: RE7 drops the composite demo's retirement mention entirely (denied the grammar fix in favour of not mentioning it), RC2 restructured to avoid "fitted", RG3 reads "In total:".

Senior read caught three dispatch drifts before commit: an orphaned CSS body where only the selector was deleted, a doubled sentence in the notes empty state, and a nonexistent fine-print class. Also folded the doubled "Quotas fail closed" opener that RE5's restored header created.

`ci test`: Executed 2 out of 707 tests, 707 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)