### PR TITLE
feat(monolith): measure cd health as Kargo chart lag, advisory only

### DIFF
--- a/projects/monolith/app/main_domain_test.py
+++ b/projects/monolith/app/main_domain_test.py
@@ -119,5 +119,11 @@ def test_cd_component_is_registered_on_the_private_tier():
     """Guards the join that broke: component registered, endpoint present."""
     from app.modules_private import ALL_MODULES
 
-    names = {n for m in ALL_MODULES if m.register_health for n in m.register_health}
+    names = {
+        n
+        for m in ALL_MODULES
+        for checks in (m.register_health, m.register_health_advisory)
+        if checks
+        for n in checks
+    }
     assert "cd" in names

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -287,9 +287,10 @@ spec:
             {{- end }}
             {{- end }}
             # cd health component thresholds (issue #4597). Values, not code
-            # constants, so retuning what pages does not need a rebuild.
-            - name: CD_HEALTH_SYNC_GRACE_S
-              value: {{ .Values.cdHealth.syncGraceSeconds | quote }}
+            # constants, so retuning the signal does not need a rebuild. The
+            # component is advisory: it reports on a 200 and pages nobody.
+            - name: CD_HEALTH_CHART_LAG_S
+              value: {{ .Values.cdHealth.chartLagSeconds | quote }}
             - name: CD_HEALTH_CI_RED_WINDOW_S
               value: {{ .Values.cdHealth.ciRedWindowSeconds | quote }}
             - name: CD_PROBE_INTERVAL_S

--- a/projects/monolith/chart/templates/rbac.yaml
+++ b/projects/monolith/chart/templates/rbac.yaml
@@ -24,6 +24,10 @@ rules:
   - apiGroups: ["argoproj.io"]
     resources: ["applications"]
     verbs: ["get", "list", "patch"]
+  # cd health reads Freight to learn which chart versions have been published.
+  - apiGroups: ["kargo.akuity.io"]
+    resources: ["freights"]
+    verbs: ["get", "list"]
   - apiGroups: ["metrics.k8s.io"]
     resources: ["nodes", "pods"]
     verbs: ["get", "list"]

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -948,9 +948,9 @@ knowledge:
 # response, which UptimeRobot polls offsite. Tunables live here so changing what
 # pages does not need a rebuild.
 cdHealth:
-  # An ArgoCD app not Synced+Healthy for longer than this trips the component.
-  # Long enough that a normal rollout never pages.
-  syncGraceSeconds: 900
+  # How far behind the newest published chart production may fall before cd
+  # reports degraded. This does not page.
+  chartLagSeconds: 7200
   # main's CI red for longer than this trips it. Red is only a fault once it
   # persists; a run being actively fixed must not page.
   ciRedWindowSeconds: 3600

--- a/projects/monolith/cluster/cd_health.py
+++ b/projects/monolith/cluster/cd_health.py
@@ -11,9 +11,9 @@ This component is advisory. A deploy in progress or production behind a chart
 is not the public site being down, so the signal is reported as metadata and
 does not make the health endpoint return 503.
 
-1. Production's live monolith chart is behind the newest monolith chart Kargo
-   has published Freight for longer than the lag window. The old ArgoCD sweep
-   faulted on permanently unconvergeable OutOfSync/Healthy diffs in authentik,
+1. Production's live monolith chart is older than the oldest unpromoted monolith
+   chart Kargo has discovered, for longer than the lag window. The old ArgoCD
+   sweep faulted on permanently unconvergeable OutOfSync/Healthy diffs in authentik,
    argocd, kyverno, and context-forge-gateway, so it was always red and
    monitored nothing. The original #4597 fault class, a targetRevision for a
    chart that was never published, is structurally impossible now that Kargo
