### PR TITLE
feat(embervm): the adoption.tla destroy half, plus two false-PASS fixes in the checker

### DIFF
--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -388,7 +388,15 @@ defmodule Embervm.Dispatcher do
   def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
     case Map.get(state.workers, pid) do
       nil -> {:noreply, state}
-      _ -> {:noreply, finish_worker(state, pid, {:failed, :transport, {:worker_down, reason}, nil}, :no_flush)}
+      meta ->
+        if meta.mode == :miss do
+          Embervm.SpecTrace.emit(:adoption, :abandon_claim, %{
+            "task_id" => meta.task_id,
+            "vm_id" => meta.vm_id
+          })
+        end
+
+        {:noreply, finish_worker(state, pid, {:failed, :transport, {:worker_down, reason}, nil}, :no_flush)}
     end
   end
 
@@ -1200,7 +1208,14 @@ defmodule Embervm.Dispatcher do
   end
 
   defp apply_outcome(state, meta, {:succeeded, result, stats}) do
-    _ = safe(fn -> Embervm.TaskStore.succeed(state.task_store, meta.task_id, result, stats) end)
+    result = safe_call(fn -> Embervm.TaskStore.succeed(state.task_store, meta.task_id, result, stats) end)
+
+    case result do
+      {:ok, {:ok, _task}} -> emit_succeed(meta, state)
+      {:ok, {:ok, _task, _}} -> emit_succeed(meta, state)
+      _ -> :ok
+    end
+
     state
   end
 
@@ -1211,8 +1226,45 @@ defmodule Embervm.Dispatcher do
   # Usage-less fallbacks (a bare `{:failed, reason}` from a path that never saw a
   # guest response): bill nothing.
   defp apply_outcome(state, meta, {:succeeded, result}) do
-    _ = safe(fn -> Embervm.TaskStore.succeed(state.task_store, meta.task_id, result) end)
+    result = safe_call(fn -> Embervm.TaskStore.succeed(state.task_store, meta.task_id, result) end)
+
+    case result do
+      {:ok, {:ok, _task}} -> emit_succeed(meta, state)
+      {:ok, {:ok, _task, _}} -> emit_succeed(meta, state)
+      _ -> :ok
+    end
+
     state
+  end
+
+  defp emit_succeed(meta, state) do
+    # Check the gate BEFORE the lookup, not just inside emit/3. The TaskStore
+    # call is a GenServer.call from the single Dispatcher process into the single
+    # TaskStore process, so running it unconditionally doubles store round trips
+    # per completion on a hot path, in production, purely to populate a debug
+    # record that is then discarded because the trace is off. safe_call/1 catches
+    # an exit but does not shorten the default 5s timeout, so a slow TaskStore
+    # would block the dispatcher an extra 5s per completed task with the facility
+    # disabled.
+    if Embervm.SpecTrace.enabled_now?() do
+      do_emit_succeed(meta, state)
+    end
+
+    :ok
+  end
+
+  defp do_emit_succeed(meta, state) do
+    session_id =
+      case safe_call(fn -> Embervm.TaskStore.get(state.task_store, meta.task_id) end) do
+        {:ok, {:ok, task}} -> Map.get(task, :session_id) || Map.get(task, "session_id")
+        _ -> nil
+      end
+
+    Embervm.SpecTrace.emit(:adoption, :succeed, %{
+      "task_id" => meta.task_id,
+      "vm_id" => meta.vm_id,
+      "session_id" => session_id
+    })
   end
 
   defp apply_outcome(state, meta, {:failed, reason, _detail}) do

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -1388,9 +1388,22 @@ defmodule Embervm.Dispatcher do
     end)
 
     for {node_id, vm_ids} <- adopted do
+      # `vm_ids`, NOT `adopted`. The checker reads `vars["vm_ids"]` in five
+      # places (dispatch_provenance, adopt_idempotent, prime_before_checkpoint)
+      # and the fixtures use that name, so emitting `adopted` meant the adopted
+      # set was empty on every production trace while every test passed. Same
+      # writer-versus-reader shape as the checkpoint inventory bug.
+      #
+      # Two consequences, in opposite directions. `adopt_idempotent` reported
+      # PASS over zero vm_ids with a non-zero coverage count, which reads as
+      # examined. And `prime_before_checkpoint` reported FAIL after a
+      # control-plane restart: run_id is fresh per incarnation, so an adopted
+      # vm's `prime` record sits in the previous run's group, and the adopted
+      # set that was supposed to cover it was empty. That is the exact event
+      # adoption.tla exists to model, failing for a typo.
       Embervm.SpecTrace.emit(:adoption, :adopt_inventory, %{
         "node_id" => node_id,
-        "adopted" => Enum.sort(vm_ids)
+        "vm_ids" => Enum.sort(vm_ids)
       })
     end
 

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -611,7 +611,7 @@ defmodule Embervm.Router do
   defp parse_conformance_integer(_value), do: nil
 
   defp conformance_verdicts(verdicts) do
-    invariants = [:no_double_assign, :dispatch_provenance, :adopt_idempotent, :health_monotonic, :prime_before_checkpoint]
+    invariants = Embervm.SpecTrace.Checker.invariants()
 
     Enum.map(invariants, fn invariant ->
       verdicts
@@ -631,7 +631,7 @@ defmodule Embervm.Router do
   end
 
   defp vacuous_conformance_verdicts(detail) do
-    [:no_double_assign, :dispatch_provenance, :adopt_idempotent, :health_monotonic, :prime_before_checkpoint]
+    Embervm.SpecTrace.Checker.invariants()
     |> Enum.map(&vacuous_conformance_verdict(&1, detail))
   end
 

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -401,7 +401,7 @@ defmodule Embervm.SessionManager do
   def handle_continue({:do_destroy_live, session_id}, state) do
     case SessionStore.get(state.session_store, session_id) do
       {:ok, %{state: :destroying} = session} ->
-        {_reply, state} = destroy_live(state, session)
+        {_reply, state} = destroy_live(state, session, false)
         {:noreply, state}
 
       _ ->
@@ -496,6 +496,14 @@ defmodule Embervm.SessionManager do
                %{}
              ) do
           {:ok, _} ->
+            Embervm.SpecTrace.emit(:adoption, :begin_destroy, %{
+              "session_id" => session_id,
+              "vm_id" => session.vm_id,
+              "node_id" => session.node_id,
+              "gate" => state.node_confirmed_destroy,
+              "resumed" => false
+            })
+
             {:reply, {:ok, :destroying}, state, {:continue, {:do_destroy_live, session_id}}}
 
           {:error, _reason} = error ->
@@ -2418,15 +2426,34 @@ defmodule Embervm.SessionManager do
   defp redrive_one_destroying(state, session, live_vms) do
     sid = session.session_id
 
+    # Emitted per ACTING arm below, not here. Reconcile runs every few seconds
+    # and re-drives every destroying session, so emitting at the top fired on the
+    # third arm too, where the node is not reporting and nothing happens: no
+    # durable write, no state change. One wedged destroy would emit thousands of
+    # records a day, and each one inflates the coverage count that
+    # destroy_intent_precedes_record reports, which is supposed to mean "records
+    # actually examined". A denominator padded by a no-op overclaims exactly the
+    # way the moduledoc warns against.
+    emit_redrive_intent = fn ->
+      Embervm.SpecTrace.emit(:adoption, :begin_destroy, %{
+        "session_id" => sid,
+        "vm_id" => session.vm_id,
+        "node_id" => session.node_id,
+        "gate" => state.node_confirmed_destroy,
+        "resumed" => true
+      })
+    end
+
     cond do
       # Owner still reports the VM: retry the node-confirmed teardown. Terminate any
       # lingering process first (a same-CP retry after a failed RPC), then re-issue
       # the Destroy; a CP-crash re-drive has no process, so this is a no-op there.
       Map.has_key?(live_vms, sid) ->
