### PR TITLE
feat(monolith): compare endpoint for session walkthroughs

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -4425,6 +4425,16 @@ py_test(
 )
 
 py_test(
+    name = "swarm_compare_router_test",
+    srcs = ["swarm/compare_router_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_swarm",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "swarm_workflows_test",
     srcs = ["swarm/workflows_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -274,16 +274,17 @@ spec:
                   key: SEMGREP_WEBHOOK_SECRET
                   optional: true
             {{- if .Values.chat.enabled }}
-            # Real GitHub API token for the webhook's changed-file fetch. The
+            # Real GitHub API token for GitHub-backed changed-file fetches,
+            # including the session compare proxy. The
             # monolith's own GITHUB_TOKEN env is a kloak: placeholder (guest
             # egress swap), useless for a direct API call, so we wire the REAL
             # token (monolith-chat-secrets key GITHUB_TOKEN, the same one
-            # git-mirror uses) under a distinct env name the webhook reads.
+            # git-mirror uses) under a distinct env name the API reads.
             - name: GITHUB_API_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "monolith.fullname" . }}-chat-secrets
-                  key: GITHUB_TOKEN
+                  key: {{ .Values.chat.githubApiTokenSecretKey }}
             {{- end }}
             {{- end }}
             # cd health component thresholds (issue #4597). Values, not code

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -960,6 +960,8 @@ cdHealth:
 
 chat:
   enabled: false
+  # The compare proxy reads this field from the existing chat 1Password item.
+  githubApiTokenSecretKey: GITHUB_TOKEN
   llamaCppUrl: ""
   embeddingUrl: ""
   searxngUrl: ""

--- a/projects/monolith/swarm/compare_router.py
+++ b/projects/monolith/swarm/compare_router.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from urllib.parse import quote
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query
+
+from swarm.rationale import parse_rationale
+
+router = APIRouter(prefix="/api/swarm/compare", tags=["swarm"])
+
+_GITHUB_API = "https://api.github.com"
+_DEFAULT_REPO = "jomcgi/homelab"
+_CACHE_TTL_S = 90.0
+_cache: dict[str, tuple[float, dict]] = {}
+
+
+def _decode(value: str | None, default):
+    if not value:
+        return default
+    try:
+        decoded = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return default
+    return decoded
+
+
+def _turn_data(session_id: int, turn_seq: int):
+    from agent_sessions import store
+    from core.db import get_engine
+    from sqlmodel import Session
+
+    with Session(get_engine()) as db:
+        turn = store.get_turn(db, session_id, turn_seq)
+        session = store.get_session(db, session_id)
+        if turn is None or session is None:
+            return None
+        return {
+            "base_sha": turn.base_sha,
+            "commit_sha": turn.commit_sha,
+            "branch": session.branch,
+            "repo": session.repo or _DEFAULT_REPO,
+            "usage_json": turn.usage_json,
+            "result_text": turn.result_text,
+        }
+
+
+def _activities(data: dict) -> tuple[set[str], bool]:
+    usage = _decode(data.get("usage_json"), {})
+    activities = usage.get("activities", []) if isinstance(usage, dict) else []
+    if not isinstance(activities, list):
+        return set(), False
+    paths = {
+        item.get("file_path")
+        for item in activities
+        if isinstance(item, dict)
+        and item.get("type") in {"edit", "write"}
+        and isinstance(item.get("file_path"), str)
+    }
+    return paths, len(activities) >= 300
+
+
+def _cache_get(key: str) -> dict | None:
+    entry = _cache.get(key)
+    if entry is None or time.monotonic() - entry[0] >= _CACHE_TTL_S:
+        return None
+    return entry[1]
+
+
+def _cache_put(key: str, value: dict) -> None:
+    _cache[key] = (time.monotonic(), value)
+
+
+async def _github_get(url: str) -> httpx.Response:
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_API_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.get(url, headers=headers)
+    return response
+
+
+async def _compare(
+    repo: str, base: str, head: str, cache_key: str, *, include_patches: bool = False
+) -> dict:
+    if not include_patches:
+        cached = _cache_get(cache_key)
+        if cached is not None:
+            return cached
+    response = await _github_get(
+        f"{_GITHUB_API}/repos/{repo}/compare/{quote(base, safe='')}...{quote(head, safe='')}"
+    )
+    if response.status_code != 200:
+        raise HTTPException(status_code=502, detail="GitHub compare unavailable")
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=502, detail="Invalid GitHub compare response")
+    files = payload.get("files", [])
+    if not isinstance(files, list):
+        files = []
+    result = {
+        "files": [
+            {
+                "path": item.get("filename"),
+                "status": item.get("status"),
+                "additions": item.get("additions", 0),
+                "deletions": item.get("deletions", 0),
+                "changes": item.get("changes", 0),
+                "patch": item.get("patch") if include_patches else None,
+            }
+            for item in files
+            if isinstance(item, dict) and isinstance(item.get("filename"), str)
+        ],
+        "truncated": bool(payload.get("truncated")),
+    }
+    if not include_patches:
+        _cache_put(cache_key, result)
+    return result
+
+
+def _public_files(compare: dict, authored: set[str], session_id: int, turn_seq: int):
+    return [
+        {
+            key: item[key]
+            for key in ("path", "status", "additions", "deletions", "changes")
+        }
+        | {
+            "classification": "authored" if item["path"] in authored else "mechanical",
+            "patch_url": f"/api/swarm/compare/{session_id}/{turn_seq}/patch?path={quote(item['path'], safe='')}"
+            if item["path"] in authored
+            else None,
+        }
+        for item in compare["files"]
+    ]
+
+
+@router.get("/{session_id}/{turn_seq}")
+async def compare_stats(session_id: int, turn_seq: int) -> dict:
+    data = await asyncio.to_thread(_turn_data, session_id, turn_seq)
+    if data is None:
+        raise HTTPException(status_code=404, detail="Agent turn not found")
+    base_sha, commit_sha, branch = data["base_sha"], data["commit_sha"], data["branch"]
+    repo = data["repo"]
+    authored, activities_truncated = _activities(data)
+    rationale = parse_rationale(data["result_text"])
+    trailer_paths = {item["path"] for item in rationale.get("paths", [])}
+
+    resolution_rung = 3
+    diff_type = None
+    compare = {"files": [], "truncated": False}
+    if base_sha and commit_sha:
+        resolution_rung, diff_type = 1, "sha"
+        compare = await _compare(
+            repo, base_sha, commit_sha, f"{base_sha}...{commit_sha}"
+        )
+    elif branch:
+        branch_response = await _github_get(
+            f"{_GITHUB_API}/repos/{repo}/branches/{quote(branch, safe='')}"
+        )
+        if branch_response.status_code == 200:
+            resolution_rung, diff_type = 2, "branch_ephemeral"
+            compare = await _compare(repo, "main", branch, f"branch:{branch}")
+
+    paths = {item["path"] for item in compare["files"]}
+    result = {
+        "resolution_rung": resolution_rung,
+        "diff_type": diff_type,
+        "base_sha": base_sha,
+        "commit_sha": commit_sha,
+        "branch": branch,
+        "files": _public_files(compare, authored, session_id, turn_seq),
+        "stats": {
+            "total_files": len(compare["files"]),
+            **(
+                {
+                    "truncated_at": 300,
+                    "truncated_reason": "GitHub files array capped at 300",
+                }
+                if compare["truncated"]
+                else {}
+            ),
+        },
+        "trailer_parsed": rationale.get("parse_status") == "parsed",
+        "authored_file_paths": sorted(authored),
+        "unexplained_files": sorted(paths - trailer_paths),
+        "contradicted_paths": sorted(trailer_paths - paths),
+    }
+    if activities_truncated:
+        result["activities_truncated"] = True
+        result["activities_truncated_reason"] = "activities ingest capped at 300"
+    if resolution_rung == 3:
+        result["error"] = "no_compare_available"
+    return result
+
+
+@router.get("/{session_id}/{turn_seq}/patch")
+async def compare_patch(session_id: int, turn_seq: int, path: str = Query(...)) -> dict:
+    data = await asyncio.to_thread(_turn_data, session_id, turn_seq)
+    if data is None:
+        raise HTTPException(status_code=404, detail="Agent turn not found")
+    if data["base_sha"] and data["commit_sha"]:
+        compare = await _compare(
+            data["repo"],
+            data["base_sha"],
+            data["commit_sha"],
+            f"{data['base_sha']}...{data['commit_sha']}",
+            include_patches=True,
+        )
+    elif data["branch"]:
+        branch_response = await _github_get(
+            f"{_GITHUB_API}/repos/{data['repo']}/branches/{quote(data['branch'], safe='')}"
+        )
+        if branch_response.status_code != 200:
+            raise HTTPException(status_code=404, detail="no_compare_available")
+        compare = await _compare(
+            data["repo"],
+            "main",
+            data["branch"],
+            f"branch:{data['branch']}",
+            include_patches=True,
+        )
+    else:
+        raise HTTPException(status_code=404, detail="no_compare_available")
+    item = next((item for item in compare["files"] if item["path"] == path), None)
+    if item is None:
+        raise HTTPException(status_code=404, detail="file not found in compare")
+    return {"path": path, "patch": item["patch"]}

