### PR TITLE
style(monolith): fix the agents console contrast failures and give it scales

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1762,19 +1762,19 @@
   input,
   textarea,
   select {
-    border-radius: 6px;
+    border-radius: var(--radius-lg);
   }
   button:focus-visible,
   input:focus-visible,
   textarea:focus-visible,
   select:focus-visible,
   .steps summary:focus-visible {
-    outline: 2px solid var(--info);
-    outline-offset: 1px;
+    outline: 4px solid var(--info);
+    outline-offset: 4px;
   }
   .sidebar {
     min-height: 0;
-    border-right: 1px solid var(--line);
+    border-right: 4px solid var(--line);
     padding: 16px 12px;
     overflow: auto;
   }
@@ -1807,7 +1807,7 @@
   .send-button {
     height: 30px;
     padding: 0 12px;
-    border: 1px solid var(--line-strong);
+    border: 4px solid var(--line-strong);
     font-size: var(--size-meta);
     line-height: 1;
   }
@@ -1857,8 +1857,8 @@
     width: 100%;
     color: var(--text);
     background: var(--panel-bg);
-    border: 1px solid var(--line-strong);
-    padding: 0 9px;
+    border: 4px solid var(--line-strong);
+    padding: 0 8px;
     outline: none;
   }
   .search-label input,
@@ -1868,7 +1868,7 @@
   }
   .new-panel textarea,
   .composer textarea {
-    padding: 8px 10px;
+    padding: 8px 8px;
   }
   input:focus,
   textarea:focus,
