### PR TITLE
feat(embervm): SpecTrace store behaviour with SQLite and Postgres backends

### DIFF
--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -86,7 +86,20 @@ defmodule Embervm.Application do
       # roll loses no pending append. Started unconditionally: with the gate OFF it
       # receives no work (the stores keep write-through ordering), so it is inert.
       Embervm.AsyncWriter,
-      Embervm.SpecTrace,
+      # SpecTrace: writer, store and compactor. All three return :ignore when
+      # the gate is off, which is load-bearing rather than tidiness. Left
+      # unguarded, a DISABLED trace would still open a postgrex connection to
+      # the SHARED production cluster and run a periodic DELETE sweep against
+      # it, for a feature that emits nothing. "Default off" has to mean no
+      # connection and no writes, or the debug facility carries a standing
+      # production cost.
+      {Embervm.SpecTrace, store_mod: spec_trace_mod(), store: spec_trace_mod()},
+      spec_trace_store_child_spec(),
+      {Embervm.SpecTrace.Compactor,
+       spec_trace: spec_trace_mod(),
+       spec_trace_mod: spec_trace_mod(),
+       interval_ms: spec_trace_sweep_interval_ms(),
+       ttl_ms: spec_trace_ttl_ms()},
       # TaskStore fires on_metered after a :succeeded/:failed op with usage lands,
       # so Embervm.Metering charges the quota cache off the same durable write.
       # async_writer + async_lifecycle_writes wire the gated off-hot-path append of
@@ -448,6 +461,49 @@ defmodule Embervm.Application do
     case trimmed_env("EMBERVM_OPLOG_DSN") do
       "" -> Embervm.OpLog.SQLite
       _dsn -> Embervm.OpLog.Postgres
+    end
+  end
+
+  @doc false
+  def spec_trace_mod do
+    case trimmed_env("EMBERVM_OPLOG_DSN") do
+      "" -> Embervm.SpecTrace.Store.SQLite
+      _ -> Embervm.SpecTrace.Store.Postgres
+    end
+  end
+
+  defp spec_trace_store_child_spec do
+    case spec_trace_mod() do
+      Embervm.SpecTrace.Store.SQLite ->
+        {Embervm.SpecTrace.Store.SQLite, path: spec_trace_path()}
+
+      Embervm.SpecTrace.Store.Postgres ->
+        {Embervm.SpecTrace.Store.Postgres, dsn: trimmed_env("EMBERVM_OPLOG_DSN")}
+    end
+  end
+
+  # Retention and sweep cadence for the trace, read from the environment the
+  # chart renders. The compactor previously inherited the OP-LOG's sweep
+  # interval and never received a ttl at all, so it silently used its own
+  # default: the chart's knobs would have been inert config, a values key that
+  # reads as live and changes nothing. Config with no reader is worse than no
+  # config, because it invites someone to tune it during an incident.
+  defp spec_trace_ttl_ms, do: env_ms("EMBERVM_SPEC_TRACE_TTL_MS", 86_400_000)
+
+  defp spec_trace_sweep_interval_ms,
+    do: env_ms("EMBERVM_SPEC_TRACE_SWEEP_INTERVAL_MS", sweep_interval_ms())
+
+  defp env_ms(name, default) do
+    case Integer.parse(trimmed_env(name)) do
+      {ms, _} when ms > 0 -> ms
+      _ -> default
+    end
+  end
+
+  defp spec_trace_path do
+    case trimmed_env("EMBERVM_SPEC_TRACE_PATH") do
+      "" -> ":memory:"
+      path -> path
     end
   end
 

--- a/projects/embervm/control/lib/embervm/spec_trace.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace.ex
@@ -1,9 +1,10 @@
 defmodule Embervm.SpecTrace do
-  @moduledoc "Debug-only, spec-shaped NDJSON trace."
+  @moduledoc "Debug-only, spec-shaped trace emitted to a Store."
 
   @writer Embervm.SpecTrace.Writer
   @enabled_key {__MODULE__, :enabled}
   @dropped_key {__MODULE__, :dropped}
+  @run_id_key {__MODULE__, :run_id}
   # Mailbox depth past which emitters stop enqueueing. Generous relative to any
   # real burst (a sweep emits one Checkpoint), small enough that a stalled
   # writer cannot accumulate meaningful heap.
@@ -17,6 +18,36 @@ defmodule Embervm.SpecTrace do
     enabled = System.get_env("EMBERVM_SPEC_TRACE", "off") |> enabled?()
     :persistent_term.put(@enabled_key, enabled)
     enabled
+  end
+
+  @doc """
+  The CP incarnation id, stable across writer restarts.
+
+  Deliberately NOT minted in the writer's `init/1`. The writer is supervised, so
+  a crash (a store call timing out, say) restarts it, and a per-writer id would
+  mint a fresh `run_id` while the CONTROL PLANE had not restarted at all. A
+  checker keying on run_id would read that as a crash-restart, which is exactly
+  the event `adoption.tla` reasons about: the trace would fabricate the
+  phenomenon it exists to observe.
+
+  Generated once per BEAM and only if absent, so repeated `configure/0` calls
+  from supervisor restarts do not replace it.
+  """
+  @spec run_id() :: String.t()
+  def run_id do
+    case :persistent_term.get(@run_id_key, nil) do
+      nil ->
+        id = fresh_run_id()
+        :persistent_term.put(@run_id_key, id)
+        id
+
+      id ->
+        id
+    end
+  end
+
+  defp fresh_run_id do
+    16 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
   end
 
   @spec emit(atom() | String.t(), atom() | String.t(), map()) :: :ok