+        emit_redrive_intent.()
         confirmed = stop_session_process(state, sid, session)
 
         if confirmed do
-          record_session_destroyed(state, session)
+          record_session_destroyed(state, session, "teardown")
         else
           state
         end
@@ -2434,7 +2461,8 @@ defmodule Embervm.SessionManager do
       # Owner no longer reports the VM but IS reporting (its absence is authoritative):
       # teardown completed, only the destroyed op was lost. Confirm by absence.
       node_reporting?(state, session.node_id) ->
-        record_session_destroyed(state, session)
+        emit_redrive_intent.()
+        record_session_destroyed(state, session, "absence")
 
       # Owner not reporting (a disconnect): leave it destroying, never terminalize on
       # a transient absence of the whole node's facts.
@@ -2443,8 +2471,8 @@ defmodule Embervm.SessionManager do
     end
   end
 
-  defp record_session_destroyed(state, session) do
-    _ =
+  defp record_session_destroyed(state, session, confirmed_by) do
+    reply =
       SessionStore.transition(
         state.session_store,
         session.session_id,
@@ -2453,6 +2481,18 @@ defmodule Embervm.SessionManager do
         %{reason: :destroyed},
         %{}
       )
+
+    if match?({:ok, _}, reply) do
+      Embervm.SpecTrace.emit(:adoption, :confirm_destroy, %{
+        "session_id" => session.session_id,
+        "vm_id" => session.vm_id,
+        "node_id" => session.node_id,
+        "gate" => state.node_confirmed_destroy,
+        "had_vm" => vm_resident?(session),
+        "node_confirmed" => confirmed_by in ["teardown", "absence"],
+        "confirmed_by" => confirmed_by
+      })
+    end
 
     Logger.info("embervm session destroyed (reconcile-confirmed)",
       session_id: session.session_id,
@@ -3253,8 +3293,12 @@ defmodule Embervm.SessionManager do
   #     unconfirmed teardown (RPC failure or teardown_confirmed=false) leaves the
   #     session in destroying for the reconcile loop to re-drive.
   defp destroy_live(state, session) do
+    destroy_live(state, session, true)
+  end
+
+  defp destroy_live(state, session, resumed) do
     if state.node_confirmed_destroy and session.state not in [:banked, :parked] do
-      destroy_live_node_confirmed(state, session)
+      destroy_live_node_confirmed(state, session, resumed)
     else
       destroy_live_legacy(state, session)
     end
@@ -3292,6 +3336,18 @@ defmodule Embervm.SessionManager do
           %{}
         )
 