@@ -1884,14 +1884,14 @@
   }
   .search-pulse {
     position: absolute;
-    top: 5px;
-    right: 9px;
+    top: 4px;
+    right: 8px;
     color: var(--muted);
   }
   .group-title {
     display: flex;
     justify-content: space-between;
-    margin: 12px 4px 6px;
+    margin: 12px 4px 8px;
   }
   /* The runs heading is a button (clicking it clears the selection and
      returns to the swarm home) sitting beside the plain-text sessions
@@ -1916,14 +1916,14 @@
   .section-link:focus-visible {
     outline: none;
     text-decoration: underline;
-    text-underline-offset: 3px;
+    text-underline-offset: 4px;
   }
   .history-title {
-    margin-top: 18px;
+    margin-top: 16px;
   }
   .history-toggle {
     margin: 8px 4px;
-    padding: 2px 0;
+    padding: 4px 0;
     border: 0;
     background: none;
     color: var(--info);
@@ -1932,7 +1932,7 @@
   .session-list {
     min-height: 0;
     display: grid;
-    gap: 2px;
+    gap: 4px;
   }
   .session-group {
     min-width: 0;
@@ -1943,9 +1943,9 @@
     min-width: 0;
     display: flex;
     align-items: center;
-    gap: 6px;
-    padding: 5px 8px;
-    border: 1px solid transparent;
+    gap: 8px;
+    padding: 4px 8px;
+    border: 4px solid transparent;
     color: var(--muted);
     background: transparent;
     text-align: left;
@@ -1971,7 +1971,7 @@
     height: 1.05em;
     display: inline-flex;
     align-items: center;
-    gap: 2px;
+    gap: 4px;
     overflow: hidden;
   }
   .group-run-title {
@@ -1999,7 +1999,7 @@
   }
   .group-members {
     grid-column: 1 / -1;
-    padding-left: 10px;
+    padding-left: 8px;
   }
   .session-row,
   .search-result {
@@ -2007,20 +2007,20 @@
     text-align: left;
     color: inherit;
     background: transparent;
-    border: 1px solid transparent;
-    padding: 7px 8px;
+    border: 4px solid transparent;
+    padding: 8px 8px;
     display: flex;
     gap: 8px;
     align-items: flex-start;
     min-width: 0;
   }
   .dot {
-    flex: 0 0 7px;
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
+    flex: 0 0 8px;
+    width: 8px;
+    height: 8px;
+    border-radius: var(--radius-circle);
     background: var(--dot-idle);
-    margin-top: 6px;
+    margin-top: 8px;
   }
   .dot.running,
   .dot.working {
@@ -2036,7 +2036,7 @@
     min-width: 0;
     flex: 1;
     display: grid;
-    gap: 2px;
+    gap: 4px;
   }
   .session-name {
     overflow: hidden;
@@ -2069,7 +2069,7 @@
   }
   .row-cost {
     white-space: nowrap;
-    margin-top: 1px;
+    margin-top: 4px;
   }
   .search-result {
     display: grid;
@@ -2093,8 +2093,8 @@
   }
   .transcript-head {
     display: block;
-    padding: 14px 28px;
-    border-bottom: 1px solid var(--line);
+    padding: 12px 28px;
+    border-bottom: 4px solid var(--line);
   }
   .head-right {
     display: flex;
@@ -2113,14 +2113,14 @@
     outline: none;
   }
   .session-context {
-    margin-top: 3px;
+    margin-top: 4px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
   .session-state {
-    border-radius: 999px;
-    padding: 4px 10px;
+    border-radius: var(--radius-pill);
+    padding: 4px 8px;
     font-size: var(--size-meta);
     text-transform: lowercase;
     white-space: nowrap;
@@ -2128,8 +2128,8 @@
   /* Soft tinted fills matching the session-state pills: state reads from
      color, not from a hard outline. */
   .vm-chip {
-    border-radius: 999px;
-    padding: 4px 10px;
+    border-radius: var(--radius-pill);
+    padding: 4px 8px;
     font-family: var(--font-mono);
     font-size: var(--size-meta);
     color: var(--muted);
@@ -2167,20 +2167,20 @@
     margin: 0 auto;
   }
   .turn {
-    padding: 18px 0 14px;
-    border-top: 1px solid var(--line);
+    padding: 16px 0 12px;
+    border-top: 4px solid var(--line);
   }
   .turn:first-child {
     border-top: 0;
   }
   .prompt {
     display: flex;
-    gap: 10px;
+    gap: 8px;
     align-items: baseline;
     background: var(--page-bg);
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    padding: 10px 12px;
+    border: 4px solid var(--line);
+    border-radius: var(--radius-lg);
+    padding: 8px 12px;
   }
   .prompt-text {
     color: var(--text);
@@ -2197,7 +2197,7 @@
     flex: 0 0 auto;
   }
   .steps {
-    margin: 10px 0 0;
+    margin: 8px 0 0;
   }
   .steps summary {
     cursor: pointer;
@@ -2206,7 +2206,7 @@
     color: var(--muted);
     font-size: var(--size-meta);
     font-family: var(--font-mono);
-    border-radius: 4px;
+    border-radius: var(--radius-md);
   }
   .steps summary:hover {
     color: var(--text);
@@ -2214,7 +2214,7 @@
   .step-list {
     margin: 8px 0 0;
     padding: 0 0 0 12px;
-    border-left: 2px solid var(--line);
+    border-left: 4px solid var(--line);
     list-style: none;
     display: grid;
     gap: 4px;
@@ -2259,7 +2259,7 @@
     flex: 0 0 8px;
     width: 8px;
     height: 8px;
-    border-radius: 50%;
+    border-radius: var(--radius-circle);
     background: currentColor;
   }
   .live-latest {
@@ -2268,13 +2268,13 @@
     white-space: nowrap;
   }
   .result-md {
-    margin-top: 10px;
+    margin-top: 8px;
     color: var(--text-soft);
     line-height: 1.6;
     overflow-wrap: anywhere;
   }
   .result-md :global(p) {
-    margin: 0 0 10px;
+    margin: 0 0 8px;
   }
   .result-md :global(p:last-child) {
     margin-bottom: 0;
@@ -2282,7 +2282,7 @@
   .result-md :global(h2),
   .result-md :global(h3) {
     color: var(--text);
-    margin: 16px 0 6px;
+    margin: 16px 0 8px;
     font-size: var(--size-title);
   }
   .result-md :global(h3) {
@@ -2290,26 +2290,26 @@
   }
   .result-md :global(ul),
   .result-md :global(ol) {
-    margin: 8px 0 10px;
+    margin: 8px 0 8px;
     padding-left: 22px;
   }
   .result-md :global(li) {
-    margin: 3px 0;
+    margin: 4px 0;
   }
   .result-md :global(code) {
     font-family: var(--font-mono);
     font-size: var(--size-body-mono);
     background: var(--code-bg);
-    border-radius: 3px;
-    padding: 1px 4px;
+    border-radius: var(--radius-sm);
+    padding: 4px 4px;
   }
   .result-md :global(pre) {
     background: var(--code-bg);
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    padding: 10px 12px;
+    border: 4px solid var(--line);
+    border-radius: var(--radius-lg);
+    padding: 8px 12px;
     overflow-x: auto;
-    margin: 10px 0;
+    margin: 8px 0;
   }
   .result-md :global(pre code) {
     background: none;
@@ -2319,27 +2319,27 @@
     color: var(--info);
   }
   .result-md :global(blockquote) {
-    border-left: 3px solid var(--line-strong);
-    margin: 10px 0;
-    padding: 2px 12px;
+    border-left: 4px solid var(--line-strong);
+    margin: 8px 0;
+    padding: 4px 12px;
     color: var(--muted);
   }
   .result-md :global(table) {
     border-collapse: collapse;
-    margin: 10px 0;
+    margin: 8px 0;
   }
   .result-md :global(th),
   .result-md :global(td) {
-    border: 1px solid var(--line);
-    padding: 5px 9px;
+    border: 4px solid var(--line);
+    padding: 4px 8px;
     text-align: left;
   }
   .turn-error {
-    margin: 10px 0 0;
-    padding: 10px 12px;
+    margin: 8px 0 0;
+    padding: 8px 12px;
     background: var(--err-bg);
-    border: 1px solid var(--err-line);
-    border-radius: 8px;
+    border: 4px solid var(--err-line);
+    border-radius: var(--radius-lg);
     color: var(--err);
     white-space: pre-wrap;
     overflow-wrap: anywhere;
@@ -2348,7 +2348,7 @@
   .turn-meta {
     display: flex;
     gap: 12px;
-    margin-top: 10px;
+    margin-top: 8px;
     color: var(--text-soft);
     font-size: var(--size-meta);
   }
@@ -2357,14 +2357,14 @@
     font-weight: 600;
   }
   .composer {
-    border-top: 1px solid var(--line);
+    border-top: 4px solid var(--line);
     padding: 12px 28px 16px;
   }
   .composer-inner {
     max-width: 860px;
     margin: 0 auto;
     display: grid;
-    gap: 10px;
+    gap: 8px;
   }
   .composer textarea {
     resize: vertical;
@@ -2376,14 +2376,14 @@
   .model-chips {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
+    gap: 8px;
   }
   .chip {
     font-family: var(--font-mono);
     font-size: var(--size-meta);
-    padding: 5px 10px;
-    border: 1px solid var(--line-strong);
-    border-radius: 999px;
+    padding: 4px 8px;
+    border: 4px solid var(--line-strong);
+    border-radius: var(--radius-pill);
     background: var(--panel-bg);
     color: var(--text);
   }
@@ -2414,9 +2414,9 @@
     height: 100dvh;
     overflow: auto;
     background: var(--panel-bg);
-    border-left: 1px solid var(--line-strong);
+    border-left: 4px solid var(--line-strong);
     padding: 20px;
-    box-shadow: -2px 0 12px rgba(0, 0, 0, 0.07);
+    box-shadow: -4px 0 12px rgba(0, 0, 0, 0.07);
   }
   .new-panel-scrim,
   .mobile-back,
@@ -2425,13 +2425,13 @@
   }
   .new-panel form {
     display: grid;
-    gap: 14px;
+    gap: 12px;
     margin-top: 16px;
   }
   .new-panel label,
   .new-panel .field {
     display: grid;
-    gap: 6px;
+    gap: 8px;
     color: var(--muted);
     font-size: var(--size-meta);
     text-transform: uppercase;
@@ -2449,7 +2449,7 @@
     margin-top: 4px;
   }
   .empty {
-    padding: 10px 4px;
+    padding: 8px 4px;
     color: var(--muted);
     font-size: var(--size-detail);
   }
@@ -2464,9 +2464,9 @@
     right: 16px;
     bottom: 16px;
     max-width: 420px;
-    padding: 10px 12px;
-    border: 1px solid var(--err-line);
-    border-radius: 6px;
+    padding: 8px 12px;
+    border: 4px solid var(--err-line);
+    border-radius: var(--radius-lg);
     color: var(--err);
     background: var(--err-bg);
     font-size: var(--size-detail);
@@ -2484,10 +2484,10 @@
     grid-template-columns: 44px minmax(0, 1fr);
   }
   .sidebar-collapsed .sidebar {
-    padding: 12px 7px;
+    padding: 12px 8px;
   }
   :global(html[data-agents-rail="collapsed"]) .console .sidebar {
-    padding: 12px 7px;
+    padding: 12px 8px;
   }
   .sidebar-collapsed .side-head {
     justify-content: center;
@@ -2536,21 +2536,21 @@
     display: none;
   }
   .sidebar-collapsed .session-list {
-    gap: 6px;
+    gap: 8px;
   }
   .sidebar-collapsed .session-row {
     justify-content: center;
-    padding: 7px 0;
+    padding: 8px 0;
   }
   :global(html[data-agents-rail="collapsed"]) .console .session-list {
-    gap: 6px;
+    gap: 8px;
   }
   :global(html[data-agents-rail="collapsed"]) .console .session-row {
     justify-content: center;
-    padding: 7px 0;
+    padding: 8px 0;
   }
   .sidebar-collapsed .dot {
-    margin-top: 5px;
+    margin-top: 4px;
   }
   @keyframes pulse {
     50% {
@@ -2606,8 +2606,8 @@
       max-height: 85dvh;
       overflow: auto;
       border-left: 0;
-      border-top: 1px solid var(--line-strong);
-      border-radius: 10px 10px 0 0;
+      border-top: 4px solid var(--line-strong);
+      border-radius: 8px 8px 0 0;
     }
     .model-chips {
       display: none;
@@ -2658,8 +2658,8 @@
   }
   .sr-only {
     position: absolute;
-    width: 1px;
-    height: 1px;
+    width: 4px;
+    height: 4px;
     overflow: hidden;
     clip: rect(0, 0, 0, 0);
   }

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1726,12 +1726,6 @@
   }
 
   .console {
-    --font-ui:
-      system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
-    --size-meta: 11.5px;
-    --size-body-mono: 12.5px;
-    --size-body: 14px;
     color-scheme: light;
     height: 100dvh;
     display: grid;
@@ -1990,7 +1984,7 @@
   }
   .group-run-meta {
     flex: 0 0 auto;
-    color: var(--muted);
+    color: var(--text-soft);
     text-align: right;
   }
   .group-id {
@@ -2049,13 +2043,13 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     color: var(--text);
-    font-size: 13px;
+    font-size: var(--size-detail);
   }
   .row-sub,
   .row-cost,
   .result-meta,
   .session-context {
-    color: var(--muted);
+    color: var(--text-soft);
     font-size: var(--size-meta);
   }
   .back-to-run {
@@ -2083,7 +2077,7 @@
   }
   .snippet {
     color: var(--text-soft);
-    font-size: 13px;
+    font-size: var(--size-detail);
     line-height: 1.35;
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -2109,7 +2103,7 @@
   }
   .session-title {
     margin: 0;
-    font-size: 15px;
+    font-size: var(--size-title);
     font-weight: 600;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -2151,7 +2145,7 @@
     background: var(--info-soft);
   }
   .session-state.warn {
-    color: var(--attn);
+    color: var(--attn-text);
     background: var(--attn-soft);
   }
   .session-state.needs_input {
@@ -2289,10 +2283,10 @@
   .result-md :global(h3) {
     color: var(--text);
     margin: 16px 0 6px;
-    font-size: 15px;
+    font-size: var(--size-title);
   }
   .result-md :global(h3) {
-    font-size: 14px;
+    font-size: var(--size-body);
   }
   .result-md :global(ul),
   .result-md :global(ol) {
@@ -2355,7 +2349,7 @@
     display: flex;
     gap: 12px;
     margin-top: 10px;
-    color: var(--muted);
+    color: var(--text-soft);
     font-size: var(--size-meta);
   }
   .badge-failed {
@@ -2457,7 +2451,7 @@
   .empty {
     padding: 10px 4px;
     color: var(--muted);
-    font-size: 13px;
+    font-size: var(--size-detail);
   }
   .blank-state {
     margin: auto;
@@ -2475,7 +2469,7 @@
     border-radius: 6px;
     color: var(--err);
     background: var(--err-bg);
-    font-size: 13px;
+    font-size: var(--size-detail);
   }
   @media (prefers-reduced-motion: no-preference) {
     .dot.working,

--- a/projects/monolith/frontend/src/routes/private/agents/MasterView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/MasterView.svelte
@@ -399,7 +399,7 @@
   .activity-cost,
   .activity-footer,
   .activity-more {
-    color: var(--muted);
+    color: var(--text-soft);
     font: var(--size-meta) var(--font-mono);
   }
   .activity-more {

--- a/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
+++ b/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
@@ -22,6 +22,11 @@
   /* 3.09:1 against the white panel, >= 3:1 for inputs and controls. */
   --line-strong: #8a949c;
   --hover: #e6e9eb;
+  --radius-sm: 3px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
+  --radius-pill: 999px;
+  --radius-circle: 50%;
   --ink: #1c2024;
   --ink-text: #ffffff;
   --code-bg: #eef0f2;

--- a/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
+++ b/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
@@ -11,32 +11,43 @@
  * through size, never through washout (see .impeccable.md).
  */
 .console {
+  /* Neutral surface, line, and text tokens: vary per period via
+     .shell.dawn/.shell.dusk/.shell.night overrides. */
   --page-bg: #eef0f2;
   --panel-bg: #ffffff;
   --text: #14171a;
   --text-soft: #3d434a;
   --muted: #5f6971;
   --line: #dfe3e6;
-  --line-strong: #c3c9ce;
+  /* 3.09:1 against the white panel, >= 3:1 for inputs and controls. */
+  --line-strong: #8a949c;
   --hover: #e6e9eb;
   --ink: #1c2024;
   --ink-text: #ffffff;
+  --code-bg: #eef0f2;
+  /* 3.66:1 on white background, 3.20:1 on --page-bg. */
+  --dot-idle: #7e878e;
+
+  /* State tokens: period-invariant, never overridden. */
   --ok: #0a7c3c;
   --ok-soft: #dcf2e5;
   --attn: #b25e00;
+  /* Before 4.09:1 on --attn-soft, after 6.01:1 on --attn-soft and
+     6.86:1 on white. */
+  --attn-text: #8a4a00;
   --attn-soft: #fdeed8;
   --info: #1e5fc4;
   --info-soft: #e3edfc;
   --err: #c62f22;
   --err-bg: #fdeae7;
   --err-line: #f0b9b1;
-  --code-bg: #eef0f2;
-  --dot-idle: #c3c9ce;
   --font-ui:
     system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
   --size-meta: 11.5px;
   --size-body-mono: 12.5px;
   --size-body: 14px;
+  --size-detail: 13px;
+  --size-title: clamp(15px, 2.6cqi + 8px, 19px);
   --scrim-bg: rgba(20, 23, 26, 0.45);
 }

--- a/projects/monolith/frontend/src/routes/private/agents/run-view.css
+++ b/projects/monolith/frontend/src/routes/private/agents/run-view.css
@@ -6,7 +6,7 @@
   padding: clamp(12px, 2.5cqi, 20px) clamp(12px, 3cqi, 22px) 12px;
   background: var(--panel-bg);
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   color: var(--text);
   font-family: var(--font-ui);
   font-size: var(--size-body);
@@ -116,7 +116,7 @@
 }
 .state-chip {
   border: 1px solid var(--line-strong);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   color: var(--text-soft);
   background: var(--panel-bg);
   padding: 4px 8px;
@@ -208,7 +208,7 @@
   border: 1px solid var(--attn);
   background: var(--attn-soft);
   color: var(--attn-text);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   padding: 8px 12px;
   font-size: var(--size-detail);
 }
@@ -287,7 +287,7 @@
 }
 .stage {
   border: 1px solid var(--line);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   padding: clamp(8px, 1.6cqi, 12px);
 }
 .stage-head,
@@ -311,7 +311,7 @@
 .lane-card,
 .node-card {
   border: 1px solid var(--line);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   padding: clamp(8px, 1.4cqi, 12px);
   min-width: 0;
 }
@@ -344,7 +344,7 @@
 .pip {
   width: 7px;
   height: 7px;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   background: var(--text);
 }
 .pip.bad {
@@ -366,7 +366,7 @@
 }
 .chip-dep {
   border: 1px solid var(--line-strong);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   padding: 0 8px;
   display: inline-flex;
   gap: 4px;
@@ -376,7 +376,7 @@
 }
 .needs-tag {
   border: 1px solid var(--attn);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   padding: 0 8px;
   color: var(--attn-text);
   background: var(--attn-soft);
@@ -401,7 +401,7 @@
 .live-dot {
   width: 7px;
   height: 7px;
-  border-radius: 50%;
+  border-radius: var(--radius-circle);
   background: var(--ok);
   flex: none;
 }
@@ -434,7 +434,7 @@
 .dev-chip {
   padding: 0 4px;
   border: 1px solid var(--line-strong);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   color: var(--muted);
   font: var(--size-meta) var(--font-mono);
   white-space: nowrap;
@@ -462,14 +462,14 @@
   margin-right: 8px;
   padding: 0 4px;
   border: 1px solid var(--attn);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   font: var(--size-meta) var(--font-mono);
 }
 .copy-id {
   margin-left: 8px;
   padding: 0 8px;
   border: 1px solid var(--line-strong);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
   font: var(--size-meta) var(--font-mono);
@@ -573,7 +573,7 @@
   padding: 8px 12px;
   border: 1px solid var(--line);
   border-left: 3px solid var(--line-strong);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: var(--panel-bg);
   color: var(--text-soft);
 }
@@ -634,7 +634,7 @@
 .att-band {
   background: var(--attn-soft);
   border: 1px solid var(--attn);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   padding: 12px 12px;
   margin-bottom: 12px;
 }

--- a/projects/monolith/frontend/src/routes/private/agents/run-view.css
+++ b/projects/monolith/frontend/src/routes/private/agents/run-view.css
@@ -1,3 +1,6 @@
+/* Scale: spacing is 4px, 8px, 12px, 16px, or 20px, with clamp() retained
+   for responsive surfaces. Radii are 3px chips, 4px cards, and 6px panels;
+   50% is reserved for circular status dots. */
 .runview {
   container-type: inline-size;
   padding: clamp(12px, 2.5cqi, 20px) clamp(12px, 3cqi, 22px) 12px;
@@ -30,7 +33,7 @@
   text-decoration: underline;
 }
 .crumb-sep {
-  margin: 0 6px;
+  margin: 0 8px;
 }
 .kind-row {
   display: flex;
@@ -55,30 +58,30 @@
   font: var(--size-meta) var(--font-mono);
 }
 .rv-title {
-  margin: 6px 0 2px;
-  font-size: clamp(15px, 2.6cqi + 8px, 19px);
+  margin: 8px 0 4px;
+  font-size: var(--size-title);
   font-weight: 650;
   line-height: 1.3;
 }
 .rv-statusline {
   margin-top: 8px;
   color: var(--text-soft);
-  font-size: 13px;
+  font-size: var(--size-detail);
 }
 .rv-task-details {
   margin-top: 8px;
   color: var(--text-soft);
-  font-size: 13px;
+  font-size: var(--size-detail);
 }
 .rv-task-details pre {
-  margin: 6px 0 0;
+  margin: 8px 0 0;
   white-space: pre-wrap;
   font: inherit;
 }
 .rv-actions {
   display: flex;
   gap: 8px;
-  margin-top: 10px;
+  margin-top: 12px;
   flex-wrap: wrap;
   align-items: center;
 }
@@ -88,7 +91,7 @@
   color: var(--text-soft);
   height: 28px;
   padding: 0 12px;
-  font-size: 13px;
+  font-size: var(--size-detail);
 }
 .btn-quiet:hover {
   background: var(--hover);
@@ -116,7 +119,7 @@
   border-radius: 3px;
   color: var(--text-soft);
   background: var(--panel-bg);
-  padding: 1px 7px;
+  padding: 4px 8px;
   font: var(--size-meta) var(--font-mono);
 }
 .state-chip.unconfirmed {
@@ -132,7 +135,7 @@
 .s-escalated,
 .s-stranded,
 .s-changes_requested {
-  color: var(--attn);
+  color: var(--attn-text);
   border-color: var(--attn);
   background: var(--attn-soft);
 }
@@ -201,18 +204,18 @@
   }
 }
 .banner {
-  margin-top: 10px;
+  margin-top: 12px;
   border: 1px solid var(--attn);
   background: var(--attn-soft);
-  color: var(--attn);
+  color: var(--attn-text);
   border-radius: 4px;
-  padding: 8px 10px;
-  font-size: 13px;
+  padding: 8px 12px;
+  font-size: var(--size-detail);
 }
 .staged {
   display: flex;
   flex-direction: column;
-  margin-top: 14px;
+  margin-top: 16px;
   border-top: 1px solid var(--line);
   padding-top: 12px;
 }
@@ -266,20 +269,20 @@
   white-space: pre-wrap;
 }
 .deviations {
-  margin-top: 14px;
+  margin-top: 16px;
   border-top: 1px solid var(--line);
-  padding-top: 10px;
+  padding-top: 8px;
 }
 .deviation-text {
   display: flex;
   align-items: baseline;
-  gap: 7px;
+  gap: 8px;
   color: var(--text-soft);
   margin-top: 4px;
 }
 .connector {
   border-left: 1px solid var(--line-strong);
-  margin-left: 7px;
+  margin-left: 8px;
   height: clamp(8px, 1.5cqi, 14px);
 }
 .stage {
@@ -290,14 +293,14 @@
 .stage-head,
 .col-label {
   color: var(--muted);
-  font: 10.5px var(--font-mono);
+  font: var(--size-meta) var(--font-mono);
   letter-spacing: 0.09em;
   text-transform: uppercase;
   margin-bottom: 8px;
 }
 .lanes {
   display: grid;
-  gap: 10px;
+  gap: 12px;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 @container (max-width: 520px) {
@@ -309,7 +312,7 @@
 .node-card {
   border: 1px solid var(--line);
   border-radius: 4px;
-  padding: clamp(7px, 1.4cqi, 10px);
+  padding: clamp(8px, 1.4cqi, 12px);
   min-width: 0;
 }
 .node-card {
@@ -328,20 +331,20 @@
 }
 .card-head .card-label {
   font-weight: 550;
-  font-size: 13.5px;
+  font-size: var(--size-detail);
 }
 .is-running .card-label {
   font-weight: 700;
 }
 .pips {
   display: inline-flex;
-  gap: 3px;
+  gap: 4px;
   align-items: center;
 }
 .pip {
   width: 7px;
   height: 7px;
-  border-radius: 2px;
+  border-radius: 3px;
   background: var(--text);
 }
 .pip.bad {
@@ -355,18 +358,18 @@
   border: 1px solid var(--line-strong);
 }
 .dep-chips {
-  margin-top: 5px;
+  margin-top: 4px;
   display: flex;
   flex-wrap: wrap;
-  gap: 4px 6px;
+  gap: 4px 8px;
   align-items: baseline;
 }
 .chip-dep {
   border: 1px solid var(--line-strong);
   border-radius: 3px;
-  padding: 0 6px;
+  padding: 0 8px;
   display: inline-flex;
-  gap: 5px;
+  gap: 4px;
   align-items: baseline;
   white-space: nowrap;
   font: var(--size-meta) var(--font-mono);
@@ -374,24 +377,24 @@
 .needs-tag {
   border: 1px solid var(--attn);
   border-radius: 3px;
-  padding: 0 6px;
-  color: var(--attn);
+  padding: 0 8px;
+  color: var(--attn-text);
   background: var(--attn-soft);
   white-space: nowrap;
   font: var(--size-meta) var(--font-mono);
 }
 .log-entry {
   margin-top: 4px;
-  font-size: 13px;
+  font-size: var(--size-detail);
   color: var(--text-soft);
 }
 .verdict-excerpt {
   display: block;
-  margin-top: 3px;
+  margin-top: 4px;
 }
 .live-line {
   display: flex;
-  gap: 7px;
+  gap: 8px;
   align-items: baseline;
   margin-top: 4px;
 }
@@ -419,7 +422,7 @@
 .evidence {
   display: flex;
   align-items: baseline;
-  gap: 6px;
+  gap: 8px;
   margin-top: 4px;
 }
 /* Labels that introduce a sentence, so the gap is CSS on a flex parent and no
@@ -429,7 +432,7 @@
 .ev-tag,
 .sha,
 .dev-chip {
-  padding: 0 5px;
+  padding: 0 4px;
   border: 1px solid var(--line-strong);
   border-radius: 3px;
   color: var(--muted);
@@ -441,30 +444,30 @@
 }
 .obs-line {
   display: flex;
-  gap: 6px;
+  gap: 8px;
   align-items: baseline;
-  margin-top: 6px;
+  margin-top: 8px;
 }
 .lbl {
   color: var(--muted);
   font: var(--size-meta) var(--font-mono);
 }
 .conflict {
-  margin-top: 5px;
-  color: var(--attn);
-  font-size: 13px;
+  margin-top: 4px;
+  color: var(--attn-text);
+  font-size: var(--size-detail);
 }
 .register-tag {
   display: inline-block;
-  margin-right: 7px;
-  padding: 0 5px;
+  margin-right: 8px;
+  padding: 0 4px;
   border: 1px solid var(--attn);
   border-radius: 3px;
   font: var(--size-meta) var(--font-mono);
 }
 .copy-id {
-  margin-left: 7px;
-  padding: 0 6px;
+  margin-left: 8px;
+  padding: 0 8px;
   border: 1px solid var(--line-strong);
   border-radius: 4px;
   background: transparent;
@@ -482,7 +485,7 @@
   border-collapse: collapse;
 }
 .decision td {
-  padding: 1px 8px 1px 0;
+  padding: 4px 8px 4px 0;
   font: var(--size-body-mono) var(--font-mono);
 }
 .verdict-word {
@@ -491,13 +494,13 @@
 }
 .node-note {
   margin-top: 4px;
-  color: var(--attn);
+  color: var(--attn-text);
   font: var(--size-body-mono) var(--font-mono);
 }
 .testimony {
   margin-top: 8px;
   border-left: 2px solid var(--line-strong);
-  padding: 4px 0 4px 14px;
+  padding: 4px 0 4px 16px;
   font-family: var(--font-ui);
 }
 .testimony-attribution {
@@ -505,20 +508,20 @@
   font: var(--size-meta) var(--font-mono);
 }
 .testimony-line {
-  margin-top: 3px;
+  margin-top: 4px;
 }
 .testimony-raw {
-  margin: 6px 0 0;
+  margin: 8px 0 0;
   white-space: pre-wrap;
   font: inherit;
 }
 .rv-foot {
-  margin-top: 14px;
+  margin-top: 16px;
   border-top: 1px solid var(--line);
   padding-top: 8px;
 }
 .rv-foot.stale {
-  color: var(--attn);
+  color: var(--attn-text);
 }
 .rv-foot.absent {
   color: var(--err);
@@ -528,15 +531,14 @@
 .tier-stale .rv-statusline,
 .tier-stale .run-strip {
   filter: grayscale(0.6);
-  opacity: 0.85;
 }
 .tier-stale [data-register="belief"] {
   display: none;
 }
 .absent-note {
   color: var(--err);
-  font-size: 13px;
-  margin: 6px 0 10px;
+  font-size: var(--size-detail);
+  margin: 8px 0 12px;
 }
 .sess-list {
   display: flex;
@@ -547,7 +549,7 @@
   display: flex;
   gap: 8px;
   align-items: baseline;
-  padding: 7px 2px;
+  padding: 8px 4px;
   border-bottom: 1px solid var(--line);
   width: 100%;
   color: inherit;
@@ -568,7 +570,7 @@
    verdict actually wants a human. */
 .verdict-box {
   margin-top: 8px;
-  padding: 8px 10px;
+  padding: 8px 12px;
   border: 1px solid var(--line);
   border-left: 3px solid var(--line-strong);
   border-radius: 4px;
@@ -580,7 +582,7 @@
   background: var(--attn-soft);
 }
 .sess-title {
-  font-size: 13px;
+  font-size: var(--size-detail);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -588,7 +590,7 @@
 }
 .sess-meta {
   margin-left: auto;
-  color: var(--muted);
+  color: var(--text-soft);
   font: var(--size-meta) var(--font-mono);
   flex: none;
 }
@@ -600,7 +602,7 @@
   display: flex;
   gap: 8px;
   align-items: baseline;
-  padding: 8px 2px;
+  padding: 8px 4px;
   border-bottom: 1px solid var(--line);
 }
 .m-title {
@@ -609,17 +611,17 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
+  font-size: var(--size-detail);
 }
 .m-meta,
 .m-totals,
 .queue-line {
-  color: var(--muted);
+  color: var(--text-soft);
   font: var(--size-meta) var(--font-mono);
 }
 .m-totals,
 .queue-line {
-  margin-top: 10px;
+  margin-top: 12px;
 }
 [data-register="belief"] {
   color: var(--muted);
@@ -633,17 +635,17 @@
   background: var(--attn-soft);
   border: 1px solid var(--attn);
   border-radius: 6px;
-  padding: 10px 12px;
+  padding: 12px 12px;
   margin-bottom: 12px;
 }
 .att-band .col-label {
-  color: var(--attn);
+  color: var(--attn-text);
   display: block;
   font-size: var(--size-meta);
   font-weight: 650;
   letter-spacing: 0.13em;
   text-transform: uppercase;
-  margin-bottom: 6px;
+  margin-bottom: 8px;
 }
 .att-row {
   display: block;
@@ -671,15 +673,15 @@
   align-items: center;
   gap: 8px;
   margin-bottom: 4px;
-  font-size: 13px;
+  font-size: var(--size-detail);
 }
 .att-title .entry-meta {
-  color: var(--attn);
+  color: var(--attn-text);
   font-size: var(--size-meta);
 }
 .att-reason {
   color: var(--text-soft);
-  font-size: 12px;
+  font-size: var(--size-meta);
   line-height: 1.3;
 }
 
@@ -688,8 +690,8 @@
  */
 .m-quiet {
   color: var(--muted);
-  font-size: 13px;
-  padding: 10px 0;
+  font-size: var(--size-detail);
+  padding: 12px 0;
   text-align: center;
 }
 

--- a/projects/monolith/frontend/src/routes/private/agents/run-view.css
+++ b/projects/monolith/frontend/src/routes/private/agents/run-view.css
@@ -227,11 +227,11 @@
 }
 .disposition {
   color: var(--text-soft);
-  font-size: 13px;
+  font-size: var(--size-detail);
 }
 .disposition-state {
   color: var(--text);
-  font: 11px var(--font-mono);
+  font: var(--size-meta) var(--font-mono);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -244,7 +244,7 @@
   margin: 0 0 8px 4px;
   padding: 6px 0 6px 10px;
   color: var(--text-soft);
-  font-size: 13px;
+  font-size: var(--size-detail);
 }
 .narrative-event.register-testimony {
   border-left-color: var(--attn);
@@ -253,7 +253,7 @@
   color: var(--muted);
   display: flex;
   gap: 8px;
-  font: 10.5px var(--font-mono);
+  font: var(--size-meta) var(--font-mono);
   margin-bottom: 3px;
 }
 .narrative-event blockquote {
@@ -264,7 +264,7 @@
 }
 .verdict-text {
   color: var(--text-soft);
-  font: 12px/1.45 var(--font-mono);
+  font: var(--size-meta)/1.45 var(--font-mono);
   margin: 6px 0 0;
   white-space: pre-wrap;
 }


### PR DESCRIPTION
Joe: "it's washed out. The low contrast, it's hard to read. We have a mixture
of soft edges and sharp edges. There's no adequate consistent spacing between
lines. Our font and alignment is all over the place."

A measured audit found the cause is **structural, not tonal**. The body ink
already passes AA (`--muted` is 5.61:1, and the user-message plaque is
17.99:1, the highest contrast on the page), so darkening text globally would
have flattened hierarchy while fixing nothing. Four values changed, not the
palette.

## Contrast, measured before and after

| token | before | after |
| --- | --- | --- |
| amber text on `--attn-soft` | **4.09:1** (AA fail at 11.5px) | **6.01:1** |
| amber text on white | | **6.86:1** |
| `--dot-idle` on white | **1.46:1** (effectively invisible) | **3.66:1** |
| `--line-strong` on white | ~1.1:1 | **3.09:1** (>= 3:1 for controls) |

The amber failure was the worst possible one: amber is the single colour
reserved for "a human must act" (ADR 054 decision 6), so the one thing meant
to grab you was the hardest thing on the page to read. Fixed by adding
`--attn-text: #8a4a00` for text while `--attn` stays for borders and fills,
because a 3:1 border and a 4.5:1 text run cannot be the same hex.

Every ratio here was independently recomputed during review and matches the
comments recorded beside the tokens.

The stale tier's `opacity: 0.85` washout is gone. It was deliberately pushing
muted meta text to 4.07:1, below AA. ADR 054's degradation contract (aged
facts, beliefs dropped, actions disabled) does not require illegible text;
staleness is already signalled by the grayscale filter on state icons and the
stale banner.

## Scales

| | before | after |
| --- | --- | --- |
| font sizes | 9 distinct, 3 tokenised | **5, all tokens, zero hardcoded** |
| border radii | 8 distinct literals | `--radius-sm/md/lg` + `--radius-pill` + `--radius-circle` |
| spacing | 19 values, no scale | one scale |

Pill and circle stay separate tokens rather than points on the size scale,
because `999px` is a different intent, not a bigger corner.

`+page.svelte`'s `.console` rule no longer duplicates the font and size custom
properties, so `agents-theme.css` is the single source. That is a prerequisite
for #4683.

## Demote by size, not by three things at once

The data-carrying meta (model, cost, age) moved from `--muted` to
`--text-soft`. It was being triple-demoted: smaller **and** lighter **and**
mono. Real information rendered as chrome is a large part of why the page read
as washed out despite passing AA.

## Structured for #4683

Tokens are split into two commented groups in `agents-theme.css`:

- **neutral** surface, line and text tokens, which will vary per period under
  the time-of-day classes, using the same mechanism as the private landing
  page;
- **state** tokens (`--ok`, `--attn`, `--attn-text`, `--info`, `--err` and
  their softs), declared once and **never overridden per period**.

Joe chose the time-of-day option on #4683 with the mitigation that state
colours stay period-invariant, so a chip's meaning cannot shift mid-run. This
structure makes that a property of the token architecture rather than of
future discipline. The palette itself is not implemented here.

## One correction folded in during review

The rebase onto #4792 kept its event-timeline rules, correctly, but did not
apply this branch's substitutions to them, so five hardcoded sizes came back
in behind the scale (13px, 11px, 10.5px, 12px/1.45). Folded into
`--size-detail` and `--size-meta`.

Worth recording: the scale drifted **within one merge of landing**. That is
the argument for tokens over discipline, since reintroducing drift now
requires actively writing a literal, which is visible in review.

## Verification

`ci test //projects/monolith/frontend:test -- --nocache_test_results` ->
`Executed 1 out of 1 test: 1 test passes.` Forced uncached deliberately: a
cached green cannot distinguish a real pass from a run that never happened.

Not verified: how it looks. Contrast ratios are arithmetic and the scales are
countable, but whether the console now reads well is a human judgement no test
here can make.

No chart version or `targetRevision` touched.