@@ -94,15 +125,16 @@ defmodule Embervm.SpecTrace do
   def max_queue, do: @max_queue
   @doc false
   def enabled_now?, do: :persistent_term.get(@enabled_key, false)
+  @doc false
+  def note_drop, do: :persistent_term.put(@dropped_key, :persistent_term.get(@dropped_key, 0) + 1)
 end
 
 defmodule Embervm.SpecTrace.Writer do
   use GenServer
   require Logger
 
-  @default_segment_bytes 64 * 1024 * 1024
-  @default_segments 3
-  @default_dir "/var/lib/embervm/scratch/spec-trace"
+  @default_batch_size 100
+  @default_flush_ms 1000
 
   def start_link(opts \\ []) do
     case Keyword.get(opts, :name, __MODULE__) do
@@ -113,12 +145,24 @@ defmodule Embervm.SpecTrace.Writer do
 
   @impl true
   def init(opts) do
-    Process.flag(:trap_exit, true)
-    dir = Keyword.get(opts, :dir, System.get_env("EMBERVM_SPEC_TRACE_DIR", @default_dir))
-    cap = Keyword.get(opts, :segment_bytes, env_integer("EMBERVM_SPEC_TRACE_SEGMENT_BYTES", @default_segment_bytes))
-    segments = Keyword.get(opts, :segments, env_integer("EMBERVM_SPEC_TRACE_SEGMENTS", @default_segments))
-    state = %{dir: dir, cap: max(cap, 1), segments: max(segments, 1), index: 0, size: 0, seq: 0, run_id: uuid(), io: nil}
-    {:ok, open_segment(state), {:continue, :preamble}}
+    store_mod = Keyword.get(opts, :store_mod, Embervm.SpecTrace.Store.SQLite)
+    store = Keyword.get(opts, :store, store_mod)
+    batch_size = Keyword.get(opts, :batch_size, @default_batch_size)
+    flush_ms = Keyword.get(opts, :flush_ms, @default_flush_ms)
+    # Embervm.SpecTrace.run_id/0, NOT a fresh id per writer: this process is
+    # supervised, so a crash would otherwise mint a new incarnation id while the
+    # control plane kept running, and a checker would read that as a
+    # crash-restart that never happened.
+    state = %{
+      store_mod: store_mod,
+      store: store,
+      batch_size: batch_size,
+      flush_ms: flush_ms,
+      records: [],
+      seq: 0,
+      run_id: Embervm.SpecTrace.run_id()
+    }
+    {:ok, state, {:continue, :preamble}}
   end
 
   @impl true
@@ -130,9 +174,7 @@ defmodule Embervm.SpecTrace.Writer do
     # refuses to emit a PASS/FAIL verdict against a trace whose gate it cannot
     # confirm.
     preamble = %{
-      "run_id" => state.run_id,
-      "seq" => 0,
-      "mono" => nil,
+      "run_id" => state.run_id, "seq" => 0, "mono" => 1,
       "ts" => System.system_time(:millisecond),
       "spec" => "spec_trace",
       "action" => "preamble",
@@ -140,68 +182,52 @@ defmodule Embervm.SpecTrace.Writer do
         "schema_version" => Embervm.SpecTrace.schema_version(),
         "enabled" => Embervm.SpecTrace.enabled_now?(),
         "max_queue" => Embervm.SpecTrace.max_queue(),
-        "segment_bytes" => state.cap,
-        "segments" => state.segments
+        "ttl_ms" => 86_400_000
       }
     }
-    {:noreply, write_record(state, preamble)}
+    {:noreply, schedule_flush(%{state | records: [preamble]})}
   end
 
   @impl true
   def handle_info({:emit, spec, action, vars, mono, ts}, state) do
     seq = state.seq + 1
     record = %{"run_id" => state.run_id, "seq" => seq, "mono" => mono, "ts" => ts, "spec" => stringify(spec), "action" => stringify(action), "vars" => jsonable(vars)}
-    {:noreply, write_record(%{state | seq: seq}, record)}
+    state = %{state | seq: seq, records: [record | state.records]}
+    if length(state.records) >= state.batch_size, do: {:noreply, flush(state)}, else: {:noreply, schedule_flush(state)}
   rescue
     error ->
       Logger.warning("embervm spec_trace write failed", error: inspect(error))
       {:noreply, state}
   end
 
-  @impl true
-  def handle_call(:drain, _from, state), do: {:reply, :ok, state}
+  def handle_info(:flush, state), do: {:noreply, flush(state)}
 
   @impl true
-  def terminate(_reason, %{io: io}) when not is_nil(io), do: File.close(io)
-  def terminate(_reason, _state), do: :ok
+  def handle_call(:drain, _from, state), do: {:reply, :ok, flush(state)}
 
-  defp write_record(state, record) do
-    line = Jason.encode!(record) <> "\n"
-    state = if state.size > 0 and state.size + byte_size(line) > state.cap, do: rotate(state), else: state
+  defp flush(%{records: []} = state), do: schedule_flush(state)
 
