### PR TITLE
feat(embervm): GET /v1/conformance, the entry point for the checker

### DIFF
--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -91,6 +91,10 @@ defmodule Embervm.Router do
     handle_nodes(conn)
   end
 
+  get "/v1/conformance" do
+    handle_conformance(conn)
+  end
+
   # POST /v1/nodes/register (NODE auth ONLY): the dial-home registration a noded
   # instance POSTs on start and on a jittered interval, advertising its identity
   # {node, pod_uid, address, boot_id} so the control plane adopts it without ever
@@ -530,6 +534,109 @@ defmodule Embervm.Router do
   # rather than failing the request.
   defp handle_nodes(conn) do
     send_json(conn, 200, %{nodes: nodes_snapshot(), dispatch: dispatch_snapshot()})
+  end
+
+  defp handle_conformance(conn) do
+    case conformance_view(conn.query_params) do
+      {:ok, view} -> send_json(conn, 200, view)
+      {:error, reason} -> send_json(conn, 500, %{error: "store error: #{inspect(reason)}"})
+    end
+  end
+
+  defp conformance_view(query_params) do
+    if Embervm.SpecTrace.enabled_now?() do
+      # Resolve the store the way the supervision tree does, NOT via
+      # Application env: nothing sets :spec_trace_store_mod, so get_env would
+      # always hand back the SQLite default and this endpoint would query a
+      # store nothing writes to whenever Postgres is configured. A conformance
+      # report that always says "nothing to check" is the vacuous-guard failure
+      # this whole programme exists to prevent, arriving in the reporting layer.
+      store_mod = Embervm.Application.spec_trace_mod()
+      store = store_mod
+      opts = conformance_query_opts(query_params)
+
+      case store_mod.read_window(store, opts) do
+        {:ok, records} ->
+          verdicts =
+            case records do
+              [] -> vacuous_conformance_verdicts("no records in trace")
+              _ -> conformance_verdicts(Embervm.SpecTrace.Checker.run(store_mod, store, opts))
+            end
+
+          {:ok,
+           %{
+             enabled: true,
+             run_ids: records |> Enum.map(& &1["run_id"]) |> Enum.uniq(),
+             verdicts: verdicts
+           }}
+
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      {:ok,
+       %{
+         enabled: false,
+         run_ids: [],
+         verdicts: vacuous_conformance_verdicts("trace gate is disabled")
+       }}
+    end
+  rescue
+    error -> {:error, error}
+  catch
+    kind, reason -> {:error, {kind, reason}}
+  end
+
+  defp conformance_query_opts(params) do
+    [
+      {:since_seq, parse_conformance_integer(params["since_seq"])},
+      {:since_ts_ms, parse_conformance_integer(params["since_ts_ms"])},
+      {:until_ts_ms, parse_conformance_integer(params["until_ts_ms"])},
+      {:run_id, params["run_id"]},
+      {:action, params["action"]},
+      {:spec, params["spec"] || "adoption"}
+    ]
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp parse_conformance_integer(nil), do: nil
+
+  defp parse_conformance_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, ""} -> integer
+      _ -> nil
+    end
+  end
+
+  defp parse_conformance_integer(value) when is_integer(value), do: value
+  defp parse_conformance_integer(_value), do: nil
+
+  defp conformance_verdicts(verdicts) do
+    invariants = [:no_double_assign, :dispatch_provenance, :adopt_idempotent, :health_monotonic, :prime_before_checkpoint]
+
+    Enum.map(invariants, fn invariant ->
+      verdicts
+      |> Enum.filter(&(&1[:invariant] == invariant))
+      |> Enum.reduce(vacuous_conformance_verdict(invariant, "no records in trace"), &merge_conformance_verdict/2)
+    end)
+  end
+
+  defp merge_conformance_verdict(verdict, current) do
+    rank = %{vacuous: 0, pass: 1, fail: 2}
+
+    if Map.get(rank, verdict[:verdict], 2) > Map.get(rank, current[:verdict], 0) do
+      Map.put(verdict, :coverage, verdict[:coverage] + current[:coverage])
+    else
+      Map.put(current, :coverage, current[:coverage] + verdict[:coverage])
+    end
+  end
+
+  defp vacuous_conformance_verdicts(detail) do
+    [:no_double_assign, :dispatch_provenance, :adopt_idempotent, :health_monotonic, :prime_before_checkpoint]
+    |> Enum.map(&vacuous_conformance_verdict(&1, detail))
+  end
+
+  defp vacuous_conformance_verdict(invariant, detail) do
+    %{invariant: invariant, verdict: :vacuous, coverage: 0, oracle: :trace_only, detail: detail}
   end
 
   defp nodes_snapshot do

--- a/projects/embervm/control/lib/embervm/spec_trace/checker.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/checker.ex
@@ -50,8 +50,17 @@ defmodule Embervm.SpecTrace.Checker do
   alias Embervm.SpecTrace.Store
 
   @spec run(module(), GenServer.server(), keyword()) :: [map()]
