### PR TITLE
feat(embervm): the remaining adoption.tla emission points

### DIFF
--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -279,7 +279,8 @@ defmodule Embervm.Dispatcher do
       retry_timers: %{},
       denials: %{cap: 0, principal_share: 0, stale_capacity: 0, no_capacity: 0, quota: 0},
       warm_hits: 0,
-      misses: 0
+      misses: 0,
+      adoption_vm_ids: MapSet.new()
     }
 
     # Named + public so the router's admit?/3 reads it lock-free. Owned here so it
@@ -298,6 +299,14 @@ defmodule Embervm.Dispatcher do
   @impl true
   def handle_continue(:boot_sweep, state) do
     state = run_sweep(state)
+    # The CP incarnation id, NOT a fresh unique integer. This record marks the
+    # boundary between incarnations, so it is only useful if it matches the
+    # run_id stamped on every other record in the trace; an arbitrary number
+    # correlates with nothing and makes the boundary unfindable. SpecTrace.run_id/0
+    # is stable across writer restarts for the same reason.
+    Embervm.SpecTrace.emit(:adoption, :restart_cp, %{
+      "incarnation_id" => Embervm.SpecTrace.run_id()
+    })
     schedule_sweep(state)
     {:noreply, state}
   end
@@ -712,6 +721,12 @@ defmodule Embervm.Dispatcher do
 
     case :queue.out(q) do
       {{:value, vm_id}, rest} ->
+        # NOTE: the vm is NOT dropped from adoption_vm_ids here, deliberately.
+        # spawn_assign_worker snapshots the set into the worker ctx AFTER this
+        # runs, and the dispatch emission reads that snapshot to record
+        # provenance. Removing here means the snapshot never contains the vm, so
+        # an adopted vm records `warm` and #4768 stays unfixed. The removal
+        # happens in spawn_assign_worker, once the snapshot has been taken.
         {%{state | inventory: Map.put(state.inventory, {node_id, wl}, rest)}, vm_id}
 
       {:empty, _} ->
@@ -757,6 +772,7 @@ defmodule Embervm.Dispatcher do
       node_id: node_id,
       mode: mode,
       vm_id: vm_id,
+      adoption_vm_ids: state.adoption_vm_ids,
       # The dispatcher pid, so a MISS worker can report the vm_id it primes back
       # here the instant it has one (see ensure_vm): that closes the window where
       # a just-primed miss VM is reported primed by the node but invisible to
@@ -809,7 +825,17 @@ defmodule Embervm.Dispatcher do
       watchdog_started_at: System.monotonic_time(:millisecond),
       watchdog_ms: watchdog_ms
     }
-    %{state | workers: Map.put(state.workers, pid, meta)}
+    # The adopted-provenance drop happens HERE, not in reserve_vm, because ctx
+    # above snapshots adoption_vm_ids for the worker's dispatch emission. Drop
+    # any earlier and the snapshot loses the vm and an adopted dispatch records
+    # `warm`, which is #4768 unfixed. Task-lane vms are single-use, so a
+    # dispatched vm never returns to inventory and this keeps the set bounded to
+    # currently-resident adopted vms.
+    %{
+      state
+      | workers: Map.put(state.workers, pid, meta),
+        adoption_vm_ids: MapSet.delete(state.adoption_vm_ids, vm_id)
+    }
   end
 
   # The worker body (runs OFF this GenServer). Fetches the guest request from the
@@ -892,6 +918,34 @@ defmodule Embervm.Dispatcher do
     # below dials the winning brick's channel, not the committed one.
     case acquire_vm(ctx, channel_fun, invalidate_fun, prime_fun) do
       {:ok, vm_id, node_id, channel} ->
