### PR TITLE
feat(swarm): add conductor recording schema

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2229,6 +2229,18 @@ py_test(
 )
 
 py_test(
+    name = "models_test",
+    srcs = ["swarm/models_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_swarm",
+        "@pip//pytest",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "rationale_test",
     srcs = ["swarm/rationale_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/migrations/20260813000000_swarm_recording_schema.sql
+++ b/projects/monolith/chart/migrations/20260813000000_swarm_recording_schema.sql
@@ -1,0 +1,72 @@
+CREATE SCHEMA IF NOT EXISTS swarm;
+
+CREATE TABLE swarm.swarm_task (
+    id TEXT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    task_text TEXT NOT NULL,
+    repo TEXT,
+    base_branch TEXT,
+    conductor_model TEXT NOT NULL,
+    budget_usd DOUBLE PRECISION,
+    workflow_id TEXT,
+    session_id INTEGER,
+    settled_at TIMESTAMPTZ
+);
+
+CREATE INDEX swarm_task_workflow_id_idx ON swarm.swarm_task (workflow_id);
+CREATE INDEX swarm_task_session_id_idx ON swarm.swarm_task (session_id);
+
+CREATE TABLE swarm.swarm_plan_version (
+    id BIGSERIAL PRIMARY KEY,
+    task_id TEXT NOT NULL REFERENCES swarm.swarm_task (id),
+    version INTEGER NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    op TEXT NOT NULL,
+    author_kind TEXT NOT NULL,
+    author TEXT NOT NULL,
+    change_json TEXT NOT NULL,
+    cause_kind TEXT NOT NULL,
+    cause_ref TEXT,
+    stated_reason TEXT,
+    CONSTRAINT swarm_plan_version_task_version_key UNIQUE (task_id, version)
+);
+
+CREATE INDEX swarm_plan_version_task_id_idx ON swarm.swarm_plan_version (task_id);
+
+CREATE TABLE swarm.swarm_plan_node (
+    id BIGSERIAL PRIMARY KEY,
+    task_id TEXT NOT NULL REFERENCES swarm.swarm_task (id),
+    node_key TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    prompt TEXT NOT NULL,
+    model TEXT,
+    deps_json TEXT NOT NULL,
+    max_cost_usd DOUBLE PRECISION NOT NULL,
+    side_effects BOOLEAN NOT NULL,
+    max_attempts INTEGER,
+    turn_timeout_seconds INTEGER,
+    created_in_version INTEGER NOT NULL,
+    discarded_in_version INTEGER,
+    cancelled_in_version INTEGER,
+    armed_at TIMESTAMPTZ,
+    base_artifact_sha TEXT,
+    CONSTRAINT swarm_plan_node_task_node_key UNIQUE (task_id, node_key)
+);
+
+CREATE INDEX swarm_plan_node_task_id_idx ON swarm.swarm_plan_node (task_id);
+
+CREATE TABLE swarm.swarm_conductor_call (
+    id BIGSERIAL PRIMARY KEY,
+    task_id TEXT NOT NULL REFERENCES swarm.swarm_task (id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    conductor_model TEXT NOT NULL,
+    tool TEXT NOT NULL,
+    args_json TEXT NOT NULL,
+    outcome TEXT NOT NULL,
+    refusal_code TEXT,
+    version_before INTEGER,
+    version_after INTEGER,
+    latency_ms INTEGER
+);
+
+CREATE INDEX swarm_conductor_call_task_id_idx ON swarm.swarm_conductor_call (task_id);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:8YShU9L8gw6A/dBbsJ+t2TAz6vJ0RVUFb7rJzdmzr/k=
+h1:PPGVg73ysigOpEkzfs8n93l1FuWoEmdaLmnW/kA9rRs=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -161,3 +161,4 @@ h1:8YShU9L8gw6A/dBbsJ+t2TAz6vJ0RVUFb7rJzdmzr/k=
 20260810000000_agent_sessions_workflow_id.sql h1:lgOBVujB+/Cp8sK7w0PnCuUnttfozKADNWhSG83M7hE=
 20260810010000_agent_sessions_triggered_by.sql h1:ZIw9yloGu+UjC4MYC4uQSzKybK7dnG9gUCj2Adhm7Gs=
 20260811000000_agent_sessions_node_key.sql h1:4zzYZjEKvM2Qc6jKM+CrclVaiuFvXrbEi8E/BryWdgw=
+20260813000000_swarm_recording_schema.sql h1:GP+CVZ9aczViVoM1k49RwXsF0CH6LaE4FkYKeKGigEo=

--- a/projects/monolith/swarm/models.py
+++ b/projects/monolith/swarm/models.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Iterator
+from uuid import uuid4
+
+from sqlalchemy import UniqueConstraint
+from sqlmodel import Field, Session, SQLModel, select
+
+from core.db import get_engine
+
+
+class SwarmTask(SQLModel, table=True):
+    __tablename__ = "swarm_task"
+    __table_args__ = {"schema": "swarm", "extend_existing": True}
+
+    id: str = Field(primary_key=True)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    task_text: str
+    repo: str | None = None
+    base_branch: str | None = None
+    conductor_model: str
+    budget_usd: float | None = None
+    workflow_id: str | None = Field(default=None, index=True)
+    session_id: int | None = Field(default=None, index=True)
+    settled_at: datetime | None = None
+
+
+class SwarmPlanVersion(SQLModel, table=True):
+    __tablename__ = "swarm_plan_version"
+    __table_args__ = (
+        UniqueConstraint(
+            "task_id", "version", name="swarm_plan_version_task_version_key"
+        ),
+        {"schema": "swarm", "extend_existing": True},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    task_id: str = Field(foreign_key="swarm.swarm_task.id", index=True)
+    version: int
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    op: str
+    author_kind: str
+    author: str
+    change_json: str
+    cause_kind: str
+    cause_ref: str | None = None
+    stated_reason: str | None = None
+
+
+class SwarmPlanNode(SQLModel, table=True):
+    __tablename__ = "swarm_plan_node"
+    __table_args__ = (
+        UniqueConstraint("task_id", "node_key", name="swarm_plan_node_task_node_key"),
+        {"schema": "swarm", "extend_existing": True},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    task_id: str = Field(foreign_key="swarm.swarm_task.id", index=True)
+    node_key: str
+    kind: str
+    prompt: str
+    model: str | None = None
+    deps_json: str
+    max_cost_usd: float
+    side_effects: bool
+    max_attempts: int | None = None
+    turn_timeout_seconds: int | None = None
+    created_in_version: int
+    discarded_in_version: int | None = None
+    cancelled_in_version: int | None = None
+    armed_at: datetime | None = None
+    base_artifact_sha: str | None = None
+
+
+class SwarmConductorCall(SQLModel, table=True):
+    __tablename__ = "swarm_conductor_call"
+    __table_args__ = {"schema": "swarm", "extend_existing": True}
+
+    id: int | None = Field(default=None, primary_key=True)
+    task_id: str = Field(foreign_key="swarm.swarm_task.id", index=True)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    conductor_model: str
+    tool: str
+    args_json: str
+    outcome: str
+    refusal_code: str | None = None
+    version_before: int | None = None
+    version_after: int | None = None
+    latency_ms: int | None = None
+
+
+@contextmanager
+def _session(session: Session | None) -> Iterator[Session]:
+    if session is not None:
+        yield session
+        return
+    with Session(get_engine()) as owned_session:
+        yield owned_session
+
+
+def mint_task_id() -> str:
+    return f"t-{uuid4()}"
+
+
+def create_task(
+    task_id: str,
+    task_text: str,
+    repo: str | None,
+    base_branch: str | None,
+    conductor_model: str,
+    budget_usd: float | None,
+    workflow_id: str | None = None,
+    session_id: int | None = None,
+    *,
+    session: Session | None = None,
+) -> SwarmTask:
+    row = SwarmTask(
+        id=task_id,
+        task_text=task_text,
+        repo=repo,
+        base_branch=base_branch,
+        conductor_model=conductor_model,
+        budget_usd=budget_usd,
+        workflow_id=workflow_id,
+        session_id=session_id,
+    )
+    with _session(session) as db:
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+    return row
+
+
+def append_plan_version(
+    task_id: str,
+    version: int,
+    op: str,
+    author_kind: str,
+    author: str,
+    change_json: str,
+    cause_kind: str,
+    cause_ref: str | None = None,
+    stated_reason: str | None = None,
+    *,
+    session: Session | None = None,
+) -> SwarmPlanVersion:
+    row = SwarmPlanVersion(
+        task_id=task_id,
+        version=version,
+        op=op,
+        author_kind=author_kind,
+        author=author,
+        change_json=change_json,
+        cause_kind=cause_kind,
+        cause_ref=cause_ref,
+        stated_reason=stated_reason,
+    )
+    with _session(session) as db:
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+    return row
+
+
+def upsert_plan_node(
+    task_id: str,
+    node_key: str,
+    kind: str,
+    prompt: str,
+    model: str | None,
+    deps_json: str,
+    max_cost_usd: float,
+    side_effects: bool,
+    max_attempts: int | None,
+    turn_timeout_seconds: int | None,
+    created_in_version: int,
+    discarded_in_version: int | None = None,
+    cancelled_in_version: int | None = None,
+    armed_at: datetime | None = None,
+    base_artifact_sha: str | None = None,
+    *,
+    session: Session | None = None,
+) -> SwarmPlanNode:
+    with _session(session) as db:
+        row = db.exec(
+            select(SwarmPlanNode).where(
+                SwarmPlanNode.task_id == task_id,
+                SwarmPlanNode.node_key == node_key,
+            )
+        ).first()
+        if row is None:
+            row = SwarmPlanNode(task_id=task_id, node_key=node_key)
+            db.add(row)
+        row.kind = kind
+        row.prompt = prompt
+        row.model = model
+        row.deps_json = deps_json
+        row.max_cost_usd = max_cost_usd
+        row.side_effects = side_effects
+        row.max_attempts = max_attempts
+        row.turn_timeout_seconds = turn_timeout_seconds
+        row.created_in_version = created_in_version
+        row.discarded_in_version = discarded_in_version
+        row.cancelled_in_version = cancelled_in_version
+        row.armed_at = armed_at
+        row.base_artifact_sha = base_artifact_sha
+        db.commit()
+        db.refresh(row)
+    return row
+
+
+def record_conductor_call(
+    task_id: str,
+    conductor_model: str,
+    tool: str,
+    args_json: str,
+    outcome: str,
+    refusal_code: str | None = None,
+    version_before: int | None = None,
+    version_after: int | None = None,
+    latency_ms: int | None = None,
+    *,
+    session: Session | None = None,
+) -> SwarmConductorCall:
+    row = SwarmConductorCall(
+        task_id=task_id,
+        conductor_model=conductor_model,
+        tool=tool,
+        args_json=args_json,
+        outcome=outcome,
+        refusal_code=refusal_code,
+        version_before=version_before,
+        version_after=version_after,
+        latency_ms=latency_ms,
+    )
+    with _session(session) as db:
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+    return row

--- a/projects/monolith/swarm/models_test.py
+++ b/projects/monolith/swarm/models_test.py
@@ -1,0 +1,162 @@
+from datetime import datetime
+from uuid import UUID
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from swarm.models import (
+    SwarmConductorCall,
+    SwarmPlanNode,
+    SwarmPlanVersion,
+    SwarmTask,
+    append_plan_version,
+    create_task,
+    mint_task_id,
+    record_conductor_call,
+    upsert_plan_node,
+)
+
+
+@pytest.fixture
+def db(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'swarm.db'}")
+    schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            schemas[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in schemas:
+                table.schema = schemas[table.name]
+
+
+def test_mint_task_id_is_prefixed_uuid():
+    task_id = mint_task_id()
+    assert task_id.startswith("t-")
+    UUID(task_id.removeprefix("t-"))
+
+
+def test_create_task_writes_row(db):
+    task_id = mint_task_id()
+    with Session(db) as session:
+        row = create_task(
+            task_id,
+            "build the thing",
+            "homelab",
+            "main",
+            "qwen",
+            2.5,
+            workflow_id="wf-1",
+            session_id=7,
+            session=session,
+        )
+
+    with Session(db) as session:
+        stored = session.get(SwarmTask, task_id)
+        assert stored is not None
+        assert stored.task_text == row.task_text == "build the thing"
+        assert stored.workflow_id == "wf-1"
+        assert stored.session_id == 7
+        assert isinstance(stored.created_at, datetime)
+
+
+def test_append_plan_version_rejects_duplicate_version(db):
+    task_id = mint_task_id()
+    with Session(db) as session:
+        create_task(task_id, "task", None, None, "model", None, session=session)
+        append_plan_version(
+            task_id, 1, "init", "system", "model", "{}", "user_message", session=session
+        )
+
+    with pytest.raises(IntegrityError):
+        with Session(db) as session:
+            append_plan_version(
+                task_id,
+                1,
+                "add_node",
+                "conductor",
+                "model",
+                "{}",
+                "condition",
+                session=session,
+            )
+
+
+def test_upsert_plan_node_inserts_and_updates(db):
+    task_id = mint_task_id()
+    with Session(db) as session:
+        create_task(task_id, "task", None, None, "model", None, session=session)
+        inserted = upsert_plan_node(
+            task_id,
+            "node-1",
+            "converse",
+            "say hello",
+            "model",
+            "[]",
+            0.5,
+            False,
+            2,
+            60,
+            1,
+            session=session,
+        )
+        updated = upsert_plan_node(
+            task_id,
+            "node-1",
+            "delivery",
+            "say goodbye",
+            None,
+            '["node-0"]',
+            1.0,
+            True,
+            3,
+            120,
+            2,
+            session=session,
+        )
+
+    assert inserted.id == updated.id
+    with Session(db) as session:
+        stored = session.exec(
+            select(SwarmPlanNode).where(SwarmPlanNode.task_id == task_id)
+        ).one()
+        assert stored.kind == "delivery"
+        assert stored.prompt == "say goodbye"
+        assert stored.deps_json == '["node-0"]'
+
+
+def test_record_conductor_call_writes_all_fields(db):
+    task_id = mint_task_id()
+    with Session(db) as session:
+        create_task(task_id, "task", None, None, "model", None, session=session)
+        row = record_conductor_call(
+            task_id,
+            "qwen",
+            "swarm_add_node",
+            '{"node_key":"node-1"}',
+            "refused",
+            refusal_code="budget_exceeded",
+            version_before=2,
+            version_after=None,
+            latency_ms=123,
+            session=session,
+        )
+
+    with Session(db) as session:
+        stored = session.get(SwarmConductorCall, row.id)
+        assert stored is not None
+        assert stored.task_id == task_id
+        assert stored.conductor_model == "qwen"
+        assert stored.tool == "swarm_add_node"
+        assert stored.args_json == '{"node_key":"node-1"}'
+        assert stored.outcome == "refused"
+        assert stored.refusal_code == "budget_exceeded"
+        assert stored.version_before == 2
+        assert stored.version_after is None
+        assert stored.latency_ms == 123
+        assert isinstance(stored.created_at, datetime)


### PR DESCRIPTION
## Summary

Implement the conductor recording schema for issue #4781 decision 10, the feedback loop for evaluating conductor planning without permission. Four tables record task submissions, plan versions as an append-only op log (with optimistic concurrency via unique (task_id, version) constraint), current node state, and all decision-bearing tool calls.

## Design adherence

Follows section 2 of the dag-tools design doc exactly:

- **swarm_task**: one row per submission, keyed on minted task_id (t-<uuid>), spanning both stage 1 execution paths with nullable workflow_id and session_id
- **swarm_plan_version**: append-only ledger with op, author_kind, author, change_json, cause_kind, cause_ref, stated_reason (register split per ADR 054)
- **swarm_plan_node**: current state; stage 2 columns (armed_at, base_artifact_sha, discarded_in_version, cancelled_in_version) ship nullable to avoid a second migration
- **swarm_conductor_call**: every decision-bearing tool call (accepted or refused) with refusal_code. Read-only tools are not recorded

## Implementation

- SQLModel models in projects/monolith/swarm/models.py following agent_sessions/models.py pattern
- One Atlas migration (2.2 KiB, schema-only, well under the 256 KiB ConfigMap cap)
- Write API functions: mint_task_id, create_task, append_plan_version, upsert_plan_node, record_conductor_call
- Unique constraint on (task_id, version) is the concurrency serialization point; duplicate insert raises IntegrityError
- All datetimes in UTC with timezone.utc; test fixtures use SQLite with naive datetime round-trip (asserted via isinstance, not tzinfo)

## Test plan

- ci lint: passed (5 files formatted)
- ci test: passed (Executed 62 out of 710 tests; 710 tests pass)
- Pre-commit hooks: passed (Conventional Commits, migration checksums, version ordering)
- 5 unit tests: mint_task_id format, create_task write, append_plan_version duplicate rejection, upsert_plan_node insert and upsert, record_conductor_call all fields

## Scope

Stage 1 only per the design:
- Models and migration: YES
- Write API: YES (internal functions)
- Unit tests: YES
- MCP tools: NO (stage 2)
- Conductor logic: NO (stage 2)
- Frontend integration: NO (stage 2)

## Migration metadata

- Filename: 20260813000000_swarm_recording_schema.sql
- Size: 2.2 KiB
- Tables: swarm_task, swarm_plan_version, swarm_plan_node, swarm_conductor_call
- Constraints: unique (task_id, version), unique (task_id, node_key)
- Indexes: task_id, workflow_id, session_id, node_key on plan_node

🤖 Generated with Claude Code