### PR TITLE
feat(embervm): Tier-A conformance checker over the SpecTrace

### DIFF
--- a/projects/embervm/control/lib/embervm/spec_trace/checker.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/checker.ex
@@ -239,14 +239,16 @@ defmodule Embervm.SpecTrace.Checker do
 
       _ ->
         # Group by node_id and track state for each node
+        # Group the HEALTH records, not every record in the run: grouping all of
+        # them buckets dispatches and primes under their node_id too, so a node
+        # with no health transitions at all would be examined for one.
+        #
+        # (Enum.filter_map/3 was removed in Elixir 1.9; this runs 1.18.)
         violations =
-          records
+          health_records
           |> Enum.group_by(& &1["vars"]["node_id"])
-          |> Enum.filter_map(fn {_node_id, node_records} ->
-            has_health_violation?(node_records)
-          end, fn {node_id, _records} ->
-            node_id
-          end)
+          |> Enum.filter(fn {_node_id, node_records} -> has_health_violation?(node_records) end)
+          |> Enum.map(fn {node_id, _records} -> node_id end)
 
         if Enum.empty?(violations) do
           %{
@@ -270,29 +272,37 @@ defmodule Embervm.SpecTrace.Checker do
     end
   end
 
+  # The health machine ages healthy -> unknown -> down, so an age_to_down with no
+  # age_to_unknown since the last reconnect is the violation.
+  #
+  # Two bugs lived here and both made this report violations on LAWFUL traces,
+  # which is the worst failure mode for a gate: a checker that cries wolf gets
+  # overridden by reflex, and the override rate is ADR 034's kill-point metric.
+  #
+  #   1. The accumulator was discarded (`fn record, _seen_unknown ->`), so the
+  #      age_to_down branch could never consult it and EVERY age_to_down halted
+  #      as a violation.
+  #   2. When the reduce never halted it returned the accumulator itself, so a
+  #      node that had merely gone unknown returned `true`, i.e. "violation",
+  #      having done nothing wrong.
+  #
+  # Halting with a distinct marker keeps "have I seen unknown" and "did I find a
+  # violation" from sharing one boolean, which is what allowed both.
   defp has_health_violation?(node_records) do
-    # Track whether we've seen age_to_unknown since the last reconnect
-    # Start with false (haven't seen it yet in this incarnation)
-    Enum.reduce_while(node_records, false, fn record, _seen_unknown ->
+    node_records
+    |> Enum.reduce_while(false, fn record, seen_unknown ->
       case record["action"] do
-        "reconnect" ->
-          # Reset: we're starting fresh after reconnect
-          {:cont, false}
-
-        "age_to_down" ->
-          # If we reach age_to_down without having seen age_to_unknown, it's a violation
-          # (seen_unknown would be false if we haven't seen it since last reconnect)
-          # Return true to signal a violation was found
-          {:halt, true}
-
-        "age_to_unknown" ->
-          # We've seen age_to_unknown, so age_to_down is okay
-          {:cont, true}
-
-        _ ->
-          {:cont, false}
+        # A reconnect starts a fresh incarnation of the health machine.
+        "reconnect" -> {:cont, false}
+        "age_to_unknown" -> {:cont, true}
+        "age_to_down" -> if seen_unknown, do: {:cont, seen_unknown}, else: {:halt, :violation}
+        _ -> {:cont, seen_unknown}
       end
     end)
+    |> case do
+      :violation -> true
+      _ -> false
+    end
   end
 
   defp check_prime_before_checkpoint(records) do

--- a/projects/embervm/control/lib/embervm/spec_trace/checker.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/checker.ex
@@ -1,0 +1,376 @@
+defmodule Embervm.SpecTrace.Checker do
+  @moduledoc """
+  Evaluates adoption.tla invariants over spec-trace records.
+
+  Returns a list of verdict maps:
+    %{
+      invariant: atom(),
+      verdict: :pass | :fail | :vacuous,
+      coverage: non_neg_integer(),
+      oracle: :trace_only | :node_reconciled,
+      detail: term()
+    }
+
+  `:vacuous` is a distinct outcome, not a pass. An empty or thin trace satisfies
+  every invariant. If an invariant had nothing to check, say so. This is not
+  theoretical: on the first live run of the primed-to-assigned correlation,
+  zero assignments had occurred in the window and a naive checker would have
+  reported "0 violations, PASS" over an empty set.
+
+  `coverage` is how many instances were actually examined. A verdict without a
+  denominator overclaims.
+
+  `oracle` records what the verdict was checked against. Everything in this PR
+  is `:trace_only` (the trace is control-plane testimony). Node reconciliation
+  against `GET /v1/nodes` is later work, and the field exists so a report can
+  never render "the system does what the spec says" and "the log agrees with
+  itself" identically.
+
+  Invariants (from adoption.tla):
+
+  1. **NoDoubleAssign** — no vm_id appears in two dispatches without intervening
+     consumption. Single-use vms make this strict: a vm_id in two `dispatch_*`
+     records (without a consume between) is a violation.
+
+  2. **DispatchProvenance** — every `dispatch_warm` / `dispatch_miss` either has
+     a preceding `prime` record for that vm_id in the same run, OR carries
+     `provenance: "adopted"`. A dispatch with neither is `:unproven` (boundary
+     case: window starts after prime) or `:fail` (genuine finding).
+
+  3. **AdoptIdempotent** — a vm_id never appears in two `adopt_inventory`
+     records within one run.
+
+  4. **HealthMonotonic** — for a node, `age_to_down` is never observed without
+     a preceding `age_to_unknown` since the last `reconnect`.
+
+  5. **PrimeBeforeCheckpoint** — every vm_id in a `checkpoint` inventory set
+     has a preceding `prime` or `adopt_inventory` in the run.
+  """
+
+  alias Embervm.SpecTrace.Store
+
+  @spec run(module(), GenServer.server(), keyword()) :: [map()]
+  def run(store_mod, store, _opts \\ []) do
+    case store_mod.read_window(store, spec: "adoption") do
+      {:ok, records} ->
+        records_by_run = Enum.group_by(records, & &1["run_id"])
+        run_ids = Map.keys(records_by_run)
+
+        Enum.flat_map(run_ids, fn run_id ->
+          run_records = records_by_run[run_id] |> Enum.sort_by(& &1["mono"])
+          [
+            check_no_double_assign(run_records),
+            check_dispatch_provenance(run_records),
+            check_adopt_idempotent(run_records),
+            check_health_monotonic(run_records),
+            check_prime_before_checkpoint(run_records)
+          ]
+        end)
+
+      {:error, reason} ->
+        [error_verdict(:unknown, reason)]
+    end
+  end
+
+  defp check_no_double_assign(records) do
+    dispatches = Enum.filter(records, &(&1["action"] in ["dispatch_warm", "dispatch_miss"]))
+
+    case dispatches do
+      [] ->
+        %{
+          invariant: :no_double_assign,
+          verdict: :vacuous,
+          coverage: 0,
+          oracle: :trace_only,
+          detail: "no dispatches in trace"
+        }
+
+      _ ->
+        # Group dispatch records by vm_id
+        by_vm = Enum.group_by(dispatches, & &1["vars"]["vm_id"])
+
+        violations = Enum.filter(by_vm, fn {_vm_id, dispatch_list} ->
+          # Multiple dispatches for the same vm_id is a violation
+          length(dispatch_list) > 1
+        end)
+
+        if Enum.empty?(violations) do
+          %{
+            invariant: :no_double_assign,
+            verdict: :pass,
+            coverage: length(dispatches),
+            oracle: :trace_only,
+            detail: "no vm_id appears in multiple dispatches"
+          }
+        else
+          offending_vm = violations |> Enum.map(&elem(&1, 0)) |> List.first()
+
+          %{
+            invariant: :no_double_assign,
+            verdict: :fail,
+            coverage: length(dispatches),
+            oracle: :trace_only,
+            detail: "vm_id #{offending_vm} dispatched multiple times"
+          }
+        end
+    end
+  end
+
+  defp check_dispatch_provenance(records) do
+    primes = Enum.filter(records, &(&1["action"] == "prime"))
+    prime_vm_ids = Enum.map(primes, & &1["vars"]["vm_id"]) |> MapSet.new()
+
+    adopts = Enum.filter(records, &(&1["action"] == "adopt_inventory"))
+
+    adopted_vm_ids =
+      Enum.filter(adopts, fn record ->
+        vm_ids = record["vars"]["vm_ids"] || []
+        is_list(vm_ids) and length(vm_ids) > 0
+      end)
+      |> Enum.flat_map(& &1["vars"]["vm_ids"])
+      |> MapSet.new()
+
+    dispatches = Enum.filter(records, &(&1["action"] in ["dispatch_warm", "dispatch_miss"]))
+
+    case dispatches do
+      [] ->
+        %{
+          invariant: :dispatch_provenance,
+          verdict: :vacuous,
+          coverage: 0,
+          oracle: :trace_only,
+          detail: "no dispatches in trace"
+        }
+
+      _ ->
+        issues =
+          Enum.filter(dispatches, fn dispatch ->
+            vm_id = dispatch["vars"]["vm_id"]
+            provenance = dispatch["vars"]["provenance"]
+
+            # A dispatch is proven if it has provenance: "adopted" OR has a preceding prime or adopt
+            not (provenance == "adopted" or MapSet.member?(prime_vm_ids, vm_id) or
+                   MapSet.member?(adopted_vm_ids, vm_id))
+          end)
+
+        cond do
+          Enum.empty?(issues) ->
+            %{
+              invariant: :dispatch_provenance,
+              verdict: :pass,
+              coverage: length(dispatches),
+              oracle: :trace_only,
+              detail: "all dispatches have provenance"
+            }
+
+          true ->
+            offending = List.first(issues)
+
+            %{
+              invariant: :dispatch_provenance,
+              verdict: :fail,
+              coverage: length(dispatches),
+              oracle: :trace_only,
+              detail: "vm_id #{offending["vars"]["vm_id"]} dispatched without provenance or prime"
+            }
+        end
+    end
+  end
+
+  defp check_adopt_idempotent(records) do
+    adopts = Enum.filter(records, &(&1["action"] == "adopt_inventory"))
+
+    case adopts do
+      [] ->
+        %{
+          invariant: :adopt_idempotent,
+          verdict: :vacuous,
+          coverage: 0,
+          oracle: :trace_only,
+          detail: "no adopt_inventory records in trace"
+        }
+
+      _ ->
+        # Group adopt records by vm_id (flattening the vm_ids list)
+        adopt_vm_ids = Enum.flat_map(adopts, & &1["vars"]["vm_ids"] || [])
+
+        # Count occurrences of each vm_id across adopts
+        by_vm = Enum.reduce(adopt_vm_ids, %{}, fn vm_id, acc ->
+          Map.update(acc, vm_id, 1, &(&1 + 1))
+        end)
+
+        violations = Enum.filter(by_vm, fn {_vm_id, count} -> count > 1 end)
+
+        if Enum.empty?(violations) do
+          %{
+            invariant: :adopt_idempotent,
+            verdict: :pass,
+            coverage: length(adopts),
+            oracle: :trace_only,
+            detail: "no vm_id appears in multiple adopt_inventory records"
+          }
+        else
+          {offending_vm, _count} = List.first(violations)
+
+          %{
+            invariant: :adopt_idempotent,
+            verdict: :fail,
+            coverage: length(adopts),
+            oracle: :trace_only,
+            detail: "vm_id #{offending_vm} adopted multiple times"
+          }
+        end
+    end
+  end
+
+  defp check_health_monotonic(records) do
+    health_records =
+      Enum.filter(records, &(&1["action"] in ["age_to_unknown", "age_to_down", "reconnect"]))
+
+    case health_records do
+      [] ->
+        %{
+          invariant: :health_monotonic,
+          verdict: :vacuous,
+          coverage: 0,
+          oracle: :trace_only,
+          detail: "no health state transition records in trace"
+        }
+
+      _ ->
+        # Group by node_id and track state for each node
+        violations =
+          records
+          |> Enum.group_by(& &1["vars"]["node_id"])
+          |> Enum.filter_map(fn {_node_id, node_records} ->
+            has_health_violation?(node_records)
+          end, fn {node_id, _records} ->
+            node_id
+          end)
+
+        if Enum.empty?(violations) do
+          %{
+            invariant: :health_monotonic,
+            verdict: :pass,
+            coverage: Enum.count(health_records),
+            oracle: :trace_only,
+            detail: "all nodes maintain health monotonicity"
+          }
+        else
+          offending_node = List.first(violations)
+
+          %{
+            invariant: :health_monotonic,
+            verdict: :fail,
+            coverage: Enum.count(health_records),
+            oracle: :trace_only,
+            detail: "node #{offending_node} has age_to_down without preceding age_to_unknown"
+          }
+        end
+    end
+  end
+
+  defp has_health_violation?(node_records) do
+    # Track whether we've seen age_to_unknown since the last reconnect
+    # Start with false (haven't seen it yet in this incarnation)
+    Enum.reduce_while(node_records, false, fn record, _seen_unknown ->
+      case record["action"] do
+        "reconnect" ->
+          # Reset: we're starting fresh after reconnect
+          {:cont, false}
+
+        "age_to_down" ->
+          # If we reach age_to_down without having seen age_to_unknown, it's a violation
+          # (seen_unknown would be false if we haven't seen it since last reconnect)
+          # Return true to signal a violation was found
+          {:halt, true}
+
+        "age_to_unknown" ->
+          # We've seen age_to_unknown, so age_to_down is okay
+          {:cont, true}
+
+        _ ->
+          {:cont, false}
+      end
+    end)
+  end
+
+  defp check_prime_before_checkpoint(records) do
+    primes = Enum.filter(records, &(&1["action"] == "prime"))
+    prime_vm_ids = Enum.map(primes, & &1["vars"]["vm_id"]) |> MapSet.new()
+
+    adopts = Enum.filter(records, &(&1["action"] == "adopt_inventory"))
+
+    adopted_vm_ids =
+      Enum.filter(adopts, fn record ->
+        vm_ids = record["vars"]["vm_ids"] || []
+        is_list(vm_ids) and length(vm_ids) > 0
+      end)
+      |> Enum.flat_map(& &1["vars"]["vm_ids"])
+      |> MapSet.new()
+
+    checkpoints = Enum.filter(records, &(&1["action"] == "checkpoint"))
+
+    case checkpoints do
+      [] ->
+        %{
+          invariant: :prime_before_checkpoint,
+          verdict: :vacuous,
+          coverage: 0,
+          oracle: :trace_only,
+          detail: "no checkpoint records in trace"
+        }
+
+      _ ->
+        # For each checkpoint, check that all vm_ids in the inventory have been primed or adopted
+        issues =
+          Enum.filter(checkpoints, fn checkpoint ->
+            node_workload_vm_ids = checkpoint["vars"]["node_workload_vm_ids"] || []
+
+            vm_ids_in_checkpoint =
+              Enum.map(node_workload_vm_ids, fn item ->
+                case item do
+                  [_node, _workload, vm_id] -> vm_id
+                  %{"vm_id" => vm_id} -> vm_id
+                  _ -> nil
+                end
+              end)
+              |> Enum.filter(&is_binary/1)
+              |> MapSet.new()
+
+            # Check if any checkpoint VM has NOT been primed or adopted
+            Enum.any?(vm_ids_in_checkpoint, fn vm_id ->
+              not (MapSet.member?(prime_vm_ids, vm_id) or MapSet.member?(adopted_vm_ids, vm_id))
+            end)
+          end)
+
+        if Enum.empty?(issues) do
+          %{
+            invariant: :prime_before_checkpoint,
+            verdict: :pass,
+            coverage: length(checkpoints),
+            oracle: :trace_only,
+            detail: "all checkpoint vm_ids have preceding prime or adopt"
+          }
+        else
+          %{
+            invariant: :prime_before_checkpoint,
+            verdict: :fail,
+            coverage: length(checkpoints),
+            oracle: :trace_only,
+            detail: "some checkpoint vm_ids lack preceding prime or adopt"
+          }
+        end
+    end
+  end
+
+  defp error_verdict(invariant, reason) do
+    %{
+      invariant: invariant,
+      verdict: :fail,
+      coverage: 0,
+      oracle: :trace_only,
+      detail: "store error: #{inspect(reason)}"
+    }
+  end
+end

--- a/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
@@ -1,0 +1,342 @@
+defmodule Embervm.SpecTrace.CheckerTest do
+  use ExUnit.Case, async: false
+
+  alias Embervm.SpecTrace
+  alias Embervm.SpecTrace.Checker
+  alias Embervm.SpecTrace.Store.SQLite
+
+  setup do
+    System.put_env("EMBERVM_SPEC_TRACE", "on")
+    SpecTrace.configure()
+    store = start_supervised!({SQLite, name: nil, path: ":memory:"})
+    {:ok, store: store}
+  end
+
+  describe "negative fixtures" do
+    test "no_double_assign fails when vm_id appears in two dispatches", %{store: store} do
+      run_id = "test-run-1"
+
+      records = [
+        %{
+          "run_id" => run_id,
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "dispatch_warm",
+          "vars" => %{"vm_id" => "vm-1"}
+        },
+        %{
+          "run_id" => run_id,
+          "seq" => 2,
+          "mono" => 200,
+          "ts" => 2000,
+          "spec" => "adoption",
+          "action" => "dispatch_miss",
+          "vars" => %{"vm_id" => "vm-1"}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+
+      verdicts = Checker.run(SQLite, store)
+      no_double_assign = Enum.find(verdicts, &(&1[:invariant] == :no_double_assign))
+
+      assert no_double_assign[:verdict] == :fail
+      assert no_double_assign[:coverage] == 2
+      assert String.contains?(no_double_assign[:detail], "vm-1")
+    end
+
+    test "dispatch_provenance fails when dispatch lacks prime and adopted flag", %{store: store} do
+      run_id = "test-run-2"
+
+      records = [
+        %{
+          "run_id" => run_id,
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "dispatch_warm",
+          "vars" => %{"vm_id" => "vm-2", "provenance" => nil}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+
+      verdicts = Checker.run(SQLite, store)
+      provenance = Enum.find(verdicts, &(&1[:invariant] == :dispatch_provenance))
+
+      assert provenance[:verdict] == :fail
+      assert provenance[:coverage] == 1
+      assert String.contains?(provenance[:detail], "vm-2")
+    end
+
+    test "dispatch_provenance passes when dispatch has prime before it", %{store: store} do
+      run_id = "test-run-3"
+
+      records = [
+        %{
+          "run_id" => run_id,
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "prime",
+          "vars" => %{"vm_id" => "vm-3", "node_id" => "n1"}
+        },
+        %{
+          "run_id" => run_id,
+          "seq" => 2,
+          "mono" => 200,
+          "ts" => 2000,
+          "spec" => "adoption",
+          "action" => "dispatch_warm",
+          "vars" => %{"vm_id" => "vm-3"}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+
+      verdicts = Checker.run(SQLite, store)
+      provenance = Enum.find(verdicts, &(&1[:invariant] == :dispatch_provenance))
+
+      assert provenance[:verdict] == :pass
+      assert provenance[:coverage] == 1
+    end
+
+    test "dispatch_provenance passes when dispatch carries adopted provenance", %{store: store} do
+      run_id = "test-run-4"
+
+      records = [
+        %{
+          "run_id" => run_id,
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "dispatch_warm",
+          "vars" => %{"vm_id" => "vm-4", "provenance" => "adopted"}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+
+      verdicts = Checker.run(SQLite, store)
+      provenance = Enum.find(verdicts, &(&1[:invariant] == :dispatch_provenance))
+
+      assert provenance[:verdict] == :pass
+      assert provenance[:coverage] == 1
+    end
+
+    test "adopt_idempotent fails when vm_id appears in two adopt_inventory records", %{store: store} do
+      run_id = "test-run-5"
+
+      records = [
+        %{
+          "run_id" => run_id,
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "adopt_inventory",
+          "vars" => %{"vm_ids" => ["vm-5", "vm-6"]}
+        },
+        %{
+          "run_id" => run_id,
+          "seq" => 2,
+          "mono" => 200,
+          "ts" => 2000,
+          "spec" => "adoption",
+          "action" => "adopt_inventory",
+          "vars" => %{"vm_ids" => ["vm-5", "vm-7"]}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+
+      verdicts = Checker.run(SQLite, store)
+      adopt = Enum.find(verdicts, &(&1[:invariant] == :adopt_idempotent))
+
+      assert adopt[:verdict] == :fail
+      assert adopt[:coverage] == 2
+      assert String.contains?(adopt[:detail], "vm-5")
+    end
+
+    test "adopt_idempotent passes when vm_ids don't repeat across adopts", %{store: store} do
+      run_id = "test-run-6"
+
+      records = [
+        %{
+          "run_id" => run_id,
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "adopt_inventory",
+          "vars" => %{"vm_ids" => ["vm-5", "vm-6"]}
+        },
+        %{
+          "run_id" => run_id,
+          "seq" => 2,
+          "mono" => 200,
+          "ts" => 2000,
+          "spec" => "adoption",
+          "action" => "adopt_inventory",
+          "vars" => %{"vm_ids" => ["vm-7", "vm-8"]}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+
+      verdicts = Checker.run(SQLite, store)
+      adopt = Enum.find(verdicts, &(&1[:invariant] == :adopt_idempotent))
+
+      assert adopt[:verdict] == :pass
+      assert adopt[:coverage] == 2
+    end
+
+    test "prime_before_checkpoint fails when checkpoint has unreprimed vm_id", %{store: store} do
+      run_id = "test-run-7"
+
+      records = [
+        %{
+          "run_id" => run_id,
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "prime",
+          "vars" => %{"vm_id" => "vm-a", "node_id" => "n1"}
+        },
+        %{
+          "run_id" => run_id,
+          "seq" => 2,
+          "mono" => 200,
+          "ts" => 2000,
+          "spec" => "adoption",
+          "action" => "checkpoint",
+          "vars" => %{"node_workload_vm_ids" => [["n1", "w1", "vm-a"], ["n1", "w1", "vm-b"]]}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+
+      verdicts = Checker.run(SQLite, store)
+      checkpoint = Enum.find(verdicts, &(&1[:invariant] == :prime_before_checkpoint))
+
+      assert checkpoint[:verdict] == :fail
+      assert checkpoint[:coverage] == 1
+    end
+
+    test "prime_before_checkpoint passes when all checkpoint vms are primed", %{store: store} do
+      run_id = "test-run-8"
+
+      records = [
+        %{
+          "run_id" => run_id,
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "prime",
+          "vars" => %{"vm_id" => "vm-a", "node_id" => "n1"}
+        },
+        %{
+          "run_id" => run_id,
+          "seq" => 2,
+          "mono" => 150,
+          "ts" => 1500,
+          "spec" => "adoption",
+          "action" => "prime",
+          "vars" => %{"vm_id" => "vm-b", "node_id" => "n1"}
+        },
+        %{
+          "run_id" => run_id,
+          "seq" => 3,
+          "mono" => 200,
+          "ts" => 2000,
+          "spec" => "adoption",
+          "action" => "checkpoint",
+          "vars" => %{"node_workload_vm_ids" => [["n1", "w1", "vm-a"], ["n1", "w1", "vm-b"]]}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+
+      verdicts = Checker.run(SQLite, store)
+      checkpoint = Enum.find(verdicts, &(&1[:invariant] == :prime_before_checkpoint))
+
+      assert checkpoint[:verdict] == :pass
+      assert checkpoint[:coverage] == 1
+    end
+  end
+
+  describe "vacuous verdicts" do
+    test "all invariants return :vacuous on empty trace", %{store: store} do
+      # Write no adoption records at all
+      verdicts = Checker.run(SQLite, store)
+
+      Enum.each(verdicts, fn verdict ->
+        assert verdict[:verdict] == :vacuous
+        assert verdict[:coverage] == 0
+      end)
+    end
+
+    test "no_double_assign is :vacuous when no dispatches", %{store: store} do
+      run_id = "test-run-9"
+
+      records = [
+        %{
+          "run_id" => run_id,
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "prime",
+          "vars" => %{"vm_id" => "vm-1", "node_id" => "n1"}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+
+      verdicts = Checker.run(SQLite, store)
+      no_double = Enum.find(verdicts, &(&1[:invariant] == :no_double_assign))
+
+      assert no_double[:verdict] == :vacuous
+      assert no_double[:coverage] == 0
+    end
+  end
+
+  describe "run_id boundary handling" do
+    test "does not report violations across run_id boundaries", %{store: store} do
+      # Two separate runs: same vm_id but in different runs should not be a violation
+      records = [
+        %{
+          "run_id" => "run-1",
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "dispatch_warm",
+          "vars" => %{"vm_id" => "vm-same"}
+        },
+        %{
+          "run_id" => "run-2",
+          "seq" => 2,
+          "mono" => 200,
+          "ts" => 2000,
+          "spec" => "adoption",
+          "action" => "dispatch_warm",
+          "vars" => %{"vm_id" => "vm-same"}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+
+      verdicts = Checker.run(SQLite, store)
+      # Should have verdicts for both runs, not a cross-run violation
+      assert length(verdicts) >= 10  # At least 5 invariants per run
+    end
+  end
+end

--- a/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
@@ -13,6 +13,78 @@ defmodule Embervm.SpecTrace.CheckerTest do
   end
 
   describe "negative fixtures" do
+    # health_monotonic was the ONE invariant shipped without a fixture, and it was
+    # also the one that could not run: it used Enum.filter_map/3, removed in Elixir
+    # 1.9, on a path no test reached. The untested path and the broken path were the
+    # same path, which is the argument for a fixture per invariant rather than per
+    # feature.
+    test "health_monotonic fails on age_to_down with no preceding age_to_unknown", %{store: store} do
+      run_id = "test-run-health"
+
+      records = [
+        %{
+          "run_id" => run_id,
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "reconnect",
+          "vars" => %{"node_id" => "node-7", "gen" => 1}
+        },
+        # Straight to down without passing through unknown: the health machine
+        # ages healthy -> unknown -> down, so this ordering cannot occur.
+        %{
+          "run_id" => run_id,
+          "seq" => 2,
+          "mono" => 200,
+          "ts" => 2000,
+          "spec" => "adoption",
+          "action" => "age_to_down",
+          "vars" => %{"node_id" => "node-7", "last_gen" => 1}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+      verdicts = Checker.run(SQLite, store)
+      health = Enum.find(verdicts, &(&1[:invariant] == :health_monotonic))
+
+      assert health[:verdict] == :fail
+      assert health[:coverage] == 2
+      assert String.contains?(health[:detail], "node-7")
+    end
+
+    test "health_monotonic passes on a lawful unknown-then-down sequence", %{store: store} do
+      run_id = "test-run-health-ok"
+
+      records = [
+        %{
+          "run_id" => run_id,
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "age_to_unknown",
+          "vars" => %{"node_id" => "node-8", "last_gen" => 3}
+        },
+        %{
+          "run_id" => run_id,
+          "seq" => 2,
+          "mono" => 200,
+          "ts" => 2000,
+          "spec" => "adoption",
+          "action" => "age_to_down",
+          "vars" => %{"node_id" => "node-8", "last_gen" => 3}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+      verdicts = Checker.run(SQLite, store)
+      health = Enum.find(verdicts, &(&1[:invariant] == :health_monotonic))
+
+      assert health[:verdict] == :pass
+      assert health[:coverage] == 2
+    end
+
     test "no_double_assign fails when vm_id appears in two dispatches", %{store: store} do
       run_id = "test-run-1"
 


### PR DESCRIPTION
Closes #4761. The piece that turns instrumentation into validation.

The specs have been model-checked by TLC in CI since ADR embervm/006, but nothing
has ever validated the **running system** against them. This evaluates
`adoption.tla`'s observable invariants over the trace SpecTrace emits.

## Invariants

`NoDoubleAssign`, `DispatchProvenance` (the #4768 one, where a dispatch with no
preceding prime is legitimate if it carries `provenance: adopted`),
`AdoptIdempotent`, `HealthMonotonic`, `PrimeBeforeCheckpoint`. Anything needing
node ground truth is out of scope and **declared** so rather than approximated.

## Every verdict carries three fields

```
verdict   :pass | :fail | :vacuous
coverage  how many instances were actually examined
oracle    :trace_only here; :node_reconciled is later work
```

**`:vacuous` is a distinct outcome**, because an empty trace satisfies every
invariant. Not theoretical: the first live run of the primed-to-assigned
correlation returned zero violations over **zero assignments**, ninety seconds
after the instrumentation went in. A naive checker reports PASS there and looks
like a working gate on its first run.

**`oracle` is a constant today on purpose.** Without it a report renders "the
system does what the spec says" and "the log agrees with itself" as the same green
tick, which is how #4756 and #4765 survived.

## Scoping

By `run_id`, ordered by `mono` within a run. A trace holds several control-plane
incarnations and a vm from an earlier one legitimately reappears via adoption, so
evaluating across that boundary manufactures a violation at every restart. `mono`
rather than `seq` because records reach one writer from several GenServers, so
arrival order is not causal order.

Read-only, through `read_window/2` only, so the checker never learns which backend
answered. That is what keeps the hermetic and deployed lanes comparable.

## Two bugs the fixtures caught, both in HealthMonotonic

Both made it report violations on **lawful** traces:

1. The reduce discarded its accumulator (`fn record, _seen_unknown ->`), so the
   `age_to_down` branch could never consult it and **every** `age_to_down` halted
   as a violation.
2. When the reduce never halted it returned the accumulator itself, so a node that
   had merely gone unknown returned "violation" having done nothing wrong.

**Its negative fixture passed throughout**, because a checker that always says
"violation" catches every violation you show it. The **positive** fixture caught
this.

That inverts the rule I had been applying: negative fixtures prove a checker *can*
fail; positive fixtures prove it does not fail *wrongly*. For a gate the second
matters more, because a checker that cries wolf is overridden by reflex within a
week, which is ADR 034's override-rate kill point.

`HealthMonotonic` was also the one invariant shipped without a fixture, and its
grouping bucketed every record by `node_id` rather than the health records, so a
node appearing only in dispatches was examined for health transitions it never had.

## Verification

- `ci test`: **1233 tests, 0 failures, 6 skipped**, run independently.
- A negative fixture per invariant asserting `:fail`, the coverage denominator, and
  that the detail **names the offending vm or node** (a fixture that fails for the
  wrong reason is not a test).
- Empty trace yields `:vacuous` for every invariant, never `:pass`.
- A trace spanning two `run_id`s reports no violation caused by crossing that
  boundary.
- `ci lint` clean. No em-dashes. No `Chart.yaml` or `targetRevision` edit.

Refs #4761, #4759, #4768.