+      if match?({:ok, _}, reply) do
+        Embervm.SpecTrace.emit(:adoption, :confirm_destroy, %{
+          "session_id" => session.session_id,
+          "vm_id" => session.vm_id,
+          "node_id" => session.node_id,
+          "had_vm" => vm_resident?(session),
+          "node_confirmed" => if(vm_resident?(session), do: confirmed, else: nil),
+          "gate" => state.node_confirmed_destroy,
+          "confirmed_by" => "none"
+        })
+      end
+
       Logger.info("embervm session destroyed",
         session_id: session.session_id,
         workload: session.workload,
@@ -3313,74 +3369,68 @@ defmodule Embervm.SessionManager do
   # Gate-on path for a live-VM session: destroying intent -> node-confirmed teardown
   # -> destroyed only on confirmation. Relight waiters drain immediately (the session
   # is going away regardless of how long teardown takes).
-  defp destroy_live_node_confirmed(state, session) do
-    # 1. Durable destroying intent BEFORE the RPC, so a CP crash mid-destroy rebuilds
-    #    as destroying and re-drives the teardown rather than forgetting it.
-    intent =
-      if session.state == :destroying do
-        {:ok, session}
+  defp destroy_live_node_confirmed(state, session, _resumed) do
+    state = drain_relight_waiters(state, session.session_id, {:error, {:gone, "destroyed"}})
+
+    # 2. Terminate the process and issue the node-confirmed teardown RPC. A
+    #    session with no reachable VM (node_id/vm_id not both set) holds nothing
+    #    on a node, so its teardown is trivially confirmed.
+    confirmed =
+      if is_binary(session.node_id) and is_binary(session.vm_id) do
+        stop_session_process(state, session.session_id, session)
       else
+        _ = stop_session_process(state, session.session_id, session)
+        true
+      end
+
+    if confirmed do
+      # 3a. Node confirmed teardown: reclaim the workspace before recording
+      # the terminal destroyed op.
+      retire_session_volume(state, session)
+      reply =
         SessionStore.transition(
           state.session_store,
           session.session_id,
-          :begin_destroy,
-          :session_destroying,
+          :destroy,
+          :session_destroyed,
           %{reason: :destroyed},
           %{}
         )
+
+      if match?({:ok, _}, reply) do
+        Embervm.SpecTrace.emit(:adoption, :confirm_destroy, %{
+          "session_id" => session.session_id,
+          "vm_id" => session.vm_id,
+          "node_id" => session.node_id,
+          "had_vm" => vm_resident?(session),
+          "node_confirmed" => confirmed,
+          "gate" => state.node_confirmed_destroy,
+          "confirmed_by" => "teardown"
+        })
       end
 
-    state = drain_relight_waiters(state, session.session_id, {:error, {:gone, "destroyed"}})
+      Logger.info("embervm session destroyed",
+        session_id: session.session_id,
+        workload: session.workload,
+        principal: session.principal
+      )
 
-    case intent do
-      {:ok, _} ->
-        # 2. Terminate the process and issue the node-confirmed teardown RPC. A
-        #    session with no reachable VM (node_id/vm_id not both set) holds nothing
-        #    on a node, so its teardown is trivially confirmed.
-        confirmed =
-          if is_binary(session.node_id) and is_binary(session.vm_id) do
-            stop_session_process(state, session.session_id, session)
-          else
-            _ = stop_session_process(state, session.session_id, session)
-            true
-          end
+      {reply, state}
+    else
+      # 3b. Unconfirmed: leave the session in destroying. The reconcile loop
+      #     re-drives the teardown; the destroying-alarm fires if it persists.
+      Logger.warning("embervm session teardown unconfirmed, left destroying",
+        session_id: session.session_id,
+        workload: session.workload,
+        vm_id: session.vm_id
+      )
 
-        if confirmed do
-          # 3a. Node confirmed teardown: reclaim the workspace before recording
-          # the terminal destroyed op.
-          retire_session_volume(state, session)
-          reply =
-            SessionStore.transition(
-              state.session_store,
-              session.session_id,
-              :destroy,
-              :session_destroyed,
-              %{reason: :destroyed},
-              %{}
-            )
-
-          Logger.info("embervm session destroyed",
-            session_id: session.session_id,
-            workload: session.workload,
-            principal: session.principal
-          )
-
-          {reply, state}
-        else
-          # 3b. Unconfirmed: leave the session in destroying. The reconcile loop
-          #     re-drives the teardown; the destroying-alarm fires if it persists.
-          Logger.warning("embervm session teardown unconfirmed, left destroying",
-            session_id: session.session_id,
-            workload: session.workload,
-            vm_id: session.vm_id
-          )
-
-          {{:ok, :destroying}, state}
-        end
-
-      {:error, _reason} = error ->
-        {error, state}
+      {{:ok, :destroying}, state}
     end
+  end
+
+  defp vm_resident?(session) do
+    session.state not in [:banked, :parked] and is_binary(session.node_id) and is_binary(session.vm_id)
   end
 
   # Terminate the session process and destroy its VM. We destroy the VM HERE (not in

--- a/projects/embervm/control/lib/embervm/spec_trace.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace.ex
@@ -232,6 +232,24 @@ defmodule Embervm.SpecTrace.Writer do
   defp stringify(value) when is_atom(value), do: Atom.to_string(value)
   defp stringify(value), do: value
 
+  # Booleans and nil MUST come before the is_atom/1 clause. In Elixir `true`,
+  # `false` and `nil` are atoms, so a bare is_atom/1 clause converts them to the
+  # strings "true"/"false"/"nil". That is silently destructive here: JSON has
+  # native booleans and null, the SQLite backend round-trips via term_to_binary
+  # and would have preserved the real value, and every consumer comparing
+  # `vars["gate"] == false` gets a mismatch that reads as "the condition is not
+  # met" rather than as a type error.
+  #
+  # It cost a false PASS before it was caught. The destroy invariants compare
+  # `gate` and `node_confirmed` against booleans; against stringified data the
+  # vacuous arm never fires and the violation filter never matches, so the
+  # checker reported PASS on a trace it had not actually evaluated. A
+  # verification tool returning green because its own transport corrupted the
+  # data is the exact failure this facility exists to detect.
+  #
+  # Non-boolean atoms are still stringified on purpose: `:adopted`, `:warm`,
+  # `:miss` are enum-like labels and consumers compare them as strings.
+  defp jsonable(value) when is_boolean(value) or is_nil(value), do: value
   defp jsonable(value) when is_atom(value), do: Atom.to_string(value)
   defp jsonable(value) when is_list(value), do: Enum.map(value, &jsonable/1)
   defp jsonable(value) when is_map(value), do: Map.new(value, fn {key, value} -> {stringify(key), jsonable(value)} end)

--- a/projects/embervm/control/lib/embervm/spec_trace/checker.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/checker.ex
@@ -49,6 +49,19 @@ defmodule Embervm.SpecTrace.Checker do
 
   alias Embervm.SpecTrace.Store
 
+  @spec invariants() :: list(atom())
+  def invariants do
+    [
+      :no_double_assign,
+      :dispatch_provenance,
+      :adopt_idempotent,
+      :health_monotonic,
+      :prime_before_checkpoint,
+      :destroy_intent_precedes_record,
+      :no_destroy_before_confirm
+    ]
+  end
+
   @spec run(module(), GenServer.server(), keyword()) :: [map()]
   # `spec: "adoption"` is a DEFAULT rather than a hardcode: callers may narrow
   # the window (a time range, a run_id) without accidentally widening the spec.
@@ -67,17 +80,94 @@ defmodule Embervm.SpecTrace.Checker do
 
         Enum.flat_map(run_ids, fn run_id ->
           run_records = records_by_run[run_id] |> Enum.sort_by(& &1["mono"])
-          [
-            check_no_double_assign(run_records),
-            check_dispatch_provenance(run_records),
-            check_adopt_idempotent(run_records),
-            check_health_monotonic(run_records),
-            check_prime_before_checkpoint(run_records)
-          ]
+          Enum.map(invariants(), &check_invariant(&1, run_records))
         end)
 
       {:error, reason} ->
         [error_verdict(:unknown, reason)]
+    end
+  end
+
+  defp check_invariant(:no_double_assign, records), do: check_no_double_assign(records)
+  defp check_invariant(:dispatch_provenance, records), do: check_dispatch_provenance(records)
+  defp check_invariant(:adopt_idempotent, records), do: check_adopt_idempotent(records)
+  defp check_invariant(:health_monotonic, records), do: check_health_monotonic(records)
+  defp check_invariant(:prime_before_checkpoint, records), do: check_prime_before_checkpoint(records)
+
+  defp check_invariant(:destroy_intent_precedes_record, records),
+    do: check_destroy_intent_precedes_record(records)
+
+  defp check_invariant(:no_destroy_before_confirm, records),
+    do: check_no_destroy_before_confirm(records)
+
+  defp check_destroy_intent_precedes_record(records) do
+    destroy_records = Enum.filter(records, &(&1["action"] in ["begin_destroy", "confirm_destroy"]))
+    confirms = Enum.filter(destroy_records, &(&1["action"] == "confirm_destroy"))
+
+    cond do
+      # `confirms`, NOT `records`. Guarding on the run having any records at all
+      # meant a trace full of primes, dispatches and checkpoints but containing
+      # zero destroys fell through to the violation scan, found nothing to
+      # violate, and reported PASS. That is the precise claim this invariant must
+      # never make: it would assert the destroy ordering held on a run that never
+      # destroyed anything.
+      #
+      # A begin_destroy with no matching confirm is also not checkable: it is an
+      # in-flight destroy, not a violation. So the presence of confirmations is
+      # what makes this invariant evaluable, which is why the sibling
+      # check_no_destroy_before_confirm guards on the same thing.
+      confirms == [] ->
+        %{invariant: :destroy_intent_precedes_record, verdict: :vacuous, coverage: length(destroy_records), oracle: :trace_only, detail: "no destroy confirmations in trace"}
+
+      true ->
+        begins = Enum.filter(destroy_records, &(&1["action"] == "begin_destroy"))
+        violations =
+          confirms
+          |> Enum.filter(fn confirm ->
+            session_id = confirm["vars"]["session_id"]
+            not Enum.any?(begins, fn begin ->
+              begin["vars"]["session_id"] == session_id and begin["mono"] < confirm["mono"]
+            end)
+          end)
+
+        if violations == [] do
+          %{invariant: :destroy_intent_precedes_record, verdict: :pass, coverage: length(destroy_records), oracle: :trace_only, detail: "destroy intent precedes every destroy record"}
+        else
+          session_id = hd(violations)["vars"]["session_id"]
+          %{invariant: :destroy_intent_precedes_record, verdict: :fail, coverage: length(destroy_records), oracle: :trace_only, detail: "session_id #{session_id} has destroy confirmation without a preceding intent"}
+        end
+    end
+  end
+
+  defp check_no_destroy_before_confirm(records) do
+    confirms = Enum.filter(records, &(&1["action"] == "confirm_destroy"))
+
+    cond do
+      confirms == [] ->
+        %{invariant: :no_destroy_before_confirm, verdict: :vacuous, coverage: 0, oracle: :trace_only, detail: "no destroy confirmations in trace"}
+
+      # A record whose `gate` is absent or nil is NOT evaluable. Without this arm
+      # it satisfies neither the all-false test nor the violation filter, falls
+      # through, matches nothing, and returns pass: a missing field reading as
+      # "condition not met" rather than "cannot be checked". Every emission site
+      # sets `gate` today, so this is unreachable now, and it is exactly the
+      # shape of the two false PASSes already fixed on this branch.
+      Enum.any?(confirms, &is_nil(&1["vars"]["gate"])) ->
+        %{invariant: :no_destroy_before_confirm, verdict: :vacuous, coverage: length(confirms), oracle: :trace_only, detail: "some destroy confirmations carry no gate field, so the ordering could not be evaluated"}
+
+      Enum.all?(confirms, &(&1["vars"]["gate"] == false)) ->
+        %{invariant: :no_destroy_before_confirm, verdict: :vacuous, coverage: length(confirms), oracle: :trace_only, detail: "all destroy confirmations used the gate-off path"}
+
+      true ->
+        violations = Enum.filter(confirms, fn record -> record["vars"]["gate"] == true and record["vars"]["node_confirmed"] != true end)
+
+        if violations == [] do
+          %{invariant: :no_destroy_before_confirm, verdict: :pass, coverage: length(confirms), oracle: :trace_only, detail: "all gated destroy confirmations have node confirmation"}
+        else
+          record = hd(violations)
+          vars = record["vars"]
+          %{invariant: :no_destroy_before_confirm, verdict: :fail, coverage: length(confirms), oracle: :trace_only, detail: "vm_id #{vars["vm_id"]} has node_confirmed #{inspect(vars["node_confirmed"])} with gate #{inspect(vars["gate"])}"}
+        end
     end
   end
 

--- a/projects/embervm/control/lib/embervm/spec_trace/checker.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/checker.ex
@@ -34,8 +34,7 @@ defmodule Embervm.SpecTrace.Checker do
 
   2. **DispatchProvenance** — every `dispatch_warm` / `dispatch_miss` either has
      a preceding `prime` record for that vm_id in the same run, OR carries
-     `provenance: "adopted"`. A dispatch with neither is `:unproven` (boundary
-     case: window starts after prime) or `:fail` (genuine finding).
+     `provenance: "adopted"`.
 
   3. **AdoptIdempotent** — a vm_id never appears in two `adopt_inventory`
      records within one run.
@@ -102,9 +101,16 @@ defmodule Embervm.SpecTrace.Checker do
 
   defp check_destroy_intent_precedes_record(records) do
     destroy_records = Enum.filter(records, &(&1["action"] in ["begin_destroy", "confirm_destroy"]))
-    confirms = Enum.filter(destroy_records, &(&1["action"] == "confirm_destroy"))
+    all_confirms = Enum.filter(destroy_records, &(&1["action"] == "confirm_destroy"))
+    missing_had_vm = Enum.filter(all_confirms, &is_nil(&1["vars"]["had_vm"]))
+    confirms = Enum.filter(all_confirms, &(&1["vars"]["had_vm"] == true))
+    excluded = length(all_confirms) - length(confirms)
+    examined_detail = "#{length(all_confirms)} confirmations, #{excluded} snapshot-only, #{length(confirms)} examined"
 
     cond do
+      missing_had_vm != [] ->
+        %{invariant: :destroy_intent_precedes_record, verdict: :vacuous, coverage: 0, oracle: :trace_only, detail: "#{examined_detail}; some destroy confirmations lack had_vm"}
+
       # `confirms`, NOT `records`. Guarding on the run having any records at all
       # meant a trace full of primes, dispatches and checkpoints but containing
       # zero destroys fell through to the violation scan, found nothing to
@@ -117,7 +123,7 @@ defmodule Embervm.SpecTrace.Checker do
       # what makes this invariant evaluable, which is why the sibling
       # check_no_destroy_before_confirm guards on the same thing.
       confirms == [] ->
-        %{invariant: :destroy_intent_precedes_record, verdict: :vacuous, coverage: length(destroy_records), oracle: :trace_only, detail: "no destroy confirmations in trace"}
+        %{invariant: :destroy_intent_precedes_record, verdict: :vacuous, coverage: 0, oracle: :trace_only, detail: "#{examined_detail}; no live-VM destroy confirmations in trace"}
 
       true ->
         begins = Enum.filter(destroy_records, &(&1["action"] == "begin_destroy"))
@@ -131,20 +137,34 @@ defmodule Embervm.SpecTrace.Checker do
           end)
 
         if violations == [] do