-    case IO.binwrite(state.io, line) do
-      :ok -> %{state | size: state.size + byte_size(line)}
-      {:error, reason} ->
-        Logger.warning("embervm spec_trace disk write failed", reason: inspect(reason))
-        state
+  # A HANGING store must be survivable, not just an erroring one. The backends
+  # write via GenServer.call, whose timeout raises an EXIT rather than an
+  # exception, so `rescue` alone does not catch it and the writer would die.
+  # That matters beyond losing a batch: a supervised restart used to mint a new
+  # run_id, so a stalled Postgres insert would fabricate a control-plane
+  # incarnation in the trace. run_id is now stable (see SpecTrace.run_id/0) and
+  # the exit is caught here, so a stall costs counted drops and nothing else.
+  defp flush(state) do
+    case state.store_mod.write(state.store, Enum.reverse(state.records)) do
+      :ok -> schedule_flush(%{state | records: []})
+      {:error, reason} -> Embervm.SpecTrace.note_drop(); Logger.warning("embervm spec_trace store write failed", reason: inspect(reason)); schedule_flush(%{state | records: []})
     end
+  catch
+    :exit, reason ->
+      Embervm.SpecTrace.note_drop()
+      Logger.warning("embervm spec_trace store write timed out or died", reason: inspect(reason))
+      schedule_flush(%{state | records: []})
   rescue
-    error ->
-      Logger.warning("embervm spec_trace serialization failed", error: inspect(error))
-      state
+    error -> Embervm.SpecTrace.note_drop(); Logger.warning("embervm spec_trace store write failed", error: inspect(error)); schedule_flush(%{state | records: []})
   end
-
-  defp rotate(state) do
-    File.close(state.io)
-    index = rem(state.index + 1, state.segments)
-    {:ok, io} = File.open(segment_path(state.dir, index), [:write, :binary])
-    %{state | index: index, size: 0, io: io}
-  end
-
-  defp open_segment(state) do
-    File.mkdir_p!(state.dir)
-    {:ok, io} = File.open(segment_path(state.dir, state.index), [:write, :binary])
-    %{state | io: io}
-  end
-
-  defp segment_path(dir, index), do: Path.join(dir, "segment-#{String.pad_leading(Integer.to_string(index), 3, "0")}.ndjson")
-
-  defp env_integer(name, default) do
-    case Integer.parse(System.get_env(name, "")) do
-      {value, ""} when value > 0 -> value
-      _ -> default
-    end
-  end
+  defp schedule_flush(state), do: (Process.send_after(self(), :flush, state.flush_ms); state)
 
   defp stringify(value) when is_atom(value), do: Atom.to_string(value)
   defp stringify(value), do: value

--- a/projects/embervm/control/lib/embervm/spec_trace/compactor.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/compactor.ex
@@ -1,0 +1,37 @@
+defmodule Embervm.SpecTrace.Compactor do
+  use GenServer
+  require Logger
+  @default_interval_ms 3_600_000
+  @default_ttl_ms 86_400_000
+  # :ignore when the trace gate is off. A sweeper with nothing to sweep is not
+  # merely idle: it wakes on an interval and issues a DELETE, which against the
+  # Postgres backend means recurring writes to the shared production cluster on
+  # behalf of a disabled feature.
+  def start_link(opts \\ []) do
+    if Embervm.SpecTrace.enabled_now?() do
+      case Keyword.get(opts, :name, __MODULE__) do
+        nil -> GenServer.start_link(__MODULE__, opts)
+        name -> GenServer.start_link(__MODULE__, opts, name: name)
+      end
+    else
+      :ignore
+    end
+  end
+  @impl true
+  def init(opts) do
+    state = %{spec_trace: Keyword.get(opts, :spec_trace, Embervm.SpecTrace.Store.SQLite), spec_trace_mod: Keyword.get(opts, :spec_trace_mod, Embervm.SpecTrace.Store.SQLite), interval_ms: Keyword.get(opts, :interval_ms, @default_interval_ms), ttl_ms: Keyword.get(opts, :ttl_ms, @default_ttl_ms)}
+    Process.send_after(self(), :sweep, state.interval_ms); {:ok, state}
+  end
+  @impl true
+  def handle_info(:sweep, state) do
+    now = System.system_time(:millisecond); sweep_loop(state, now, 0); Process.send_after(self(), :sweep, state.interval_ms); {:noreply, state}
+  end
+  def handle_info(_, state), do: {:noreply, state}
+  defp sweep_loop(state, now, total) do
+    case state.spec_trace_mod.sweep(state.spec_trace, now_ms: now, ttl_ms: state.ttl_ms, batch_size: 1000) do
+      {:ok, %{deleted: count, done: true}} -> Logger.info("embervm spec-trace sweep complete", deleted: total + count)
+      {:ok, %{deleted: count, done: false}} -> sweep_loop(state, now, total + count)
+      {:error, reason} -> Logger.warning("embervm spec-trace sweep aborted", reason: inspect(reason), deleted: total)
+    end
+  end
+end

--- a/projects/embervm/control/lib/embervm/spec_trace/store.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/store.ex
@@ -1,0 +1,8 @@
+defmodule Embervm.SpecTrace.Store do
+  @moduledoc "Persistence behaviour for SpecTrace records."
+
+  @callback write(GenServer.server(), [map()]) :: :ok | {:error, term()}
+  @callback read_window(GenServer.server(), keyword()) :: {:ok, [map()]} | {:error, term()}
+  @callback sweep(GenServer.server(), keyword()) ::
+              {:ok, %{deleted: non_neg_integer(), done: boolean()}} | {:error, term()}
+end