-  def run(store_mod, store, _opts \\ []) do
-    case store_mod.read_window(store, spec: "adoption") do
+  # `spec: "adoption"` is a DEFAULT rather than a hardcode: callers may narrow
+  # the window (a time range, a run_id) without accidentally widening the spec.
+  # Dropping the filter entirely would let these invariants examine
+  # bank_relight and quota records, which inflates every coverage count with
+  # records the checks then ignore, and a coverage number that counts records
+  # it never examined is exactly the overclaim the verdict triple exists to
+  # prevent.
+  def run(store_mod, store, opts \\ []) do
+    opts = Keyword.put_new(opts, :spec, "adoption")
+
+    case store_mod.read_window(store, opts) do
       {:ok, records} ->
         records_by_run = Enum.group_by(records, & &1["run_id"])
         run_ids = Map.keys(records_by_run)

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -1081,6 +1081,16 @@ defmodule Embervm.RouterTest do
   describe "GET /v1/conformance" do
     setup do
       Application.put_env(:embervm, :authenticator, FakeAuth)
+
+      # Establish the gate state this block asserts on rather than inheriting
+      # it. The gate is a global `:persistent_term`, so before the restores in
+      # checker_test and spec_trace_test these cases passed or failed on ExUnit
+      # seed alone. Those leaks are fixed, but a test whose precondition is set
+      # by whichever module ran first is one edit away from breaking again, and
+      # the failure reads as flakiness rather than as a missing on_exit.
+      System.put_env("EMBERVM_SPEC_TRACE", "off")
+      Embervm.SpecTrace.configure()
+
       on_exit(fn -> Application.delete_env(:embervm, :authenticator) end)
       :ok
     end

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -1077,4 +1077,69 @@ defmodule Embervm.RouterTest do
     with_stateful_manager_fake()
     assert req(:delete, "/v1/stateful/wl-clean/volume").status == 401
   end
+
+  describe "GET /v1/conformance" do
+    setup do
+      Application.put_env(:embervm, :authenticator, FakeAuth)
+      on_exit(fn -> Application.delete_env(:embervm, :authenticator) end)
+      :ok
+    end
+
+    # THE TEST THAT MATTERS MOST for this endpoint. Both a disabled gate and an
+    # empty trace are legitimately VACUOUS, but they must never render alike: an
+    # operator reaching for this during an incident is exactly the person who
+    # would read "nothing to report" as "the system is conforming". #4758 is the
+    # precedent, a gate defaulted off with nothing in the data saying so.
+    test "with the trace gate OFF, reports vacuous and says so, never passing" do
+      {:ok, resp} =
+        Finch.build(:get, "http://127.0.0.1:8080/v1/conformance", [{"authorization", "Bearer good"}])
+        |> Finch.request(Embervm.Finch)
+
+      assert resp.status == 200
+      body = Jason.decode!(resp.body)
+
+      # Disabled is stated, not inferred from an absence.
+      assert body["enabled"] == false
+
+      verdicts = body["verdicts"]
+      assert verdicts != [] and verdicts != nil,
+             "a disabled gate must still enumerate the invariants, not return an empty list"
+
+      # Every invariant vacuous, NONE passing. A pass here would be a claim about
+      # a system nothing observed.
+      assert Enum.all?(verdicts, &(&1["verdict"] == "vacuous")),
+             "expected all vacuous, got #{inspect(Enum.map(verdicts, & &1["verdict"]))}"
+
+      refute Enum.any?(verdicts, &(&1["verdict"] == "pass"))
+
+      # The reason names the gate, so the caller can tell this from an empty trace.
+      assert Enum.all?(verdicts, fn v -> v["detail"] =~ "gate" end),
+             "the vacuous reason must name the disabled gate so it is distinguishable from an empty trace"
+    end
+
+    test "the verdict triple is present, never flattened to pass/fail" do
+      {:ok, resp} =
+        Finch.build(:get, "http://127.0.0.1:8080/v1/conformance", [{"authorization", "Bearer good"}])
+        |> Finch.request(Embervm.Finch)
+
+      body = Jason.decode!(resp.body)
+      verdict = List.first(body["verdicts"])
+
+      # coverage and oracle are what stop a green tick being read as more than it
+      # checked; a caller must be able to tell "checked 400, all clean" from
+      # "checked nothing".
+      assert Map.has_key?(verdict, "verdict")
+      assert Map.has_key?(verdict, "coverage")
+      assert Map.has_key?(verdict, "oracle")
+      assert verdict["oracle"] == "trace_only"
+    end
+
+    test "requires auth like every other /v1 route" do
+      {:ok, resp} =
+        Finch.build(:get, "http://127.0.0.1:8080/v1/conformance")
+        |> Finch.request(Embervm.Finch)
+
+      assert resp.status == 401
+    end
+  end
 end

--- a/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
@@ -8,16 +8,31 @@ defmodule Embervm.SpecTrace.CheckerTest do
   setup do
     System.put_env("EMBERVM_SPEC_TRACE", "on")
     SpecTrace.configure()