+        case ctx.mode do
+          # PROVENANCE BELONGS ON THE WARM BRANCH, and this is the whole point
+          # of the emission (#4768). An ADOPTED vm is reconciled back INTO
+          # inventory after a control-plane restart, so a task that takes it
+          # takes it from inventory: that is a warm hit, never a miss. A miss
+          # Primes a fresh vm, which by definition was not adopted.
+          #
+          # Getting this backwards is not cosmetic: it leaves every adopted vm
+          # recorded as an ordinary warm hit, a checker still cannot tell it
+          # from a primed one, and the ~50% post-restart false-violation rate
+          # #4768 measured stays exactly where it was.
+          :warm ->
+            Embervm.SpecTrace.emit(:adoption, :dispatch_warm, %{
+              "task_id" => ctx.task_id,
+              "vm_id" => vm_id,
+              "node_id" => node_id,
+              "provenance" =>
+                if(MapSet.member?(ctx.adoption_vm_ids, vm_id), do: :adopted, else: :warm)
+            })
+
+          :miss ->
+            Embervm.SpecTrace.emit(:adoption, :dispatch_miss, %{
+              "task_id" => ctx.task_id,
+              "vm_id" => vm_id,
+              "node_id" => node_id,
+              "provenance" => :miss
+            })
+        end
         guest_req = build_guest_request(req_env, ctx.invoke_path)
 
         assign_req = %AssignRequest{
@@ -1261,17 +1315,34 @@ defmodule Embervm.Dispatcher do
   defp adopt_inventory(state) do
     facts = NodeCapacity.all(state.capacity_table)
 
-    Enum.reduce(facts, state, fn f, acc ->
+    {state, adopted} = Enum.reduce(facts, {state, %{}}, fn f, {acc, adopted} ->
       # Key the adopted inventory by the INSTANCE id ("node/pod_uid"), the same key
       # pick_node dispatches against, so an adopted warm pool is reachable (R0 PR-2).
       node_id = instance_id_of(f)
 
-      Enum.reduce(f.workloads || %{}, acc, fn {wl, wc}, acc2 ->
-        Enum.reduce(Map.get(wc, :primed_vm_ids, []) || [], acc2, fn vm_id, acc3 ->
-          put_vm_if_unknown(acc3, node_id, wl, vm_id)
+      Enum.reduce(f.workloads || %{}, {acc, adopted}, fn {wl, wc}, {acc2, adopted2} ->
+        Enum.reduce(Map.get(wc, :primed_vm_ids, []) || [], {acc2, adopted2}, fn vm_id, {acc3, adopted3} ->
+          if MapSet.member?(known_vm_ids(acc3), vm_id) do
+            {acc3, adopted3}
+          else
+            acc4 = put_vm_if_unknown(acc3, node_id, wl, vm_id)
+            {
+              %{acc4 | adoption_vm_ids: MapSet.put(acc4.adoption_vm_ids, vm_id)},
+              Map.update(adopted3, node_id, [vm_id], &[vm_id | &1])
+            }
+          end
         end)
       end)
     end)
+
+    for {node_id, vm_ids} <- adopted do
+      Embervm.SpecTrace.emit(:adoption, :adopt_inventory, %{
+        "node_id" => node_id,
+        "adopted" => Enum.sort(vm_ids)
+      })
+    end
+
+    state
   end
 
   # Enqueue a primed vm_id into the {node,wl} inventory unless we already hold it

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -366,7 +366,17 @@ defmodule Embervm.NodeRegistry do
   @impl true
   def handle_info({:node_status, pid, status}, state) do
     case Map.get(state.streamers, pid) do
-      nil -> {:noreply, state}
+      nil ->
+        Embervm.SpecTrace.emit(:adoption, :recv_status, %{
+          "gen" => nil,
+          "accepted" => false,
+          "rejected" => true,
+          "reason" => :stale_stream,
+          "msg_primed" => primed_vm_ids(status),
+          "health" => nil
+        })
+
+        {:noreply, state}
       node_id -> {:noreply, apply_status(state, node_id, status)}
     end
   end
@@ -545,8 +555,18 @@ defmodule Embervm.NodeRegistry do
     prev = state.node_runtime[instance_id]
     rt = %{prev | last_status_at: now, health: :healthy, draining: status.draining}
     state = put_in(state.node_runtime[instance_id], rt)
+    Embervm.SpecTrace.emit(:adoption, :recv_status, %{
+      "gen" => rt.gen,
+      "accepted" => true,
+      "msg_primed" => primed_vm_ids(status),
+      "health" => rt.health
+    })
     notify_drain_edge(state, rt, prev, status)
     refresh_capacity(state, instance_id, status)
+  end
+
+  defp primed_vm_ids(%NodeStatus{workloads: workloads}) do
+    for %WorkloadCapacity{primed_vm_ids: vm_ids} <- workloads, vm_id <- vm_ids, do: vm_id
   end
 
   # On the RISING edge of draining (false -> true) notify the drain listener exactly
@@ -1068,6 +1088,24 @@ defmodule Embervm.NodeRegistry do
   end
 
   defp apply_health_transition(state, node_id, old_health, new_health) do
+    rt = state.node_runtime[node_id]
+
+    case new_health do
+      :unknown ->
+        Embervm.SpecTrace.emit(:adoption, :age_to_unknown, %{
+          "node_id" => node_id,
+          "last_gen" => rt.gen,
+          "health" => new_health
+        })
+
+      :down ->
+        Embervm.SpecTrace.emit(:adoption, :age_to_down, %{
+          "node_id" => node_id,
+          "last_gen" => rt.gen,
+          "health" => new_health
+        })
+    end
+
     state = put_in(state, [:node_runtime, node_id, :health], new_health)
     state = retract_capacity(state, node_id)
 
@@ -1127,6 +1165,8 @@ defmodule Embervm.NodeRegistry do
   # result even if the watch raises.
   defp start_streamer(state, node_id) do
     rt = state.node_runtime[node_id]
+    gen = Map.get(rt, :gen, 0) + 1
+    Embervm.SpecTrace.emit(:adoption, :reconnect, %{"node_id" => node_id, "gen" => gen})
     owner = self()
     address = rt.address
     configured_id = rt.configured_id
@@ -1173,7 +1213,7 @@ defmodule Embervm.NodeRegistry do
         send(owner, {:watch_result, streamer, result})
       end)
 
-    rt = %{rt | streamer: {pid, ref}, watch_started_at: state.clock.()}
+    rt = %{rt | streamer: {pid, ref}, watch_started_at: state.clock.(), gen: gen}
 
     state
     |> put_in([:node_runtime, node_id], rt)
@@ -1409,7 +1449,8 @@ defmodule Embervm.NodeRegistry do
       # two-signal expiry (the other is a dead stream).
       last_registered_at: nil,
       health: :starting,
-      draining: false
+      draining: false,
+      gen: 0
     }
   end
 

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -1166,4 +1166,87 @@ defmodule Embervm.DispatcherTest do
       end
     end
   end
+
+  # THE REGRESSION TEST FOR #4768's PROVENANCE FIX.
+  #
+  # An adopted vm is reconciled back INTO inventory after a control-plane
+  # restart, so a task that takes it takes it from inventory: a WARM hit. The
+  # trace must record provenance :adopted rather than :warm, because a checker
+  # asserting "assigned implies previously primed" otherwise reports a false
+  # violation for every adopted vm (measured at 2 of 4 assignments in the ten
+  # minutes after a real restart).
+  #
+  # The dispatch happens in a LATER sweep than the adoption on purpose. An
+  # earlier revision cleared the adoption set at the top of every sweep, which
+  # left provenance correct only for a dispatch in the same sweep that adopted
+  # the vm, i.e. almost never. Asserting across sweeps is what pins that.
+  test "an adopted vm dispatched in a LATER sweep records provenance :adopted" do
+    System.put_env("EMBERVM_SPEC_TRACE", "on")
+    Embervm.SpecTrace.configure()
+    trace_path = Path.join(System.tmp_dir!(), "spec_trace_prov_#{System.unique_integer([:positive])}.db")
+
+    on_exit(fn ->
+      System.put_env("EMBERVM_SPEC_TRACE", "off")
+      Embervm.SpecTrace.configure()
+      File.rm_rf!(trace_path)
+    end)
+
+    store = start_supervised!({Embervm.SpecTrace.Store.SQLite, name: nil, path: trace_path})
+    writer = start_supervised!({Embervm.SpecTrace.Writer, store_mod: Embervm.SpecTrace.Store.SQLite, store: store, batch_size: 1, flush_ms: 5})
+
+    ctx = start_stack()
+    put_catalog(ctx, "wl-a", cap: 10)
+
+    # Sweep 1 adopts the node-reported vm with no task waiting, so nothing
+    # consumes it and it stays resident in inventory.
+    put_facts(ctx, "wl-a", free: 1, primed_ids: ["vm-adopted-1"], live: 8, max: 8)
+    Dispatcher.sweep(ctx.name)
+
+    # Sweep 2 (a separate sweep) is where the dispatch happens.
+    tid = submit(ctx, "wl-a", "p1")
+    Dispatcher.sweep(ctx.name)
+    assert eventually(fn -> state_of(ctx, tid) == :succeeded end)
+
+    :ok = Embervm.SpecTrace.drain(writer)
+    {:ok, records} = Embervm.SpecTrace.Store.SQLite.read_window(store, action: "dispatch_warm")
+
+    record = Enum.find(records, &(&1["vars"]["vm_id"] == "vm-adopted-1"))
+    assert record, "no dispatch_warm record for the adopted vm: #{inspect(records)}"
+    assert record["vars"]["provenance"] == "adopted"
+    assert record["vars"]["task_id"] == tid
+  end
+
+  # The negative half: adoption that adopts NOTHING must emit no record.
+  # adopt_inventory is additive and idempotent and runs every sweep, so emitting
+  # per sweep would flood the trace with no-ops and make a genuine adoption
+  # indistinguishable from background noise.
+  test "a sweep that adopts nothing emits no adopt_inventory record" do
+    System.put_env("EMBERVM_SPEC_TRACE", "on")
+    Embervm.SpecTrace.configure()
+    trace_path = Path.join(System.tmp_dir!(), "spec_trace_noadopt_#{System.unique_integer([:positive])}.db")
+
+    on_exit(fn ->
+      System.put_env("EMBERVM_SPEC_TRACE", "off")
+      Embervm.SpecTrace.configure()
+      File.rm_rf!(trace_path)
+    end)
+
+    store = start_supervised!({Embervm.SpecTrace.Store.SQLite, name: nil, path: trace_path})
+    writer = start_supervised!({Embervm.SpecTrace.Writer, store_mod: Embervm.SpecTrace.Store.SQLite, store: store, batch_size: 1, flush_ms: 5})
+
+    ctx = start_stack()
+    put_catalog(ctx, "wl-a", cap: 10)
+    put_facts(ctx, "wl-a", free: 1, primed_ids: ["vm-1"], live: 8, max: 8)
+
+    # First sweep adopts vm-1. The second and third adopt nothing new.
+    Dispatcher.sweep(ctx.name)
+    Dispatcher.sweep(ctx.name)
+    Dispatcher.sweep(ctx.name)
+
+    :ok = Embervm.SpecTrace.drain(writer)
+    {:ok, records} = Embervm.SpecTrace.Store.SQLite.read_window(store, action: "adopt_inventory")
+
+    assert length(records) == 1,
+           "adopt_inventory must emit once for one genuine adoption, got #{length(records)}"
+  end
 end

--- a/projects/embervm/control/test/embervm/spec_trace_sites_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_sites_test.exs
@@ -59,4 +59,5 @@ defmodule Embervm.SpecTraceSitesTest do
                "passes through)."
     end
   end
+
 end

--- a/projects/embervm/specs/vocabulary.exs
+++ b/projects/embervm/specs/vocabulary.exs
@@ -211,6 +211,14 @@
     # is the control plane failing to adopt, and absence is invisible in an
     # event stream, so this periodic state observation is what makes
     # non-progress detectable at all.
-    checkpoint: "dispatcher.ex"
+    checkpoint: "dispatcher.ex",
+    recv_status: "node_registry.ex",
+    adopt_inventory: "dispatcher.ex",
+    dispatch_warm: "dispatcher.ex",
+    dispatch_miss: "dispatcher.ex",
+    age_to_unknown: "node_registry.ex",
+    age_to_down: "node_registry.ex",
+    reconnect: "node_registry.ex",
+    restart_cp: "dispatcher.ex"
   }
 }