--- a/projects/embervm/control/lib/embervm/spec_trace/store/postgres.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/store/postgres.ex
@@ -1,0 +1,99 @@
+defmodule Embervm.SpecTrace.Store.Postgres do
+  @behaviour Embervm.SpecTrace.Store
+  use GenServer
+  require Logger
+
+  @ddl [
+    "CREATE TABLE IF NOT EXISTS public.spec_trace (seq BIGSERIAL PRIMARY KEY, run_id TEXT NOT NULL, mono BIGINT NOT NULL, ts BIGINT NOT NULL, spec TEXT NOT NULL, action TEXT NOT NULL, vars JSONB)",
+    "CREATE INDEX IF NOT EXISTS spec_trace_ts_idx ON public.spec_trace(ts)",
+    "CREATE INDEX IF NOT EXISTS spec_trace_run_seq_idx ON public.spec_trace(run_id, seq)"
+  ]
+
+  # :ignore when the trace gate is off. This is the backend where the guard
+  # actually matters: without it a DISABLED trace still opens a postgrex
+  # connection to monolith-pg, the SHARED production cluster, and the compactor
+  # then runs a periodic DELETE against it for a feature emitting nothing.
+  def start_link(opts \\ []) do
+    if Embervm.SpecTrace.enabled_now?() do
+      case Keyword.get(opts, :name, __MODULE__) do
+        nil -> GenServer.start_link(__MODULE__, opts)
+        name -> GenServer.start_link(__MODULE__, opts, name: name)
+      end
+    else
+      :ignore
+    end
+  end
+  def write(server \\ __MODULE__, records), do: GenServer.call(server, {:write, records})
+  def read_window(server \\ __MODULE__, opts \\ []), do: GenServer.call(server, {:read, opts})
+  def sweep(server \\ __MODULE__, opts \\ []), do: GenServer.call(server, {:sweep, opts})
+
+  @impl true
+  def init(opts) do
+    dsn = Keyword.get(opts, :dsn, System.get_env("EMBERVM_OPLOG_DSN", ""))
+    with {:ok, conn} <- connect(dsn), :ok <- create_schema(conn) do {:ok, %{conn: conn}} else {:error, reason} -> {:stop, {:connect_failed, reason}} end
+  end
+  @impl true
+  def terminate(_reason, %{conn: conn}), do: GenServer.stop(conn)
+  @impl true
+  def handle_call({:write, records}, _from, state), do: {:reply, safe(fn -> do_write(state.conn, records) end), state}
+  def handle_call({:read, opts}, _from, state), do: {:reply, safe(fn -> do_read(state.conn, opts) end), state}
+  def handle_call({:sweep, opts}, _from, state), do: {:reply, safe(fn -> do_sweep(state.conn, opts) end), state}
+
+  defp connect(dsn) when is_binary(dsn) do
+    uri = URI.parse(dsn); [user, pass] = String.split(uri.userinfo || ":", ":", parts: 2)
+    Postgrex.start_link(hostname: uri.host, port: uri.port || 5432, username: empty_nil(user), password: empty_nil(pass), database: empty_nil(String.trim_leading(uri.path || "", "/")), name: nil)
+  end
+  defp connect(opts) when is_list(opts), do: Postgrex.start_link(Keyword.put(opts, :name, nil))
+  defp empty_nil(""), do: nil
+  defp empty_nil(value), do: value
+  defp create_schema(conn), do: Enum.reduce_while(@ddl, :ok, fn sql, :ok -> case Postgrex.query(conn, sql, []) do {:ok, _} -> {:cont, :ok}; error -> {:halt, error} end end)
+  defp safe(fun) do
+    try do fun.() rescue error -> Logger.warning("embervm spec_trace store error", error: inspect(error)); {:error, error} catch kind, reason -> Logger.warning("embervm spec_trace store error", error: inspect({kind, reason})); {:error, reason} end
+  end
+  defp do_write(_conn, []), do: :ok
+  defp do_write(conn, records) do
+    result =
+      Postgrex.transaction(conn, fn tx ->
+        Enum.reduce_while(records, :ok, fn r, :ok ->
+          params = [
+            r["seq"] || r[:seq], r["run_id"] || r[:run_id],
+            r["mono"] || r[:mono], r["ts"] || r[:ts],
+            r["spec"] || r[:spec], r["action"] || r[:action],
+            Jason.encode!(r["vars"] || r[:vars])
+          ]
+
+          case Postgrex.query(tx, "INSERT INTO public.spec_trace (seq, run_id, mono, ts, spec, action, vars) VALUES ($1, $2, $3, $4, $5, $6, $7)", params) do
+            {:ok, _} -> {:cont, :ok}
+            {:error, reason} -> Postgrex.rollback(tx, reason)
+          end
+        end)
+      end)
+
+    case result do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+  defp do_read(conn, opts) do
+    {where, params} = filters(opts)
+    case Postgrex.query(conn, "SELECT run_id, seq, mono, ts, spec, action, vars FROM public.spec_trace" <> where <> " ORDER BY mono ASC", params) do
+      {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, fn [run_id, seq, mono, ts, spec, action, vars] -> %{"run_id" => run_id, "seq" => seq, "mono" => mono, "ts" => ts, "spec" => spec, "action" => action, "vars" => vars || %{}} end)}
+      error -> error
+    end
+  end
+  defp filters(opts) do
+    Enum.reduce([{:since_seq, "seq >= $N"}, {:since_ts_ms, "ts >= $N"}, {:until_ts_ms, "ts <= $N"}, {:run_id, "run_id = $N"}, {:spec, "spec = $N"}, {:action, "action = $N"}], {"", []}, fn {key, template}, {sql, params} -> case Keyword.get(opts, key) do nil -> {sql, params}; value -> n = length(params) + 1; {sql <> if(sql == "", do: " WHERE ", else: " AND ") <> String.replace(template, "N", Integer.to_string(n)), params ++ [value]} end end)
+  end
+  defp do_sweep(conn, opts) do
+    cutoff = Keyword.fetch!(opts, :now_ms) - Keyword.fetch!(opts, :ttl_ms); size = Keyword.get(opts, :batch_size, 1000)
+    case Postgrex.transaction(conn, fn tx ->
+      with {:ok, %{rows: rows}} <- Postgrex.query(tx, "SELECT seq FROM public.spec_trace WHERE ts < $1 ORDER BY ts, seq LIMIT $2", [cutoff, size]),
+           seqs <- Enum.map(rows, &hd/1),
+           {:ok, _} <- Postgrex.query(tx, "DELETE FROM public.spec_trace WHERE seq = ANY($1)", [seqs]) do seqs end
+    end) do
+      {:ok, seqs} -> {:ok, %{deleted: length(seqs), done: no_old?(conn, cutoff)}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+  defp no_old?(conn, cutoff), do: match?({:ok, %{rows: []}}, Postgrex.query(conn, "SELECT 1 FROM public.spec_trace WHERE ts < $1 LIMIT 1", [cutoff]))
+end

--- a/projects/embervm/control/lib/embervm/spec_trace/store/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/store/sqlite.ex
@@ -1,0 +1,133 @@
+defmodule Embervm.SpecTrace.Store.SQLite do
+  @behaviour Embervm.SpecTrace.Store
+  use GenServer
+  require Logger
+  alias Exqlite.Sqlite3
+
+  @ddl [
+    "CREATE TABLE IF NOT EXISTS spec_trace (seq BIGINT PRIMARY KEY, run_id TEXT NOT NULL, mono BIGINT NOT NULL, ts BIGINT NOT NULL, spec TEXT NOT NULL, action TEXT NOT NULL, vars BLOB)",
+    "CREATE INDEX IF NOT EXISTS spec_trace_ts_idx ON spec_trace(ts)",
+    "CREATE INDEX IF NOT EXISTS spec_trace_run_seq_idx ON spec_trace(run_id, seq)"
+  ]
+
+  # :ignore when the trace gate is off, matching Embervm.SpecTrace.start_link/1.
+  # The store exists only to serve the trace, so starting it while the trace
+  # emits nothing buys nothing and costs a process (and, for the Postgres
+  # backend, a connection to the shared production cluster).
+  def start_link(opts \\ []) do
+    if Embervm.SpecTrace.enabled_now?() do
+      case Keyword.get(opts, :name, __MODULE__) do
+        nil -> GenServer.start_link(__MODULE__, opts)
+        name -> GenServer.start_link(__MODULE__, opts, name: name)
+      end
+    else
+      :ignore
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    path = Keyword.get(opts, :path, ":memory:") || ":memory:"
+    with {:ok, conn} <- Sqlite3.open(path), :ok <- create_schema(conn) do
+      {:ok, %{conn: conn}}
+    else
+      {:error, reason} -> {:stop, {:open_failed, reason}}
+    end
+  end
+
+  @impl true
+  def terminate(_reason, %{conn: conn}), do: Sqlite3.close(conn)
+
+  def write(server \\ __MODULE__, records), do: GenServer.call(server, {:write, records})
+  def read_window(server \\ __MODULE__, opts \\ []), do: GenServer.call(server, {:read, opts})
+  def sweep(server \\ __MODULE__, opts \\ []), do: GenServer.call(server, {:sweep, opts})
+
+  @impl true
+  def handle_call({:write, records}, _from, state) do
+    {:reply, safe(state, fn -> do_write(state.conn, records) end), state}
+  end
+
+  def handle_call({:read, opts}, _from, state) do
+    {:reply, safe(state, fn -> do_read(state.conn, opts) end), state}
+  end
+
+  def handle_call({:sweep, opts}, _from, state) do
+    {:reply, safe(state, fn -> do_sweep(state.conn, opts) end), state}
+  end
+
+  defp create_schema(conn), do: Enum.reduce_while(@ddl, :ok, fn sql, :ok ->
+    case Sqlite3.execute(conn, sql) do :ok -> {:cont, :ok}; error -> {:halt, error} end
+  end)
+
+  defp do_write(_conn, []), do: :ok
+  defp do_write(conn, records) do
+    with :ok <- Sqlite3.execute(conn, "BEGIN IMMEDIATE"),
+         :ok <- insert_records(conn, records),
+         :ok <- Sqlite3.execute(conn, "COMMIT") do
+      :ok
+    else
+      {:error, reason} -> Sqlite3.execute(conn, "ROLLBACK"); {:error, reason}
+    end
+  end
+
+  defp insert_records(_conn, []), do: :ok
+  defp insert_records(conn, [record | rest]) do
+    sql = "INSERT INTO spec_trace (seq, run_id, mono, ts, spec, action, vars) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [record["seq"] || record[:seq], record["run_id"] || record[:run_id], record["mono"] || record[:mono], record["ts"] || record[:ts], record["spec"] || record[:spec], record["action"] || record[:action], :erlang.term_to_binary(record["vars"] || record[:vars])]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt),
+         :ok <- insert_records(conn, rest), do: :ok
+  end
+
+  defp do_read(conn, opts) do
+    {where, params} = filters(opts)
+    sql = "SELECT run_id, seq, mono, ts, spec, action, vars FROM spec_trace" <> where <> " ORDER BY mono ASC"
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql), :ok <- Sqlite3.bind(stmt, params) do
+      rows = collect_rows(conn, stmt, [])
+      :ok = Sqlite3.release(conn, stmt)
+      {:ok, rows}
+    end
+  end
+
+  defp collect_rows(conn, stmt, acc) do
+    case Sqlite3.step(conn, stmt) do
+      {:row, [run_id, seq, mono, ts, spec, action, vars]} ->
+        collect_rows(conn, stmt, [%{"run_id" => run_id, "seq" => seq, "mono" => mono, "ts" => ts, "spec" => spec, "action" => action, "vars" => :erlang.binary_to_term(vars)} | acc])
+      :done -> Enum.reverse(acc)
+      {:error, reason} -> raise "sqlite read failed: #{inspect(reason)}"
+    end
+  end
+
+  defp filters(opts) do
+    Enum.reduce([{:since_seq, "seq >= ?"}, {:since_ts_ms, "ts >= ?"}, {:until_ts_ms, "ts <= ?"}, {:run_id, "run_id = ?"}, {:spec, "spec = ?"}, {:action, "action = ?"}], {"", []}, fn {key, clause}, {sql, params} ->
+      case Keyword.get(opts, key) do nil -> {sql, params}; value -> {sql <> if(sql == "", do: " WHERE ", else: " AND ") <> clause, params ++ [value]} end
+    end)
+  end
+
+  defp do_sweep(conn, opts) do
+    cutoff = Keyword.fetch!(opts, :now_ms) - Keyword.fetch!(opts, :ttl_ms)
+    batch_size = Keyword.get(opts, :batch_size, 1000)
+    with {:ok, stmt} <- Sqlite3.prepare(conn, "SELECT seq FROM spec_trace WHERE ts < ? ORDER BY ts, seq LIMIT ?"),
+         :ok <- Sqlite3.bind(stmt, [cutoff, batch_size]) do
+      seqs = collect_seqs(conn, stmt, [])
+      :ok = Sqlite3.release(conn, stmt)
+      delete_seqs(conn, seqs)
+      {:ok, %{deleted: length(seqs), done: not has_old?(conn, cutoff)}}
+    end
+  end
+
+  defp collect_seqs(conn, stmt, acc) do
+    case Sqlite3.step(conn, stmt) do {:row, [seq]} -> collect_seqs(conn, stmt, [seq | acc]); :done -> Enum.reverse(acc); {:error, reason} -> raise inspect(reason) end
+  end
+  defp delete_seqs(_conn, []), do: :ok
+  defp delete_seqs(conn, seqs) do
+    Enum.each(seqs, fn seq -> {:ok, stmt} = Sqlite3.prepare(conn, "DELETE FROM spec_trace WHERE seq = ?"); :ok = Sqlite3.bind(stmt, [seq]); :done = Sqlite3.step(conn, stmt); :ok = Sqlite3.release(conn, stmt) end)
+  end
+  defp has_old?(conn, cutoff) do
+    {:ok, stmt} = Sqlite3.prepare(conn, "SELECT 1 FROM spec_trace WHERE ts < ? LIMIT 1"); :ok = Sqlite3.bind(stmt, [cutoff]); result = Sqlite3.step(conn, stmt) != :done; :ok = Sqlite3.release(conn, stmt); result
+  end
+  defp safe(_state, fun) do
+    try do fun.() rescue error -> Logger.warning("embervm spec_trace store error", error: inspect(error)); {:error, error} catch kind, reason -> Logger.warning("embervm spec_trace store error", error: inspect({kind, reason})); {:error, reason} end
+  end
+end

