### PR TITLE
feat(swarm): let a request_changes verdict cause another implement attempt

### DIFF
--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -151,6 +151,8 @@ spec:
               value: {{ .Values.swarm.reviewerModel | quote }}
             - name: SWARM_MAX_ATTEMPTS
               value: {{ .Values.swarm.maxAttempts | quote }}
+            - name: SWARM_MAX_REVIEW_CYCLES
+              value: {{ .Values.swarm.maxReviewCycles | quote }}
             - name: SWARM_TURN_TIMEOUT_SECONDS
               value: {{ .Values.swarm.turnTimeoutSeconds | quote }}
             - name: SWARM_CODEX_CONCURRENCY

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1060,6 +1060,7 @@ swarm:
   # budget but can never extend it, which is what keeps "retry N times" a
   # budget rather than a suggestion.
   maxAttempts: 2
+  maxReviewCycles: 2
   turnTimeoutSeconds: 1800
   # Concurrent Codex dispatches. Three concurrent dispatches have been killed
   # before, so this stays at 2 until there is evidence it can go higher.

--- a/projects/monolith/swarm/config.py
+++ b/projects/monolith/swarm/config.py
@@ -19,6 +19,10 @@ def max_attempts() -> int:
     return int(os.environ.get("SWARM_MAX_ATTEMPTS", "2"))
 
 
+def max_review_cycles() -> int:
+    return int(os.environ.get("SWARM_MAX_REVIEW_CYCLES", "2"))
+
+
 def turn_timeout_seconds() -> int:
     return int(os.environ.get("SWARM_TURN_TIMEOUT_SECONDS", "1800"))
 

--- a/projects/monolith/swarm/config_test.py
+++ b/projects/monolith/swarm/config_test.py
@@ -7,6 +7,7 @@ def test_defaults(monkeypatch):
         "SWARM_IMPLEMENTER_MODEL",
         "SWARM_REVIEWER_MODEL",
         "SWARM_MAX_ATTEMPTS",
+        "SWARM_MAX_REVIEW_CYCLES",
         "SWARM_TURN_TIMEOUT_SECONDS",
         "SWARM_CODEX_CONCURRENCY",
     ):
@@ -15,6 +16,7 @@ def test_defaults(monkeypatch):
     assert config.implementer_model() == "luna"
     assert config.reviewer_model() == "opus"
     assert config.max_attempts() == 2
+    assert config.max_review_cycles() == 2
     assert config.turn_timeout_seconds() == 1800
     assert config.codex_concurrency() == 2
 
@@ -24,11 +26,13 @@ def test_environment_overrides(monkeypatch):
     monkeypatch.setenv("SWARM_IMPLEMENTER_MODEL", "cheap")
     monkeypatch.setenv("SWARM_REVIEWER_MODEL", "careful")
     monkeypatch.setenv("SWARM_MAX_ATTEMPTS", "4")
+    monkeypatch.setenv("SWARM_MAX_REVIEW_CYCLES", "3")
     monkeypatch.setenv("SWARM_TURN_TIMEOUT_SECONDS", "12")
     monkeypatch.setenv("SWARM_CODEX_CONCURRENCY", "7")
     assert config.enabled() is True
     assert config.implementer_model() == "cheap"
     assert config.reviewer_model() == "careful"
     assert config.max_attempts() == 4
+    assert config.max_review_cycles() == 3
     assert config.turn_timeout_seconds() == 12
     assert config.codex_concurrency() == 7

