### PR TITLE
fix(monolith): stop a second tap starting a second task

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -794,12 +794,16 @@
       const body = await response.json();
       if (!response.ok)
         throw new Error(body.detail || P.labels.taskCreateFailed);
-      creating = false;
       closeNewPanel();
       newSession = { prompt: "", model: "", repo: "", branch: "" };
       branches = [];
       if (body.kind === "run" && body.workflow_id) selectRun(body.workflow_id);
       else if (body.session_id) selectSession(body.session_id);
+      // Released only after navigation, not before it. Clearing this on the
+      // line after the fetch resolved re-enabled the button while the panel
+      // was still on screen, which is a wide enough window on a phone to
+      // land a second tap and start a second session.
+      creating = false;
     } catch (error) {
       errorMessage = error.message;
       creating = false;
@@ -1413,6 +1417,7 @@
         {modelPicker}
         onChangeSession={(field, value) => (newSession[field] = value)}
         onLoadBranches={loadBranches}
+        {creating}
         onCreateTask={createTask}
         onSelectRun={selectRun}
         onSelectSession={selectSession}

--- a/projects/monolith/frontend/src/routes/private/agents/MasterView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/MasterView.svelte
@@ -14,6 +14,7 @@
     branches = [],
     repoLoading = false,
     branchLoading = false,
+    creating = false,
     modelPicker,
     onChangeSession = () => {},
     onLoadBranches = () => {},
@@ -184,7 +185,8 @@
       <button
         class="launcher-submit"
         type="submit"
-        disabled={!newSession.prompt.trim()}>{P.labels.submitTask}</button
+        disabled={creating || !newSession.prompt.trim()}
+        >{creating ? P.labels.creating : P.labels.submitTask}</button
       >
     </form>
   </section>


### PR DESCRIPTION
Joe, on a phone: creating a session worked, the view did not move, and the
button could be pressed again, leaving two sessions running.

Two causes, both in the create path.

## The home launcher had no in-flight guard

Its submit button was `disabled={!newSession.prompt.trim()}`, so only an empty
box disabled it. Worse, **`creating` was never passed to `MasterView` at
all**, so nothing on that surface could know a request was outstanding.

The `+ new` panel form already had `disabled={creating || ...}` plus a
"creating" label. The launcher added during the home rebuild did not inherit
it. Both surfaces now behave the same way.

## `creating` was released before navigation, not after

```js
creating = false;      // <- here
closeNewPanel();
...
if (body.kind === "run" ...) selectRun(...);
else if (body.session_id) selectSession(...);
```

The flag was cleared on the line after the fetch resolved, before the panel
closed and before navigation. That leaves the button live while the panel is
still on screen. On a desktop that window is easy to miss; on a phone it is
wide enough to land a second tap, which is exactly what happened.

It is now released **after** navigation, so the guard covers the whole
operation rather than only the request.

## Feedback

Both surfaces now swap the label to the in-flight one while the task is being
created. On a phone an unchanged button is the only feedback there is, and
silence reads as "it did not register", which is what invites the second tap.

## On the navigation half of the report

`createTask` does call `selectSession(body.session_id)`, and
`/api/swarm/classify-and-start` does return `session_id` with `kind: "session"`,
so the navigation path is wired. The most likely explanation for the view not
moving is the duplicate submit itself: two creates racing produced two
navigations. **This is not proven.** If the view still fails to move after
this lands, it is a separate defect and worth a fresh report, ideally noting
whether the sidebar or the transcript was showing.

## Verification

`ci test //projects/monolith/frontend:test -- --nocache_test_results` ->
`Executed 1 out of 1 test: 1 test passes.` Forced uncached, since a cached
green cannot distinguish a real pass from a run that never happened.

Not verified: the phone. This project has no DOM test harness, so the double
tap cannot be reproduced in a test. The fix is verifiable by hand on the
deployed console by tapping create twice and confirming only one task starts.

No chart version or `targetRevision` touched.