### PR TITLE
fix(monolith): style the runs heading and move focus to what you opened

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -876,7 +876,14 @@
     if (runId != null) loadRunDetail(runId, runRequestSequence);
     if (sessionId != null) loadDetail(sessionId, requestSequence);
 
-    if (isMobileViewport() && sessionId != null) {
+    // Every tier, not just mobile. goto keeps focus rather than dropping it
+    // to <body>, so without this the ring stays on the sidebar row you
+    // clicked while the pane beside it is what actually changed. Moving it
+    // to the title announces the session to a screen reader and puts the
+    // focus mark on the content you navigated to. titleEl is tabindex="-1"
+    // and renders from the already-loaded session row, so it exists by the
+    // time tick() resolves, before the detail fetch returns.
+    if (sessionId != null) {
       tick().then(() => titleEl?.focus({ preventScroll: true }));
     } else if (
       isMobileViewport() &&
@@ -1791,6 +1798,31 @@
     display: flex;
     justify-content: space-between;
     margin: 12px 4px 6px;
+  }
+  /* The runs heading is a button (clicking it clears the selection and
+     returns to the swarm home) sitting beside the plain-text sessions
+     heading. Without this reset it kept the UA button chrome, a bordered
+     lowercase pill, and the two collection headings read as different
+     kinds of thing. Every other button in this console carries an explicit
+     reset for the same reason; see .session-row. Inherit rather than
+     restate the .group-title type so the two headings cannot drift apart. */
+  .section-link {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: inherit;
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+    text-align: left;
+  }
+  .section-link:hover {
+    color: var(--text);
+  }
+  .section-link:focus-visible {
+    outline: none;
+    text-decoration: underline;
+    text-underline-offset: 3px;
   }
   .history-title {
     margin-top: 18px;


### PR DESCRIPTION
Two defects the navigation fix (#4776) made visible. Neither is new code:
both were unreachable states until selection started working.

## The runs heading was an unstyled button

`.section-link` had no CSS rule anywhere in the repo. It is referenced
once, in markup, and never styled, so it kept the UA button chrome and
rendered as a bordered lowercase pill beside the plain-text `SESSIONS`
heading. Every other button in this console carries an explicit reset for
exactly this reason (compare `.session-row`, which resets colour,
background, border and alignment).

Both words are lowercase in the lexicon (`runsWord`, `sessionsSection`);
the uppercase is `.group-title`. They were always meant to match.

The new rule inherits `.group-title`'s type rather than restating it, so
the two collection headings cannot drift apart if that type changes.
Focus renders as an underline rather than a box, since a hard outline on
what reads as a label looked like a defect.

## Focus landed on the row you left, not the pane you opened

`goto` retains focus rather than dropping it to `<body>`, which is
correct: losing focus to the document breaks keyboard navigation. But the
focus mark was staying on the sidebar row while the pane beside it was
what changed.

Focus now moves to the transcript title on every tier. Mobile already did
this; desktop did nothing. Moving it announces the session to a screen
reader and puts the mark on the content you navigated to. `titleEl` is
`tabindex="-1"` and renders from the already-loaded session row, so it
exists by the time `tick()` resolves, before the detail fetch returns.

## Not in this PR

The sidebar reads `runs 0 / none yet` beside 45 sessions because finished
runs are filtered out server-side (`swarm/router.py` defaults
`active=True`). That is a separate fix.

No chart version or `targetRevision` touched.