### PR TITLE
feat(embervm): SpecTrace core, a debug-gated spec-shaped trace

### DIFF
--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -38,6 +38,7 @@ defmodule Embervm.Application do
     # the usage-admin list per request) see them. Empty budgets = quota off.
     Application.put_env(:embervm, :quota, quota_config())
     Application.put_env(:embervm, :usage_admins, usage_admins())
+    Embervm.SpecTrace.configure()
 
     # The noded ServiceAccount username the router authenticates dial-home
     # registrations against (R0 PR-2), from EMBERVM_NODED_SERVICE_ACCOUNT. Set
@@ -85,6 +86,7 @@ defmodule Embervm.Application do
       # roll loses no pending append. Started unconditionally: with the gate OFF it
       # receives no work (the stores keep write-through ordering), so it is inert.
       Embervm.AsyncWriter,
+      Embervm.SpecTrace,
       # TaskStore fires on_metered after a :succeeded/:failed op with usage lands,
       # so Embervm.Metering charges the quota cache off the same durable write.
       # async_writer + async_lifecycle_writes wire the gated off-hot-path append of

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -1206,11 +1206,41 @@ defmodule Embervm.Dispatcher do
         state
         |> reduce_backlog(backlog, tracked)
         |> adopt_inventory()
+        |> emit_spec_trace_checkpoint()
         |> drain_all()
 
       _ ->
         state
     end
+  end
+
+  defp emit_spec_trace_checkpoint(state) do
+    node_workload_vm_ids =
+      for {{node_id, workload}, queue} <- state.inventory, into: %{} do
+        {"#{node_id}:#{workload}", :queue.to_list(queue)}
+      end
+
+    reserved_vm_ids =
+      state.workers
+      |> Map.values()
+      |> Enum.map(&Map.get(&1, :vm_id))
+      |> Enum.filter(&is_binary/1)
+
+    Embervm.SpecTrace.emit(:adoption, :checkpoint, %{
+      "node_workload_vm_ids" => node_workload_vm_ids,
+      "reserved_vm_ids" => reserved_vm_ids,
+      "node_health" => safe_node_health()
+    })
+
+    state
+  rescue
+    _ -> state
+  end
+
+  defp safe_node_health do
+    Embervm.NodeRegistry.node_health()
+  catch
+    :exit, _ -> %{}
   end
 
   # Reconcile the dispatch inventory with each node's reported primed pool: adopt

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -183,6 +183,14 @@ defmodule Embervm.NodeRegistry do
     GenServer.call(server, :status)
   end
 