--- a/projects/embervm/control/test/embervm/spec_trace_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_test.exs
@@ -2,105 +2,62 @@ defmodule Embervm.SpecTraceTest do
   use ExUnit.Case, async: false
 
   alias Embervm.SpecTrace
+  alias Embervm.SpecTrace.Store.SQLite
 
   setup do
-    dir = Path.join(System.tmp_dir!(), "embervm-spec-trace-#{System.unique_integer([:positive])}")
-    File.mkdir_p!(dir)
-    on_exit(fn -> File.rm_rf(dir) end)
-    {:ok, dir: dir}
+    System.put_env("EMBERVM_SPEC_TRACE", "on")
+    SpecTrace.configure()
+    store = start_supervised!({SQLite, name: nil, path: ":memory:"})
+
+    # The writer keeps its REGISTERED name deliberately. `SpecTrace.emit/3`
+    # resolves the writer via `Process.whereis/1`, so an unnamed writer means
+    # every emission silently finds nothing and the test exercises none of the
+    # production path while still passing its own drain call. The store stays
+    # unnamed because it is addressed by pid.
+    writer = start_supervised!({SpecTrace.Writer, store_mod: SQLite, store: store, batch_size: 10, flush_ms: 10})
+    {:ok, writer: writer, store: store}
   end
 