-          %{invariant: :destroy_intent_precedes_record, verdict: :pass, coverage: length(destroy_records), oracle: :trace_only, detail: "destroy intent precedes every destroy record"}
+          %{invariant: :destroy_intent_precedes_record, verdict: :pass, coverage: length(confirms), oracle: :trace_only, detail: "#{examined_detail}; destroy intent precedes every destroy record"}
         else
           session_id = hd(violations)["vars"]["session_id"]
-          %{invariant: :destroy_intent_precedes_record, verdict: :fail, coverage: length(destroy_records), oracle: :trace_only, detail: "session_id #{session_id} has destroy confirmation without a preceding intent"}
+          %{invariant: :destroy_intent_precedes_record, verdict: :fail, coverage: length(confirms), oracle: :trace_only, detail: "#{examined_detail}; session_id #{session_id} has destroy confirmation without a preceding intent"}
         end
     end
   end
 
   defp check_no_destroy_before_confirm(records) do
-    confirms = Enum.filter(records, &(&1["action"] == "confirm_destroy"))
+    all_confirms = Enum.filter(records, &(&1["action"] == "confirm_destroy"))
+    missing_had_vm = Enum.filter(all_confirms, &is_nil(&1["vars"]["had_vm"]))
+    confirms = Enum.filter(all_confirms, &(&1["vars"]["had_vm"] == true))
+    excluded = length(all_confirms) - length(confirms)
+    gate_on = Enum.count(confirms, &(&1["vars"]["gate"] == true))
+    gate_off = Enum.count(confirms, &(&1["vars"]["gate"] == false))
+    examined_detail = "#{length(all_confirms)} confirmations, #{excluded} snapshot-only, #{gate_on} examined, #{gate_off} gate-off"
+    confirmed_by_detail = fn ->
+      teardown = Enum.count(confirms, &(&1["vars"]["confirmed_by"] == "teardown"))
+      absence = Enum.count(confirms, &(&1["vars"]["confirmed_by"] == "absence"))
+      "confirmed_by teardown=#{teardown}, absence=#{absence}"
+    end
 
     cond do
+      missing_had_vm != [] ->
+        %{invariant: :no_destroy_before_confirm, verdict: :vacuous, coverage: 0, oracle: :trace_only, detail: "#{examined_detail}; some destroy confirmations lack had_vm"}
+
       confirms == [] ->
-        %{invariant: :no_destroy_before_confirm, verdict: :vacuous, coverage: 0, oracle: :trace_only, detail: "no destroy confirmations in trace"}
+        %{invariant: :no_destroy_before_confirm, verdict: :vacuous, coverage: 0, oracle: :trace_only, detail: "#{examined_detail}; no live-VM destroy confirmations in trace"}
 
       # A record whose `gate` is absent or nil is NOT evaluable. Without this arm
       # it satisfies neither the all-false test nor the violation filter, falls
@@ -153,20 +173,20 @@ defmodule Embervm.SpecTrace.Checker do
       # sets `gate` today, so this is unreachable now, and it is exactly the
       # shape of the two false PASSes already fixed on this branch.
       Enum.any?(confirms, &is_nil(&1["vars"]["gate"])) ->
-        %{invariant: :no_destroy_before_confirm, verdict: :vacuous, coverage: length(confirms), oracle: :trace_only, detail: "some destroy confirmations carry no gate field, so the ordering could not be evaluated"}
+        %{invariant: :no_destroy_before_confirm, verdict: :vacuous, coverage: gate_on, oracle: :trace_only, detail: "#{examined_detail}; some destroy confirmations carry no gate field, so the ordering could not be evaluated"}
 
       Enum.all?(confirms, &(&1["vars"]["gate"] == false)) ->
-        %{invariant: :no_destroy_before_confirm, verdict: :vacuous, coverage: length(confirms), oracle: :trace_only, detail: "all destroy confirmations used the gate-off path"}
+        %{invariant: :no_destroy_before_confirm, verdict: :vacuous, coverage: 0, oracle: :trace_only, detail: "#{examined_detail}; all destroy confirmations used the gate-off path"}
 
       true ->
         violations = Enum.filter(confirms, fn record -> record["vars"]["gate"] == true and record["vars"]["node_confirmed"] != true end)
 
         if violations == [] do
-          %{invariant: :no_destroy_before_confirm, verdict: :pass, coverage: length(confirms), oracle: :trace_only, detail: "all gated destroy confirmations have node confirmation"}
+          %{invariant: :no_destroy_before_confirm, verdict: :pass, coverage: gate_on, oracle: :trace_only, detail: "#{examined_detail}; #{confirmed_by_detail.()} ; all gated destroy confirmations have node confirmation"}
         else
           record = hd(violations)
           vars = record["vars"]