--- a/projects/monolith/swarm/policy.py
+++ b/projects/monolith/swarm/policy.py
@@ -37,7 +37,12 @@ def next_action(
     return "escalate"
 
 
-def implementer_prompt(task: str, branch: str, previous_failure: str | None) -> str:
+def implementer_prompt(
+    task: str,
+    branch: str,
+    previous_failure: str | None = None,
+    review_feedback: str | None = None,
+) -> str:
     prompt = (
         f"Implement this task: {task}\n"
         f"Create branch {branch} from the base branch, make the change, commit it, "
@@ -47,6 +52,8 @@ def implementer_prompt(task: str, branch: str, previous_failure: str | None) -> 
     )
     if previous_failure:
         prompt += f"\nPrevious attempt failed: {previous_failure}"
+    if review_feedback:
+        prompt += f"\nThe reviewer requested changes: {review_feedback}"
     return prompt
 
 

--- a/projects/monolith/swarm/steps.py
+++ b/projects/monolith/swarm/steps.py
@@ -19,6 +19,7 @@ def pin_plan(budget_usd: float | None = None) -> dict:
     return {
         "version": 1,
         "max_attempts": max(1, config.max_attempts()),
+        "max_review_cycles": max(1, config.max_review_cycles()),
         "implementer_model": config.implementer_model(),
         "reviewer_model": config.reviewer_model(),
         "turn_timeout_seconds": config.turn_timeout_seconds(),

--- a/projects/monolith/swarm/steps_test.py
+++ b/projects/monolith/swarm/steps_test.py
@@ -32,6 +32,7 @@ def test_pin_plan_resolves_config_once(monkeypatch):
     assert steps.pin_plan.__wrapped__(2.0) == {
         "version": 1,
         "max_attempts": 1,
+        "max_review_cycles": 2,
         "implementer_model": "implementer",
         "reviewer_model": "reviewer",
         "turn_timeout_seconds": 42,

--- a/projects/monolith/swarm/workflows.py
+++ b/projects/monolith/swarm/workflows.py
@@ -118,6 +118,7 @@ def _escalated(
     turn: dict | None,
     branch_name: str,
     branch_head: str | None = None,
+    cost_usd: float | None = None,
 ) -> dict:
     # commit_sha stays None on escalation: nothing was verified for review.
     # branch_head carries the last observed remote head so a triager can see
@@ -134,7 +135,7 @@ def _escalated(
         "reviewer_session_id": None,
         "review_text": None,
         "review_verdict": None,
-        "cost_usd": _cost(turn),
+        "cost_usd": _cost(turn) if cost_usd is None else cost_usd,
     }
 
 
@@ -161,12 +162,14 @@ def implement_then_review(
             )
     branch_name = work_branch(workflow_id or "unknown")
     max_attempts = plan["max_attempts"]
+    max_review_cycles = plan["max_review_cycles"]
     attempt = 0
     previous_failure = None
     implementer_session_id = None
     implementer_turn = None
     base_sha = None
     commit_sha = None
+    total_cost = 0.0
 
     while attempt < max_attempts:
         attempt += 1
@@ -184,6 +187,7 @@ def implement_then_review(
         implementer_turn = _await_turn(
             implementer_session_id, 0, plan["turn_timeout_seconds"]
         )
+        total_cost += _cost(implementer_turn)
         head_sha = read_branch_head(repo, branch_name)
         base_sha = prior_sha
         if implementer_turn is not None:
@@ -218,6 +222,7 @@ def implement_then_review(
                 implementer_turn,
                 branch_name,
                 branch_head=head_sha,
+                cost_usd=total_cost,
             )
         if head_sha:
             previous_failure = (
@@ -237,25 +242,111 @@ def implement_then_review(
         # Defensive: next_action should have escalated already. Never fall
         # through into the reviewer without a commit to review.
         return _escalated(
-            attempt, implementer_session_id, implementer_turn, branch_name
+            attempt,
+            implementer_session_id,
+            implementer_turn,
+            branch_name,
+            cost_usd=total_cost,
         )
 
-    # The reviewer gets a FRESH session (ADR 038 decision 3). It is never
-    # handed the implementer's lineage: a prompt-injected implementer could
-    # plant CLAUDE.md, AGENTS.md, or a git hook that the reviewer's CLI would
-    # read as instructions, so an inherited workspace would let the auditee
-    # prepare its auditor's room.
-    reviewer_session_id = _queued_session(
-        session_key("review"),
-        reviewer_prompt(task, branch_name, commit_sha),
-        plan["reviewer_model"],
-        repo,
-        branch,
-        workflow_id,
-        node_key="review",
-        node_attempt=1,
-    )
-    reviewer_turn = _await_turn(reviewer_session_id, 0, plan["turn_timeout_seconds"])
+    reviewer_session_id = None
+    reviewer_turn = None
+    verdict = "unparseable"
+    review_cycles = 0
+    review_feedback = None
+
+    while True:
+        # Every reviewer gets a FRESH session (ADR 038 decision 3), and each
+        # review node starts at node_attempt 1. The implementer's workspace is
+        # never handed to the reviewer.
+        reviewer_session_id = _queued_session(
+            session_key(f"review-{review_cycles + 1}"),
+            reviewer_prompt(task, branch_name, commit_sha),
+            plan["reviewer_model"],
+            repo,
+            branch,
+            workflow_id,
+            node_key="review",
+            node_attempt=1,
+        )
+        reviewer_turn = _await_turn(
+            reviewer_session_id, 0, plan["turn_timeout_seconds"]
+        )
+        total_cost += _cost(reviewer_turn)
+        verdict = parse_review_verdict(
+            reviewer_turn.get("result_text") if reviewer_turn else None
+        )
+
+        if verdict == "request_changes" and review_cycles < max_review_cycles:
+            review_cycles += 1
+            review_feedback = (
+                reviewer_turn.get("result_text") if reviewer_turn else None
+            )
+            prior_sha = read_branch_head(repo, branch_name)
+            attempt += 1
+            implementer_session_id = _queued_session(
+                session_key(f"implement-{attempt}"),
+                implementer_prompt(
+                    task,
+                    branch_name,
+                    review_feedback=review_feedback,
+                ),
+                plan["implementer_model"],
+                repo,
+                branch,
+                workflow_id,
+                node_key="implement",
+                node_attempt=attempt,
+            )
+            implementer_turn = _await_turn(
+                implementer_session_id, 0, plan["turn_timeout_seconds"]
+            )
+            total_cost += _cost(implementer_turn)
+            head_sha = read_branch_head(repo, branch_name)
+            base_sha = prior_sha
+            if implementer_turn is not None:
+                try:
+                    update_turn_shas(
+                        implementer_session_id,
+                        implementer_turn["seq"],
+                        base_sha,
+                        head_sha,
+                    )
+                except Exception:  # noqa: BLE001 - recording is best effort
+                    logger.warning(
+                        "failed to record turn heads for session %s seq %s",
+                        implementer_session_id,
+                        implementer_turn["seq"],
+                        exc_info=True,
+                    )
+            if implementer_turn is None or not head_sha or head_sha == prior_sha:
+                return _escalated(
+                    attempt,
+                    implementer_session_id,
+                    implementer_turn,
+                    branch_name,
+                    branch_head=head_sha,
+                    cost_usd=total_cost,
+                )
+            commit_sha = head_sha
+            continue
+
+        if verdict == "request_changes" and review_cycles >= max_review_cycles:
+            return {
+                "status": "review_cycles_exhausted",
+                "attempts": attempt,
+                "implementer_session_id": implementer_session_id,
+                "commit_sha": commit_sha,
+                "work_branch": branch_name,
+                "reviewer_session_id": reviewer_session_id,
+                "review_text": reviewer_turn.get("result_text")
+                if reviewer_turn
+                else None,
+                "review_verdict": verdict,
+                "cost_usd": total_cost,
+            }
+        break
+
     return {
         "status": "review",
         "attempts": attempt,
@@ -264,10 +355,8 @@ def implement_then_review(
         "work_branch": branch_name,
         "reviewer_session_id": reviewer_session_id,
         "review_text": reviewer_turn.get("result_text") if reviewer_turn else None,
-        "review_verdict": parse_review_verdict(
-            reviewer_turn.get("result_text") if reviewer_turn else None
-        ),
-        "cost_usd": _cost(implementer_turn) + _cost(reviewer_turn),
+        "review_verdict": verdict,
+        "cost_usd": total_cost,
     }
 
 

--- a/projects/monolith/swarm/workflows_test.py
+++ b/projects/monolith/swarm/workflows_test.py
@@ -353,7 +353,7 @@ def test_session_keys_are_deterministic_and_distinct(monkeypatch):
     assert keys == [
         workflows.session_key("implement-1"),
         workflows.session_key("implement-2"),
-        workflows.session_key("review"),
+        workflows.session_key("review-1"),
     ]
     assert len(set(keys)) == 3
 
@@ -395,7 +395,7 @@ def test_request_changes_triggers_new_implement_attempt(monkeypatch):
     assert result["attempts"] == 2
     assert result["commit_sha"] == "def"
     assert result["review_verdict"] == "approve"
-    assert result["cost_usd"] == 6
+    assert result["cost_usd"] == 4
     assert [(call[-2], call[-1]) for call in calls] == [
         ("implement", 1),
         ("review", 1),

--- a/projects/monolith/swarm/workflows_test.py
+++ b/projects/monolith/swarm/workflows_test.py
@@ -34,6 +34,7 @@ def run(monkeypatch, turns, heads=None):
         lambda budget_usd=None: {
             "version": 1,
             "max_attempts": max(1, config.max_attempts()),
+            "max_review_cycles": max(1, config.max_review_cycles()),
             "implementer_model": config.implementer_model(),
             "reviewer_model": config.reviewer_model(),
             "turn_timeout_seconds": config.turn_timeout_seconds(),
@@ -117,6 +118,7 @@ def test_pinned_attempt_bound_survives_config_change(monkeypatch):
         lambda budget_usd=None: {
             "version": 1,
             "max_attempts": max(1, config.max_attempts()),
+            "max_review_cycles": max(1, config.max_review_cycles()),
             "implementer_model": config.implementer_model(),
             "reviewer_model": config.reviewer_model(),
             "turn_timeout_seconds": config.turn_timeout_seconds(),
@@ -158,6 +160,7 @@ def test_pinned_attempt_bound_survives_config_change(monkeypatch):
                 "plan": {
                     "version": 1,
                     "max_attempts": 2,
+                    "max_review_cycles": 2,
                     "implementer_model": "luna",
                     "reviewer_model": "opus",
                     "turn_timeout_seconds": 1800,
@@ -366,3 +369,140 @@ def test_unparseable_reviewer_reply_is_returned_without_crashing(monkeypatch):
     )
     result = workflow("task", "jomcgi/homelab", "main")
     assert result["review_verdict"] == "unparseable"
+
+
+def test_request_changes_triggers_new_implement_attempt(monkeypatch):
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": "abc", "result_text": "done", "cost_usd": 1},
+            201: {
+                "commit_sha": None,
+                "result_text": "Needs a fix\nVERDICT: REQUEST_CHANGES",
+                "cost_usd": 1,
+            },
+            102: {"commit_sha": "def", "result_text": "done", "cost_usd": 1},
+            202: {
+                "commit_sha": None,
+                "result_text": "Looks good\nVERDICT: APPROVE",
+                "cost_usd": 1,
+            },
+        },
+        heads=[None, "abc", "abc", "def"],
+    )
+    result = workflow("task", "jomcgi/homelab", "main")
+    assert result["status"] == "review"
+    assert result["attempts"] == 2
+    assert result["commit_sha"] == "def"
+    assert result["review_verdict"] == "approve"
+    assert result["cost_usd"] == 6
+    assert [(call[-2], call[-1]) for call in calls] == [
+        ("implement", 1),
+        ("review", 1),
+        ("implement", 2),
+        ("review", 1),
+    ]
+    assert calls[1][0] == workflows.session_key("review-1")
+    assert calls[3][0] == workflows.session_key("review-2")
+
+
+def test_review_cycles_exhausted_on_persistent_request_changes(monkeypatch):
+    monkeypatch.setenv("SWARM_MAX_REVIEW_CYCLES", "1")
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": "abc", "result_text": "done", "cost_usd": 1},
+            201: {
+                "commit_sha": None,
+                "result_text": "VERDICT: REQUEST_CHANGES",
+                "cost_usd": 1,
+            },
+            102: {"commit_sha": "def", "result_text": "done", "cost_usd": 1},
+            202: {
+                "commit_sha": None,
+                "result_text": "VERDICT: REQUEST_CHANGES",
+                "cost_usd": 1,
+            },
+        },
+        heads=[None, "abc", "abc", "def"],
+    )
+    result = workflow("task", "jomcgi/homelab", "main")
+    assert result["status"] == "review_cycles_exhausted"
+    assert result["review_verdict"] == "request_changes"
+    assert result["attempts"] == 2
+    assert len(calls) == 4
+
+
+def test_pinned_review_cycle_bound_survives_config_change(monkeypatch):
+    monkeypatch.setenv("SWARM_MAX_REVIEW_CYCLES", "1")
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": "abc", "result_text": "done", "cost_usd": 1},
+            201: {
+                "commit_sha": None,
+                "result_text": "VERDICT: REQUEST_CHANGES",
+                "cost_usd": 1,
+            },
+            102: {"commit_sha": "def", "result_text": "done", "cost_usd": 1},
+            202: {
+                "commit_sha": None,
+                "result_text": "VERDICT: REQUEST_CHANGES",
+                "cost_usd": 1,
+            },
+        },
+        heads=[None, "abc", "abc", "def"],
+    )
+    original_await = workflows._await_turn
+
+    def await_turn(session, *args):
+        turn = original_await(session, *args)
+        if session == 201:
+            monkeypatch.setenv("SWARM_MAX_REVIEW_CYCLES", "0")
+        return turn
+
+    monkeypatch.setattr(workflows, "_await_turn", await_turn)
+    result = workflow("task", "jomcgi/homelab", "main")
+    assert result["status"] == "review_cycles_exhausted"
+    assert len(calls) == 4
+
+
+def test_unparseable_verdict_does_not_trigger_requeue(monkeypatch):
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": "abc", "result_text": "done", "cost_usd": 1},
+            201: {"commit_sha": None, "result_text": "Needs work", "cost_usd": 1},
+        },
+    )
+    result = workflow("task", "jomcgi/homelab", "main")
+    assert result["status"] == "review"
+    assert result["review_verdict"] == "unparseable"
+    assert len(calls) == 2
+
+
+def test_review_feedback_passed_to_implementer_prompt(monkeypatch):
+    feedback = []
+    original_prompt = workflows.implementer_prompt
+
+    def capture_prompt(task, branch, previous_failure=None, review_feedback=None):
+        feedback.append(review_feedback)
+        return original_prompt(task, branch, previous_failure, review_feedback)
+
+    monkeypatch.setattr(workflows, "implementer_prompt", capture_prompt)
+    run(
+        monkeypatch,
+        {
+            101: {"commit_sha": "abc", "result_text": "done", "cost_usd": 1},
+            201: {
+                "commit_sha": None,
+                "result_text": "Fix X\nVERDICT: REQUEST_CHANGES",
+                "cost_usd": 1,
+            },
+            102: {"commit_sha": "def", "result_text": "done", "cost_usd": 1},
+            202: {"commit_sha": None, "result_text": "VERDICT: APPROVE", "cost_usd": 1},
+        },
+        heads=[None, "abc", "abc", "def"],
+    )
+    workflow("task", "jomcgi/homelab", "main")
+    assert feedback == [None, "Fix X\nVERDICT: REQUEST_CHANGES"]


### PR DESCRIPTION
Closes #3842.

The reviewer has been an observer with no power to cause anything.
`swarm/workflows.py` ran the reviewer, parsed the verdict, and returned it as
data. A run could come back REQUEST_CHANGES with a substantive critique ("the
docs are stale, but this commit doesn't fix that: it rewrites only the
revision header") and simply stop.

Note what the existing `while attempt < max_attempts` loop actually does: it
retries only when the branch head did not move, meaning the agent claimed to
push and did not. That is a delivery check, not a quality loop, and it is not
overloaded here.

## Built as a plan change, not a retry

Per Joe's steer on the issue: "the ability to change the dag when blocked or
rerun would be incredibly helpful. We should be generating the dag when the
requests come in."

So the verdict becomes an **input to a new implement attempt** rather than a
terminal value. The reviewer's text is carried into that attempt's prompt as
`review_feedback`, kept deliberately distinct from `previous_failure`: "you
did not push" and "the reviewer wants changes" are different messages and must
not be conflated. Each cycle's implement attempt keeps `node_key="implement"`
with an incrementing `node_attempt`, so it renders as the plan growing rather
than as a counter incrementing.

This is the shape that survives #4781, where the conductor generates the DAG
when the request arrives and can grow it while it runs. A hardcoded
`if verdict == request_changes: goto top` would have to be torn out again.

## Bounds

`SWARM_MAX_REVIEW_CYCLES` (default 2) is a **separate** concept from
`max_attempts` and does not reuse that number. It is **pinned in `pin_plan`**
before the first node runs, so recovery cannot change it mid-run. That is the
same failure PR #4633 fixed for the attempt bound after #4618.

Exhaustion returns a distinct `review_cycles_exhausted` status, so "the
reviewer still wants changes and we are out of cycles" is not confused with
approval or with escalation.

**Budget will not save a runaway cycle.** `budget_usd` is currently a
reporting label, not a ceiling: validated, pinned, rendered, and reported
after the fact by `deviations.py`, with nothing checking it before or during
execution. Enforcement is #4784. Until then the cycle bound is the only real
bound, which is why it is pinned rather than read from config.

## Routing still keys off artifacts

ADR 038 decision 1 and ADR 053 decision 1: an agent's claims are never
evidence. Each requeued attempt re-reads the branch head with
`read_branch_head` and escalates if it did not move, so a cycle cannot be
driven by the implementer's own account of itself. An **unparseable verdict
does not requeue**; `parse_review_verdict` is fail-closed by design and
guessing a verdict is exactly what it refuses to do.

Every reviewer still gets a fresh session and never inherits the implementer's
workspace, preserved across all cycles: a prompt-injected implementer could
otherwise plant a `CLAUDE.md`, `AGENTS.md` or a git hook that the reviewer's
CLI would read as instructions, letting the auditee prepare its auditor's
room.

Cost accumulates across every cycle and accrues to the run, not to the
surviving attempt.

## Known follow-up, not in this PR

`review_cycles_exhausted` is a new status and `view.py` does not know it. It
degrades safely (`_derived_state` still yields `changes_requested` via the
verdict, and node states resolve correctly), but **the exhaustion is
invisible**: the console shows "changes requested" without saying it tried
twice and gave up. That belongs with the explicit terminal-disposition field
in the run-narrative work rather than a patch here.

The env var is wired through `config.py`, `chart/values.yaml` and
`chart/templates/deployment.yaml` together, since a partial rename leaves the
whole block unrendered.

## Verification

`ci test`: `Executed 1 out of 710 tests: 710 tests pass.`

Not verified: a real request_changes cycle end to end. Observable after deploy
by giving a run a task the reviewer will reject and confirming a second
implement attempt starts carrying the reviewer's text.

No chart version or `targetRevision` touched.