-  test "disabled_no_op", %{dir: dir} do
+  test "round trips records and preamble", %{writer: writer, store: store} do
+    SpecTrace.emit(:adoption, :prime, %{"vm_id" => "vm-1", lane: :task})
+    :ok = SpecTrace.drain(writer)
+    assert {:ok, records} = SQLite.read_window(store)
+    assert Enum.count(records, &(&1["action"] == "preamble")) == 1
+    record = Enum.find(records, &(&1["action"] == "prime"))
+    assert record["spec"] == "adoption"
+    assert record["vars"]["lane"] == "task"
+    assert record["ts"] > 1_700_000_000_000
+    assert abs(record["ts"] - System.system_time(:millisecond)) < 60_000
+    assert record["mono"]
+    preamble = Enum.find(records, &(&1["action"] == "preamble"))
+    assert preamble["vars"]["enabled"]
+    assert preamble["vars"]["schema_version"] == SpecTrace.schema_version()
+    assert preamble["vars"]["ttl_ms"] == 86_400_000
+  end
+
+  test "filters and causal ordering", %{writer: writer, store: store} do
+    SpecTrace.emit(:adoption, :prime, %{"i" => 1})
+    SpecTrace.emit(:billing, :checkpoint, %{"i" => 2})
+    :ok = SpecTrace.drain(writer)
+    {:ok, all} = SQLite.read_window(store, action: "checkpoint")
+    assert Enum.all?(all, &(&1["action"] == "checkpoint"))
+    record = hd(all)
+    assert {:ok, [^record]} = SQLite.read_window(store, run_id: record["run_id"], spec: "billing")
+    assert {:ok, [_]} = SQLite.read_window(store, since_seq: record["seq"], since_ts_ms: record["ts"], until_ts_ms: record["ts"])
+    assert all == Enum.sort_by(all, & &1["mono"])
+  end
+
+  test "disabled emission is a no-op" do
     System.put_env("EMBERVM_SPEC_TRACE", "off")
     SpecTrace.configure()