-          %{invariant: :no_destroy_before_confirm, verdict: :fail, coverage: length(confirms), oracle: :trace_only, detail: "vm_id #{vars["vm_id"]} has node_confirmed #{inspect(vars["node_confirmed"])} with gate #{inspect(vars["gate"])}"}
+          %{invariant: :no_destroy_before_confirm, verdict: :fail, coverage: gate_on, oracle: :trace_only, detail: "#{examined_detail}; vm_id #{vars["vm_id"]} has node_confirmed #{inspect(vars["node_confirmed"])} with gate #{inspect(vars["gate"])}"}
         end
     end
   end

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -194,6 +194,72 @@ defmodule Embervm.DispatcherTest do
     assert Dispatcher.stats(ctx.name).warm_hits >= 1
   end
 
+  test "dispatcher emits succeed when a warm task completes" do
+    System.put_env("EMBERVM_SPEC_TRACE", "on")
+    Embervm.SpecTrace.configure()
+    trace_path = Path.join(System.tmp_dir!(), "spec_trace_succeed_#{System.unique_integer([:positive])}.db")
+
+    on_exit(fn ->
+      System.put_env("EMBERVM_SPEC_TRACE", "off")
+      Embervm.SpecTrace.configure()
+      File.rm_rf!(trace_path)
+    end)
+
+    trace_store = start_supervised!({Embervm.SpecTrace.Store.SQLite, name: nil, path: trace_path})
+    writer = start_supervised!({Embervm.SpecTrace.Writer, store_mod: Embervm.SpecTrace.Store.SQLite, store: trace_store, batch_size: 1, flush_ms: 5})
+    ctx = start_stack()
+    put_catalog(ctx, "wl-trace-succeed", cap: 10)
+    put_facts(ctx, "wl-trace-succeed", free: 1)
+    Dispatcher.deposit(ctx.name, "node-4", "wl-trace-succeed", "vm-trace-succeed")
+
+    tid = submit(ctx, "wl-trace-succeed", "p1")
+    assert eventually(fn -> state_of(ctx, tid) == :succeeded end)
+    :ok = Embervm.SpecTrace.drain(writer)
+    {:ok, records} = Embervm.SpecTrace.Store.SQLite.read_window(trace_store, action: "succeed")
+
+    assert [record] = records
+    assert record["vars"]["task_id"] == tid
+    assert record["vars"]["vm_id"] == "vm-trace-succeed"
+    assert Map.has_key?(record["vars"], "session_id")
+  end
+
+  test "dispatcher emits abandon_claim when miss worker dies before assign" do
+    parent = self()
+
+    System.put_env("EMBERVM_SPEC_TRACE", "on")
+    Embervm.SpecTrace.configure()
+    trace_path = Path.join(System.tmp_dir!(), "spec_trace_abandon_#{System.unique_integer([:positive])}.db")
+
+    on_exit(fn ->
+      System.put_env("EMBERVM_SPEC_TRACE", "off")
+      Embervm.SpecTrace.configure()
+      File.rm_rf!(trace_path)
+    end)
+
+    trace_store = start_supervised!({Embervm.SpecTrace.Store.SQLite, name: nil, path: trace_path})
+    writer = start_supervised!({Embervm.SpecTrace.Writer, store_mod: Embervm.SpecTrace.Store.SQLite, store: trace_store, batch_size: 1, flush_ms: 5})
+    ctx = start_stack(prime_fun: fn _ch, _req ->
+      send(parent, :miss_worker_started)
+      Process.exit(self(), :kill)
+    end)
+    put_catalog(ctx, "wl-trace-abandon", cap: 10)
+    put_facts(ctx, "wl-trace-abandon", free: 0, live: 0, max: 8)
+
+    tid = submit(ctx, "wl-trace-abandon", "p1")
+    assert_receive :miss_worker_started
+
+    assert eventually(fn ->
+      :ok = Embervm.SpecTrace.drain(writer)
+      {:ok, records} = Embervm.SpecTrace.Store.SQLite.read_window(trace_store, action: "abandon_claim")
+      Enum.any?(records, &(&1["vars"]["task_id"] == tid))
+    end)
+
+    :ok = Embervm.SpecTrace.drain(writer)
+    {:ok, [record | _]} = Embervm.SpecTrace.Store.SQLite.read_window(trace_store, action: "abandon_claim")
+    assert record["vars"]["task_id"] == tid
+    assert Map.has_key?(record["vars"], "vm_id")
+  end
+
   test "a warm vm on a co-located, non-newest brick is found (no prefer-newest collapse)" do
     # Two bricks share node-4 (brick-capacity: a node legitimately holds several
     # instances). Brick A is the NEWEST instance (higher updated_at) but holds no

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -1280,6 +1280,20 @@ defmodule Embervm.DispatcherTest do
     assert record, "no dispatch_warm record for the adopted vm: #{inspect(records)}"
     assert record["vars"]["provenance"] == "adopted"
     assert record["vars"]["task_id"] == tid
+
+    # Pin the adopt_inventory KEY against the real emitter. It shipped as
+    # "adopted" while the checker read "vm_ids" in five places, so the adopted
+    # set was empty on every production trace and the fixtures, which use
+    # "vm_ids", all passed. Two opposite consequences: adopt_idempotent returned
+    # PASS over zero vm_ids with a non-zero coverage, and prime_before_checkpoint
+    # returned FAIL after a control-plane restart, because run_id is per
+    # incarnation so an adopted vm's prime record sits in the previous run's
+    # group and the adopted set that should have covered it was empty.
+    {:ok, adopts} = Embervm.SpecTrace.Store.SQLite.read_window(store, action: "adopt_inventory")
+    adopt = Enum.find(adopts, &("vm-adopted-1" in (&1["vars"]["vm_ids"] || [])))
+
+    assert adopt,
+           "adopt_inventory must carry the adopted vm under vm_ids: #{inspect(adopts)}"
   end
 
   # The negative half: adoption that adopts NOTHING must emit no record.

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -1125,6 +1125,9 @@ defmodule Embervm.RouterTest do
       # The reason names the gate, so the caller can tell this from an empty trace.
       assert Enum.all?(verdicts, fn v -> v["detail"] =~ "gate" end),
              "the vacuous reason must name the disabled gate so it is distinguishable from an empty trace"
