### PR TITLE
feat(agents): capture the walkthrough data that cannot be backfilled

### DIFF
--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -11,6 +11,7 @@ from sqlmodel import Session
 from agent_sessions import model_family, store
 from agent_sessions.codex_login import codex_login_gate, watch_for_login
 from agent_sessions.mcp import (
+    _append_rationale_trailer,
     _clear_ember_bindings_for,
     _load_session_row,
     _persist_pending_message,
@@ -146,6 +147,7 @@ async def start_session_for_thread(
         model,
         repo,
         discord_thread=thread_id,
+        system_prompt=_append_rationale_trailer(None, repo),
     )
     await asyncio.to_thread(_persist_pending_message, row.id, prompt, model)
     login = await codex_login_gate(model)

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -18,6 +18,7 @@ import httpx
 import agent.api as agent_api
 from agent_sessions import store, voice
 from agent_sessions import model_family
+from agent_sessions.rationale import rationale_trailer_instruction
 from agent_sessions.models import AgentSession, AgentTurn
 from agent_sessions.transport import (
     EmberSession,
@@ -156,6 +157,18 @@ def _persist_pending_message(
         row = store.create_pending_message(db_session, session_id, message_text, model)
         assert row.seq is not None
         return row.seq
+
+
+def _append_rationale_trailer(
+    system_prompt: str | None, repo: str | None
+) -> str | None:
+    """Add walkthrough rationale guidance when the session has a repository."""
+    if repo is None:
+        return system_prompt
+    trailer = rationale_trailer_instruction()
+    if system_prompt is None:
+        return trailer
+    return f"{system_prompt.rstrip()}\n\n{trailer}"
 
 
 def _persist_session(
@@ -682,7 +695,7 @@ async def monolith_agent_session_start(
         model,
         selected_repo,
         discord_thread=None,
-        system_prompt=voice.VOICE_INSTRUCTION,
+        system_prompt=_append_rationale_trailer(voice.VOICE_INSTRUCTION, selected_repo),
     )
     turn = await asyncio.to_thread(_persist_pending_message, row.id, prompt, model)
     _schedule_next_message(row.id)

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -52,7 +52,11 @@ def test_session_start_stores_voice_system_prompt(monkeypatch, session):
     result = asyncio.run(mcp.monolith_agent_session_start("hello"))
 
     row = store.get_session(session, result["session_id"])
-    assert row.system_prompt == voice.VOICE_INSTRUCTION
+    # The voice instruction is no longer the whole prompt: repo-backed
+    # sessions also carry the walkthrough rationale trailer, appended rather
+    # than replacing what the caller set (ADR 056 decision 9).
+    assert row.system_prompt.startswith(voice.VOICE_INSTRUCTION)
+    assert "RATIONALE" in row.system_prompt
 
 
 def test_execute_pending_message_forwards_system_prompt_only_when_set(

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -88,6 +88,7 @@ class AgentTurn(SQLModel, table=True):
     stop_reason: str | None = Field(default=None)
     permission_denials: str | None = Field(default=None)
     commit_sha: str | None = Field(default=None, index=True)
+    base_sha: str | None = Field(default=None, index=True)
     usage_json: str | None = Field(default=None)
     cost_usd: float | None = Field(default=None)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/agent_sessions/rationale.py
+++ b/projects/monolith/agent_sessions/rationale.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+def rationale_trailer_instruction() -> str:
+    """Return the plain-text trailer instruction used by agent sessions."""
+    return (
+        "End your reply with a plain-text trailer in exactly this shape:\n"
+        "\nRATIONALE\n"
+        "- path: <repo-relative path> · why: <one or two sentences>\n"
+        "- path: ... (repeat per important path, most important first)\n"
+        "- deviation: <anything you did differently from the task, and why> (zero or more)\n"
+        "\nKeep it under 12 lines. Do not use markdown formatting inside the trailer."
+    )

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -18,6 +18,7 @@ from agent_sessions import model_family, store
 from agent_sessions.codex_login import codex_login_gate, watch_for_login
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.mcp import (
+    _append_rationale_trailer,
     _clear_ember_bindings_for,
     _load_session_row,
     _mark_ui_originated,
@@ -458,6 +459,7 @@ def get_session_detail(
                 "stop_reason": turn.stop_reason,
                 "permission_denials": _decode(turn.permission_denials, []),
                 "commit_sha": turn.commit_sha,
+                "base_sha": turn.base_sha,
                 "usage": _decode(turn.usage_json, {}),
                 "cost_usd": turn.cost_usd,
                 "created_at": _iso(turn.created_at),
@@ -501,6 +503,7 @@ async def start_session(request: Request, start_request: StartRequest) -> dict:
         start_request.branch,
         start_request.model,
         start_request.repo,
+        system_prompt=_append_rationale_trailer(None, start_request.repo),
         triggered_by=triggered_by,
     )
     turn = await asyncio.to_thread(

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -1024,7 +1024,7 @@ def test_start_session_marks_message_ui_originated(client, session, monkeypatch)
     mcp._ui_originated.clear()
 
 
-def test_start_session_for_discord_thread_has_no_system_prompt(session, monkeypatch):
+def test_start_session_for_discord_thread_adds_rationale_prompt(session, monkeypatch):
     async def broker_request(*args):
         return {"state": "granted"}
 
@@ -1047,7 +1047,7 @@ def test_start_session_for_discord_thread_has_no_system_prompt(session, monkeypa
 
     row = store.get_session(session, session_id)
     assert row.discord_thread == "thread-1"
-    assert row.system_prompt is None
+    assert "RATIONALE" in row.system_prompt
 
 
 @pytest.mark.parametrize("model", ["opus", "qwen"])

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -1041,13 +1041,22 @@ def test_start_session_for_discord_thread_adds_rationale_prompt(session, monkeyp
         ),
     )
 
-    session_id = asyncio.run(
+    # A path-anchored trailer is meaningless without a repo to anchor into,
+    # so a repo-less session must not be asked for one. Both directions are
+    # asserted: an absent trailer here is the intended behaviour, not a gap.
+    repoless_id = asyncio.run(
         api.start_session_for_thread("thread-1", "Hello", repo=None)
     )
+    repoless = store.get_session(session, repoless_id)
+    assert repoless.discord_thread == "thread-1"
+    assert repoless.system_prompt is None
 
-    row = store.get_session(session, session_id)
-    assert row.discord_thread == "thread-1"
-    assert "RATIONALE" in row.system_prompt
+    with_repo_id = asyncio.run(
+        api.start_session_for_thread("thread-2", "Hello", repo="jomcgi/homelab")
+    )
+    with_repo = store.get_session(session, with_repo_id)
+    assert "RATIONALE" in with_repo.system_prompt
+    assert "path:" in with_repo.system_prompt
 
 
 @pytest.mark.parametrize("model", ["opus", "qwen"])

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -260,6 +260,25 @@ def get_turn(session: Session, session_id: int, turn_seq: int) -> AgentTurn | No
     ).first()
 
 
+def update_turn_shas(
+    session: Session,
+    session_id: int,
+    turn_seq: int,
+    base_sha: str | None,
+    commit_sha: str | None,
+) -> AgentTurn | None:
+    """Attach branch heads to a turn after the swarm observes its completion."""
+    row = get_turn(session, session_id, turn_seq)
+    if row is None:
+        return None
+    row.base_sha = base_sha
+    row.commit_sha = commit_sha
+    session.add(row)
+    session.commit()
+    session.refresh(row)
+    return row
+
+
 def lexical_search(session: Session, query_text: str, limit: int = 20) -> list[dict]:
     """Search agent turns and return ranked session/turn result dictionaries."""
     if not query_text or not query_text.strip():

--- a/projects/monolith/chart/migrations/20260813120000_agent_turn_base_sha.sql
+++ b/projects/monolith/chart/migrations/20260813120000_agent_turn_base_sha.sql
@@ -1,0 +1,3 @@
+-- Record pre-attempt branch head to enable correct compare/{base}...{head} links
+ALTER TABLE agent_sessions.agent_turns ADD COLUMN base_sha TEXT;
+CREATE INDEX IF NOT EXISTS agent_turns_base_sha_idx ON agent_sessions.agent_turns (base_sha);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:PPGVg73ysigOpEkzfs8n93l1FuWoEmdaLmnW/kA9rRs=
+h1:wQQDZuQV+zkBZ8GCo/NWk5S8a9Zp8j0vI+85MCqGpi8=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -162,3 +162,4 @@ h1:PPGVg73ysigOpEkzfs8n93l1FuWoEmdaLmnW/kA9rRs=
 20260810010000_agent_sessions_triggered_by.sql h1:ZIw9yloGu+UjC4MYC4uQSzKybK7dnG9gUCj2Adhm7Gs=
 20260811000000_agent_sessions_node_key.sql h1:4zzYZjEKvM2Qc6jKM+CrclVaiuFvXrbEi8E/BryWdgw=
 20260813000000_swarm_recording_schema.sql h1:GP+CVZ9aczViVoM1k49RwXsF0CH6LaE4FkYKeKGigEo=
+20260813120000_agent_turn_base_sha.sql h1:AW26zU3owy+k5jqTmVXpK413P2Xy/z1dTBFMrPQhkNY=

--- a/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
@@ -346,9 +346,9 @@
               )}
             </div>
             {#if attempt.rationale.parse_status === "parsed"}
-              {#each attempt.rationale.areas as area}
+              {#each attempt.rationale.paths as path}
                 <div class="testimony-line">
-                  {joinMeta(area.area, area.why)}
+                  {joinMeta(path.path, path.why)}
                 </div>
               {/each}
               {#each attempt.rationale.deviations as deviation}

--- a/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
@@ -167,11 +167,11 @@ const running = run("running", "running", {
             observed_head: "86dcbf41",
           },
           rationale: {
-            raw: "RATIONALE\n- area: swarm/rows.py · why: carries the final turn\n- area: run view · why: shows testimony\n- deviation: kept routing unchanged",
+            raw: "RATIONALE\n- path: swarm/rows.py · why: carries the final turn\n- path: swarm/run_view.py · why: shows testimony\n- deviation: kept routing unchanged",
             parse_status: "parsed",
-            areas: [
-              { area: "swarm/rows.py", why: "carries the final turn" },
-              { area: "run view", why: "shows testimony" },
+            paths: [
+              { path: "swarm/rows.py", why: "carries the final turn" },
+              { path: "swarm/run_view.py", why: "shows testimony" },
             ],
             deviations: ["kept routing unchanged"],
             parser_version: 1,
@@ -186,7 +186,7 @@ const running = run("running", "running", {
           rationale: {
             raw: null,
             parse_status: "none",
-            areas: [],
+            paths: [],
             deviations: [],
             parser_version: 1,
           },

--- a/projects/monolith/swarm/policy.py
+++ b/projects/monolith/swarm/policy.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import re
 
+from agent_sessions.rationale import rationale_trailer_instruction
+
 
 def work_branch(workflow_id: str) -> str:
     """The scratch branch one swarm run pushes its implementation to.
@@ -40,12 +42,8 @@ def implementer_prompt(task: str, branch: str, previous_failure: str | None) -> 
         f"Implement this task: {task}\n"
         f"Create branch {branch} from the base branch, make the change, commit it, "
         f"and push {branch} to GitHub. Do not open a pull request. Do not push to main."
-        "\nEnd your reply with a plain-text trailer in exactly this shape:\n"
-        "\nRATIONALE\n"
-        "- area: <file or component> · why: <one or two sentences>\n"
-        "- area: ... (repeat per important area, most important first)\n"
-        "- deviation: <anything you did differently from the task, and why> (zero or more)\n"
-        "\nKeep it under 12 lines. Do not use markdown formatting inside the trailer."
+        "\n"
+        f"{rationale_trailer_instruction()}"
     )
     if previous_failure:
         prompt += f"\nPrevious attempt failed: {previous_failure}"

--- a/projects/monolith/swarm/rationale.py
+++ b/projects/monolith/swarm/rationale.py
@@ -7,8 +7,10 @@ import re
 
 _RATIONALE_TAIL_LINES = 12
 _HEADER = re.compile(r"RATIONALE", re.IGNORECASE)
-_AREA = re.compile(
-    r"area\s*:\s*(?P<area>.+?)(?:\s+(?:·|-|–)\s*why\s*:\s*(?P<why>.*))?$",
+_PATH = re.compile(
+    r"path\s*:\s*"
+    r"(?P<path>(?!/)(?!\./)(?!\.\./)(?![A-Za-z]:[\\/])[^\s·]+(?:/[^\s·]+)*)"
+    r"(?:\s+(?:·|-|–)\s*why\s*:\s*(?P<why>.*))?$",
     re.IGNORECASE,
 )
 _DEVIATION = re.compile(r"deviation\s*:\s*(?P<deviation>.+)$", re.IGNORECASE)
@@ -18,7 +20,7 @@ def _empty(status: str, raw: str | None = None) -> dict:
     return {
         "raw": raw,
         "parse_status": status,
-        "areas": [],
+        "paths": [],
         "deviations": [],
         "parser_version": 1,
     }
@@ -48,7 +50,7 @@ def parse_rationale(text: str | None) -> dict:
 
         header = headers[0]
         raw = "\n".join(lines[header:])
-        areas = []
+        paths = []
         deviations = []
         meaningful = 0
         for line in lines[header + 1 :]:
@@ -56,14 +58,14 @@ def parse_rationale(text: str | None) -> dict:
             if not stripped:
                 continue
             bullet = stripped.lstrip("-* \t")
-            area = _AREA.fullmatch(bullet)
+            path = _PATH.fullmatch(bullet)
             deviation = _DEVIATION.fullmatch(bullet)
-            if area:
+            if path:
                 meaningful += 1
-                areas.append(
+                paths.append(
                     {
-                        "area": area.group("area").strip(),
-                        "why": (area.group("why") or "").strip(),
+                        "path": path.group("path").strip(),
+                        "why": (path.group("why") or "").strip(),
                     }
                 )
             elif deviation:
@@ -78,7 +80,7 @@ def parse_rationale(text: str | None) -> dict:
         return {
             "raw": raw,
             "parse_status": "parsed",
-            "areas": areas,
+            "paths": paths,
             "deviations": deviations,
             "parser_version": 1,
         }

--- a/projects/monolith/swarm/rationale_test.py
+++ b/projects/monolith/swarm/rationale_test.py
@@ -1,17 +1,17 @@
 from swarm.rationale import parse_rationale
 
 
-def test_clean_trailer_parses_areas_and_deviation():
+def test_clean_trailer_parses_paths_and_deviation():
     result = parse_rationale(
         "work done\nRATIONALE\n"
-        "- area: swarm/rows.py · why: carries the final turn text\n"
-        "- area: run view · why: keeps testimony with its attempt\n"
+        "- path: swarm/rows.py · why: carries the final turn text\n"
+        "- path: swarm/run_view.py · why: keeps testimony with its attempt\n"
         "- deviation: left routing unchanged because rationale is display only"
     )
     assert result["parse_status"] == "parsed"
-    assert result["areas"] == [
-        {"area": "swarm/rows.py", "why": "carries the final turn text"},
-        {"area": "run view", "why": "keeps testimony with its attempt"},
+    assert result["paths"] == [
+        {"path": "swarm/rows.py", "why": "carries the final turn text"},
+        {"path": "swarm/run_view.py", "why": "keeps testimony with its attempt"},
     ]
     assert result["deviations"] == [
         "left routing unchanged because rationale is display only"
@@ -21,17 +21,17 @@ def test_clean_trailer_parses_areas_and_deviation():
 
 def test_markdown_decoration_is_tolerated():
     result = parse_rationale(
-        "## RATIONALE\n* - area: view · why: show it\n* - deviation: none"
+        "## RATIONALE\n* - path: swarm/view.py · why: show it\n* - deviation: none"
     )
     assert result["parse_status"] == "parsed"
-    assert result["areas"] == [{"area": "view", "why": "show it"}]
+    assert result["paths"] == [{"path": "swarm/view.py", "why": "show it"}]
 
 
 def test_no_trailer_is_absent():
     assert parse_rationale("ordinary reply") == {
         "raw": None,
         "parse_status": "none",
-        "areas": [],
+        "paths": [],
         "deviations": [],
         "parser_version": 1,
     }
@@ -41,26 +41,36 @@ def test_garbage_header_preserves_raw():
     result = parse_rationale("RATIONALE\nthis is not a bullet")
     assert result["parse_status"] == "unparseable"
     assert result["raw"] == "RATIONALE\nthis is not a bullet"
-    assert result["areas"] == []
+    assert result["paths"] == []
 
 
 def test_header_outside_tail_window_is_absent():
     assert (
-        parse_rationale("RATIONALE\n- area: old · why: old\n" + "noise\n" * 12)[
+        parse_rationale("RATIONALE\n- path: old.py · why: old\n" + "noise\n" * 12)[
             "parse_status"
         ]
         == "none"
     )
 
 
-def test_area_without_why_does_not_invent_one():
-    result = parse_rationale("RATIONALE\n- area: an untouched file")
-    assert result["areas"] == [{"area": "an untouched file", "why": ""}]
+def test_path_without_why_does_not_invent_one():
+    result = parse_rationale("RATIONALE\n- path: untouched/file.py")
+    assert result["paths"] == [{"path": "untouched/file.py", "why": ""}]
+
+
+def test_missing_or_absolute_path_fails_closed():
+    for bullet in (
+        "- path: · why: missing",
+        "- path: /absolute/file.py · why: bad",
+    ):
+        result = parse_rationale(f"RATIONALE\n{bullet}")
+        assert result["parse_status"] == "unparseable"
+        assert result["paths"] == []
 
 
 def test_duplicated_blocks_fail_closed():
     result = parse_rationale(
-        "RATIONALE\n- area: one · why: first\nRATIONALE\n- area: two · why: second"
+        "RATIONALE\n- path: one.py · why: first\nRATIONALE\n- path: two.py · why: second"
     )
     assert result["parse_status"] == "unparseable"
-    assert result["areas"] == []
+    assert result["paths"] == []

--- a/projects/monolith/swarm/steps.py
+++ b/projects/monolith/swarm/steps.py
@@ -90,6 +90,23 @@ def poll_turn(session_id: int, after_seq: int) -> dict | None:
         }
 
 
+@DBOS.step()
+def update_turn_shas(
+    session_id: int, turn_seq: int, base_sha: str | None, commit_sha: str | None
+) -> bool:
+    """Attach the swarm's pre- and post-attempt heads to a persisted turn."""
+    from sqlmodel import Session
+
+    from agent_sessions import store
+    from core.db import get_engine
+
+    with Session(get_engine()) as session:
+        return (
+            store.update_turn_shas(session, session_id, turn_seq, base_sha, commit_sha)
+            is not None
+        )
+
+
 @DBOS.step(retries_allowed=True, max_attempts=3, backoff_rate=2.0)
 def read_branch_head(repo: str, branch: str) -> str | None:
     """Read a pushed branch head from GitHub, independently of the agent claim."""

--- a/projects/monolith/swarm/view_test.py
+++ b/projects/monolith/swarm/view_test.py
@@ -204,7 +204,7 @@ def _running_implement(workflow_id):
             "last_turn_at": datetime(2026, 8, 10, 22, 56, tzinfo=timezone.utc),
             "total_cost_usd": 0.09,
             "final_result_text": (
-                "RATIONALE\n- area: swarm/view.py · why: attaches testimony\n"
+                "RATIONALE\n- path: swarm/view.py · why: attaches testimony\n"
                 "- deviation: no routing changes"
             ),
         }

--- a/projects/monolith/swarm/workflows.py
+++ b/projects/monolith/swarm/workflows.py
@@ -12,7 +12,13 @@ from swarm.policy import (
     work_branch,
 )
 from swarm.queues import codex_queue
-from swarm.steps import pin_plan, poll_turn, read_branch_head, start_agent_session
+from swarm.steps import (
+    pin_plan,
+    poll_turn,
+    read_branch_head,
+    start_agent_session,
+    update_turn_shas,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +165,7 @@ def implement_then_review(
     previous_failure = None
     implementer_session_id = None
     implementer_turn = None
+    base_sha = None
     commit_sha = None
 
     while attempt < max_attempts:
@@ -178,6 +185,28 @@ def implement_then_review(
             implementer_session_id, 0, plan["turn_timeout_seconds"]
         )
         head_sha = read_branch_head(repo, branch_name)
+        base_sha = prior_sha
+        if implementer_turn is not None:
+            # Recording the heads is a convenience write for the walkthrough,
+            # not part of the decision this loop makes: next_action reads
+            # head_sha and prior_sha directly, just below. A failure here must
+            # not be able to fail the attempt, for the same reason the pinned
+            # plan copy above is guarded. The heads are lost for that turn and
+            # the run continues.
+            try:
+                update_turn_shas(
+                    implementer_session_id,
+                    implementer_turn["seq"],
+                    base_sha,
+                    head_sha,
+                )
+            except Exception:  # noqa: BLE001 - the attempt outranks the record
+                logger.warning(
+                    "failed to record turn heads for session %s seq %s",
+                    implementer_session_id,
+                    implementer_turn["seq"],
+                    exc_info=True,
+                )
         action = next_action(attempt, max_attempts, head_sha, prior_sha)
         if action == "review":
             commit_sha = head_sha

--- a/projects/monolith/swarm/workflows_test.py
+++ b/projects/monolith/swarm/workflows_test.py
@@ -41,6 +41,7 @@ def run(monkeypatch, turns, heads=None):
         },
     )
     monkeypatch.setattr(workflows, "start_agent_session", lambda *args: 0)
+    monkeypatch.setattr(workflows, "update_turn_shas", lambda *args: True)
     monkeypatch.setattr(workflows, "_await_turn", lambda session, *_: turns[session])
     monkeypatch.setattr(workflows, "read_branch_head", lambda *_: next(branch_heads))
     monkeypatch.setattr(

--- a/projects/monolith/swarm/workflows_test.py
+++ b/projects/monolith/swarm/workflows_test.py
@@ -42,7 +42,14 @@ def run(monkeypatch, turns, heads=None):
     )
     monkeypatch.setattr(workflows, "start_agent_session", lambda *args: 0)
     monkeypatch.setattr(workflows, "update_turn_shas", lambda *args: True)
-    monkeypatch.setattr(workflows, "_await_turn", lambda session, *_: turns[session])
+    # seq is part of poll_turn's real contract (swarm/steps.py), so the stub
+    # carries it too. Defaulted rather than added to every literal below, and
+    # overridable by any stub that cares which turn it is.
+    monkeypatch.setattr(
+        workflows,
+        "_await_turn",
+        lambda session, *_: {"seq": 0, **turns[session]},
+    )
     monkeypatch.setattr(workflows, "read_branch_head", lambda *_: next(branch_heads))
     monkeypatch.setattr(
         workflows,
@@ -136,7 +143,7 @@ def test_pinned_attempt_bound_survives_config_change(monkeypatch):
         "_await_turn",
         lambda session, *_: (
             monkeypatch.setenv("SWARM_MAX_ATTEMPTS", "5")
-            or {"result_text": "no", "cost_usd": 1}
+            or {"seq": 0, "result_text": "no", "cost_usd": 1}
         ),
     )
 


### PR DESCRIPTION
ADR 056 specifies session and run walkthroughs. This is **capture only**: no
compare endpoint, no cross-check, no UI. Those all operate on data that will
still be there tomorrow. Capture does not: a diff can be reconstructed from
git forever, but what an agent was thinking at turn time cannot be
reconstructed at all.

ADR 056 decision 9 names `AgentTurn.commit_sha` as the precedent for getting
this wrong: a column declared, indexed and serialized that never held a
value. Every session that ran before this lands is permanently
walkthrough-poor.

## Points are anchored to paths now

The trailer asked for `area: <file or component>`. ADR 056 decision 3's
cross-check needs a **path**, so a changed file that no point mentions can
surface as unexplained, and a point naming a file absent from the diff can
render as a contradiction. A free-text component cannot be compared to a
diff.

The parser rejects absolute, `./`, `../` and drive-prefixed paths rather than
accepting and normalising them, preserving its fail-closed contract: a
malformed point is a parse failure for that point, never an invented path.

**This is a breaking change to the trailer shape**, taken deliberately.
Nothing consumes it yet, so there is no dual-shape transition.

## Sessions outside the swarm are asked too

The instruction moved to `agent_sessions/rationale.py` so console, MCP and
Discord sessions get the same trailer through the `AgentSession.system_prompt`
seam (ADR 056 decision 9). It **appends** rather than replaces, so a caller's
own prompt survives (the MCP voice instruction still leads), and it is
skipped for sessions with no repo, where a path-anchored trailer has nothing
to anchor into.

## Both SHAs are recorded per turn

`commit_sha` is finally populated and `base_sha` joins it.

**Both values already existed and were being discarded.** `swarm/workflows.py`
reads the branch head before every attempt and again after it, and both are
recorded DBOS step outputs. #4600 assumed no base SHA existed anywhere and
that obtaining one meant new plumbing at hydration; for swarm runs it is
computed on every attempt already.

Storing both makes a correct `compare/{base}...{head}` possible later, which
matters because this repo deletes branches on merge and allows rebase merges
only, so comparing by branch name has a shelf life measured in days.

The write is guarded. Recording heads is a convenience write for the
walkthrough and not part of the decision the attempt loop makes (`next_action`
reads the heads directly), so a failure logs and continues rather than failing
the attempt. Same reasoning, and same shape, as the pinned-plan copy above it.

**Non-swarm sessions do not get SHAs in this PR.** There is no equivalent
value in hand for them and it would need a fresh GitHub read at turn end.
Stated rather than silently skipped.

## Test corrections, no production changes

- `workflows_test` stubbed `_await_turn` with dicts carrying no `seq`, while
  `poll_turn`'s real contract always returns one. Recording the heads reads
  that `seq`, so 11 tests raised `KeyError` against a stub that had drifted
  from the thing it stands in for. Fixed in the stub, not across 14 literals.
- A new Discord test asserted a trailer on a `repo=None` session, which is
  the one case that must not get one. It now asserts both directions, pinning
  the absence as intended behaviour.
- An MCP test asserted the stored prompt equalled the voice instruction
  exactly. It now asserts the prefix and the trailer's presence.

## Verification

`ci test`: `Executed 2 out of 710 tests: 710 tests pass.` on the final run,
after earlier runs surfaced and fixed the 11 + 2 failures above. The
migration is 241 bytes, schema-only, far under the 256 KiB ConfigMap cap.

Not verified: any of this against a live run. Capture correctness on real
traffic is observable once deployed, by checking that `base_sha` and
`commit_sha` are populated on new swarm turns and that trailers parse.

No chart version or `targetRevision` touched.