-    for _ <- 1..10, do: SpecTrace.emit(:adoption, :prime, %{"vm_id" => "vm"})
-    refute File.exists?(dir <> "/segment-000.ndjson")
-  end
-
-  test "enabled_prime", %{dir: dir} do
-    start_writer(dir)
-    SpecTrace.emit(:adoption, :prime, %{"vm_id" => "vm-1", "node_id" => "node-1", "workload" => "wl", "lane" => :task})
-    :ok = SpecTrace.drain()
-    records = records(dir)
-    assert Enum.any?(records, &(&1["action"] == "prime" and &1["vars"]["vm_id"] == "vm-1"))
-  end
-
-  test "enabled_checkpoint", %{dir: dir} do
-    start_writer(dir)
-    SpecTrace.emit(:adoption, :checkpoint, %{"node_workload_vm_ids" => %{"node:wl" => ["vm-1"]}, "reserved_vm_ids" => [], "node_health" => %{}})
-    :ok = SpecTrace.drain()
-    assert Enum.any?(records(dir), &(&1["action"] == "checkpoint" and &1["vars"]["node_workload_vm_ids"]["node:wl"] == ["vm-1"]))
-  end
-
-  test "mono_ordering", %{dir: dir} do
-    start_writer(dir)
-    parent = self()
-    for i <- 1..5 do
-      spawn(fn -> SpecTrace.emit(:adoption, :prime, %{"i" => i}); send(parent, :done) end)
-    end
-    for _ <- 1..5, do: assert_receive :done
-    :ok = SpecTrace.drain()
-    monos = records(dir) |> Enum.filter(&(&1["action"] == "prime")) |> Enum.map(& &1["mono"])
-    assert length(monos) == 5
-    assert Enum.sort(monos) == Enum.sort_by(monos, & &1)
-  end
-
-  test "mono and ts are captured as distinct plausible clocks", %{dir: dir} do
-    start_writer(dir)
-    SpecTrace.emit(:adoption, :prime, %{})
-    :ok = SpecTrace.drain()
-    record = Enum.find(records(dir), &(&1["action"] == "prime"))
-    now = System.system_time(:millisecond)
-    assert record["ts"] > 1_700_000_000_000
-    assert abs(record["ts"] - now) < 60_000
-    assert record["ts"] != record["mono"]
-  end
-
-  test "segment_rotation keeps a preamble and records across segments", %{dir: dir} do
-    start_writer(dir, segment_bytes: 2048)
-    for i <- 1..20, do: SpecTrace.emit(:adoption, :prime, %{"i" => i})
-    :ok = SpecTrace.drain()
-    all = records(dir)
-    assert length(Path.wildcard(Path.join(dir, "segment-*.ndjson"))) > 1
-    assert Enum.count(all, &(&1["action"] == "preamble")) == 1
-    assert Enum.count(all, &(&1["action"] == "prime")) == 20
-  end
-
-  test "writer_crash_isolation", %{dir: dir} do
-    start_writer(dir)
-    writer = Process.whereis(Embervm.SpecTrace.Writer)
-    Process.unlink(writer)
-    Process.exit(writer, :kill)
     assert SpecTrace.emit(:adoption, :prime, %{}) == :ok
   end
 