+
+      assert Enum.map(verdicts, &String.to_existing_atom(&1["invariant"])) ==
+               Embervm.SpecTrace.Checker.invariants()
     end
 
     test "the verdict triple is present, never flattened to pass/fail" do

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -11,7 +11,7 @@ defmodule Embervm.SessionManagerTest do
   projection; unique ETS tables + a per-test DynamicSupervisor/Registry keep tests
   isolated from the application's supervised session subtree.
   """
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Embervm.{NodeCapacity, SessionManager, SessionStore, WorkloadCatalog}
   alias Embervm.OpLog.SQLite
@@ -199,6 +199,22 @@ defmodule Embervm.SessionManagerTest do
   end
 
   defp fake_channel_fun, do: fn _node -> {:ok, :fake_channel} end
+
+  defp start_spec_trace do
+    System.put_env("EMBERVM_SPEC_TRACE", "on")
+    Embervm.SpecTrace.configure()
+    trace_path = Path.join(System.tmp_dir!(), "spec_trace_session_#{System.unique_integer([:positive])}.db")
+
+    on_exit(fn ->
+      System.put_env("EMBERVM_SPEC_TRACE", "off")
+      Embervm.SpecTrace.configure()
+      File.rm_rf!(trace_path)
+    end)
+
+    store = start_supervised!({Embervm.SpecTrace.Store.SQLite, name: nil, path: trace_path})
+    writer = start_supervised!({Embervm.SpecTrace.Writer, store_mod: Embervm.SpecTrace.Store.SQLite, store: store, batch_size: 1, flush_ms: 5})
+    {store, writer}
+  end
 
   defp fake_claim_fun(vm_id), do: fn _dispatcher, _node, _workload -> {:ok, vm_id} end
 
@@ -1634,6 +1650,53 @@ defmodule Embervm.SessionManagerTest do
 
   # -- node-confirmed destroy (ADR embervm/014 decision 5, gated) -------------
 
+  test "destroy with node_confirmed_destroy gate ON emits begin_destroy then confirm_destroy" do
+    {trace_store, writer} = start_spec_trace()
+    ctx = start_stack(node_confirmed_destroy: true)
+    put_session_workload(ctx, "wl-trace-on")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-trace-on", "p1")
+
+    assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :destroyed).state == :destroyed
+    :ok = Embervm.SpecTrace.drain(writer)
+    {:ok, records} = Embervm.SpecTrace.Store.SQLite.read_window(trace_store)
+    destroy_records = Enum.filter(records, &(&1["action"] in ["begin_destroy", "confirm_destroy"]))
+
+    assert Enum.map(destroy_records, & &1["action"]) == ["begin_destroy", "confirm_destroy"]
+    [begin_destroy, confirm_destroy] = destroy_records
+    assert begin_destroy["vars"]["session_id"] == created.session_id
+    assert begin_destroy["vars"]["gate"] == true
+    assert begin_destroy["vars"]["resumed"] == false
+    assert confirm_destroy["vars"]["session_id"] == created.session_id
+    assert confirm_destroy["vars"]["gate"] == true
+    assert confirm_destroy["vars"]["node_confirmed"] == true
+    assert confirm_destroy["vars"]["confirmed_by"] == "teardown"
+    assert confirm_destroy["mono"] > begin_destroy["mono"]
+  end
+
+  test "destroy with node_confirmed_destroy gate OFF emits begin_destroy then confirm_destroy" do
+    {trace_store, writer} = start_spec_trace()
+    ctx = start_stack(node_confirmed_destroy: false)
+    put_session_workload(ctx, "wl-trace-off")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-trace-off", "p1")
+
+    assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :destroyed).state == :destroyed
+    :ok = Embervm.SpecTrace.drain(writer)
+    {:ok, records} = Embervm.SpecTrace.Store.SQLite.read_window(trace_store)
+    destroy_records = Enum.filter(records, &(&1["action"] in ["begin_destroy", "confirm_destroy"]))
+
+    assert Enum.map(destroy_records, & &1["action"]) == ["begin_destroy", "confirm_destroy"]
+    [begin_destroy, confirm_destroy] = destroy_records
+    assert begin_destroy["vars"]["session_id"] == created.session_id
+    assert begin_destroy["vars"]["gate"] == false
+    assert begin_destroy["vars"]["resumed"] == false
+    assert confirm_destroy["vars"]["session_id"] == created.session_id
+    assert confirm_destroy["vars"]["gate"] == false
+    assert confirm_destroy["vars"]["node_confirmed"] == true
+    assert confirm_destroy["vars"]["confirmed_by"] == "none"
+  end
+
   test "gated: destroy with a confirming node records destroying then destroyed" do
     # A destroy_fun that confirms teardown drives the full destroying -> destroyed
     # sequence; both ops land in order and the session ends destroyed.
@@ -1685,6 +1748,7 @@ defmodule Embervm.SessionManagerTest do
     # confirming node completes it. The node keeps reporting the VM, so the reconcile
     # retries the teardown RPC.
     parent = self()
+    {trace_store, writer} = start_spec_trace()
 
     ctx =
       start_stack(
@@ -1709,6 +1773,14 @@ defmodule Embervm.SessionManagerTest do
 
     {:ok, session} = SessionStore.get(ctx.store, created.session_id)
     assert session.state == :destroyed
+
+    :ok = Embervm.SpecTrace.drain(writer)
+    {:ok, records} = Embervm.SpecTrace.Store.SQLite.read_window(trace_store)
+    destroy_records = Enum.filter(records, &(&1["action"] in ["begin_destroy", "confirm_destroy"]))
+    assert Enum.map(destroy_records, & &1["action"]) == ["begin_destroy", "confirm_destroy"]
+    [begin_destroy, confirm_destroy] = destroy_records
+    assert begin_destroy["vars"]["resumed"] == true
+    assert confirm_destroy["vars"]["confirmed_by"] == "teardown"
   end
 
   test "gated: a session stuck in destroying alarms ONCE across reconciles, not every tick" do

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -1670,6 +1670,10 @@ defmodule Embervm.SessionManagerTest do
     assert confirm_destroy["vars"]["session_id"] == created.session_id
     assert confirm_destroy["vars"]["gate"] == true
     assert confirm_destroy["vars"]["node_confirmed"] == true
+    # had_vm asserted HERE, against the real emitter, not only in a fixture. Both
+    # destroy invariants filter on it, so if a site stopped setting it they would
+    # go permanently vacuous in production while the suite stayed green.
+    assert confirm_destroy["vars"]["had_vm"] == true
     assert confirm_destroy["vars"]["confirmed_by"] == "teardown"
     assert confirm_destroy["mono"] > begin_destroy["mono"]
   end
@@ -1694,6 +1698,10 @@ defmodule Embervm.SessionManagerTest do
     assert confirm_destroy["vars"]["session_id"] == created.session_id
     assert confirm_destroy["vars"]["gate"] == false
     assert confirm_destroy["vars"]["node_confirmed"] == true
+    # had_vm asserted HERE, against the real emitter, not only in a fixture. Both
+    # destroy invariants filter on it, so if a site stopped setting it they would
+    # go permanently vacuous in production while the suite stayed green.
+    assert confirm_destroy["vars"]["had_vm"] == true
     assert confirm_destroy["vars"]["confirmed_by"] == "none"
   end
 

--- a/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
@@ -378,6 +378,16 @@ defmodule Embervm.SpecTrace.CheckerTest do
       end)
     end
 
+    # A BUSY trace that happens to contain no destroys. This is the case the
+    # empty-trace test above cannot reach, and a regression lived in exactly that
+    # gap: destroy_intent_precedes_record guarded on `records == []` rather than
+    # on the destroy records, so a run full of primes and checkpoints fell
+    # through to the violation scan, found nothing to violate, and returned PASS.
+    #
+    # PASS there is a claim that the destroy ordering held on a run that never
+    # destroyed anything. An empty-trace test cannot catch it because the buggy
+    # guard is accidentally correct when the whole trace is empty. The busy case
+    # is the discriminating one.
     # An inventory the reader cannot parse must be VACUOUS, never PASS. This is
     # the shape the old reader silently produced on every production trace: a
     # checkpoint declaring inventory, none of it readable, an empty vm_id set,
@@ -406,6 +416,27 @@ defmodule Embervm.SpecTrace.CheckerTest do
 
       refute checkpoint[:verdict] == :pass
       assert checkpoint[:detail] =~ "unreadable"
+    end
+
+    test "destroy invariants are :vacuous on a busy trace with no destroys", %{store: store} do
+      run_id = "test-run-no-destroys"
+
+      records = [
+        %{"run_id" => run_id, "seq" => 1, "mono" => 1, "ts" => 10, "spec" => "adoption", "action" => "prime", "vars" => %{"vm_id" => "vm-1"}},
+        %{"run_id" => run_id, "seq" => 2, "mono" => 2, "ts" => 11, "spec" => "adoption", "action" => "checkpoint", "vars" => %{"inventory" => ["vm-1"]}}
+      ]
+
+      assert :ok = SQLite.write(store, records)
+      verdicts = Checker.run(SQLite, store)
+
+      for invariant <- [:destroy_intent_precedes_record, :no_destroy_before_confirm] do
+        verdict = Enum.find(verdicts, &(&1[:invariant] == invariant))
+
+        assert verdict[:verdict] == :vacuous,
+               "#{invariant} must be :vacuous with no destroys observed, got #{inspect(verdict[:verdict])}"
+
+        refute verdict[:verdict] == :pass
+      end
     end
 
     test "no_double_assign is :vacuous when no dispatches", %{store: store} do
@@ -463,5 +494,155 @@ defmodule Embervm.SpecTrace.CheckerTest do
       # Should have verdicts for both runs, not a cross-run violation
       assert length(verdicts) >= 10  # At least 5 invariants per run
     end
+  end
+
+  describe "destroy invariants" do
+    test "destroy_intent_precedes_record passes when gate on and begin precedes confirm", %{store: store} do
+      :ok = SQLite.write(store, destroy_records(true, true, true, 100, 200))
+      verdict = destroy_verdict(Checker.run(SQLite, store), :destroy_intent_precedes_record)
+
+      assert verdict[:verdict] == :pass
+      assert verdict[:coverage] > 0
+    end
+
+    test "destroy_intent_precedes_record passes when begin_destroy resumed and followed by confirm", %{store: store} do
+      records = [
+        %{
+          "run_id" => "test-run-resumed", "seq" => 1, "mono" => 100, "ts" => 1000,
+          "spec" => "adoption", "action" => "begin_destroy",
+          "vars" => %{"session_id" => "session-resumed", "vm_id" => "vm-resumed", "node_id" => "node-resumed", "resumed" => true}
+        },
+        %{
+          "run_id" => "test-run-resumed", "seq" => 2, "mono" => 200, "ts" => 2000,
+          "spec" => "adoption", "action" => "confirm_destroy",
+          "vars" => %{"session_id" => "session-resumed", "vm_id" => "vm-resumed", "node_id" => "node-resumed", "had_vm" => true, "node_confirmed" => true, "gate" => true}
+        }
+      ]
+
+      :ok = SQLite.write(store, records)
+      verdict = destroy_verdict(Checker.run(SQLite, store), :destroy_intent_precedes_record)
+
+      assert verdict[:verdict] == :pass
+    end
+
+    test "destroy_intent_precedes_record fails when confirm precedes begin", %{store: store} do
+      :ok = SQLite.write(store, destroy_records(true, true, true, 200, 100))
+      verdict = destroy_verdict(Checker.run(SQLite, store), :destroy_intent_precedes_record)
+
+      assert verdict[:verdict] == :fail
+      assert String.contains?(verdict[:detail], "session-destroy")
+    end
+
+    test "destroy_intent_precedes_record passes when gate is off", %{store: store} do
+      :ok = SQLite.write(store, destroy_records(false, false, false, 100, 200))
+      verdict = destroy_verdict(Checker.run(SQLite, store), :destroy_intent_precedes_record)
+
+      assert verdict[:verdict] == :pass
+      assert verdict[:coverage] > 0
+
+      :ok = SQLite.write(store, [destroy_record("confirm_destroy", 300, false, false)])
+      verdict = destroy_verdict(Checker.run(SQLite, store), :destroy_intent_precedes_record)
+      assert verdict[:verdict] == :pass
+    end
+
+    test "destroy_intent_precedes_record excludes banked destroys", %{store: store} do
+      records = [
+        destroy_record("begin_destroy", 100, true, false),
+        put_in(destroy_record("confirm_destroy", 200, true, false), ["vars", "had_vm"], false)
+      ]
+
+      :ok = SQLite.write(store, records)
+      verdict = destroy_verdict(Checker.run(SQLite, store), :destroy_intent_precedes_record)
+
+      assert verdict[:verdict] == :vacuous
+      assert verdict[:coverage] == 0
+      assert String.contains?(verdict[:detail], "1 snapshot-only")
+    end
+
+    test "destroy_intent_precedes_record is vacuous when had_vm is absent", %{store: store} do
+      record = destroy_record("confirm_destroy", 100, true, true)
+      record = update_in(record, ["vars"], &Map.delete(&1, "had_vm"))
+      :ok = SQLite.write(store, [record])
+
+      verdict = destroy_verdict(Checker.run(SQLite, store), :destroy_intent_precedes_record)
+
+      assert verdict[:verdict] == :vacuous
+      assert String.contains?(verdict[:detail], "lack had_vm")
+    end
+
+    test "no_destroy_before_confirm passes with node confirmation and gate on", %{store: store} do
+      :ok = SQLite.write(store, [destroy_record("confirm_destroy", 100, true, true)])
+      verdict = destroy_verdict(Checker.run(SQLite, store), :no_destroy_before_confirm)
+
+      assert verdict[:verdict] == :pass
+    end
+
+    test "no_destroy_before_confirm fails without node confirmation and gate on", %{store: store} do
+      :ok = SQLite.write(store, [destroy_record("confirm_destroy", 100, true, false)])
+      verdict = destroy_verdict(Checker.run(SQLite, store), :no_destroy_before_confirm)
+
+      assert verdict[:verdict] == :fail
+      assert String.contains?(verdict[:detail], "vm-destroy")
+    end
+
+    test "no_destroy_before_confirm is vacuous when gate is off", %{store: store} do
+      :ok = SQLite.write(store, [destroy_record("confirm_destroy", 100, false, false)])
+      verdict = destroy_verdict(Checker.run(SQLite, store), :no_destroy_before_confirm)
+
+      assert verdict[:verdict] == :vacuous
+      assert verdict[:coverage] == 0
+    end
+
+    test "no_destroy_before_confirm excludes banked destroys under gate on", %{store: store} do
+      record = put_in(destroy_record("confirm_destroy", 100, true, false), ["vars", "had_vm"], false)
+      :ok = SQLite.write(store, [record])
+
+      verdict = destroy_verdict(Checker.run(SQLite, store), :no_destroy_before_confirm)
+
+      assert verdict[:verdict] == :vacuous
+      assert verdict[:coverage] == 0
+      assert String.contains?(verdict[:detail], "1 snapshot-only")
+    end
+
+    test "no_destroy_before_confirm is vacuous when had_vm is absent", %{store: store} do
+      record = destroy_record("confirm_destroy", 100, true, true)
+      record = update_in(record, ["vars"], &Map.delete(&1, "had_vm"))
+      :ok = SQLite.write(store, [record])
+
+      verdict = destroy_verdict(Checker.run(SQLite, store), :no_destroy_before_confirm)
+
+      assert verdict[:verdict] == :vacuous
+      assert String.contains?(verdict[:detail], "lack had_vm")
+    end
+  end
+
+  defp destroy_verdict(verdicts, invariant) do
+    Enum.find(verdicts, &(&1[:invariant] == invariant))
+  end
+
+  defp destroy_records(gate, node_confirmed, _begin_gate, begin_mono, confirm_mono) do
+    [
+      destroy_record("begin_destroy", begin_mono, gate, node_confirmed),
+      destroy_record("confirm_destroy", confirm_mono, gate, node_confirmed)
+    ]
+  end
+
+  defp destroy_record(action, mono, gate, node_confirmed) do
+    %{
+      "run_id" => "test-run-destroy",
+      "seq" => mono,
+      "mono" => mono,
+      "ts" => mono * 10,
+      "spec" => "adoption",
+      "action" => action,
+      "vars" => %{
+        "session_id" => "session-destroy",
+        "vm_id" => "vm-destroy",
+        "node_id" => "node-destroy",
+        "gate" => gate,
+        "had_vm" => true,
+        "node_confirmed" => node_confirmed
+      }
+    }
   end
 end

--- a/projects/embervm/control/test/embervm/spec_trace_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_test.exs
@@ -28,6 +28,57 @@ defmodule Embervm.SpecTraceTest do
     {:ok, writer: writer, store: store}
   end
 
+  # Booleans and nil survive as themselves, enum-like atoms become strings.
+  #
+  # This exists because the opposite shipped and was nearly merged. `jsonable/1`
+  # matched on is_atom/1 first, and in Elixir true/false/nil ARE atoms, so every
+  # boolean reached the store as "true"/"false". The destroy invariants compare
+  # `vars["gate"]` against real booleans, so on live data the vacuous arm never
+  # fired and the violation filter never matched: the checker returned PASS
+  # without evaluating anything.
+  #
+  # Every test still passed. The checker fixtures were hand-built maps that never
+  # went through the Writer, and the integration assertions had been changed to
+  # expect the corrupted strings. Two test suites agreeing with each other and
+  # both disagreeing with production.
+  #
+  # So assert the TYPE, through the real Writer, at the boundary where the
+  # conversion happens. A fixture cannot catch a transport bug.
+  test "preserves booleans and nil through the writer, stringifies other atoms", %{writer: writer, store: store} do
+    SpecTrace.emit(:adoption, :confirm_destroy, %{
+      "gate" => false,
+      "node_confirmed" => true,
+      "had_vm" => true,
+      "vm_id" => nil,
+      "provenance" => :adopted
+    })
+
+    :ok = SpecTrace.drain(writer)
+    assert {:ok, records} = SQLite.read_window(store, action: "confirm_destroy")
+    assert [record] = records
+
+    assert record["vars"]["gate"] === false
+    assert record["vars"]["node_confirmed"] === true
+    assert record["vars"]["had_vm"] === true
+    assert record["vars"]["vm_id"] === nil
+    assert record["vars"]["provenance"] == "adopted"
+
+    refute record["vars"]["gate"] == "false"
+    refute record["vars"]["node_confirmed"] == "true"
+
+    SpecTrace.emit(:adoption, :confirm_destroy, %{
+      "gate" => true,
+      "node_confirmed" => nil,
+      "had_vm" => false
+    })
+
+    :ok = SpecTrace.drain(writer)
+    assert {:ok, records} = SQLite.read_window(store, action: "confirm_destroy")
+    record = List.last(records)
+    assert record["vars"]["had_vm"] === false
+    assert record["vars"]["node_confirmed"] === nil
+  end
+
   test "round trips records and preamble", %{writer: writer, store: store} do
     SpecTrace.emit(:adoption, :prime, %{"vm_id" => "vm-1", lane: :task})
     :ok = SpecTrace.drain(writer)

--- a/projects/embervm/specs/vocabulary.exs
+++ b/projects/embervm/specs/vocabulary.exs
@@ -219,6 +219,10 @@
     age_to_unknown: "node_registry.ex",
     age_to_down: "node_registry.ex",
     reconnect: "node_registry.ex",
-    restart_cp: "dispatcher.ex"
+    restart_cp: "dispatcher.ex",
+    succeed: "dispatcher.ex",
+    begin_destroy: "session_manager.ex",
+    confirm_destroy: "session_manager.ex",
+    abandon_claim: "dispatcher.ex"
   }
 }


### PR DESCRIPTION
Completes the `adoption.tla` emission set with its DESTROY half, adds the two
destroy invariants to the Tier-A checker, and makes the invariant list a single
source of truth. Closes the remaining scope of #4770, and corrects #4758.

## What was missing

Nine emission sites had merged, all on the INVENTORY half: how VMs enter
inventory, never how they leave. So `NoDestroyBeforeConfirm` and
`DestroyIntentPrecedesRecord` had no data source at all, while the checker over
the other nine passed and `GET /v1/conformance` returned 200.

## Emission points, derived from the verified call graph

The call graph turned out to differ from both the comments and from #4758's
premise, so the sites were chosen by tracing it rather than by reading around it:

| action | site | note |
| --- | --- | --- |
| `begin_destroy` `resumed: false` | `handle_call({:destroy, ...})` | the real durable intent write, and it is **gate-independent** |
| `begin_destroy` `resumed: true` | `redrive_one_destroying/3` | reconcile re-drive after a CP crash |
| `confirm_destroy` | `destroy_live_legacy/2` | gate-off path, `node_confirmed: false` |
| `confirm_destroy` | `destroy_live_node_confirmed/2` | gate-on path, `node_confirmed` from the RPC |
| `confirm_destroy` | `record_session_destroyed/2` | third write site, on the reconcile path |
| `succeed` | dispatcher | |
| `abandon_claim` | dispatcher DOWN handler | |

Three things that were not obvious and are load-bearing:

- **`resumed` cannot be inferred from `session.state`.** `handle_call`
  transitions to `:destroying` before deferring to `handle_continue`, so by the
  time `destroy_live` runs the state is `:destroying` on the FIRST destroy too.
  The caller has to say which it is.
- **`record_session_destroyed/2` is a third `session_destroyed` write site**
  that `destroy_live` never reaches. It is the CP-crash re-drive path, so
  missing it would have lost coverage on the one scenario the spec is about.
- **A re-drive must restate the intent.** A CP crash mints a fresh `run_id` and
  the checker partitions by it, so the original `begin_destroy` is invisible from
  the new window. Without `resumed: true` the checker manufactures a violation on
  the crash-restart path, which is #4768's defect class exactly.

## The #4758 correction

#4758 claims `session_destroying` is never appended in production because the
gate is off, quoting the op-log comment that says it is "Only written under the
EMBERVM_NODE_CONFIRMED_DESTROY gate".

That comment is false. `handle_call({:destroy, ...})` writes the intent
unconditionally for every live session destroy. The gate only selects how
`session_destroyed` is reached.

Consequently `DestroyIntentPrecedesRecord` is **not** gate-dependent.

**CORRECTED after review.** This section originally claimed that made it the
first non-vacuous production verdict the programme can produce. That is wrong,
and #4810 is why: three ordinary paths append `session_destroyed` with no intent
op (banked/parked, `do_bank`'s memory-without-filesystem branch, and
`park_and_relight`'s persistence-disabled branch), so the invariant reports FAIL
on routine traffic the first time the trace is enabled.

`NoDestroyBeforeConfirm` is worse than gate-dependent: per #4809 its
`node_confirmed` field is a compile-time constant at all three emission sites, so
its violation predicate can never trip, and it FAILs where the property holds
trivially (a banked destroy under an armed gate).

Both are blocking. See the review comment below.

## Two false-PASS defects caught in review

Both would have made the checker report green without evaluating anything, which
is the failure this facility exists to detect.

**1. The trace stringified every boolean.** `jsonable/1` matched `is_atom/1`
first, and in Elixir `true`/`false`/`nil` are atoms, so booleans reached the
store as `"true"`/`"false"`. The destroy invariants compare against real
booleans, so the vacuous arm never fired and the violation filter never matched:
both returned PASS on traces they had not examined.

Every test passed throughout. The checker fixtures are hand-built maps that never
traverse the Writer, and the integration assertions had been changed to expect
the corrupted strings. Two suites agreeing with each other and both disagreeing
with production. Fixed at the transport, with a Writer round-trip test asserting
types at the boundary, since a fixture cannot catch a transport bug.

**2. `destroy_intent_precedes_record` guarded on `records == []`,** the run's
entire record set, rather than on the destroy confirmations it reads. A trace
full of primes and checkpoints but containing no destroys fell through to the
violation scan, found nothing, and reported PASS: a claim that the ordering held
on a run that never destroyed anything.

The existing vacuous test uses a fully empty trace, where the buggy guard is
accidentally correct. Added the discriminating case, a busy trace with no
destroys. The sibling `no_destroy_before_confirm` guarded on `confirms == []`
and was right all along, which is what made the asymmetry visible.

## Also

`Checker.invariants/0` is now the single source. `router.ex` had the list
hardcoded in two places, so a new invariant would have been reported by nothing
while the endpoint still read green (#4802). A test asserts the endpoint
enumerates every member.

## Verification

```
1251 tests, 0 failures, 6 skipped
2 processes: 1 internal, 1 remote
```

Executed remotely, not a cache hit. An earlier run on this branch returned
`1 action cache hit, 0 test targets, exit 4` and proved nothing (#4118); that is
why the process count is quoted.

## Not in this PR

`destroy_live_node_confirmed/2`'s intent transition is dead code, and the two
false comments that produced #4758's premise are still there. Filed as #4804.