--- a/projects/monolith/swarm/compare_router_test.py
+++ b/projects/monolith/swarm/compare_router_test.py
@@ -1,0 +1,147 @@
+import json
+
+import pytest
+
+from swarm import compare_router as mod
+
+
+def _data(**overrides):
+    value = {
+        "base_sha": "base",
+        "commit_sha": "head",
+        "branch": "claude/swarm-1",
+        "repo": "jomcgi/homelab",
+        "usage_json": json.dumps(
+            {"activities": [{"type": "edit", "file_path": "a.py"}]}
+        ),
+        "result_text": "RATIONALE\n- path: a.py · why: change it",
+    }
+    value.update(overrides)
+    return value
+
+
+class Response:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _compare_payload(truncated=False):
+    return {
+        "files": [
+            {
+                "filename": "a.py",
+                "status": "modified",
+                "additions": 2,
+                "deletions": 1,
+                "changes": 3,
+                "patch": "@@ a",
+            },
+            {
+                "filename": "generated.py",
+                "status": "added",
+                "additions": 1,
+                "deletions": 0,
+                "changes": 1,
+                "patch": "@@ g",
+            },
+        ],
+        "truncated": truncated,
+    }
+
+
+@pytest.mark.asyncio
+async def test_sha_resolution_is_stats_first(monkeypatch):
+    mod._cache.clear()
+    calls = []
+
+    async def get(url):
+        calls.append(url)
+        return Response(200, _compare_payload())
+
+    monkeypatch.setattr(mod, "_turn_data", lambda *_: _data())
+    monkeypatch.setattr(mod, "_github_get", get)
+    result = await mod.compare_stats(1, 1)
+    assert result["resolution_rung"] == 1
+    assert result["diff_type"] == "sha"
+    assert result["files"][0]["classification"] == "authored"
+    assert result["files"][0]["patch_url"]
+    assert result["files"][1]["classification"] == "mechanical"
+    assert result["files"][1]["patch_url"] is None
+    assert "patch" not in result["files"][0]
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_branch_and_absence_resolution(monkeypatch):
+    mod._cache.clear()
+
+    async def branch_get(url):
+        return (
+            Response(200, {})
+            if "/branches/" in url
+            else Response(200, _compare_payload())
+        )
+
+    monkeypatch.setattr(
+        mod, "_turn_data", lambda *_: _data(base_sha=None, commit_sha=None)
+    )
+    monkeypatch.setattr(mod, "_github_get", branch_get)
+    result = await mod.compare_stats(1, 1)
+    assert result["resolution_rung"] == 2
+    assert result["diff_type"] == "branch_ephemeral"
+
+    monkeypatch.setattr(
+        mod, "_turn_data", lambda *_: _data(base_sha=None, commit_sha=None, branch=None)
+    )
+    result = await mod.compare_stats(1, 1)
+    assert result["resolution_rung"] == 3
+    assert result["error"] == "no_compare_available"
+
+
+@pytest.mark.asyncio
+async def test_truncation_activities_and_cross_checks(monkeypatch):
+    mod._cache.clear()
+    activities = [{"type": "edit", "file_path": "a.py"}] + [
+        {"type": "read", "file_path": f"x{i}.py"} for i in range(299)
+    ]
+    data = _data(
+        usage_json=json.dumps({"activities": activities}),
+        result_text="RATIONALE\n- path: missing.py · why: absent",
+    )
+    monkeypatch.setattr(mod, "_turn_data", lambda *_: data)
+    monkeypatch.setattr(
+        mod,
+        "_github_get",
+        lambda *_: _async_response(Response(200, _compare_payload(True))),
+    )
+    result = await mod.compare_stats(1, 1)
+    assert result["activities_truncated"] is True
+    assert result["stats"]["truncated_at"] == 300
+    assert result["unexplained_files"] == ["a.py", "generated.py"]
+    assert result["contradicted_paths"] == ["missing.py"]
+
+
+@pytest.mark.asyncio
+async def test_lazy_patch_and_cache(monkeypatch):
+    mod._cache.clear()
+    calls = []
+
+    async def get(url):
+        calls.append(url)
+        return Response(200, _compare_payload())
+
+    monkeypatch.setattr(mod, "_turn_data", lambda *_: _data())
+    monkeypatch.setattr(mod, "_github_get", get)
+    await mod.compare_stats(1, 1)
+    await mod.compare_stats(1, 1)
+    assert len(calls) == 1
+    patch = await mod.compare_patch(1, 1, "a.py")
+    assert patch == {"path": "a.py", "patch": "@@ a"}
+
+
+async def _async_response(response):
+    return response