### PR DESCRIPTION
Completes SpecTrace's coverage of `adoption.tla`. Part of #4770, and it delivers
the fix for #4768.

## Emissions

`RecvStatus`, `AdoptInventory`, `DispatchWarm`, `DispatchMiss`, `AgeToUnknown`,
`AgeToDown`, `Reconnect`, `RestartCP` — joining the existing `Prime` and
`Checkpoint`. All registered in `spec_trace_sites`, all emitted with a **literal**
action atom so each stays statically locatable. A dynamically dispatched action
would satisfy any runtime test while defeating the registry that makes the
spec-to-code direction auditable.

Derived from the spec's prose map **top-down**, not from convenient code sites.
That direction is the point: bottom-up instrumentation is what put `:primed` on a
path production never takes (#4765).

## Provenance took four fixes, each of which looks correct alone

`provenance` is the whole reason `DispatchWarm` exists. #4768 measured 2 of 4
assignments in the ten minutes after a restart referencing VMs with no `:primed`
record, none of them violations.

| # | defect | why it reads as correct |
| --- | --- | --- |
| 1 | the adopted check sat on the **miss** branch | an adopted vm is reconciled INTO inventory, so it dispatches **warm**; on the miss branch the condition can never fire |
| 2 | `adoption_vm_ids` cleared at the **top** of `run_sweep` | before the `reduce_backlog` pass that dispatches, so those reads saw an empty set |
| 3 | the set was **per-sweep** | a vm adopted earlier was forgotten, which is exactly the population #4768 measured |
| 4 | removal ran in `reserve_vm` | which executes **before** `spawn_assign_worker` snapshots the set into the ctx the emission reads |

Each alone yields a field that is sometimes wrong. Together they yield one that is
never right, while the diff reads as a careful implementation complete with a
`MapSet` membership test doing nothing.

Provenance is now a **durable property of how a vm entered inventory**: added on
genuine adoption, removed in `spawn_assign_worker` once the ctx snapshot is taken.
Single-use task vms never return, so the set stays bounded to resident adopted vms.

`RestartCP` carries `SpecTrace.run_id/0` rather than a fresh unique integer, since
that record marks the boundary between incarnations and is only useful if it
matches the run_id on every other record.

## Tests: eleven removed, two written

The generated tests called `SpecTrace.emit` directly with the values they wanted
and asserted `emit` returned `:ok`, which it does unconditionally, even when
disabled:

```elixir
test "dispatch_warm with adopted provenance (vm was adopted in an earlier sweep)" do
  result = SpecTrace.emit(:adoption, :dispatch_warm, %{"provenance" => :adopted})
  assert result == :ok
end
```

Accurate name, empty body. That suite would have passed with every emission
deleted from the codebase, while reporting eleven green tests covering all eight
actions.

The replacements drive the **real dispatcher** through the existing adoption
harness:

- an adopted vm dispatched in a **later sweep** records `provenance: "adopted"`
- a sweep that adopts nothing emits **no** `adopt_inventory` record

Those two assertions are chosen because a circular test cannot fake them: you
cannot get "adopted in sweep 1, dispatched in sweep 2, still adopted" without the
durable-provenance code actually working. Defect 4 above was caught by that test
within minutes of it existing, having survived my own review of the diff.

Honest gap: the other six emissions have registry coverage but not runtime value
assertions yet. They are pass-through emissions with no branching logic, which is
why I prioritised the one with four bugs in it.

## Verification

- `ci test`: **1222 tests, 0 failures, 6 skipped**, run independently.
- `ci lint` clean. No em-dashes. No `Chart.yaml` or `targetRevision` edit.
- Nothing added to the op-log `@kinds` enum: provenance belongs in the trace, not
  the durable log, which is the reason SpecTrace exists.

Refs #4770, #4768, #4759.