### PR TITLE
feat(embervm): wire the SpecTrace gate through the chart, off in production

### DIFF
--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -107,6 +107,20 @@ spec:
               value: {{ mul .Values.opLog.sweepIntervalSeconds 1000 | quote }}
             - name: EMBERVM_OPLOG_JOURNAL_HORIZON_MS
               value: {{ mul .Values.opLog.journalHorizonDays 86400 1000 | quote }}
+            # SpecTrace gate for spec validation (GitHub issue #4770):
+            # the debug-gated, spec-shaped trace reads once at boot.
+            # OFF means no process, no connection, no sweep.
+            - name: EMBERVM_SPEC_TRACE
+              value: {{ if .Values.specTrace.enabled }}"on"{{ else }}"off"{{ end }}
+            {{- if .Values.specTrace.path }}
+            - name: EMBERVM_SPEC_TRACE_PATH
+              value: {{ .Values.specTrace.path | quote }}
+            {{- end }}
+            # SpecTrace retention and sweep interval (seconds converted to ms).
+            - name: EMBERVM_SPEC_TRACE_TTL_MS
+              value: {{ mul .Values.specTrace.ttlSeconds 1000 | quote }}
+            - name: EMBERVM_SPEC_TRACE_SWEEP_INTERVAL_MS
+              value: {{ mul .Values.specTrace.sweepIntervalSeconds 1000 | quote }}
             # Node membership for Embervm.NodeRegistry. Dial-home registration
             # (R0 PR-2, ADR embervm/005): each noded instance POSTs its identity to
             # /v1/nodes/register and the control plane adopts it keyed by

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -150,6 +150,26 @@ opLog:
   # audit lives in SigNoz.
   journalHorizonDays: 30
 
+# SpecTrace gate for spec validation (GitHub issue #4770). A debug-gated, spec-shaped
+# trace that validates TLA+ specs against real behaviour, read once at boot. OFF means
+# no process, no connection, no sweep.
+#
+# Backend selection reuses EMBERVM_OPLOG_DSN: set means the Postgres backend (its own
+# table in the existing `embervm_oplog` database), unset means SQLite. This mirrors the
+# existing op_log_mod/0 selection and avoids inventing a second switch.
+specTrace:
+  # Default OFF in production. ON in dev for local spec validation.
+  enabled: false
+  # SQLite path for spec trace rows, used only when EMBERVM_OPLOG_DSN is unset.
+  # Empty string means in-memory database.
+  path: ""
+  # Retention for trace rows (seconds).
+  ttlSeconds: 86400
+  # How often the supervised sweeper runs compaction (seconds). Matches opLog's hourly
+  # cadence for consistency; correctness is enforced at read time, so this only governs
+  # how promptly reclaimed space is freed.
+  sweepIntervalSeconds: 3600
+
 # Node discovery for the control plane (artifact-decoupling PR-C, C4). noded is a
 # DaemonSet behind a HEADLESS Service, so the control plane DISCOVERS every
 # daemon's individual pod endpoint via EndpointSlice discovery and dials each one

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -592,3 +592,10 @@ claudeRuntimeWorkload:
   # another 4 GiB per brick until the GC is fixed, so watch headroom under
   # /var/lib/embervm/scratch on node-1/2/3 rather than on node-4.
   persistenceEnabled: true
+
+# SpecTrace gate for spec validation (GitHub issue #4770). Debug-gated, spec-shaped
+# trace that validates TLA+ specs against real behaviour. Deliberately OFF in production.
+# Chart defaults are all OFF; flip specTrace.enabled=true locally or in a dev values
+# override to enable spec validation.
+# specTrace:
+#   enabled: false


### PR DESCRIPTION
Chart half of #4770. Pairs with #4789 (the store), which provides the readers for
the knobs rendered here.

## What it renders

`EMBERVM_SPEC_TRACE` plus the trace's retention and sweep interval, into the
control-plane container env alongside the existing `EMBERVM_OPLOG_*` vars.
Production keeps the default **off**, and with the gate off the writer, store and
compactor all return `:ignore`, so there is no process, no connection to the
shared production cluster, and no sweep.

## The gate renders ALWAYS, explicitly "off"

Not omitted when disabled, and this is deliberate against the idiomatic Helm
choice. An env var present and explicitly `off` is greppable in a running pod. An
absent one is ambiguous between "disabled", "this chart predates the feature" and
"the template is broken" — and the person running `env | grep SPEC_TRACE` is by
definition trying to work out why they cannot see something.

This repo has been bitten by exactly that: **#4758** is a gate that defaulted off
and was rendered nowhere, which left two modeled invariants describing an ordering
production had never run, with nothing in the data saying so.

## Backend selection reuses EMBERVM_OPLOG_DSN

Set means the Postgres backend (its own table in the existing `embervm_oplog`
database), unset means SQLite. Mirrors the existing `op_log_mod/0` selection
rather than inventing a second switch.

## Verified both ways

```
$ helm template ... -f deploy/values.yaml
  - name: EMBERVM_SPEC_TRACE
    value: "off"

$ helm template ... --set specTrace.enabled=true
  - name: EMBERVM_SPEC_TRACE
    value: "on"
```

## Note on the pairing

The TTL and sweep-interval env vars rendered here initially had **no reader**: the
compactor inherited the op-log's sweep interval and was never passed a `ttl_ms`, so
it silently used its own default. That is inert config, a values knob that reads as
live and changes nothing, which is worse than no knob because it invites someone to
tune it during an incident.

The readers were added to #4789 so the vars and their consumers land together. Worth
recording because the defect lived in the *gap between* two PRs, each of which
reviewed clean on its own. Splitting work by file type hides that class, and the
cheap defence is to grep the consuming code for every env var a chart adds.

## Verification

- `ci test`: **1223 tests, 0 failures, 6 skipped**, `Executed 3 out of 710` (the
  template tests exercised it).
- `ci lint` clean. No em-dashes. No `Chart.yaml` version or `targetRevision` edit.
- Production values unchanged apart from a comment pointing at the block.

Refs #4770, #4759, #4789, #4758.