### PR TITLE
fix(monolith): navigate the agents console instead of shallow routing

### DIFF
--- a/bazel/semgrep/defs/semgrep-test.sh
+++ b/bazel/semgrep/defs/semgrep-test.sh
@@ -158,6 +158,12 @@ detect_lang() {
 	java) echo "java" ;;
 	rb) echo "ruby" ;;
 	rs) echo "rust" ;;
+	# semgrep-core has no Svelte parser. The repo's Svelte rules are all
+	# languages: [generic] regex rules, so map .svelte onto the generic
+	# analyzer. Without this the extension falls through to "", the file
+	# contributes no language, and a Svelte-only target scans nothing and
+	# reports PASSED.
+	svelte) echo "generic" ;;
 	*) echo "" ;;
 	esac
 }

--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -480,6 +480,24 @@ semgrep_test(
     tags = ["semgrep"],
 )
 
+# no-shallow-routing-for-url-state uses languages: [generic] scoped to projects sources.
+# Wired to its own bad/ok .svelte annotation fixtures independently of
+# typescript_rules_test (which only scans *.ts fixtures). The rule also runs for
+# real against the frontend Svelte tree via
+# //projects/monolith/frontend:svelte_url_state_semgrep_test.
+filegroup(
+    name = "no_shallow_routing_for_url_state_rule",
+    srcs = ["typescript/no-shallow-routing-for-url-state.yaml"],
+)
+
+semgrep_test(
+    name = "no_shallow_routing_for_url_state_test",
+    srcs = ["//bazel/semgrep/tests:no_shallow_routing_for_url_state_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":no_shallow_routing_for_url_state_rule"],
+    tags = ["semgrep"],
+)
+
 # svelte-hardcoded-color-in-style uses languages: [generic] scoped to **/*.svelte.
 # Wired to its own .svelte annotation fixture independently of typescript_rules_test
 # (which only scans *.ts fixtures).

--- a/bazel/semgrep/rules/typescript/no-shallow-routing-for-url-state.yaml
+++ b/bazel/semgrep/rules/typescript/no-shallow-routing-for-url-state.yaml
@@ -1,0 +1,32 @@
+rules:
+  - id: no-shallow-routing-for-url-state
+    languages: [generic]
+    severity: ERROR
+    paths:
+      include:
+        - "**/projects/**/*.svelte"
+        - "**/projects/**/*.js"
+        - "**/projects/**/*.ts"
+    message: >-
+      This file imports pushState or replaceState from $app/navigation and also
+      reads page.url.searchParams. Shallow routing writes the address bar and
+      page.state, but it never reassigns page.url (only a real navigation or a
+      popstate does), so any $derived built on page.url.searchParams recomputes
+      to the same value and never fires. Deep links work, clicks do not. Use
+      goto(url, { noScroll: true, keepFocus: true }) instead, adding
+      replaceState: true when the change must not add a history entry. Keep
+      pushState only for genuine shallow routing that reads page.state.
+    metadata:
+      category: correctness
+      subcategory: sveltekit-routing
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [svelte, sveltekit, typescript]
+      description: shallow routing driving state derived from page.url.searchParams
+    # One spanning regex rather than a `patterns:` conjunction: the import and
+    # the searchParams read are on different lines, and semgrep requires the
+    # operands of `patterns:` to overlap. Imports precede use in module scope,
+    # so anchoring on the import and scanning forward is sound. Non-greedy so
+    # the reported finding stops at the first offending read.
+    pattern-regex: 'import\s*\{[^}]*\b(?:pushState|replaceState)\b[^}]*\}\s*from\s*[''"]\$app/navigation[''"][\s\S]*?\$?page\.url\.searchParams'

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -63,6 +63,16 @@ filegroup(
     srcs = ["fixtures/no-create-event-dispatcher-runes.svelte"],
 )
 
+# Fixtures for the no-shallow-routing-for-url-state rule (languages: generic).
+# The rule matches across lines (import, then the searchParams read), so a single
+# file cannot hold both a violating and a non-violating case: the spanning regex
+# would join them. Split into bad/ok files like memory-request-ne-limit.
+# Referenced by //bazel/semgrep/rules:no_shallow_routing_for_url_state_test.
+filegroup(
+    name = "no_shallow_routing_for_url_state_fixtures",
+    srcs = glob(["svelte/no-shallow-routing-for-url-state/*.svelte"]),
+)
+
 # Fixture for the svelte-hardcoded-color-in-style rule (languages: generic, paths: **/*.svelte).
 # Referenced by //bazel/semgrep/rules:svelte_hardcoded_color_in_style_test.
 filegroup(

--- a/bazel/semgrep/tests/svelte/no-shallow-routing-for-url-state/bad.svelte
+++ b/bazel/semgrep/tests/svelte/no-shallow-routing-for-url-state/bad.svelte
@@ -1,0 +1,25 @@
+<!--
+  Bad case for no-shallow-routing-for-url-state.
+  Selection state is derived from page.url.searchParams, but navigation goes
+  through pushState/replaceState, which never reassign page.url. The derived
+  value therefore never changes and the effect never runs.
+-->
+<script>
+  // ruleid: no-shallow-routing-for-url-state
+  import { pushState, replaceState } from "$app/navigation";
+  import { page } from "$app/stores";
+
+  const selectedId = $derived($page.url.searchParams.get("session"));
+
+  function select(id) {
+    pushState(`${$page.url.pathname}?session=${id}`, {});
+  }
+
+  function clear() {
+    replaceState($page.url.pathname, {});
+  }
+</script>
+
+<button onclick={() => select("abc")}>select</button>
+<button onclick={clear}>clear</button>
+<p>{selectedId}</p>

--- a/bazel/semgrep/tests/svelte/no-shallow-routing-for-url-state/ok-goto.svelte
+++ b/bazel/semgrep/tests/svelte/no-shallow-routing-for-url-state/ok-goto.svelte
@@ -1,0 +1,25 @@
+<!--
+  Ok case for no-shallow-routing-for-url-state: the remedy.
+
+  Selection is still derived from page.url.searchParams, but navigation goes
+  through goto, which runs a real navigation and reassigns page.url, so the
+  derived value recomputes. noScroll holds the scroll position and keepFocus
+  leaves focus alone for components that manage it themselves.
+-->
+<script>
+  // ok: no-shallow-routing-for-url-state
+  import { goto } from "$app/navigation";
+  import { page } from "$app/stores";
+
+  const selectedId = $derived($page.url.searchParams.get("session"));
+
+  function select(id) {
+    goto(`${$page.url.pathname}?session=${id}`, {
+      noScroll: true,
+      keepFocus: true,
+    });
+  }
+</script>
+
+<button onclick={() => select("abc")}>select</button>
+<p>{selectedId}</p>

--- a/bazel/semgrep/tests/svelte/no-shallow-routing-for-url-state/ok.svelte
+++ b/bazel/semgrep/tests/svelte/no-shallow-routing-for-url-state/ok.svelte
@@ -1,0 +1,23 @@
+<!--
+  Ok cases for no-shallow-routing-for-url-state.
+
+  Genuine shallow routing: pushState carries page.state and the component reads
+  page.state, never page.url.searchParams. page.url staying stale is the point
+  of the API here, not a bug, so this must not fire.
+-->
+<script>
+  // ok: no-shallow-routing-for-url-state
+  import { pushState } from "$app/navigation";
+  import { page } from "$app/stores";
+
+  const photo = $derived($page.state.selectedPhoto);
+
+  function openModal(item) {
+    pushState("", { selectedPhoto: item });
+  }
+</script>
+
+<button onclick={() => openModal({ id: 1 })}>open</button>
+{#if photo}
+  <dialog open>{photo.id}</dialog>
+{/if}

--- a/projects/monolith/frontend/BUILD
+++ b/projects/monolith/frontend/BUILD
@@ -4,6 +4,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//projects/monolith/frontend:vite/package_json.bzl", vite_bin = "bin")
 load("@npm//projects/monolith/frontend:vitest/package_json.bzl", vitest_bin = "bin")
+load("//bazel/semgrep/defs:defs.bzl", "semgrep_test")
 load("//bazel/tools/oci:apko_image.bzl", "apko_image")
 
 npm_link_all_packages(name = "node_modules")
@@ -223,6 +224,18 @@ vitest_bin.vitest_test(
         ":src",
         ":test_lib",
     ],
+)
+
+# Scans the Svelte tree for shallow routing driving URL-derived state. Wired to
+# the single rule rather than :typescript_rules on purpose: semgrep-core ignores
+# each rule's paths: filter, so the broad filegroup would run every TypeScript
+# rule against every component. Widening this is a separate decision, and
+# svelte-hardcoded-color-in-style currently has findings here.
+semgrep_test(
+    name = "svelte_url_state_semgrep_test",
+    srcs = glob(["src/**/*.svelte"]),
+    rules = ["//bazel/semgrep/rules:no_shallow_routing_for_url_state_rule"],
+    tags = ["semgrep"],
 )
 
 apko_image(

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount, tick } from "svelte";
-  import { pushState, replaceState } from "$app/navigation";
+  import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { renderAgentMarkdown } from "./markdown.js";
   import { RUN_FIXTURES } from "./run-fixtures.js";
@@ -505,14 +505,32 @@
   // URL in the address bar that nobody types or shares, and it only failed
   // quietly because the reroute guard skips paths already under /private/.
   // Keep whichever path the browser actually arrived on.
+  //
+  // goto, not pushState/replaceState from $app/navigation. Shallow routing
+  // moves the address bar and sets page.state, but it never reassigns
+  // page.url (only update_url() does, on a real navigation or popstate), so
+  // every selection derived from page.url.searchParams recomputed to the
+  // same string and the transcript pane never loaded. Deep links worked
+  // because the server load set page.url; clicks did not. Do not "optimise"
+  // this back. Semgrep no-shallow-routing-for-url-state guards it.
+  //
+  // noScroll keeps the transcript where it was, keepFocus is load-bearing
+  // for the mobile drill below, which hand-manages focus after selection.
   function navigateTo(search) {
-    pushState(withSearch($page.url.pathname, search), {});
+    goto(withSearch($page.url.pathname, search), {
+      noScroll: true,
+      keepFocus: true,
+    });
   }
 
   // Correcting the URL for a selection that no longer exists, so it must not
   // add a history entry the back button has to walk back through.
   function replaceWith(search) {
-    replaceState(withSearch($page.url.pathname, search), {});
+    goto(withSearch($page.url.pathname, search), {
+      replaceState: true,
+      noScroll: true,
+      keepFocus: true,
+    });
   }
 
   function selectRun(runOrId) {


### PR DESCRIPTION
## The bug

`projects/monolith/frontend/src/routes/private/agents/+page.svelte` derived
every selection from the URL:

```js
const selectedId = $derived($page.url.searchParams.get("session"));
const selectedRunId = $derived($page.url.searchParams.get("run"));
```

but navigated with SvelteKit shallow routing (`pushState` / `replaceState`
from `$app/navigation`).

**Shallow routing never reassigns `page.url`.** Verified against the installed
kit source in `node_modules/@sveltejs/kit/src/runtime/client/client.js`:
`pushState` calls `history.pushState(...)`, then assigns only `page.state` and
re-renders via `root.$set({ page: clone_page(page) })`. `clone_page` copies
`url: page.url` by reference. `page.url` is only ever reassigned in
`update_url()` (`current.url = page.url = url`), which real navigations and
`popstate` call and shallow routing does not.

So the store fired, the `$derived` recomputed to the identical old string,
Svelte's equality check stopped propagation, the `$effect` never ran, and
`loadDetail` / `loadRunDetail` were never called. The transcript pane never
changed.

Symptom shape: deep links work (the server load sets `page.url` correctly),
clicks do not, and pressing Back makes the UI suddenly jump, because
`popstate` routes through `update_url()` and the accumulated derived state
finally recomputes.

Regressed in #4642 (`f2c03cf7e`) and carried through #4666 (`f22f60faf`).

## What this restores

The run view, master view and agent breakdown shipped but unreachable:
#4637, #4641, #4647, #4658, #4655, #4679.

## The fix

`goto` with `noScroll: true, keepFocus: true`, matching what every other
URL-mirroring page in this frontend already does (hikes, stars, ships,
notes, dr-jobs, wc2026, trips timeline).

- `keepFocus` is load-bearing. The mobile drill hand-manages focus after a
  selection (`titleEl?.focus()`, `getElementById('agent-session-...')`), and a
  default `goto` resets focus to the body.
- `noScroll` keeps the transcript from jumping on every selection.
- `replaceWith` keeps `replaceState: true` so correcting a URL for a
  selection that no longer exists adds no history entry.
- No `invalidateAll`: `+page.server.js` destructures only `{ fetch }` and
  never reads `url`, so SvelteKit does not re-run the load on a search-param
  change.

`url-state.js` is untouched. Its eight pure functions are correct and its
nine tests still pass.

## The guard

New semgrep rule `no-shallow-routing-for-url-state`: fires when a file
imports `pushState` or `replaceState` from `$app/navigation` and also reads
`page.url.searchParams`. Genuine shallow routing carries `page.state` and
never reads `page.url`, so it does not match; there is an `ok.svelte` fixture
proving that, plus an `ok-goto.svelte` fixture proving the remedy passes.

One spanning regex rather than a `patterns:` conjunction, because the import
and the `searchParams` read are on different lines and semgrep requires
`patterns:` operands to overlap.

Evaluated against the repo: matches the pre-fix `+page.svelte`, matches
nothing else across all 133 `.svelte` files and the `.js`/`.ts` tree, and
stops matching after the fix.

### The runner could not have scanned Svelte at all

`bazel/semgrep/defs/semgrep-test.sh`'s `detect_lang` had no `.svelte` case, so
a Svelte file contributed no language, the per-language scan loop had nothing
to iterate, and the target reported `PASSED: No semgrep findings` without
scanning. Mapped `.svelte` onto the `generic` analyzer, which is what all
three of the repo's Svelte rules already declare. Inert for every existing
target: no other `semgrep_test` has `.svelte` sources.

The new production target is wired to this single rule rather than
`:typescript_rules`, because `semgrep-core` ignores each rule's `paths:`
filter and the broad filegroup would run every TypeScript rule against every
component. `svelte-hardcoded-color-in-style` has 119 findings across 15 files
today, so widening it is a separate decision.

## Verification, honestly

- `ci test`: `Executed 3 out of 709 tests: 709 tests pass.` (a prior full run
  in the same session was `Executed 98 out of 709 tests: 709 tests pass.`)
- `projects/monolith/frontend:test` re-run with `--nocache_test_results`:
  73 test files, 611 tests passed, including
  `src/routes/private/agents/url-state.test.js (9 tests)`.
- All seven format-stage guards run locally on the full checkout: pass.

**The behavioural fix is not covered by an automated test.** There is no DOM
test harness in this project (`vitest.config.js` sets `environment: "node"`;
no jsdom, no `@testing-library/svelte`), and adding one is a real dependency
addition across pnpm, Bazel and the apko image, so it is out of scope here.
The fix is verified by reasoning against the kit source above, plus the
semgrep guard. **A human click-through on the deployed console is the
remaining verification.**

**The semgrep guard does not currently enforce anything, and neither does any
other semgrep rule in this repo.** Every `semgrep_test` target exits 0 with:

```
SKIPPED: semgrep-core found but cannot execute on this platform (Linux/x86_64)
```

Reproduced on the BuildBuddy Linux runner against the pre-existing, untouched
`//projects:__init___semgrep_test` as well as the new target, so it is not
introduced here. Semgrep is a no-op green across the whole repo and needs its
own fix; the rule added here starts enforcing the moment the engine executes.

No chart version or `targetRevision` touched.