@@ -101,6 +101,10 @@ def _evaluate_chart_lag(
     live = _chart_version(live_version)
     if live is None:
         return None, "prod chart version unreadable"
+    if not freight:
+        # This component is advisory and pages nobody, so a false positive is
+        # acceptable, but a false negative when the entire signal dies is not.
+        return "no monolith Freight found, chart discovery may be broken", None
 
     newer = []
     for item in freight:
@@ -138,7 +142,7 @@ async def _chart_lag_fault(lag_s: float) -> tuple[str | None, str | None]:
     from cluster.kubernetes import KubernetesClient  # noqa: PLC0415
 
     kubernetes = KubernetesClient()
-    live = await kubernetes.get_argocd_app_target_revision(PROD_APP_NAME)
+    live = await kubernetes.get_argocd_app_deployed_revision(PROD_APP_NAME)
     freight = await kubernetes.list_kargo_freight(KARGO_NAMESPACE)
     return _evaluate_chart_lag(live, freight, lag_s, datetime.now(timezone.utc))
 

--- a/projects/monolith/cluster/cd_health.py
+++ b/projects/monolith/cluster/cd_health.py
@@ -1,4 +1,4 @@
-"""CD health: can the platform's desired state actually reach the cluster?
+"""Advisory CD health: is production keeping up with published chart Freight?
 
 Folded into the deep ``/api/health`` response as the ``cd`` component, which
 UptimeRobot already polls offsite. Issue #4597 has the full rationale; the short
@@ -7,19 +7,18 @@ chart was never published, and ArgoCD's ``targetRevision`` pointed at something
 that does not exist for ~35 minutes. Nothing alerted, because every alerting
 path in this repo lives inside the cluster it is watching.
 
-Two signals, both derived from timestamps the upstreams already carry, so this
-component holds no state and needs no prober or latch table:
+This component is advisory. A deploy in progress or production behind a chart
+is not the public site being down, so the signal is reported as metadata and
+does not make the health endpoint return 503.
 
-1. An ArgoCD Application not Synced+Healthy for longer than the grace period.
-   Covers the unreachable-chart case above, a failed sync, and a degraded
-   workload, without needing registry credentials: an app pinned to a chart
-   that was never published does not reach Synced.
-
-   The two faults are dated from different clocks, which took an incident to
-   get right. A degraded app is dated by ``.status.health``'s
-   lastTransitionTime; a merely OutOfSync one by the last sync operation,
-   because ``.status.sync`` carries no transition time. Dating a health fault
-   from the last SYNC meant a settled app got no grace at all.
+1. Production's live monolith chart is behind the newest monolith chart Kargo
+   has published Freight for longer than the lag window. The old ArgoCD sweep
+   faulted on permanently unconvergeable OutOfSync/Healthy diffs in authentik,
+   argocd, kyverno, and context-forge-gateway, so it was always red and
+   monitored nothing. The original #4597 fault class, a targetRevision for a
+   chart that was never published, is structurally impossible now that Kargo
+   owns targetRevision and only promotes discovered Freight. What can still
+   happen is production sitting on an old chart while newer charts pile up.
 2. main's CI: the most recent commit WITH A COMPLETED STATUS is red and older
    than the red window, or there were commits inside that window and none of
    them completed at all.
@@ -81,84 +80,67 @@ def _parse_ts(value: str | None) -> datetime | None:
         return None
 
 
-async def _argocd_fault(grace_s: float) -> str | None:
-    """Fetch the apps, then judge them. I/O here, decision in _argocd_fault_real."""
+PROD_APP_NAME = "monolith"
+KARGO_NAMESPACE = "kargo-monolith"
+
+
+def _chart_version(value: str | None) -> tuple[int, int, int] | None:
+    try:
+        parts = value.split(".") if value is not None else []
+        if len(parts) != 3 or any(not part.isdigit() for part in parts):
+            return None
+        return tuple(int(part) for part in parts)  # type: ignore[return-value]
+    except (AttributeError, ValueError):
+        return None
+
+
+def _evaluate_chart_lag(
+    live_version: str | None, freight: list[dict], lag_s: float, now: datetime
+) -> tuple[str | None, str | None]:
+    """Judge production chart lag without doing any I/O."""
+    live = _chart_version(live_version)
+    if live is None:
+        return None, "prod chart version unreadable"
+
+    newer = []
+    for item in freight:
+        version = _chart_version(item.get("version"))
+        if version is not None and version > live and _parse_ts(item.get("created_at")):
+            newer.append(item)
+    if not newer:
+        return None, f"prod on {live_version}, up to date"
+
+    # The oldest unpromoted Freight owns the clock. New charts arriving every
+    # 20 minutes must not reset how long production has actually been behind.
+    oldest = min(newer, key=lambda item: _parse_ts(item["created_at"]))
+    since = _parse_ts(oldest["created_at"])
+    assert since is not None
+    age_s = max(0.0, (now - since).total_seconds())
+    count = len(newer)
+    newest = max(newer, key=lambda item: _chart_version(item["version"]) or (0, 0, 0))
+    # Kargo's creationTimestamp is when its Warehouse discovered the chart, up
+    # to one poll interval (5m) after publication. Against 2h, that slack is
+    # immaterial, but it should not surprise the next reader.
+    if age_s > lag_s:
+        return (
+            f"prod on {live_version}, {count} chart(s) behind through "
+            f"{newest['version']}, waiting {age_s / 60:.0f}m",
+            None,
+        )
+    return None, (
+        f"prod {count} chart(s) behind through {newest['version']} "
+        f"for {age_s / 60:.0f}m"
+    )
+
+
+async def _chart_lag_fault(lag_s: float) -> tuple[str | None, str | None]:
+    """Read the live Application and Kargo Freight, then judge chart lag."""
     from cluster.kubernetes import KubernetesClient  # noqa: PLC0415
 
-    apps = await KubernetesClient().list_argocd_app_health()
-    return await _argocd_fault_real(apps, grace_s)
-
-
-def _non_prod_apps() -> frozenset[str]:
-    """ArgoCD apps whose health is reported but does NOT fault this component.
-
-    This check was written when every ArgoCD app WAS production, so "any app
-    unhealthy" and "production unhealthy" were the same predicate. Introducing
-    monolith-dev broke that equivalence silently, and the check kept evaluating
-    the old one: a dev environment with a stuck Atlas migration took
-    jomcgi.dev/health to 503 while production was entirely fine.
-
-    These are still worth reporting. A dev environment that cannot sync is a
-    real signal and often an early one, since it runs the same chart production
-    is about to. It is just not a reason to tell the outside world that this
-    site is down.
-    """
-    raw = os.environ.get("CD_HEALTH_NON_PROD_APPS", "monolith-dev")
-    return frozenset(n.strip() for n in raw.split(",") if n.strip())
-
-
-async def _argocd_fault_real(
-    apps: list[dict], grace_s: float, non_prod: frozenset[str] | None = None
-) -> tuple[str | None, str | None]:
-    """Split unhealthy apps into (production faults, non-production notes).
-
-    Returns a pair so the caller can decide differently about each. Only the
-    first makes /api/health 503; the second rides along in the detail string so
-    the signal is kept rather than discarded.
-    """
-    if non_prod is None:
-        non_prod = _non_prod_apps()
-    now = datetime.now(timezone.utc)
-    faults: list[str] = []
-    notes: list[str] = []
-    for app in apps:
-        if app.get("sync") == "Synced" and app.get("health") == "Healthy":
-            continue
-        # Date the fault by whatever actually went wrong, because the two
-        # faults have different clocks.
-        #
-        # A degraded app is dated by its health transition. Using the last SYNC
-        # time here was a defect: embervm last synced 622 minutes before it went
-        # Progressing, so the 15 minute grace was not shortened, it was skipped,
-        # and jomcgi.dev/health 503'd on the first bad tick. The inversion is
-        # the tell, since a settled app has the stalest finished_at and so got
-        # the least grace, which is backwards.
-        #
-        # A merely OutOfSync app has no transition time of its own
-        # (`.status.sync` carries none), so the last sync attempt stands. That
-        # is a weaker signal in the other direction, since an app that retries
-        # forever keeps refreshing it, which is #4727 and not fixed here.
-        if app.get("health") != "Healthy":
-            since = _parse_ts(app.get("health_changed_at"))
-        else:
-            since = _parse_ts(app.get("finished_at"))
-        # Undateable means in-flight rather than page. A genuinely stuck app
-        # acquires a timestamp on its next transition, and guessing here would
-        # page on every fresh rollout. Deliberately NOT falling back to
-        # finished_at for a health fault: that fallback IS the bug above.
-        if since is None:
-            continue
-        age_s = (now - since).total_seconds()
-        if age_s > grace_s:
-            line = (
-                f"{app['name']} is {app.get('sync')}/{app.get('health')} "
-                f"for {age_s / 60:.0f}m"
-            )
-            (notes if app.get("name") in non_prod else faults).append(line)
-    return (
-        "; ".join(sorted(faults)) if faults else None,
-        "; ".join(sorted(notes)) if notes else None,
-    )
+    kubernetes = KubernetesClient()
+    live = await kubernetes.get_argocd_app_target_revision(PROD_APP_NAME)
+    freight = await kubernetes.list_kargo_freight(KARGO_NAMESPACE)
+    return _evaluate_chart_lag(live, freight, lag_s, datetime.now(timezone.utc))
 
 
 async def _ci_fault(red_window_s: float) -> str | None:
@@ -250,34 +232,31 @@ def _evaluate_ci(
 
 
 async def cd_health() -> dict:
-    """The ``cd`` health component. Any fault makes /api/health return 503."""
+    """The advisory ``cd`` health component, plus the existing CI signal."""
     global _cache
     if _cache is not None and (time.monotonic() - _cache[0]) < _CACHE_TTL_S:
         return _cache[1]
 
-    grace_s = _env_seconds("CD_HEALTH_SYNC_GRACE_S", 900.0)
+    lag_s = _env_seconds("CD_HEALTH_CHART_LAG_S", 7200.0)
     red_window_s = _env_seconds("CD_HEALTH_CI_RED_WINDOW_S", 3600.0)
 
     details: list[str] = []
     ok = True
 
     try:  # nosemgrep: no-broad-except-swallow - reported in-band, logged below
-        argocd = await _argocd_fault(grace_s)
+        chart_lag = await _chart_lag_fault(lag_s)
     except Exception as exc:  # noqa: BLE001
         # Includes the Forbidden an RBAC gap would produce. Report it rather
         # than 503: a broken checker must not masquerade as a broken platform.
-        logger.warning("cd health: argocd check failed: %s", exc)
-        details.append(f"argocd check unavailable ({exc})")
+        logger.warning("cd health: chart lag check failed: %s", exc)
+        details.append(f"chart lag check unavailable ({exc})")
     else:
-        argocd_fault, argocd_note = argocd
-        if argocd_fault:
+        chart_lag_fault, chart_lag_note = chart_lag
+        if chart_lag_fault:
             ok = False
-            details.append(argocd_fault)
-        if argocd_note:
-            # Reported, deliberately NOT faulting. See _non_prod_apps: a dev
-            # environment failing to sync is worth surfacing and is not a
-            # reason to tell the outside world this site is down.
-            details.append(f"non-prod: {argocd_note}")
+            details.append(chart_lag_fault)
+        if chart_lag_note:
+            details.append(chart_lag_note)
 
     if not os.environ.get("GITHUB_API_TOKEN", ""):
         details.append("ci check disabled: no GITHUB_API_TOKEN")

--- a/projects/monolith/cluster/cd_health_test.py
+++ b/projects/monolith/cluster/cd_health_test.py
@@ -37,6 +37,15 @@ def test_up_to_date_is_ok():
     assert note == "prod on 0.301.1, up to date"
 
 
+def test_empty_freight_faults_instead_of_saying_up_to_date():
+    fault, note = mod._evaluate_chart_lag(
+        "0.301.1", [], 7200, datetime.now(timezone.utc)
+    )
+    assert fault is not None and "no monolith Freight found" in fault
+    assert note is None
+    assert "up to date" not in fault
+
+
 def test_behind_inside_window_does_not_fault_and_says_how_far():
     now = datetime.now(timezone.utc)
     fault, note = mod._evaluate_chart_lag(

--- a/projects/monolith/cluster/cd_health_test.py
+++ b/projects/monolith/cluster/cd_health_test.py
@@ -1,8 +1,4 @@
-"""Tests for the cd health component (issue #4597).
-
-The cases that matter are the ones that decide whether Joe gets paged at 3am,
-so they are named for the judgement rather than the mechanics.
-"""
+"""Tests for the advisory chart-lag and CI signals."""
 
 from __future__ import annotations
 
@@ -24,354 +20,143 @@ def _clear_cache():
     mod._cache = None
 
 
-# --------------------------------------------------------------------------
-# ArgoCD signal
-# --------------------------------------------------------------------------
+def _freight(version: str, created_at: datetime) -> dict:
+    return {
+        "name": f"freight-{version}",
+        "version": version,
+        "created_at": _iso(created_at),
+    }
 
 
-@pytest.mark.asyncio
-async def test_all_apps_synced_healthy_is_ok():
-    apps = [
-        {"name": "monolith", "sync": "Synced", "health": "Healthy", "finished_at": None}
-    ]
-    assert (await mod._argocd_fault_real(apps, 900.0))[0] is None
+def test_up_to_date_is_ok():
+    now = datetime.now(timezone.utc)
+    fault, note = mod._evaluate_chart_lag(
+        "0.301.1", [_freight("0.301.0", now)], 7200, now
+    )
+    assert fault is None
+    assert note == "prod on 0.301.1, up to date"
 
 
-@pytest.mark.asyncio
-async def test_app_stuck_unsynced_past_grace_trips():
-    old = _iso(datetime.now(timezone.utc) - timedelta(minutes=40))
-    apps = [
-        {"name": "monolith", "sync": "Unknown", "health": "Healthy", "finished_at": old}
-    ]
-    fault, _note = await mod._argocd_fault_real(apps, 900.0)
+def test_behind_inside_window_does_not_fault_and_says_how_far():
+    now = datetime.now(timezone.utc)
+    fault, note = mod._evaluate_chart_lag(
+        "0.301.1", [_freight("0.302.0", now - timedelta(minutes=30))], 7200, now
+    )
+    assert fault is None
+    assert note is not None and "0.302.0" in note and "30m" in note
+
+
+def test_behind_past_window_faults_with_versions_and_age():
+    now = datetime.now(timezone.utc)
+    fault, note = mod._evaluate_chart_lag(
+        "0.301.1", [_freight("0.302.0", now - timedelta(hours=3))], 7200, now
+    )
+    assert note is None
     assert fault is not None
-    assert "monolith is Unknown/Healthy" in fault
+    assert "0.301.1" in fault and "0.302.0" in fault and "180m" in fault
 
 
-@pytest.mark.asyncio
-async def test_app_mid_rollout_inside_grace_does_not_trip():
-    recent = _iso(datetime.now(timezone.utc) - timedelta(minutes=2))
-    apps = [
-        {
-            "name": "monolith",
-            "sync": "Synced",
-            "health": "Progressing",
-            "finished_at": recent,
-            "health_changed_at": recent,
-        }
+def test_oldest_unpromoted_freight_owns_the_clock():
+    now = datetime.now(timezone.utc)
+    freight = [
+        _freight("0.302.0", now - timedelta(hours=3)),
+        _freight("0.303.0", now - timedelta(minutes=10)),
     ]
-    assert (await mod._argocd_fault_real(apps, 900.0))[0] is None
+    fault, _ = mod._evaluate_chart_lag("0.301.1", freight, 7200, now)
+    assert fault is not None and "180m" in fault
 
 
-@pytest.mark.asyncio
-async def test_app_with_no_finish_time_does_not_trip():
-    """Cannot date the fault, so treat as in-flight rather than page.
-
-    A genuinely stuck app acquires a finishedAt on its next attempt; guessing
-    here would page on every fresh rollout.
-    """
-    apps = [
-        {
-            "name": "new-app",
-            "sync": "OutOfSync",
-            "health": "Missing",
-            "finished_at": None,
-            "health_changed_at": None,
-        }
-    ]
-    assert (await mod._argocd_fault_real(apps, 900.0))[0] is None
+def test_unreadable_live_version_reports_rather_than_faulting():
+    fault, note = mod._evaluate_chart_lag(
+        "latest", [], 7200, datetime.now(timezone.utc)
+    )
+    assert fault is None
+    assert note == "prod chart version unreadable"
 
 
-@pytest.mark.asyncio
-async def test_a_settled_app_going_unhealthy_gets_its_full_grace():
-    """The defect that 503'd jomcgi.dev, in its exact shape.
-
-    embervm had been Synced and untouched since 07:36. When a brick could not
-    be scheduled it went Progressing, and the check dated that fault from the
-    last SYNC, computed 622 minutes, and blew past a 15 minute grace on the
-    first bad tick.
-
-    The inversion is what makes it worth a test rather than a comment: the more
-    settled an app is, the staler its finished_at, so the LESS grace it got.
-    A healthy deployment history actively reduced the protection.
-    """
-    apps = [
-        {
-            "name": "embervm",
-            "sync": "Synced",
-            "health": "Progressing",
-            "finished_at": _iso(datetime.now(timezone.utc) - timedelta(minutes=622)),
-            "health_changed_at": _iso(
-                datetime.now(timezone.utc) - timedelta(minutes=2)
-            ),
-        }
-    ]
-    assert (await mod._argocd_fault_real(apps, 900.0))[0] is None
+def test_unparseable_freight_versions_are_ignored():
+    now = datetime.now(timezone.utc)
+    fault, note = mod._evaluate_chart_lag(
+        "0.301.1", [_freight("main", now - timedelta(days=2))], 7200, now
+    )
+    assert fault is None and note == "prod on 0.301.1, up to date"
 
 
-@pytest.mark.asyncio
-async def test_a_genuinely_stuck_app_still_trips_and_reports_the_right_age():
-    """The other half: the grace must still expire, and say so honestly.
-
-    Asserting the minutes matters. The old message read "for 622m" while the
-    app had been unhealthy for two, so the number was not merely early, it
-    described a different event.
-    """
-    apps = [
-        {
-            "name": "embervm",
-            "sync": "Synced",
-            "health": "Progressing",
-            "finished_at": _iso(datetime.now(timezone.utc) - timedelta(minutes=622)),
-            "health_changed_at": _iso(
-                datetime.now(timezone.utc) - timedelta(minutes=40)
-            ),
-        }
-    ]
-    fault, _note = await mod._argocd_fault_real(apps, 900.0)
-    assert fault is not None
-    assert "embervm is Synced/Progressing for 40m" in fault, fault
+def test_freight_older_than_live_is_ignored():
+    now = datetime.now(timezone.utc)
+    fault, note = mod._evaluate_chart_lag(
+        "0.301.1", [_freight("0.300.9", now - timedelta(days=2))], 7200, now
+    )
+    assert fault is None and note == "prod on 0.301.1, up to date"
 
 
-@pytest.mark.asyncio
-async def test_outofsync_but_healthy_is_still_dated_from_the_last_sync():
-    """Unchanged, and deliberately so.
-
-    `.status.sync` carries no transition time, so the last sync attempt is the
-    only clock available. That is a weaker signal in the opposite direction,
-    since an app retrying forever keeps refreshing it (#4727), which this
-    change does not attempt to fix.
-    """
-    apps = [
-        {
-            "name": "kyverno",
-            "sync": "OutOfSync",
-            "health": "Healthy",
-            "finished_at": _iso(datetime.now(timezone.utc) - timedelta(minutes=40)),
-            "health_changed_at": _iso(datetime.now(timezone.utc) - timedelta(days=3)),
-        }
-    ]
-    fault, _note = await mod._argocd_fault_real(apps, 900.0)
-    assert fault is not None
-    assert "kyverno is OutOfSync/Healthy for 40m" in fault, fault
-
-
-@pytest.mark.asyncio
-async def test_unhealthy_app_with_no_health_transition_does_not_trip():
-    """No fallback to finished_at, because that fallback IS the bug.
-
-    ArgoCD always stamps health.lastTransitionTime, so this is defensive. If it
-    is ever missing the honest move is to treat the app as undateable rather
-    than reach for the timestamp that caused the incident.
-    """
-    apps = [
-        {
-            "name": "embervm",
-            "sync": "Synced",
-            "health": "Degraded",
-            "finished_at": _iso(datetime.now(timezone.utc) - timedelta(minutes=622)),
-            "health_changed_at": None,
-        }
-    ]
-    assert (await mod._argocd_fault_real(apps, 900.0))[0] is None
-
-
-# --------------------------------------------------------------------------
 # CI signal. These encode the rules that took several passes to settle.
-# --------------------------------------------------------------------------
-
-
 def test_quiet_green_main_is_healthy_at_any_age():
-    """No commits does NOT mean no signal: the last completed status stands.
-
-    Treating silence as staleness would page every night and every weekend.
-    """
     week_old = datetime.now(timezone.utc) - timedelta(days=7)
-    fault = mod._evaluate_ci(
-        recent_commit_count=0,
-        newest_completed={
-            "state": "success",
-            "sha": "abc123456",
-            "updated_at": _iso(week_old),
-        },
-        red_window_s=3600.0,
-    )
-    assert fault is None
-
-
-def test_red_but_recent_does_not_page():
-    """Someone is probably mid-fix. Red only matters once it persists."""
-    ten_min = datetime.now(timezone.utc) - timedelta(minutes=10)
-    fault = mod._evaluate_ci(
-        recent_commit_count=1,
-        newest_completed={
-            "state": "failure",
-            "sha": "abc123456",
-            "updated_at": _iso(ten_min),
-        },
-        red_window_s=3600.0,
-    )
-    assert fault is None
-
-
-def test_red_past_the_window_pages():
-    two_h = datetime.now(timezone.utc) - timedelta(hours=2)
-    fault = mod._evaluate_ci(
-        recent_commit_count=0,
-        newest_completed={
-            "state": "failure",
-            "sha": "abc123456",
-            "updated_at": _iso(two_h),
-        },
-        red_window_s=3600.0,
-    )
-    assert fault is not None
-    assert "abc123456" in fault
-
-
-def test_commits_with_nothing_completed_pages_as_ci_down():
-    """The meta-monitoring gap: if CI stops reporting, "is the latest red"
-    reports green forever."""
-    fault = mod._evaluate_ci(
-        recent_commit_count=3, newest_completed=None, red_window_s=3600.0
-    )
-    assert fault is not None
-    assert "CI may be down" in fault
-
-
-def test_no_commits_and_nothing_completed_is_ok():
-    """Nothing to assert. A repo with no completed statuses in range is not a
-    platform fault."""
     assert (
         mod._evaluate_ci(
-            recent_commit_count=0, newest_completed=None, red_window_s=3600.0
+            0,
+            {"state": "success", "sha": "abc123456", "updated_at": _iso(week_old)},
+            3600.0,
         )
         is None
     )
 
 
-# --------------------------------------------------------------------------
-# Component wiring
-# --------------------------------------------------------------------------
+def test_red_but_recent_does_not_page():
+    recent = datetime.now(timezone.utc) - timedelta(minutes=10)
+    assert (
+        mod._evaluate_ci(
+            1,
+            {"state": "failure", "sha": "abc123456", "updated_at": _iso(recent)},
+            3600.0,
+        )
+        is None
+    )
+
+
+def test_red_past_the_window_pages():
+    old = datetime.now(timezone.utc) - timedelta(hours=2)
+    fault = mod._evaluate_ci(
+        0,
+        {"state": "failure", "sha": "abc123456", "updated_at": _iso(old)},
+        3600.0,
+    )
+    assert fault is not None and "abc123456" in fault
+
+
+def test_commits_with_nothing_completed_pages_as_ci_down():
+    fault = mod._evaluate_ci(3, None, 3600.0)
+    assert fault is not None and "CI may be down" in fault
+
+
+def test_no_commits_and_nothing_completed_is_ok():
+    assert mod._evaluate_ci(0, None, 3600.0) is None
 
 
 @pytest.mark.asyncio
-async def test_missing_github_token_fails_open_but_says_so(monkeypatch):
-    """A config gap is not a platform outage and must not page, but it must not
-    be silent either."""
+async def test_chart_lag_check_error_reports_but_does_not_fault(monkeypatch):
     monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
 
-    async def _no_argocd_fault(grace_s):
-        return (None, None)
+    async def _boom(lag_s):
+        raise RuntimeError("freights.kargo.akuity.io is forbidden")
 
-    monkeypatch.setattr(mod, "_argocd_fault", _no_argocd_fault)
+    monkeypatch.setattr(mod, "_chart_lag_fault", _boom)
     result = await mod.cd_health()
     assert result["ok"] is True
-    assert "no GITHUB_API_TOKEN" in result["detail"]
-
-
-@pytest.mark.asyncio
-async def test_argocd_check_error_reports_but_does_not_page(monkeypatch):
-    """Includes the Forbidden an RBAC gap produces. A broken checker must not
-    masquerade as a broken platform."""
-    monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
-
-    async def _boom(grace_s):
-        raise RuntimeError("applications.argoproj.io is forbidden")
-
-    monkeypatch.setattr(mod, "_argocd_fault", _boom)
-    result = await mod.cd_health()
-    assert result["ok"] is True
-    assert "argocd check unavailable" in result["detail"]
-
-
-@pytest.mark.asyncio
-async def test_argocd_fault_makes_the_component_not_ok(monkeypatch):
-    monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
-
-    async def _fault(grace_s):
-        return ("monolith is Unknown/Healthy for 40m", None)
-
-    monkeypatch.setattr(mod, "_argocd_fault", _fault)
-    result = await mod.cd_health()
-    assert result["ok"] is False
-    assert "40m" in result["detail"]
+    assert "chart lag check unavailable" in result["detail"]
 
 
 @pytest.mark.asyncio
 async def test_result_is_cached(monkeypatch):
-    """UptimeRobot polls frequently; neither upstream should be hit per request."""
     monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
     calls = []
 
-    async def _counting(grace_s):
+    async def _counting(lag_s):
         calls.append(1)
-        return (None, None)
+        return None, "prod on 0.301.1, up to date"
 
-    monkeypatch.setattr(mod, "_argocd_fault", _counting)
+    monkeypatch.setattr(mod, "_chart_lag_fault", _counting)
     await mod.cd_health()
     await mod.cd_health()
     assert len(calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_non_prod_app_is_reported_but_does_not_fault():
-    """A dev environment must not 503 the public health endpoint.
-
-    This is the regression test for a real outage: monolith-dev sat
-    Synced/Degraded on a stuck Atlas migration and took jomcgi.dev/health to
-    503 while production was entirely healthy.
-    """
-    old = _iso(datetime.now(timezone.utc) - timedelta(minutes=40))
-    apps = [
-        {
-            "name": "monolith-dev",
-            "sync": "Synced",
-            "health": "Degraded",
-            "finished_at": old,
-            "health_changed_at": old,
-        }
-    ]
-    fault, note = await mod._argocd_fault_real(
-        apps, 900.0, non_prod=frozenset({"monolith-dev"})
-    )
-    assert fault is None, "a non-production app must not fault the component"
-    assert note is not None and "monolith-dev is Synced/Degraded" in note, (
-        "it must still be REPORTED: a dev app failing to sync is an early "
-        "signal, since it runs the chart production is about to run"
-    )
-
-
-@pytest.mark.asyncio
-async def test_production_still_faults_alongside_a_non_prod_note():
-    """Scoping must not swallow the signal it was narrowed around."""
-    old = _iso(datetime.now(timezone.utc) - timedelta(minutes=40))
-    apps = [
-        {
-            "name": "monolith",
-            "sync": "Unknown",
-            "health": "Healthy",
-            "finished_at": old,
-        },
-        {
-            "name": "monolith-dev",
-            "sync": "Synced",
-            "health": "Degraded",
-            "finished_at": old,
-            "health_changed_at": old,
-        },
-    ]
-    fault, note = await mod._argocd_fault_real(
-        apps, 900.0, non_prod=frozenset({"monolith-dev"})
-    )
-    assert fault is not None and "monolith is Unknown/Healthy" in fault
-    assert "monolith-dev" not in (fault or ""), "dev must not leak into the fault"
-    assert note is not None and "monolith-dev" in note
-
-
-@pytest.mark.asyncio
-async def test_non_prod_list_is_configurable_and_defaults_to_dev(monkeypatch):
-    monkeypatch.delenv("CD_HEALTH_NON_PROD_APPS", raising=False)
-    assert "monolith-dev" in mod._non_prod_apps()
-    monkeypatch.setenv("CD_HEALTH_NON_PROD_APPS", "a , b,")
-    assert mod._non_prod_apps() == frozenset({"a", "b"})

--- a/projects/monolith/cluster/kubernetes.py
+++ b/projects/monolith/cluster/kubernetes.py
@@ -194,9 +194,10 @@ class KubernetesClient:
                 plural="applications",
                 name=name,
             )
-        except client.exceptions.ApiException as exc:
-            if exc.status == 404:
-                return None
+        except client.exceptions.ApiException:
+            # Every API failure reads the same to the caller, which reports
+            # "prod chart version unreadable" and deliberately does not fault:
+            # a broken checker must not masquerade as a broken platform.
             return None
         status = result.get("status") or {}
         sync = status.get("sync") or {}

--- a/projects/monolith/cluster/kubernetes.py
+++ b/projects/monolith/cluster/kubernetes.py
@@ -119,50 +119,6 @@ class KubernetesClient:
         )
         return len(result.get("items", []))
 
-    async def list_argocd_app_health(self, namespace: str = "argocd") -> list[dict]:
-        """Return {name, sync, health, finished_at, health_changed_at} per app.
-
-        One list call rather than N gets, because the cd health component reads
-        every app on each probe.
-
-        Two timestamps because the two faults are dated differently.
-        `finished_at` is the last sync operation's finish time, which is all
-        there is for a merely OutOfSync app: `.status.sync` carries no
-        transition time. `health_changed_at` is `.status.health`'s
-        lastTransitionTime, which is when the app's health ACTUALLY changed.
-
-        Reading finished_at for a health fault was a real defect: embervm last
-        synced 622 minutes before it went Progressing, so the 15 minute grace
-        was not shortened, it was skipped, and jomcgi.dev/health 503'd on the
-        first bad tick. The more settled an app is, the staler its finished_at,
-        so the less grace it got, which is exactly backwards.
-        """
-        api = await self._ensure_client()
-        custom = client.CustomObjectsApi(api)
-        result = await custom.list_namespaced_custom_object(
-            group="argoproj.io",
-            version="v1alpha1",
-            namespace=namespace,
-            plural="applications",
-        )
-        apps = []
-        for item in result.get("items", []):
-            status = item.get("status") or {}
-            apps.append(
-                {
-                    "name": (item.get("metadata") or {}).get("name", "?"),
-                    "sync": (status.get("sync") or {}).get("status"),
-                    "health": (status.get("health") or {}).get("status"),
-                    "finished_at": (status.get("operationState") or {}).get(
-                        "finishedAt"
-                    ),
-                    "health_changed_at": (status.get("health") or {}).get(
-                        "lastTransitionTime"
-                    ),
-                }
-            )
-        return apps
-
     async def get_argocd_app_status(
         self, name: str, namespace: str = "argocd"
     ) -> dict | None:
@@ -216,14 +172,17 @@ class KubernetesClient:
                     break
         return freight
 
-    async def get_argocd_app_target_revision(
+    async def get_argocd_app_deployed_revision(
         self, name: str, namespace: str = "argocd"
     ) -> str | None:
-        """Return an Application's live target revision, or None when absent.
+        """Return the revision deployed by an Application, or None on 404.
 
-        Supports both the multi-source ``.spec.sources[0]`` shape and the
-        legacy single-source ``.spec.source`` shape. A missing Application is
-        treated like ``get_argocd_app_status`` treats it.
+        Prefer status because Kargo's ``argocd-update`` patches
+        ``targetRevision`` before ``argocd-wait``. If a promotion patches the
+        target and then fails, the target can point at a new chart with nothing
+        serving it. The deployed revision in status keeps that incomplete
+        promotion visible. The spec fallbacks cover an Application that has
+        never synced and both multi-source and legacy single-source shapes.
         """
         api = await self._ensure_client()
         custom = client.CustomObjectsApi(api)
@@ -235,8 +194,17 @@ class KubernetesClient:
                 plural="applications",
                 name=name,
             )
-        except client.exceptions.ApiException:
+        except client.exceptions.ApiException as exc:
+            if exc.status == 404:
+                return None
             return None
+        status = result.get("status") or {}
+        sync = status.get("sync") or {}
+        revisions = sync.get("revisions") or []
+        if revisions and revisions[0]:
+            return revisions[0]
+        if sync.get("revision"):
+            return sync["revision"]
         spec = result.get("spec") or {}
         sources = spec.get("sources") or []
         if sources:

--- a/projects/monolith/cluster/kubernetes.py
+++ b/projects/monolith/cluster/kubernetes.py
@@ -186,6 +186,63 @@ class KubernetesClient:
             return None
         return result.get("status")
 
+    async def list_kargo_freight(self, namespace: str = "kargo-monolith") -> list[dict]:
+        """Return published monolith chart Freight in creation order-independent form.
+
+        Kargo stores ``charts`` at the TOP LEVEL of a Freight object, not under
+        ``spec`` or ``status``. For each Freight, use the first chart whose
+        repoURL identifies the monolith chart and skip Freight without one.
+        """
+        api = await self._ensure_client()
+        custom = client.CustomObjectsApi(api)
+        result = await custom.list_namespaced_custom_object(
+            group="kargo.akuity.io",
+            version="v1alpha1",
+            namespace=namespace,
+            plural="freights",
+        )
+        freight = []
+        for item in result.get("items", []):
+            metadata = item.get("metadata") or {}
+            for chart in item.get("charts") or []:
+                if (chart.get("repoURL") or "").endswith("/charts/monolith"):
+                    freight.append(
+                        {
+                            "name": metadata.get("name"),
+                            "version": chart.get("version"),
+                            "created_at": metadata.get("creationTimestamp"),
+                        }
+                    )
+                    break
+        return freight
+
+    async def get_argocd_app_target_revision(
+        self, name: str, namespace: str = "argocd"
+    ) -> str | None:
+        """Return an Application's live target revision, or None when absent.
+
+        Supports both the multi-source ``.spec.sources[0]`` shape and the
+        legacy single-source ``.spec.source`` shape. A missing Application is
+        treated like ``get_argocd_app_status`` treats it.
+        """
+        api = await self._ensure_client()
+        custom = client.CustomObjectsApi(api)
+        try:
+            result = await custom.get_namespaced_custom_object(
+                group="argoproj.io",
+                version="v1alpha1",
+                namespace=namespace,
+                plural="applications",
+                name=name,
+            )
+        except client.exceptions.ApiException:
+            return None
+        spec = result.get("spec") or {}
+        sources = spec.get("sources") or []
+        if sources:
+            return sources[0].get("targetRevision")
+        return (spec.get("source") or {}).get("targetRevision")
+
     async def _node_rss_bytes(self, v1: "client.CoreV1Api", node: str) -> float | None:
         """Anonymous resident memory for one node, from the kubelet Summary API.
 

--- a/projects/monolith/cluster/kubernetes_test.py
+++ b/projects/monolith/cluster/kubernetes_test.py
@@ -78,41 +78,24 @@ async def test_count_argocd_applications(k8s_client):
 
 
 @pytest.mark.asyncio
-async def test_list_argocd_app_health_reads_both_clocks(k8s_client):
-    """The extraction, which the cd_health judge tests cannot cover.
-
-    Those tests feed the judge a dict directly, so a wrong field name here
-    would leave every one of them green while the judge received None and
-    silently declined to page. The payload below is the real shape off a live
-    Application, including the nesting of lastTransitionTime UNDER health
-    rather than beside it, which is the part that is easy to get wrong.
-    """
+async def test_list_kargo_freight_parses_real_shape(k8s_client):
     mock_api = MagicMock()
     mock_custom = MagicMock()
     mock_custom.list_namespaced_custom_object = AsyncMock(
         return_value={
             "items": [
                 {
-                    "metadata": {"name": "embervm"},
-                    "status": {
-                        "sync": {"status": "Synced"},
-                        "health": {
-                            "status": "Progressing",
-                            "lastTransitionTime": "2026-08-12T17:55:00Z",
-                        },
-                        "operationState": {
-                            "finishedAt": "2026-08-12T07:36:24Z",
-                        },
+                    "metadata": {
+                        "name": "freight-123",
+                        "creationTimestamp": "2026-08-13T10:00:00Z",
                     },
-                },
-                # An app ArgoCD has never synced: no operationState at all.
-                {
-                    "metadata": {"name": "fresh"},
-                    "status": {
-                        "sync": {"status": "OutOfSync"},
-                        "health": {"status": "Missing"},
-                    },
-                },
+                    "charts": [
+                        {
+                            "repoURL": "oci://ghcr.io/jomcgi/homelab/charts/monolith",
+                            "version": "0.301.1",
+                        }
+                    ],
+                }
             ]
         }
     )
@@ -122,15 +105,118 @@ async def test_list_argocd_app_health_reads_both_clocks(k8s_client):
         patch("cluster.kubernetes.ApiClient", return_value=mock_api),
         patch("cluster.kubernetes.client.CustomObjectsApi", return_value=mock_custom),
     ):
-        apps = await k8s_client.list_argocd_app_health()
+        result = await k8s_client.list_kargo_freight()
+    assert result == [
+        {
+            "name": "freight-123",
+            "version": "0.301.1",
+            "created_at": "2026-08-13T10:00:00Z",
+        }
+    ]
 
-    by_name = {a["name"]: a for a in apps}
-    assert by_name["embervm"]["health_changed_at"] == "2026-08-12T17:55:00Z"
-    assert by_name["embervm"]["finished_at"] == "2026-08-12T07:36:24Z", (
-        "both clocks must survive: the judge picks between them"
+
+@pytest.mark.asyncio
+async def test_list_kargo_freight_skips_non_monolith_and_missing_charts(k8s_client):
+    mock_api = MagicMock()
+    mock_custom = MagicMock()
+    mock_custom.list_namespaced_custom_object = AsyncMock(
+        return_value={
+            "items": [
+                {
+                    "metadata": {"name": "other"},
+                    "charts": [
+                        {"repoURL": "oci://example/charts/other", "version": "1.0.0"}
+                    ],
+                },
+                {"metadata": {"name": "missing"}},
+            ]
+        }
     )
-    assert by_name["fresh"]["health_changed_at"] is None
-    assert by_name["fresh"]["finished_at"] is None
+    with (
+        patch("cluster.kubernetes.config.load_incluster_config"),
+        patch("cluster.kubernetes.ApiClient", return_value=mock_api),
+        patch("cluster.kubernetes.client.CustomObjectsApi", return_value=mock_custom),
+    ):
+        assert await k8s_client.list_kargo_freight() == []
+
+
+async def _deployed_revision(k8s_client, result):
+    mock_api = MagicMock()
+    mock_custom = MagicMock()
+    mock_custom.get_namespaced_custom_object = AsyncMock(return_value=result)
+    with (
+        patch("cluster.kubernetes.config.load_incluster_config"),
+        patch("cluster.kubernetes.ApiClient", return_value=mock_api),
+        patch("cluster.kubernetes.client.CustomObjectsApi", return_value=mock_custom),
+    ):
+        return await k8s_client.get_argocd_app_deployed_revision("monolith")
+
+
+@pytest.mark.asyncio
+async def test_deployed_revision_prefers_status_over_spec(k8s_client):
+    assert (
+        await _deployed_revision(
+            k8s_client,
+            {
+                "status": {
+                    "sync": {
+                        "revisions": [
+                            "0.301.1",
+                            "7a0c8c25c48fbb65d18b62f4e93fc4231629f8a0",
+                        ]
+                    }
+                },
+                "spec": {"sources": [{"targetRevision": "0.302.0"}]},
+            },
+        )
+        == "0.301.1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deployed_revision_falls_back_to_spec(k8s_client):
+    assert (
+        await _deployed_revision(
+            k8s_client, {"spec": {"sources": [{"targetRevision": "0.302.0"}]}}
+        )
+        == "0.302.0"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deployed_revision_handles_single_source_legacy_shape(k8s_client):
+    assert (
+        await _deployed_revision(
+            k8s_client,
+            {
+                "status": {"sync": {"revision": "0.301.1"}},
+                "spec": {"sources": [], "source": {"targetRevision": "0.300.9"}},
+            },
+        )
+        == "0.301.1"
+    )
+    assert (
+        await _deployed_revision(
+            k8s_client,
+            {"spec": {"sources": [], "source": {"targetRevision": "0.300.9"}}},
+        )
+        == "0.300.9"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deployed_revision_returns_none_on_404(k8s_client):
+    mock_api = MagicMock()
+    mock_custom = MagicMock()
+    mock_custom.get_namespaced_custom_object = AsyncMock(
+        side_effect=ApiException(status=404)
+    )
+    with (
+        patch("cluster.kubernetes.config.load_incluster_config"),
+        patch("cluster.kubernetes.ApiClient", return_value=mock_api),
+        patch("cluster.kubernetes.client.CustomObjectsApi", return_value=mock_custom),
+    ):
+        assert await k8s_client.get_argocd_app_deployed_revision("missing") is None
 
 
 def _node(name: str, allocatable: dict) -> MagicMock:

--- a/projects/monolith/core/platform_probe.py
+++ b/projects/monolith/core/platform_probe.py
@@ -94,7 +94,7 @@ async def write_probe(name: str, ok: bool, detail: str) -> None:
     await asyncio.to_thread(_write_sync, name, ok, detail)
 
 
-def probe_health(name: str, staleness_s: float, advisory: bool = False):
+def probe_health(name: str, staleness_s: float):
     """Build a health component that reads one latch row.
 
     Mirrors ember_public.health.synthetic_probe_health, which reads the ember
@@ -102,20 +102,12 @@ def probe_health(name: str, staleness_s: float, advisory: bool = False):
     leaves a stale green row, and reporting that as healthy is the exact
     meta-monitoring gap this component exists to close.
 
-    ``advisory`` means the component reports but never contributes to the 503
-    decision. The flag is included on every result so it describes the
-    component rather than its current outcome.
     """
 
     async def check() -> dict:
-        def _result(**values) -> dict:
-            if advisory:
-                values["advisory"] = True
-            return values
-
         row = await read_probe(name)
         if row is None:
-            return _result(ok=True, detail="no probe recorded yet")
+            return {"ok": True, "detail": "no probe recorded yet"}
 
         now = datetime.now(timezone.utc)
 
@@ -127,14 +119,14 @@ def probe_health(name: str, staleness_s: float, advisory: bool = False):
             if row.last_ok_at is not None:
                 down_s = max(0.0, (now - _utc(row.last_ok_at)).total_seconds())
                 detail = f"{detail}, down for {down_s / 60:.0f}m"
-            return _result(ok=False, detail=detail)
+            return {"ok": False, "detail": detail}
 
         age_s = (now - _utc(row.checked_at)).total_seconds()
         if age_s > staleness_s:
-            return _result(
-                ok=False,
-                detail=f"last probe was {age_s / 60:.0f}m ago, writer may be dead",
-            )
-        return _result(ok=True, detail=row.detail or "ok")
+            return {
+                "ok": False,
+                "detail": f"last probe was {age_s / 60:.0f}m ago, writer may be dead",
+            }
+        return {"ok": True, "detail": row.detail or "ok"}
 
     return check

--- a/projects/monolith/core/platform_probe.py
+++ b/projects/monolith/core/platform_probe.py
@@ -94,19 +94,28 @@ async def write_probe(name: str, ok: bool, detail: str) -> None:
     await asyncio.to_thread(_write_sync, name, ok, detail)
 
 
-def probe_health(name: str, staleness_s: float):
+def probe_health(name: str, staleness_s: float, advisory: bool = False):
     """Build a health component that reads one latch row.
 
     Mirrors ember_public.health.synthetic_probe_health, which reads the ember
     latch. Staleness matters as much as the ok flag: a writer that has died
     leaves a stale green row, and reporting that as healthy is the exact
     meta-monitoring gap this component exists to close.
+
+    ``advisory`` means the component reports but never contributes to the 503
+    decision. The flag is included on every result so it describes the
+    component rather than its current outcome.
     """
 
     async def check() -> dict:
+        def _result(**values) -> dict:
+            if advisory:
+                values["advisory"] = True
+            return values
+
         row = await read_probe(name)
         if row is None:
-            return {"ok": True, "detail": "no probe recorded yet"}
+            return _result(ok=True, detail="no probe recorded yet")
 
         now = datetime.now(timezone.utc)
 
@@ -118,14 +127,14 @@ def probe_health(name: str, staleness_s: float):
             if row.last_ok_at is not None:
                 down_s = max(0.0, (now - _utc(row.last_ok_at)).total_seconds())
                 detail = f"{detail}, down for {down_s / 60:.0f}m"
-            return {"ok": False, "detail": detail}
+            return _result(ok=False, detail=detail)
 
         age_s = (now - _utc(row.checked_at)).total_seconds()
         if age_s > staleness_s:
-            return {
-                "ok": False,
-                "detail": f"last probe was {age_s / 60:.0f}m ago, writer may be dead",
-            }
-        return {"ok": True, "detail": row.detail or "ok"}
+            return _result(
+                ok=False,
+                detail=f"last probe was {age_s / 60:.0f}m ago, writer may be dead",
+            )
+        return _result(ok=True, detail=row.detail or "ok")
 
     return check

--- a/projects/monolith/core/platform_probe_test.py
+++ b/projects/monolith/core/platform_probe_test.py
@@ -49,6 +49,36 @@ async def test_fresh_ok_row_is_healthy(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_advisory_flag_is_present_on_ok_not_ok_and_stale(monkeypatch):
+    async def _ok(name):
+        return _Row(ok=True, detail="cd ok")
+
+    monkeypatch.setattr(mod, "read_probe", _ok)
+    assert (await mod.probe_health("cd", 750.0, advisory=True)())["advisory"] is True
+
+    async def _bad(name):
+        return _Row(ok=False, detail="behind")
+
+    monkeypatch.setattr(mod, "read_probe", _bad)
+    assert (await mod.probe_health("cd", 750.0, advisory=True)())["advisory"] is True
+
+    async def _stale(name):
+        return _Row(ok=True, checked_at=datetime.now(timezone.utc) - timedelta(hours=3))
+
+    monkeypatch.setattr(mod, "read_probe", _stale)
+    assert (await mod.probe_health("cd", 750.0, advisory=True)())["advisory"] is True
+
+
+@pytest.mark.asyncio
+async def test_advisory_flag_is_absent_by_default(monkeypatch):
+    async def _row(name):
+        return _Row(ok=True)
+
+    monkeypatch.setattr(mod, "read_probe", _row)
+    assert "advisory" not in (await mod.probe_health("cd", 750.0)())
+
+
+@pytest.mark.asyncio
 async def test_stale_green_row_is_a_fault(monkeypatch):
     """A dead writer leaves a stale GREEN row. Reporting that as healthy is the
     exact meta-monitoring gap this component exists to close."""

--- a/projects/monolith/core/platform_probe_test.py
+++ b/projects/monolith/core/platform_probe_test.py
@@ -49,28 +49,7 @@ async def test_fresh_ok_row_is_healthy(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_advisory_flag_is_present_on_ok_not_ok_and_stale(monkeypatch):
-    async def _ok(name):
-        return _Row(ok=True, detail="cd ok")
-
-    monkeypatch.setattr(mod, "read_probe", _ok)
-    assert (await mod.probe_health("cd", 750.0, advisory=True)())["advisory"] is True
-
-    async def _bad(name):
-        return _Row(ok=False, detail="behind")
-
-    monkeypatch.setattr(mod, "read_probe", _bad)
-    assert (await mod.probe_health("cd", 750.0, advisory=True)())["advisory"] is True
-
-    async def _stale(name):
-        return _Row(ok=True, checked_at=datetime.now(timezone.utc) - timedelta(hours=3))
-
-    monkeypatch.setattr(mod, "read_probe", _stale)
-    assert (await mod.probe_health("cd", 750.0, advisory=True)())["advisory"] is True
-
-
-@pytest.mark.asyncio
-async def test_advisory_flag_is_absent_by_default(monkeypatch):
+async def test_probe_results_have_no_advisory_flag(monkeypatch):
     async def _row(name):
         return _Row(ok=True)
 

--- a/projects/monolith/ember_public/health_test.py
+++ b/projects/monolith/ember_public/health_test.py
@@ -26,6 +26,10 @@ def test_module_registers_synthetic_postgres_health_hook():
     }
 
 
+def test_module_has_no_advisory_health_components():
+    assert MODULE.register_health_advisory is None
+
+
 @pytest.mark.asyncio
 async def test_probe_postgres_unconfigured_is_not_ok(monkeypatch):
     monkeypatch.delenv("DEMO_POSTGRES_DSN", raising=False)

--- a/projects/monolith/framework/core.py
+++ b/projects/monolith/framework/core.py
@@ -268,10 +268,12 @@ def _add_health(app: FastAPI, profile: Profile, modules: Sequence[Module]) -> No
         health_logger = logging.getLogger("monolith.public")
         health_message = "public health check failed"
         component_message = "public health components unhealthy"
+        advisory_message = "public health advisory components degraded"
     else:
         health_logger = logger
         health_message = "deep health check failed"
         component_message = "deep health components unhealthy"
+        advisory_message = "deep health advisory components degraded"
 
     component_checks: dict[str, HealthCheck] = {}
     for m in modules:
@@ -294,8 +296,9 @@ def _add_health(app: FastAPI, profile: Profile, modules: Sequence[Module]) -> No
         this route; a DB outage returns a clean 503 (logged once per probe)
         instead of a traceback. Module-contributed components (see
         ``Module.register_health``) run alongside SELECT 1 and are folded
-        into a ``components`` map; any component not ok makes the whole
-        response 503, same as the SELECT 1 baseline.
+        into a ``components`` map. Fatal components make the response 503;
+        advisory components are reported in ``degraded`` while the response
+        remains 200.
         """
         from sqlmodel import Session, text
 
@@ -317,25 +320,38 @@ def _add_health(app: FastAPI, profile: Profile, modules: Sequence[Module]) -> No
             )
             components = dict(zip(names, results))
 
-        all_ok = db_ok and all(c.get("ok") for c in components.values())
+        fatal = {
+            n: c
+            for n, c in components.items()
+            if not c.get("advisory") and not c.get("ok")
+        }
+        advisory = {
+            n: c for n, c in components.items() if c.get("advisory") and not c.get("ok")
+        }
+        all_ok = db_ok and not fatal
         # Ember checks return {"ok": False, detail} in-band and never raise
         # (see ember_public/synthetic_probe.py), so _run_component's exception
         # log never fires for them and a component-caused 503 was silent. This
-        # warning is the only server-side record of which component tripped.
-        if not all_ok:
-            failing = {n: c for n, c in components.items() if not c.get("ok")}
-            if failing:
-                health_logger.warning(
-                    "%s: %s",
-                    component_message,
-                    "; ".join(
-                        f"{n}={c.get('detail') or 'no detail'}"
-                        for n, c in sorted(failing.items())
-                    ),
-                )
+        # This warning is the server-side record for fatal component failures.
+        if fatal:
+            health_logger.warning(
+                "%s: %s",
+                component_message,
+                "; ".join(
+                    f"{n}={c.get('detail') or 'no detail'}"
+                    for n, c in sorted(fatal.items())
+                ),
+            )
+        if advisory:
+            # INFO, and deliberately NOT component_message. SigNoz alerts and
+            # runbooks key on that exact warning text, so an advisory component
+            # emitting it would move the pager rather than remove it.
+            health_logger.info("%s: %s", advisory_message, ", ".join(sorted(advisory)))
         body = {"status": "ok" if all_ok else "unhealthy"}
         if components:
             body["components"] = components
+        if advisory:
+            body["degraded"] = sorted(advisory)
         if not all_ok:
             return JSONResponse(body, status_code=503)
         return body

--- a/projects/monolith/framework/core.py
+++ b/projects/monolith/framework/core.py
@@ -153,6 +153,8 @@ class Module:
       into the deep ``/api/health`` response (see ``_add_health``). A check
       returns ``{"ok": bool, "detail": str}``; a crashing check is caught by
       the framework and reported not-ok rather than 500ing the whole handler.
+    - ``register_health_advisory``: optional ``{name: async check}`` components
+      reported but never contributes to the 503 decision.
     - ``requires_secrets``: secret env names the module's PRIVATE surface
       uses (leader hooks, MCP, write routers). A restricted private profile
       refuses to compose such a module; the public tier ignores it because it
@@ -167,6 +169,7 @@ class Module:
     leader_start: LeaderStartHook | None = None
     leader_stop: LeaderStopHook | None = None
     register_health: dict[str, HealthCheck] | None = None
+    register_health_advisory: dict[str, HealthCheck] | None = None
     requires_secrets: frozenset[str] = frozenset()
 
 
@@ -279,6 +282,15 @@ def _add_health(app: FastAPI, profile: Profile, modules: Sequence[Module]) -> No
     for m in modules:
         if m.register_health:
             component_checks.update(m.register_health)
+    advisory_names = {
+        name
+        for m in modules
+        if m.register_health_advisory
+        for name in m.register_health_advisory
+    }
+    for m in modules:
+        if m.register_health_advisory:
+            component_checks.update(m.register_health_advisory)
 
     async def _run_component(name: str, check: HealthCheck) -> dict:
         try:  # nosemgrep: no-broad-except-swallow - logged via health_logger below
@@ -323,10 +335,12 @@ def _add_health(app: FastAPI, profile: Profile, modules: Sequence[Module]) -> No
         fatal = {
             n: c
             for n, c in components.items()
-            if not c.get("advisory") and not c.get("ok")
+            if n not in advisory_names and not c.get("ok")
         }
         advisory = {
-            n: c for n, c in components.items() if c.get("advisory") and not c.get("ok")
+            n: c
+            for n, c in components.items()
+            if n in advisory_names and not c.get("ok")
         }
         all_ok = db_ok and not fatal
         # Ember checks return {"ok": False, detail} in-band and never raise

--- a/projects/monolith/framework/core_test.py
+++ b/projects/monolith/framework/core_test.py
@@ -197,12 +197,12 @@ def test_advisory_failure_returns_200_degraded_and_logs_info(
     _sqlite_engine, caplog, _public_app_with_logs
 ):
     async def unhealthy_check():
-        return {"ok": False, "detail": "widget is behind", "advisory": True}
+        return {"ok": False, "detail": "widget is behind"}
 
     module = Module(
         name="m",
         register_public=lambda app: None,
-        register_health={"widget": unhealthy_check},
+        register_health_advisory={"widget": unhealthy_check},
     )
     app = _public_app_with_logs([module])
     with caplog.at_level(logging.INFO, logger="monolith.public"):
@@ -225,7 +225,7 @@ def test_fatal_failure_alongside_advisory_still_503s_and_warns(
     _sqlite_engine, caplog, _public_app_with_logs
 ):
     async def advisory_check():
-        return {"ok": False, "advisory": True}
+        return {"ok": False}
 
     async def fatal_check():
         return {"ok": False, "detail": "fatal"}
@@ -233,7 +233,8 @@ def test_fatal_failure_alongside_advisory_still_503s_and_warns(
     module = Module(
         name="m",
         register_public=lambda app: None,
-        register_health={"widget": advisory_check, "database": fatal_check},
+        register_health={"database": fatal_check},
+        register_health_advisory={"widget": advisory_check},
     )
     app = _public_app_with_logs([module])
     with caplog.at_level(logging.INFO, logger="monolith.public"):
@@ -246,6 +247,24 @@ def test_fatal_failure_alongside_advisory_still_503s_and_warns(
         and "database" in r.message
         for r in caplog.records
     )
+
+
+def test_raising_advisory_stays_200_and_is_degraded(
+    _sqlite_engine, caplog, _public_app_with_logs
+):
+    async def crashing_check():
+        raise RuntimeError("advisory boom")
+
+    module = Module(
+        name="m",
+        register_public=lambda app: None,
+        register_health_advisory={"widget": crashing_check},
+    )
+    app = _public_app_with_logs([module])
+    with caplog.at_level(logging.INFO, logger="monolith.public"):
+        resp = TestClient(app).get("/api/health")
+    assert resp.status_code == 200
+    assert resp.json()["degraded"] == ["widget"]
 
 
 def test_public_tier_health_503_logs_failing_component(

--- a/projects/monolith/framework/core_test.py
+++ b/projects/monolith/framework/core_test.py
@@ -193,6 +193,61 @@ def test_public_tier_health_folds_in_module_components(_sqlite_engine):
     assert body["components"] == {"widget": {"ok": True, "detail": "all good"}}
 
 
+def test_advisory_failure_returns_200_degraded_and_logs_info(
+    _sqlite_engine, caplog, _public_app_with_logs
+):
+    async def unhealthy_check():
+        return {"ok": False, "detail": "widget is behind", "advisory": True}
+
+    module = Module(
+        name="m",
+        register_public=lambda app: None,
+        register_health={"widget": unhealthy_check},
+    )
+    app = _public_app_with_logs([module])
+    with caplog.at_level(logging.INFO, logger="monolith.public"):
+        resp = TestClient(app).get("/api/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["degraded"] == ["widget"]
+    assert not any(
+        "public health components unhealthy" in r.message for r in caplog.records
+    )
+    assert any(
+        r.levelno == logging.INFO
+        and "public health advisory components degraded" in r.message
+        for r in caplog.records
+    )
+
+
+def test_fatal_failure_alongside_advisory_still_503s_and_warns(
+    _sqlite_engine, caplog, _public_app_with_logs
+):
+    async def advisory_check():
+        return {"ok": False, "advisory": True}
+
+    async def fatal_check():
+        return {"ok": False, "detail": "fatal"}
+
+    module = Module(
+        name="m",
+        register_public=lambda app: None,
+        register_health={"widget": advisory_check, "database": fatal_check},
+    )
+    app = _public_app_with_logs([module])
+    with caplog.at_level(logging.INFO, logger="monolith.public"):
+        resp = TestClient(app).get("/api/health")
+    assert resp.status_code == 503
+    assert resp.json()["degraded"] == ["widget"]
+    assert any(
+        r.levelno == logging.WARNING
+        and "public health components unhealthy" in r.message
+        and "database" in r.message
+        for r in caplog.records
+    )
+
+
 def test_public_tier_health_503_logs_failing_component(
     _sqlite_engine, caplog, _public_app_with_logs
 ):

--- a/projects/monolith/frontend/src/routes/public/health/+server.js
+++ b/projects/monolith/frontend/src/routes/public/health/+server.js
@@ -50,12 +50,7 @@ export async function GET({ fetch }) {
   }
 
   const body = await res.json();
-  const degraded =
-    body.degraded ??
-    Object.entries(body.components ?? {})
-      .filter(([, component]) => !component?.ok)
-      .map(([name]) => name)
-      .sort();
+  const degraded = body.degraded ?? [];
   return json(
     {
       status: body.status,

--- a/projects/monolith/frontend/src/routes/public/health/+server.js
+++ b/projects/monolith/frontend/src/routes/public/health/+server.js
@@ -49,7 +49,20 @@ export async function GET({ fetch }) {
     );
   }
 
-  return json(await res.json(), {
-    headers: { "cache-control": HEALTH_CACHE_CONTROL },
-  });
+  const body = await res.json();
+  const degraded =
+    body.degraded ??
+    Object.entries(body.components ?? {})
+      .filter(([, component]) => !component?.ok)
+      .map(([name]) => name)
+      .sort();
+  return json(
+    {
+      status: body.status,
+      ...(degraded.length ? { degraded } : {}),
+    },
+    {
+      headers: { "cache-control": HEALTH_CACHE_CONTROL },
+    },
+  );
 }

--- a/projects/monolith/frontend/src/routes/public/health/server.test.js
+++ b/projects/monolith/frontend/src/routes/public/health/server.test.js
@@ -31,6 +31,24 @@ describe("/public/health GET", () => {
     expect(HEALTH_CACHE_CONTROL).not.toContain("stale-while-revalidate");
   });
 
+  it("returns degraded names on 200 without component details", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        status: "ok",
+        degraded: ["cd"],
+        components: { cd: { ok: false, detail: "secret chart version" } },
+      }),
+    });
+
+    const res = await GET({ fetch });
+    const body = await res.json();
+    expect(body).toEqual({ status: "ok", degraded: ["cd"] });
+    expect(JSON.stringify(body)).not.toContain("components");
+    expect(JSON.stringify(body)).not.toContain("detail");
+  });
+
   it("returns an uncached 503 when the backend reports unhealthy", async () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: false,

--- a/projects/monolith/home/module.py
+++ b/projects/monolith/home/module.py
@@ -36,5 +36,9 @@ MODULE = _Module(
     # module is in both the private and public registries, so registering the
     # reader here is what puts the component on the tier UptimeRobot polls.
     # The public tier needs no new privilege to serve it, which is the point.
-    register_health={"cd": probe_health("cd", _CD_STALENESS_S)},
+    # Production being behind on a chart, or a mid-flight deploy, is not the
+    # public site being down, so report it as metadata on a 200 rather than
+    # paging. Nothing pages on cd now, it is a payload signal that must be
+    # looked at.
+    register_health={"cd": probe_health("cd", _CD_STALENESS_S, advisory=True)},
 )

--- a/projects/monolith/home/module.py
+++ b/projects/monolith/home/module.py
@@ -40,5 +40,5 @@ MODULE = _Module(
     # public site being down, so report it as metadata on a 200 rather than
     # paging. Nothing pages on cd now, it is a payload signal that must be
     # looked at.
-    register_health={"cd": probe_health("cd", _CD_STALENESS_S, advisory=True)},
+    register_health_advisory={"cd": probe_health("cd", _CD_STALENESS_S)},
 )

--- a/projects/monolith/stars/health_test.py
+++ b/projects/monolith/stars/health_test.py
@@ -20,6 +20,7 @@ def _snapshot(**overrides):
 
 def test_module_registers_stars_health():
     assert MODULE.register_health == {"stars": health.stars_health}
+    assert MODULE.register_health_advisory is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

`jomcgi.dev/health` has been returning `{"status":"unhealthy","backendStatus":503,"failing":["cd"]}` essentially permanently. The cause is the `cd` component's ArgoCD sweep, which faults on **any** app not Synced+Healthy past a 15 minute grace. Several apps in this cluster sit indefinitely `OutOfSync/Healthy` because they carry unconvergeable diffs while running perfectly:

```
cd=authentik is OutOfSync/Healthy for 43m, down for 32m
```

`argocd`, `kyverno` and `context-forge-gateway` are in the same state. A monitor that is always red monitors nothing.

## What changes

**1. The signal.** The whole-cluster sweep is replaced by chart lag: production's live monolith `targetRevision` compared against the newest monolith chart Kargo has published Freight for. Over 2h behind reports degraded (`cdHealth.chartLagSeconds`).

Two decisions in there that are easy to get backwards:

- **The clock is the oldest unpromoted Freight, not the newest.** Measuring the newest chart's age would read zero lag forever in a repo that merges every 20 minutes, however long production had been frozen. The oldest version production has not taken is the thing that actually answers "how long has prod been standing still".
- **Production's version is read from the live ArgoCD Application, not from `Stage/prod`.** Kargo promotes by patching the live Application, and `canada`'s `selfHeal` can stamp the git value back over a successful promotion. The field ArgoCD acts on can see that; Kargo's own status reports success throughout and cannot.

The original #4597 fault class (a `targetRevision` pinned to a chart that was never published) is structurally impossible now that Kargo owns `targetRevision` and only promotes Freight its Warehouse discovered in the registry. The CI red signal is unchanged.

**2. The severity.** Components may now declare `advisory=True`. An advisory component stays out of the `all_ok` computation, so it reports on a **200** in a new `degraded` list instead of 503ing. `cd` is the first one. Production being behind a chart, or mid-deploy, is not the public site being down.

Advisory failures log at INFO under a distinct message. They deliberately do **not** emit `public health components unhealthy`, which SigNoz alerts and runbooks key on, so this removes the page rather than relocating it.

```
before  503  {"status":"unhealthy","backendStatus":503,"failing":["cd"]}
after   200  {"status":"ok","degraded":["cd"]}
```

**Consequence, stated plainly: nothing pages on `cd` any more.** It is a payload signal that has to be looked at. A floor under that, if wanted later, is a second UptimeRobot monitor on the same URL with an inverse keyword check on `degraded`, no code required.

**3. A leak closed on the way past.** The public `/health` route passed the entire backend body through on the 200 path, `components` map and `detail` strings included, carrying ArgoCD app names, chart versions and CI shas to an internet-reachable endpoint. That was low stakes only while a 200 meant every component was fine. It now returns `status` and `degraded` names only, matching what the 503 path already did.

## Removed rather than left inert

`CD_HEALTH_SYNC_GRACE_S`, `cdHealth.syncGraceSeconds`, `CD_HEALTH_NON_PROD_APPS` and `_non_prod_apps()` are all deleted. An env var that is set, spelled correctly and read by nothing is a recurring defect class here, so they go rather than linger.

## Verification

- `Executed 386 out of 710 tests: 710 tests pass.` The changed targets cannot be cache hits, their sources moved.
- `ci lint` clean.
- All four format-stage guards run locally (hooks-executable, readme structure, doc links, helm deps), since PR CI runs those on the full checkout and `ci lint` does not.
- `helm template` confirms `CD_HEALTH_CHART_LAG_S=7200` renders and the old var is gone, and that the new `kargo.akuity.io/freights` get+list rule lands in the ClusterRole. Green tests prove nothing about Helm config.
- No `Chart.yaml` `version:` or `targetRevision:` touched.

## RBAC

Adds `kargo.akuity.io` / `freights` / `get,list` to the monolith ClusterRole. Read-only, and the only kargo permission granted. If it is ever missing the component reports `chart lag check unavailable (...)` and stays ok, because a broken checker must not masquerade as a broken platform.

## Note on live state

At the time of writing prod is on `0.301.1`, which is the newest Freight, so the new signal reads zero lag. The rework will be visibly green rather than visibly fixed, and the honest test of it is the next slow promotion.