### PR TITLE
fix(monolith): make finished runs, run timestamps and selection visible

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1633,7 +1633,7 @@
 
 {#snippet terminalRunRow(run)}
   <button
-    class="group-header group-main run-entry"
+    class="group-header group-main run-entry run-row"
     class:chosen={String(selectedRunId) === String(run.workflow_id)}
     type="button"
     title={run.workflow_id}
@@ -1656,7 +1656,7 @@
 
 {#snippet runRow(run)}
   <button
-    class="group-header group-main run-entry"
+    class="group-header group-main run-entry run-row"
     class:chosen={String(selectedRunId) === String(run.workflow_id)}
     type="button"
     title={run.workflow_id}
@@ -1843,6 +1843,10 @@
     background: var(--hover);
   }
   .session-row.chosen {
+    background: var(--panel-bg);
+    border-color: var(--line);
+  }
+  .run-row.chosen {
     background: var(--panel-bg);
     border-color: var(--line);
   }
@@ -2110,6 +2114,9 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  .session-title:focus:not(:focus-visible) {
+    outline: none;
   }
   .session-context {
     margin-top: 3px;

--- a/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
@@ -248,8 +248,10 @@
           {#each capacityPips(run.plan, node) as pip}<span class={pip}
             ></span>{/each}
         </span>
-        {#if run.plan?.pinned}<span class="entry-meta"
-            >{run.plan.max_attempts} {P.labels.attempts}</span
+        {#if run.plan?.pinned && node.attempts.length > 1}<span
+            class="entry-meta"
+            >{run.plan.max_attempts}
+            {P.labels.pushAttempts}</span
           >{/if}
       {/if}
       {#if node.state === "escalated" || node.blocked_on?.kind === "human"}<span
@@ -368,8 +370,15 @@
         {/if}
       </div>
     {/each}
-    {#if node.verdict}<div class="verdict-box" data-register="belief">
-        <div class="verdict-word">{P.labels.verdict} {node.verdict.value}</div>
+    {#if node.verdict}<div
+        class="verdict-box"
+        class:wants-human={node.verdict.value !== "approve"}
+        data-register="belief"
+      >
+        <div class="verdict-word">
+          {P.labels.verdict}
+          {P.stateWords[node.verdict.value] || node.verdict.value}
+        </div>
         <div class="verdict-excerpt">{node.verdict.excerpt}</div>
         {#if node.verdict.commit_url}<a
             class="commit-link"

--- a/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
@@ -261,6 +261,22 @@ const approved = run("approved", "approved", {
   ],
 });
 
+const requestChanges = run("request-changes", "changes_requested", {
+  dbos_status: "SUCCESS",
+  nodes: [
+    node("implement", "implement", "done", { attempts: [attempt(1, "done")] }),
+    node("push_gate", "push gate", "passed"),
+    node("review", "review", "done", {
+      verdict: {
+        value: "request_changes",
+        excerpt: "Please address the requested changes before merging.",
+        commit_sha: "86dcbf41",
+        commit_url: "https://github.com/jomcgi/homelab/commit/86dcbf41",
+      },
+    }),
+  ],
+});
+
 const terminalExample = run("terminal-example", "approved", {
   dbos_status: "SUCCESS",
   completed_at: "2026-08-10T22:55:00Z",
@@ -330,6 +346,7 @@ export const RUN_FIXTURES = {
   queued: entry(queued),
   cancelled: entry(cancelled),
   approved: entry(approved),
+  "request-changes": entry(requestChanges),
   "terminal-example": entry(terminalExample),
   stranded: entry(stranded),
   unpinned: entry(unpinned, [

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -54,6 +54,7 @@ export const RUN_LEXICON = {
     buildWord: "build",
     serverBuildWord: "server",
     attempts: "attempts",
+    pushAttempts: "push attempts",
     retriesRemain: "retries remain",
     waitsOn: "waits on",
     needsYou: "needs you",

--- a/projects/monolith/frontend/src/routes/private/agents/run-view.css
+++ b/projects/monolith/frontend/src/routes/private/agents/run-view.css
@@ -500,6 +500,35 @@
   align-items: baseline;
   padding: 7px 2px;
   border-bottom: 1px solid var(--line);
+  width: 100%;
+  color: inherit;
+  background: transparent;
+  border-left: 0;
+  border-right: 0;
+  border-top: 0;
+  text-align: left;
+  font: inherit;
+}
+.sess-row:hover {
+  background: var(--hover);
+}
+/* Neutral by default. ADR 054 decision 6 reserves amber for blocked-on-human,
+   and this box wraps every verdict including approve, so tinting it amber
+   unconditionally would spend the one colour that means "act" on the outcome
+   that needs nothing. The amber variant below is applied only when the
+   verdict actually wants a human. */
+.verdict-box {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--line-strong);
+  border-radius: 4px;
+  background: var(--panel-bg);
+  color: var(--text-soft);
+}
+.verdict-box.wants-human {
+  border-left-color: var(--attn);
+  background: var(--attn-soft);
 }
 .sess-title {
   font-size: 13px;

--- a/projects/monolith/swarm/view.py
+++ b/projects/monolith/swarm/view.py
@@ -70,6 +70,15 @@ def _iso(value: Any) -> str | None:
     A timestamp that cannot be serialized is absent, and absent has to look
     absent. Strings are trusted only if they parse as a timestamp.
     """
+    if isinstance(value, int) and not isinstance(value, bool):
+        try:
+            return (
+                datetime.fromtimestamp(value / 1000, tz=timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
+        except (OverflowError, OSError, ValueError):
+            return None
     if isinstance(value, datetime):
         return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
     if isinstance(value, str) and value:
@@ -316,7 +325,15 @@ def compose_run(dbos, workflow_id, session_rows, server_app_version) -> dict | N
         gate_state, review_state = "cancelled", "cancelled"
     elif output.get("status") == "escalated":
         implement_state, gate_state, review_state = "escalated", "refused", "cancelled"
-    elif output.get("review_verdict") == "approve":
+    elif output.get("review_verdict") == "unparseable":
+        # parse_review_verdict is fail-closed and says so: "routing must never
+        # guess a verdict". Painting the review node done would put a check
+        # mark on an outcome the server explicitly does not know. Implement and
+        # the gate are still facts (the head moved, which is why review ran).
+        implement_state, gate_state, review_state = "done", "passed", "escalated"
+    elif output.get("review_verdict") in {"approve", "request_changes", "blocked"}:
+        # The review node ran to completion in all three cases. Which way it
+        # went is the run's state and the verdict box, not the node's.
         implement_state, gate_state, review_state = "done", "passed", "done"
     elif review_attempts and _value(review_attempts[-1], "state") == "running":
         implement_state, gate_state, review_state = "done", "passed", "running"

--- a/projects/monolith/swarm/view_test.py
+++ b/projects/monolith/swarm/view_test.py
@@ -288,6 +288,32 @@ def test_shas_render_at_eight_characters():
     )
 
 
+def test_request_changes_run_paints_completed_nodes_and_timestamps():
+    status = Status(
+        "wf-request-changes",
+        "SUCCESS",
+        ["task", "repo", "main"],
+        output={
+            "status": "review",
+            "review_verdict": "request_changes",
+        },
+        created_at=1783725765000,
+        updated_at=1783726258000,
+        completed_at=1783726258000,
+    )
+    run = compose_run(
+        DBOS(Workflow(status)),
+        "wf-request-changes",
+        [session(1, status="completed"), session(2, status="completed", node="review")],
+        "unknown",
+    )
+    assert [node["state"] for node in run["nodes"]] == ["done", "passed", "done"]
+    # 1783725765000 ms since the epoch, computed rather than eyeballed.
+    assert run["created_at"] == "2026-07-10T23:22:45Z"
+    assert run["updated_at"] == "2026-07-10T23:30:58Z"
+    assert run["completed_at"] == "2026-07-10T23:30:58Z"
+
+
 def test_attempt_carries_prior_head_alongside_finding():
     status = Status("wf-prior", "SUCCESS", ["task", "repo", "main"])
     run = compose_run(
@@ -343,14 +369,9 @@ def test_review_does_not_inherit_the_implement_lane_head_reads():
 
 
 def test_unserializable_timestamp_is_absent_not_passed_through():
-    """A timestamp the server cannot serialize must not reach the client.
-
-    It used to pass through untouched, where Date.parse returned NaN and the
-    client's `Number(x) || 0` printed it as a confident "0s ago" beside a real
-    elapsed time.
-    """
+    """A timestamp the server cannot serialize must not reach the client."""
     status = Status("wf-clock", "SUCCESS", ["task", "repo", "main"])
-    status.created_at = 1786423167
+    status.created_at = object()
     run = compose_run(DBOS(Workflow(status)), "wf-clock", [], "unknown")
     assert run["created_at"] is None
 


### PR DESCRIPTION
Five verified defects behind most of the console's recent UX complaints.
Several of them looked like design problems and were data problems.

## Finished runs painted every node as "not started"

`swarm/view.py`'s node-state mapping branched on cancelled, escalated,
`approve` and the two running cases, then fell through to
`future, future, future`. A run ending in `request_changes` therefore rendered
implement, push gate and review all as not-started, despite implement having
pushed a commit and review having returned a verdict. Confirmed live on
workflow `06ccd147-a59b-45e7-919f-c5f69904156e`.

That fall-through also drew the entire run rail in the future-state icon,
which measures **1.67:1 against white**. It is the literal cause of the run
view reading as washed out, so this is not a cosmetic fix.

**An unparseable verdict escalates the review node rather than completing
it.** `parse_review_verdict` is fail-closed and its docstring says "routing
must never guess a verdict", so a check mark there would assert an outcome the
server does not have. Implement and the gate stay facts: the head moved, which
is why review ran at all.

## Every run timestamp was null

`created_at`, `updated_at` and `completed_at` came back `None` on every run,
verified against the live API. DBOS carries them as **Unix epoch
milliseconds** (`dbos/_sys_db.py`: `created_at: Optional[int]  # Unix epoch
timestamp in ms`), and `_iso` understood only datetimes and strings, so every
value silently became absent.

One null, two broken features:

- the sidebar printed "never" for every run and showed **"EARLIER 7" directly
  above "No earlier runs"**, because `recentRuns()` filters a 24h window on
  `completed_at ?? updated_at ?? created_at`;
- the home reported **"0 runs"** in its 7 day summary on a screen that
  simultaneously said "1 in flight", and no run ever reached RECENT.

So this repairs #4782's run history and #4783's home activity, both of which
have been silently empty since they merged.

## Three unstyled or half-styled elements

- **`.verdict-box`** had no CSS rule anywhere, which is why the verdict read as
  loose disjointed text. Now neutral by default with an amber variant applied
  only when the verdict wants a human: ADR 054 decision 6 reserves amber for
  blocked-on-human, and this box wraps `approve` too, so tinting it
  unconditionally would spend the one "act on this" colour on the outcome that
  needs nothing.
- **Run rows had `class:chosen` with no matching rule**, so a selected run was
  invisible in the sidebar while a selected session was not.
- **`.sess-row`** is a `<button>` whose rule set only layout. The console's
  global reset covers `font` and `border-radius` but not `background`,
  `border` or `color`, so UA chrome leaked through as a beveled lozenge.

## Focus ring regression from #4780

Moving focus to the transcript title after selection is correct (`goto`
retains focus rather than dropping it to `<body>`), but the `tabindex="-1"`
heading showed a visible ring. Suppressed for programmatic focus via
`:focus:not(:focus-visible)` while keeping it focusable for screen readers and
ringed for keyboard users.

## Attempt pips relabelled

The retry loop fires **only when the branch head did not move**, meaning the
agent claimed to push and did not. It has nothing to do with work quality, so
"2 attempts" was reading as an iteration budget the engine does not have,
which is actively misleading next to a "changes requested" verdict. Relabelled
in `run-lexicon.js`; the pips stay, per ADR 054 decision 7.

## Verification

`ci test`: `Executed 1 out of 710 tests: 710 tests pass.`

Three defects were found while reviewing this branch and are fixed here: the
unparseable node state above, the unconditional amber, and **two wrong
timestamp assertions** in the new test (an epoch of `1783725765000` was
asserted as `04:42:45Z` when it is `23:22:45Z`; both values were computed, not
eyeballed).

Not verified: live behaviour. Observable after deploy by opening a finished
run and confirming the nodes read done/passed/done, and that the sidebar shows
real ages instead of "never".

No chart version or `targetRevision` touched.