--- a/projects/monolith/swarm/router.py
+++ b/projects/monolith/swarm/router.py
@@ -8,11 +8,14 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from swarm import config, runtime
 from goosecracker.api import REPO_CATALOG
+from swarm import config, runtime
+from swarm.compare_router import router as compare_router
 
 router = APIRouter(prefix="/api/swarm", tags=["swarm"])
 logger = logging.getLogger(__name__)
+
+router.include_router(compare_router)
 
 
 class RunRequest(BaseModel):


### PR DESCRIPTION
ADR 056's **capture** half landed in PR #4786: rationale trailers are
path-anchored, and both `base_sha` and `commit_sha` are recorded per turn.
**Nothing rendered any of it, because the diff was not reachable.** This is
that missing piece. Backend only; the walkthrough UI is a separate follow-up.

## Proxied, because the repo is private

ADR 056 decision 8: the token cannot go client side. Follows the established
pattern in this codebase (`GITHUB_API_TOKEN`, `httpx`, `api.github.com`; see
`swarm/steps.py` and `cluster/cd_health.py`).

Async throughout: `httpx.AsyncClient` awaited for GitHub, and database reads
through `asyncio.to_thread` with the helper opening its own session, per
`projects/monolith/CLAUDE.md`. Both matter here: PR #4797 had to be corrected
today for calling a synchronous `httpx.post` inside an `async def`, and the
semgrep rule that catches the database variant is currently inert (#4777), so
nothing would have warned.

## Resolution ladder, with the rung in the response

ADR 056 decision 6:

| rung | condition | result |
| --- | --- | --- |
| 1 | both SHAs recorded | `compare/{base}...{head}`, authoritative |
| 2 | branch still exists, no SHAs | compare by name, labelled `branch_ephemeral` |
| 3 | neither | absence returned explicitly, nothing fabricated |

The rung is in the payload. A reader must be able to tell an authoritative
compare from an expiring one, and rung 2 genuinely expires: this repo deletes
branches on merge and allows rebase merges only, so a name-based compare has a
shelf life measured in days.

## Stats primary, patches lazy

Per-file stats up front; a separate call fetches one file's patch on demand. A
200-file compare is megabytes and this console polls.

**Truncation is a labelled fact, never silent.** GitHub caps the files array
around 300 and truncates without saying so clearly, so the response carries
`truncated`, `truncated_at` and `truncated_reason` rather than quietly
under-reporting a large change.

## The mechanical classifier

ADR 056 decision 5: a file in the compare that no edit or write activity
touched was produced by a script. Read from `usage_json.activities`, which
already carries `file_path`.

This is what will let the UI collapse "ci regen produced 143 files" into one
step instead of 143. The activities ingest also caps at 300, so
`activities_truncated` is reported rather than silently treating everything
beyond the cap as mechanical.

## The cross-check

ADR 056 decision 3, the property that makes a self-authored narrative safe to
show:

- `unexplained_files`: changed but mentioned by no trailer point;
- `contradicted_paths`: claimed by a trailer point but absent from the diff.

Both are **presentation data only**. Joe decided flag-never-block (decision
4), so this gates nothing. It reuses `swarm/rationale.py`'s parsed output
rather than re-parsing the trailer.

## Verification

`ci test //projects/monolith:swarm_compare_router_test -- --nocache_test_results`
-> `Executed 1 out of 1 test: 1 test passes.` Forced uncached, since a cached
green cannot distinguish a real pass from a run that never happened.

Not verified: the live GitHub API. Tests stub it, so rate-limit behaviour and
real truncation on a genuinely large compare are unproven until this runs
against real traffic.

The env var is wired through `chart/values.yaml` and
`chart/templates/deployment.yaml` together with the code, since a partial wire
leaves the whole block unrendered.

No chart version or `targetRevision` touched.