+
+    # The gate lives in `:persistent_term`, which is global to the BEAM and is
+    # NOT rolled back between test modules. Without this restore, every module
+    # ordered after this one starts with the trace enabled, and `async: false`
+    # means that is decided by the ExUnit seed rather than by anything visible
+    # in the file. It failed exactly that way: router_test's conformance cases
+    # assert `enabled == false`, saw a leaked `true`, queried a store that is
+    # not running in their context, and got a 500 whose body has no "verdicts"
+    # key at all.
+    on_exit(fn ->
+      System.put_env("EMBERVM_SPEC_TRACE", "off")
+      SpecTrace.configure()
+    end)
+
     store = start_supervised!({SQLite, name: nil, path: ":memory:"})
     {:ok, store: store}
   end
 
   describe "negative fixtures" do
     # health_monotonic was the ONE invariant shipped without a fixture, and it was
-    # also the one that could not run: it used Enum.filter_map/3, removed in Elixir
-    # 1.9, on a path no test reached. The untested path and the broken path were the
-    # same path, which is the argument for a fixture per invariant rather than per
-    # feature.
+    # also the one that was wrong. Two real bugs sat on a path no test reached: it
+    # grouped ALL records rather than health records, and its reducer discarded the
+    # accumulator, so every age_to_down halted as a violation and a node that merely
+    # went unknown reported one. The untested path and the broken path were the same
+    # path, which is the argument for a fixture per invariant rather than per feature.
     test "health_monotonic fails on age_to_down with no preceding age_to_unknown", %{store: store} do
       run_id = "test-run-health"
 

--- a/projects/embervm/control/test/embervm/spec_trace_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_test.exs
@@ -7,6 +7,16 @@ defmodule Embervm.SpecTraceTest do
   setup do
     System.put_env("EMBERVM_SPEC_TRACE", "on")
     SpecTrace.configure()
+
+    # Restore the global `:persistent_term` gate, see the same note in
+    # checker_test. This module leaks in a second way too: "disabled emission is
+    # a no-op" flips the gate off mid-module, so without a restore the value a
+    # later module inherits depends on which test happened to run last.
+    on_exit(fn ->
+      System.put_env("EMBERVM_SPEC_TRACE", "off")
+      SpecTrace.configure()
+    end)
+
     store = start_supervised!({SQLite, name: nil, path: ":memory:"})
 
     # The writer keeps its REGISTERED name deliberately. `SpecTrace.emit/3`


### PR DESCRIPTION
The last piece of #4761. Completes the chain: emit -> store -> check -> **read**.

`Embervm.SpecTrace.Checker` evaluates `adoption.tla`'s observable invariants and
is tested, but **nothing invoked it**. A checker nobody runs is code on a dead
path, which is the exact defect this programme has found five times (#4756,
#4765, #4766, #4768). This gives it a caller.

## Shape

Read-only, same auth as `/v1/nodes`, returning the checker's **full verdict
triple** per invariant rather than flattening to pass/fail. A caller must be able
to tell "checked 400 dispatches, all clean" from "checked nothing".

Optional query params narrow the window (time range, `run_id`) so an operator can
scope to an incident.

## Gate-off and empty-trace are both vacuous and must never render alike

An operator reaching for this during an incident is exactly the person who would
read "nothing to report" as "the system is conforming".

```
gate off     enabled: false   detail names the disabled gate
empty trace  enabled: true    detail "no records in trace"
```

**#4758** is the precedent: a gate defaulted off with nothing in the data saying
so, which left two modeled invariants describing an ordering production had never
run.

## Two bugs fixed on the dispatched diff

**1. The store was resolved from a key nothing sets.**
`Application.get_env(:embervm, :spec_trace_store_mod, SQLite)` always returned the
SQLite default. In production, where `EMBERVM_OPLOG_DSN` selects Postgres, this
endpoint would have queried a store nothing writes to and reported **vacuous
forever, with a 200**. A conformance report that always says "nothing to check" is
indistinguishable from a conforming system to anyone not looking closely, and it
sits at the point where a human forms a belief about correctness.

Now resolved via `Embervm.Application.spec_trace_mod/0`, the same path the
supervision tree uses. Hard to catch by reading, because `get_env` with a sensible
default is idiomatic; the bug is that the resolution path already existed
elsewhere and was never routed through app env.

**2. Passing opts straight through dropped the `spec: "adoption"` filter**, so
`bank_relight` and `quota` records entered the window and inflated every coverage
count with records the checks then ignore. A coverage number counting records it
never examined is precisely the overclaim the verdict triple exists to prevent.
Now a `Keyword.put_new` default: callers narrow without accidentally widening.

## Tests

Written here, not in the dispatched diff. The one that matters most, and which I
asked for first, asserts the gate-off response is **distinguishable** from an
empty trace: every invariant vacuous, none passing, and the reason naming the
gate. Plus the verdict triple is present with `oracle: trace_only`, and the route
requires auth.

## Verification

- `ci test`: **1238 tests, 0 failures, 6 skipped**, run independently.
- `ci lint` clean. No em-dashes. No `Chart.yaml` or `targetRevision` edit.

Refs #4761, #4759, #4770.