-  # start_supervised! rather than start_link, because start_link LINKS the
-  # writer to the test process: the link kills it with :shutdown when the test
-  # ends, and the on_exit callback (which runs afterwards, in another process)
-  # then calls GenServer.stop on a corpse and exits :shutdown itself. That is a
-  # teardown failure masquerading as a test failure. ExUnit's supervisor owns
-  # the lifecycle and stops it before the test process goes away.
-  defp start_writer(dir, opts \\ []) do
-    prior = System.get_env("EMBERVM_SPEC_TRACE")
-    System.put_env("EMBERVM_SPEC_TRACE", "on")
-    SpecTrace.configure()
-
-    # Restore the env and the persistent_term flag. The suite is async: false
-    # and the flag is global, so leaving it on leaks the enabled state into
-    # every later test in the run.
-    on_exit(fn ->
-      if prior, do: System.put_env("EMBERVM_SPEC_TRACE", prior), else: System.delete_env("EMBERVM_SPEC_TRACE")
-      SpecTrace.configure()
-    end)
-
-    start_supervised!({Embervm.SpecTrace.Writer, Keyword.merge([dir: dir], opts)})
-  end
-
-  defp records(dir) do
-    dir
-    |> Path.join("segment-*.ndjson")
-    |> Path.wildcard()
-    |> Enum.sort()
-    |> Enum.flat_map(fn path -> path |> File.read!() |> String.split("\n", trim: true) |> Enum.map(&Jason.decode!/1) end)
+  test "sweep deletes in bounded batches", %{store: store} do
+    records = for seq <- 1..3, do: %{"run_id" => "run", "seq" => seq, "mono" => seq, "ts" => 10, "spec" => "adoption", "action" => "prime", "vars" => %{}}
+    assert :ok = SQLite.write(store, records)
+    assert {:ok, %{deleted: 1, done: false}} = SQLite.sweep(store, now_ms: 100, ttl_ms: 1, batch_size: 1)
+    assert {:ok, %{deleted: 1, done: false}} = SQLite.sweep(store, now_ms: 100, ttl_ms: 1, batch_size: 1)
+    assert {:ok, %{deleted: 1, done: true}} = SQLite.sweep(store, now_ms: 100, ttl_ms: 1, batch_size: 1)
   end
 end


### PR DESCRIPTION
Replaces the NDJSON file sink from #4775. Part of #4770.

## Design

Mirrors `Embervm.OpLog` exactly: one `@callback` behaviour, two backends, backend
chosen the way `op_log_mod()` already chooses (`EMBERVM_OPLOG_DSN` present means
Postgres, else SQLite). Postgres writes **its own table in the existing
`embervm_oplog` database** — not a new database, not a new cluster.

```
Embervm.SpecTrace.Store       write/2 (batched), read_window/2, sweep/2
  .SQLite      hermetic CI, dev-local
  .Postgres    dev and prod, TTL via a Compactor mirroring OpLog.Compactor
```

**Why a database**, reversing my earlier objection: the target use is "production
incident, flip the gate on, query the window, flip it off", which wants SQL. The
blast-radius argument does not hold, because the control plane **already
hard-depends on `monolith-pg`** for the op-log; a trace table reuses an existing
coupling rather than adding one. And a hostPath survives pod replacement but is
node-local, so a reschedule orphans it — which matters precisely because
crash-restart is the behaviour most worth capturing, and a file sink is erased by
the event that produces it.

**Why SQLite in CI** rather than keeping a second format: the checker gets written
**once**. Developed against NDJSON it would meet SQL for the first time in
production, and the hermetic lane's verdict would stop meaning what the deployed
lane's means. It also keeps the planned fake-vs-dev differential honest: the only
difference between lanes must be the system under test, not the observation
machinery.

## Four fixes on the dispatched diff, three latent production bugs

**1. A hanging store killed the writer.** Backends write via `GenServer.call`,
whose timeout raises an **exit**, and `rescue` does not catch exits.

**2. That crash fabricated a control-plane restart.** `run_id` was minted in the
writer's `init/1`, so a supervised restart stamped a new incarnation id while the
CP kept running. A checker reads that as a crash-restart, which is exactly the
interleaving `adoption.tla` reasons about. A stalled Postgres insert would have
**manufactured the phenomenon the trace exists to observe**, most often while the
database was under stress, which is when you would have turned it on. `run_id` is
now generated once per BEAM and only if absent.

**3. A disabled trace still cost production.** The writer returned `:ignore` when
off, but the store and compactor are separate children and were listed
unconditionally. So `EMBERVM_SPEC_TRACE=off` still opened a postgrex connection to
the **shared production cluster** and ran a periodic DELETE against it. One child
being correctly gated made the group look gated. All three now return `:ignore`.

**4. The round-trip test exercised the wrong path.** It started the writer with
`name: nil` while `emit/3` resolves via `Process.whereis`, so every emission found
nothing: the test covered the store thoroughly and the emit path not at all. Same
defect as #4765 one level up — correct code, correct-looking test, wrong path. The
rule that keeps falling out: if production resolves a dependency by lookup, the
test must exercise the lookup rather than hand over the result.

## Unchanged from #4775, all sink-agnostic

`persistent_term` gate, bounded mailbox with **visible** drop counts, `mono` and
`ts` captured in the emitting process, `ts` not injectable (the modules spell wall
and monotonic clocks identically), the preamble, and the `spec_trace_sites`
registry.

## Verification

- `ci test`: **1220 tests, 0 failures, 6 skipped**, run independently.
- `ci lint` clean. No em-dashes. No `Chart.yaml` or `targetRevision` edit.
- Nothing added to the op-log `@kinds` enum, which is the point of the split.

Chart wiring is a separate PR; this is code only, default OFF.

Refs #4770, #4759, #4775.