+  @doc "Return the health state for every registered node instance."
+  @spec node_health(GenServer.server()) :: %{String.t() => atom()}
+  def node_health(server \\ __MODULE__) do
+    server
+    |> status()
+    |> Map.new(fn {instance_id, facts} -> {instance_id, facts.health} end)
+  end
+
   @doc """
   Applies one `NodeStatus` as if it arrived from the given node's current stream.
   Test/operational seam: production status flows in from the streamer process,

--- a/projects/embervm/control/lib/embervm/primed_op.ex
+++ b/projects/embervm/control/lib/embervm/primed_op.ex
@@ -31,12 +31,21 @@ defmodule Embervm.PrimedOp do
 
   @spec build(String.t(), String.t(), String.t(), String.t(), atom()) :: Op.t()
   def build(tenant, workload, vm_id, node_id, lane) do
-    %Op{
+    op = %Op{
       kind: :primed,
       tenant: tenant,
       workload: workload,
       ts: System.system_time(:millisecond),
       payload: %{lane: lane, workload: workload, vm_id: vm_id, node_id: node_id}
     }
+
+    Embervm.SpecTrace.emit(:adoption, :prime, %{
+      "vm_id" => vm_id,
+      "node_id" => node_id,
+      "workload" => workload,
+      "lane" => lane
+    })
+
+    op
   end
 end

--- a/projects/embervm/control/lib/embervm/spec_trace.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace.ex
@@ -1,0 +1,218 @@
+defmodule Embervm.SpecTrace do
+  @moduledoc "Debug-only, spec-shaped NDJSON trace."
+
+  @writer Embervm.SpecTrace.Writer
+  @enabled_key {__MODULE__, :enabled}
+  @dropped_key {__MODULE__, :dropped}
+  # Mailbox depth past which emitters stop enqueueing. Generous relative to any
+  # real burst (a sweep emits one Checkpoint), small enough that a stalled
+  # writer cannot accumulate meaningful heap.
+  @max_queue 10_000
+  # Bumped whenever the record shape changes, so a consumer reading an old
+  # segment knows what it is parsing rather than guessing from the fields.
+  @schema_version 1
+
+  @spec configure() :: boolean()
+  def configure do
+    enabled = System.get_env("EMBERVM_SPEC_TRACE", "off") |> enabled?()
+    :persistent_term.put(@enabled_key, enabled)
+    enabled
+  end
+
+  @spec emit(atom() | String.t(), atom() | String.t(), map()) :: :ok
+  def emit(spec, action, vars) when is_map(vars) do
+    if :persistent_term.get(@enabled_key, false) do
+      mono = System.monotonic_time(:nanosecond)
+      ts = System.system_time(:millisecond)
+
+      case Process.whereis(@writer) do
+        pid when is_pid(pid) -> maybe_send(pid, {:emit, spec, action, vars, mono, ts})
+        _ -> :ok
+      end
+    end
+
+    :ok
+  end
+
+  # BOUNDED fire-and-forget. `send/2` never blocks, which is the property we
+  # want, but an unbounded mailbox is how a debug facility OOMs a control
+  # plane: a writer stalled on disk would grow this queue without limit while
+  # every emitter happily continued. So refuse to enqueue past a depth and
+  # count the refusals instead.
+  #
+  # Dropping MUST be visible. A silently lossy trace is the same failure as a
+  # sampled one: it looks like coverage while missing records, and a checker
+  # would read the gap as the system not acting. The dropped count rides the
+  # next record that does get through, so a consumer can tell "nothing
+  # happened" from "we stopped looking".
+  defp maybe_send(pid, msg) do
+    case Process.info(pid, :message_queue_len) do
+      {:message_queue_len, len} when len < @max_queue ->
+        dropped = :persistent_term.get(@dropped_key, 0)
+        if dropped > 0, do: :persistent_term.put(@dropped_key, 0)
+        send(pid, put_dropped(msg, dropped))
+
+      _ ->
+        # Counter only, no send: the queue is already the problem.
+        :persistent_term.put(@dropped_key, :persistent_term.get(@dropped_key, 0) + 1)
+    end
+
+    :ok
+  end
+
+  defp put_dropped(msg, 0), do: msg
+  defp put_dropped({:emit, spec, action, vars, mono, ts}, n),
+    do: {:emit, spec, action, Map.put(vars, :spec_trace_dropped_before, n), mono, ts}
+
+  @doc "Wait until all events already sent to the named writer are written."
+  @spec drain(GenServer.server()) :: :ok
+  def drain(server \\ @writer), do: GenServer.call(server, :drain)
+
+  def start_link(opts \\ []) do
+    configure()
+
+    if :persistent_term.get(@enabled_key, false) do
+      @writer.start_link(opts)
+    else
+      :ignore
+    end
+  end
+
+  def child_spec(opts) do
+    %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}, type: :worker}
+  end
+
+  defp enabled?(value), do: String.downcase(String.trim(value)) in ["on", "true", "1"]
+
+  # Exposed for the Writer, which is a SEPARATE top-level module and therefore
+  # cannot see these attributes. Kept as functions rather than duplicating the
+  # literals, so the preamble can never disagree with the behaviour it claims
+  # to describe.
+  @doc false
+  def schema_version, do: @schema_version
+  @doc false
+  def max_queue, do: @max_queue
+  @doc false
+  def enabled_now?, do: :persistent_term.get(@enabled_key, false)
+end
+
+defmodule Embervm.SpecTrace.Writer do
+  use GenServer
+  require Logger
+
+  @default_segment_bytes 64 * 1024 * 1024
+  @default_segments 3
+  @default_dir "/var/lib/embervm/scratch/spec-trace"
+
+  def start_link(opts \\ []) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+    dir = Keyword.get(opts, :dir, System.get_env("EMBERVM_SPEC_TRACE_DIR", @default_dir))
+    cap = Keyword.get(opts, :segment_bytes, env_integer("EMBERVM_SPEC_TRACE_SEGMENT_BYTES", @default_segment_bytes))
+    segments = Keyword.get(opts, :segments, env_integer("EMBERVM_SPEC_TRACE_SEGMENTS", @default_segments))
+    state = %{dir: dir, cap: max(cap, 1), segments: max(segments, 1), index: 0, size: 0, seq: 0, run_id: uuid(), io: nil}
+    {:ok, open_segment(state), {:continue, :preamble}}
+  end
+
+  @impl true
+  def handle_continue(:preamble, state) do
+    # The preamble states what a consumer is reading rather than letting it
+    # assume. #4758 is the lesson: a gate defaulted off and rendered nowhere
+    # made two modeled invariants describe behaviour production never ran, and
+    # nothing in the data said so. A harness preflight reads this record and
+    # refuses to emit a PASS/FAIL verdict against a trace whose gate it cannot
+    # confirm.
+    preamble = %{
+      "run_id" => state.run_id,
+      "seq" => 0,
+      "mono" => nil,
+      "ts" => System.system_time(:millisecond),
+      "spec" => "spec_trace",
+      "action" => "preamble",
+      "vars" => %{
+        "schema_version" => Embervm.SpecTrace.schema_version(),
+        "enabled" => Embervm.SpecTrace.enabled_now?(),
+        "max_queue" => Embervm.SpecTrace.max_queue(),
+        "segment_bytes" => state.cap,
+        "segments" => state.segments
+      }
+    }
+    {:noreply, write_record(state, preamble)}
+  end
+
+  @impl true
+  def handle_info({:emit, spec, action, vars, mono, ts}, state) do
+    seq = state.seq + 1
+    record = %{"run_id" => state.run_id, "seq" => seq, "mono" => mono, "ts" => ts, "spec" => stringify(spec), "action" => stringify(action), "vars" => jsonable(vars)}
+    {:noreply, write_record(%{state | seq: seq}, record)}
+  rescue
+    error ->
+      Logger.warning("embervm spec_trace write failed", error: inspect(error))
+      {:noreply, state}
+  end
+
+  @impl true
+  def handle_call(:drain, _from, state), do: {:reply, :ok, state}
+
+  @impl true
+  def terminate(_reason, %{io: io}) when not is_nil(io), do: File.close(io)
+  def terminate(_reason, _state), do: :ok
+
+  defp write_record(state, record) do
+    line = Jason.encode!(record) <> "\n"
+    state = if state.size > 0 and state.size + byte_size(line) > state.cap, do: rotate(state), else: state
+
+    case IO.binwrite(state.io, line) do
+      :ok -> %{state | size: state.size + byte_size(line)}
+      {:error, reason} ->
+        Logger.warning("embervm spec_trace disk write failed", reason: inspect(reason))
+        state
+    end
+  rescue
+    error ->
+      Logger.warning("embervm spec_trace serialization failed", error: inspect(error))
+      state
+  end
+
+  defp rotate(state) do
+    File.close(state.io)
+    index = rem(state.index + 1, state.segments)
+    {:ok, io} = File.open(segment_path(state.dir, index), [:write, :binary])
+    %{state | index: index, size: 0, io: io}
+  end
+
+  defp open_segment(state) do
+    File.mkdir_p!(state.dir)
+    {:ok, io} = File.open(segment_path(state.dir, state.index), [:write, :binary])
+    %{state | io: io}
+  end
+
+  defp segment_path(dir, index), do: Path.join(dir, "segment-#{String.pad_leading(Integer.to_string(index), 3, "0")}.ndjson")
+
+  defp env_integer(name, default) do
+    case Integer.parse(System.get_env(name, "")) do
+      {value, ""} when value > 0 -> value
+      _ -> default
+    end
+  end
+
+  defp stringify(value) when is_atom(value), do: Atom.to_string(value)
+  defp stringify(value), do: value
+
+  defp jsonable(value) when is_atom(value), do: Atom.to_string(value)
+  defp jsonable(value) when is_list(value), do: Enum.map(value, &jsonable/1)
+  defp jsonable(value) when is_map(value), do: Map.new(value, fn {key, value} -> {stringify(key), jsonable(value)} end)
+  defp jsonable(value), do: value
+
+  defp uuid do
+    <<a::binary-size(4), b::binary-size(2), c::binary-size(2), d::binary-size(2), e::binary-size(6)>> = :crypto.strong_rand_bytes(16)
+    Enum.join(Enum.map([a, b, c, d, e], &Base.encode16(&1, case: :lower)), "-")
+  end
+end

--- a/projects/embervm/control/test/embervm/spec_trace_sites_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_sites_test.exs
@@ -1,0 +1,62 @@
+defmodule Embervm.SpecTraceSitesTest do
+  @moduledoc """
+  Layer-1 guard for SpecTrace emission sites (#4770), mirroring the
+  `op_kind_sites` test in `spec_vocabulary_test.exs`.
+
+  The property is that every spec action the manifest CLAIMS is emitted has a
+  real emission site in the module named. Three earlier versions of the
+  equivalent op-log guard were wrong in instructive ways, and this test is
+  written to avoid all three:
+
+    * A bare-atom substring match is too LOOSE: it matches comments, metrics
+      keys and any unrelated atom. This matches an emission CONTEXT,
+      `SpecTrace.emit(:spec, :action`, not the atom alone.
+    * Declaring the transport module (`spec_trace.ex`) would make the guard
+      UNFALSIFIABLE, since every action passes through it. The first run of
+      this test caught exactly that, which is why the manifest now names
+      `primed_op.ex` and `dispatcher.ex`.
+    * Asserting the manifest equals a hardcoded literal validates NOTHING: it
+      duplicates the manifest and fails on every legitimate addition. The
+      manifest is checked against the CODE, never against a copy of itself.
+
+  Known limitation, stated rather than implied: this proves a site EXISTS, not
+  that the path RUNS. #4765 was an append on a code path production never took,
+  and no static check can see that. The runtime half belongs to the harness
+  coverage assertion.
+  """
+  use ExUnit.Case, async: true
+
+  @specs_dir System.get_env(
+               "EMBERVM_SPECS_DIR",
+               Path.expand("../../../specs", __DIR__)
+             )
+
+  @lib_dir Path.expand("../../lib", __DIR__)
+
+  test "every declared SpecTrace emission site exists and emits its action" do
+    {vocabulary, _binding} = Code.eval_file(Path.join(@specs_dir, "vocabulary.exs"))
+    sites = Map.fetch!(vocabulary, :spec_trace_sites)
+
+    # Guard the guard: an empty manifest would make every assertion below
+    # vacuous, which is the failure mode this whole programme keeps finding.
+    assert map_size(sites) > 0,
+           "spec_trace_sites is empty, so this test asserts nothing"
+
+    for {action, basename} <- sites do
+      matches = Path.wildcard(Path.join([@lib_dir, "**", basename]))
+
+      assert matches != [],
+             "spec_trace_sites names #{basename} as the emission site for " <>
+               "#{inspect(action)}, but no such file exists under #{@lib_dir}."
+
+      source = Enum.map_join(matches, "\n", &File.read!/1)
+
+      assert Regex.match?(~r/SpecTrace\.emit\(\s*:\w+\s*,\s*:#{action}\b/, source),
+             "#{inspect(action)} is declared to be emitted by #{basename}, but that " <>
+               "file contains no `SpecTrace.emit(:spec, :#{action}, ...)` call. Either " <>
+               "add the emission, or point the manifest at the module that really " <>
+               "emits it (NOT spec_trace.ex, which is the transport every action " <>
+               "passes through)."
+    end
+  end
+end

--- a/projects/embervm/control/test/embervm/spec_trace_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_test.exs
@@ -1,0 +1,106 @@
+defmodule Embervm.SpecTraceTest do
+  use ExUnit.Case, async: false
+
+  alias Embervm.SpecTrace
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "embervm-spec-trace-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf(dir) end)
+    {:ok, dir: dir}
+  end
+
+  test "disabled_no_op", %{dir: dir} do
+    System.put_env("EMBERVM_SPEC_TRACE", "off")
+    SpecTrace.configure()
+    for _ <- 1..10, do: SpecTrace.emit(:adoption, :prime, %{"vm_id" => "vm"})
+    refute File.exists?(dir <> "/segment-000.ndjson")
+  end
+
+  test "enabled_prime", %{dir: dir} do
+    start_writer(dir)
+    SpecTrace.emit(:adoption, :prime, %{"vm_id" => "vm-1", "node_id" => "node-1", "workload" => "wl", "lane" => :task})
+    :ok = SpecTrace.drain()
+    records = records(dir)
+    assert Enum.any?(records, &(&1["action"] == "prime" and &1["vars"]["vm_id"] == "vm-1"))
+  end
+
+  test "enabled_checkpoint", %{dir: dir} do
+    start_writer(dir)
+    SpecTrace.emit(:adoption, :checkpoint, %{"node_workload_vm_ids" => %{"node:wl" => ["vm-1"]}, "reserved_vm_ids" => [], "node_health" => %{}})
+    :ok = SpecTrace.drain()
+    assert Enum.any?(records(dir), &(&1["action"] == "checkpoint" and &1["vars"]["node_workload_vm_ids"]["node:wl"] == ["vm-1"]))
+  end
+
+  test "mono_ordering", %{dir: dir} do
+    start_writer(dir)
+    parent = self()
+    for i <- 1..5 do
+      spawn(fn -> SpecTrace.emit(:adoption, :prime, %{"i" => i}); send(parent, :done) end)
+    end
+    for _ <- 1..5, do: assert_receive :done
+    :ok = SpecTrace.drain()
+    monos = records(dir) |> Enum.filter(&(&1["action"] == "prime")) |> Enum.map(& &1["mono"])
+    assert length(monos) == 5
+    assert Enum.sort(monos) == Enum.sort_by(monos, & &1)
+  end
+
+  test "mono and ts are captured as distinct plausible clocks", %{dir: dir} do
+    start_writer(dir)
+    SpecTrace.emit(:adoption, :prime, %{})
+    :ok = SpecTrace.drain()
+    record = Enum.find(records(dir), &(&1["action"] == "prime"))
+    now = System.system_time(:millisecond)
+    assert record["ts"] > 1_700_000_000_000
+    assert abs(record["ts"] - now) < 60_000
+    assert record["ts"] != record["mono"]
+  end
+
+  test "segment_rotation keeps a preamble and records across segments", %{dir: dir} do
+    start_writer(dir, segment_bytes: 2048)
+    for i <- 1..20, do: SpecTrace.emit(:adoption, :prime, %{"i" => i})
+    :ok = SpecTrace.drain()
+    all = records(dir)
+    assert length(Path.wildcard(Path.join(dir, "segment-*.ndjson"))) > 1
+    assert Enum.count(all, &(&1["action"] == "preamble")) == 1
+    assert Enum.count(all, &(&1["action"] == "prime")) == 20
+  end
+
+  test "writer_crash_isolation", %{dir: dir} do
+    start_writer(dir)
+    writer = Process.whereis(Embervm.SpecTrace.Writer)
+    Process.unlink(writer)
+    Process.exit(writer, :kill)
+    assert SpecTrace.emit(:adoption, :prime, %{}) == :ok
+  end
+
+  # start_supervised! rather than start_link, because start_link LINKS the
+  # writer to the test process: the link kills it with :shutdown when the test
+  # ends, and the on_exit callback (which runs afterwards, in another process)
+  # then calls GenServer.stop on a corpse and exits :shutdown itself. That is a
+  # teardown failure masquerading as a test failure. ExUnit's supervisor owns
+  # the lifecycle and stops it before the test process goes away.
+  defp start_writer(dir, opts \\ []) do
+    prior = System.get_env("EMBERVM_SPEC_TRACE")
+    System.put_env("EMBERVM_SPEC_TRACE", "on")
+    SpecTrace.configure()
+
+    # Restore the env and the persistent_term flag. The suite is async: false
+    # and the flag is global, so leaving it on leaks the enabled state into
+    # every later test in the run.
+    on_exit(fn ->
+      if prior, do: System.put_env("EMBERVM_SPEC_TRACE", prior), else: System.delete_env("EMBERVM_SPEC_TRACE")
+      SpecTrace.configure()
+    end)
+
+    start_supervised!({Embervm.SpecTrace.Writer, Keyword.merge([dir: dir], opts)})
+  end
+
+  defp records(dir) do
+    dir
+    |> Path.join("segment-*.ndjson")
+    |> Path.wildcard()
+    |> Enum.sort()
+    |> Enum.flat_map(fn path -> path |> File.read!() |> String.split("\n", trim: true) |> Enum.map(&Jason.decode!/1) end)
+  end
+end

--- a/projects/embervm/specs/vocabulary.exs
+++ b/projects/embervm/specs/vocabulary.exs
@@ -191,5 +191,26 @@
     session_evicted: "session_manager.ex",
     session_destroying: "session_manager.ex",
     session_destroyed: "session_manager.ex"
+  },
+  # -- SpecTrace emission sites (#4770) ---------------------------------------
+  # Which module EMITS each spec action, mirroring op_kind_sites above. Name the
+  # emission site, NOT `spec_trace.ex`: that module is the transport, and every
+  # action passes through it, so declaring it would make this registry
+  # unfalsifiable. The first run of this test caught exactly that mistake.
+  #
+  # Same limitation as op_kind_sites, stated so nobody mistakes it for more: this
+  # proves a site EXISTS, not that the path RUNS. #4765 was an append on a code
+  # path production never took, and no static registry can see that. The runtime
+  # half is the harness coverage assertion (a run with zero `prime` records
+  # alongside `assigned` ops is VACUOUS, not PASS).
+  spec_trace_sites: %{
+    # One hook inside the shared builder covers all three prime sites
+    # (dispatcher cold-miss, PoolManager refill, SessionManager session prime).
+    prime: "primed_op.ex",
+    # On the dispatcher's sweep, emitted EVEN WHEN NOTHING ELSE FIRES. A wedge
+    # is the control plane failing to adopt, and absence is invisible in an
+    # event stream, so this periodic state observation is what makes
+    # non-progress detectable at all.
+    checkpoint: "dispatcher.ex"
   }
 }


### PR DESCRIPTION
First build of #4770. **Default OFF**, no chart wiring in this PR.

## Why a separate stream

The op-log is the durable book of record: audit, billing, projection rebuild,
closed enum, deliberately narrow. Four defects came from trying to make it
serve as a verification trace as well (#4756, #4765, #4766, #4768).

> The op-log answers "what happened to this task or session as a business
> object". The trace answers "did the protocol behave". Any request to widen
> `@kinds` must say which question it answers.

## Scope: core plus two emissions

- **`Prime`**, hooked inside the shared `PrimedOp` builder so **one hook covers
  all three prime sites** (dispatcher cold-miss, PoolManager refill,
  SessionManager session prime).
- **`Checkpoint`**, on the dispatcher sweep, **emitted even when nothing else
  fires**. This is the load-bearing one and the reason a trace can do what an
  event log cannot: a wedge is the control plane *failing* to adopt, and
  absence of events is invisible in any event stream. A periodic state
  observation makes non-progress detectable, which TLA models as a stuttering
  step.

The remaining `adoption.tla` emission points follow in later PRs.

## Bounded fire-and-forget, and the bound is not optional

`send/2` never blocks, which is the property wanted. But **never blocks** and
**never harms** are different properties, and an unbounded mailbox is how a
debug facility OOMs a control plane: a writer stalled on disk grows the queue
without limit while every emitter continues happily.

Emitters refuse past 10k and **count** the refusals; the dropped count rides
the next record that lands. Dropping must be *visible*, because a silently
lossy trace is the same failure as a sampled one, it looks like coverage while
a checker reads the gap as the system not acting. Same reason there is **no
sampling, ever**.

## Two clock traps designed around

**`mono` is captured in the emitting process**, not at the writer. Records
reach one writer from several GenServers, so arrival order is not causal order;
a checker sorts by `mono`, sound on a single BEAM node, and noted in the
moduledoc as the bound to revisit under ADR 007 cells.

**`ts` is taken inside `emit/3` and is deliberately not injectable.**
`SessionManager` has both `clock` (wall) and `monotonic_clock`, while
`PoolManager`'s `clock` is *monotonic*. An injected clock is a coin flip, and a
wrong `ts` silently mis-orders the trace, which is the one field a validator
depends on.

## The preamble states what you are reading

Schema version, gate state, queue bound, segment config. #4758 is the lesson: a
gate defaulted off and rendered nowhere left two modeled invariants describing
behaviour production never ran, with nothing in the data saying so. A harness
preflight reads this rather than assuming.

Exposed as functions rather than duplicated literals, so the preamble cannot
disagree with the behaviour it describes.

## The site registry caught a real mistake on its first run

`spec_trace_sites` declares the emission site per action. Both actions were
initially declared against `spec_trace.ex`, **the transport every action passes
through**, which would have made the guard unfalsifiable. Corrected to
`primed_op.ex` and `dispatcher.ex`.

Falsified before being trusted:

```
old declaration (transport module)   RED   both actions
corrected declaration                GREEN
deliberately wrong site              RED   prime not emitted by node_registry.ex
```

The test asserts the manifest against the **code**, never against a copy of
itself. An earlier version compared it to a hardcoded literal, which is
circular: it cannot detect a wrong site, only an edited one, so it fails on
every legitimate addition while passing on every incorrect declaration.

Limitation stated rather than implied: this proves a site EXISTS, not that the
path RUNS. #4765 was an append on a path production never took, and no static
check sees that. The runtime half is the harness coverage assertion.

## Verification

- `ci test`: **1220 tests, 0 failures, 6 skipped**, run independently.
- `ci lint` clean. No em-dashes. No `Chart.yaml` or `targetRevision` edit.
- Nothing added to the op-log `@kinds` enum, which is the point.

Refs #4770, #4759.