### PR TITLE
refactor(monolith): delete the run narrative rail, tell the run once

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
@@ -203,34 +203,14 @@
       {/each}
     </div>
     {#if run.disposition}<div class="disposition" data-register="fact">
-        <div class="disposition-state">{run.disposition.state}</div>
+        <div class="disposition-state">
+          {P.dispositionStates[run.disposition.state] ?? run.disposition.state}
+        </div>
         <div>{run.disposition.reason}</div>
         {#if run.disposition.next}<div class="disposition-next">
             {run.disposition.next}
           </div>{/if}
       </div>{/if}
-    {#if run.events?.length}<section
-        class="narrative-rail"
-        aria-label="Run narrative"
-      >
-        <div class="stage-head">Run narrative</div>
-        {#each run.events as event}
-          <article
-            class={`narrative-event register-${event.register}`}
-            data-register={event.register}
-          >
-            <div class="narrative-meta">
-              <span class="register-tag">{event.register}</span>
-              {event.at ?? "time unavailable"}
-            </div>
-            {#if event.register === "testimony"}
-              <blockquote>{event.text}</blockquote>
-            {:else}
-              <div>{event.text}</div>
-            {/if}
-          </article>
-        {/each}
-      </section>{/if}
     {#if run.deviations?.length}<div class="deviations" data-register="fact">
         <div class="stage-head">{P.labels.deviations}</div>
         {#each run.deviations as deviation}<div class="deviation-text">

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -163,7 +163,6 @@ export const RUN_LEXICON = {
     budget_exceeded: "budget exceeded",
     attempts_exhausted: "attempts exhausted",
     model_mismatch: "model mismatch",
-    verdict_not_approve: "verdict",
   },
   eventWords: {
     started: "started",
@@ -180,6 +179,7 @@ export const RUN_LEXICON = {
     escalated: "escalated, awaiting decision",
     cancelled: "cancelled",
     review_cycles_exhausted: "review cycles exhausted, awaiting decision",
+    gated: "waiting at a gate",
   },
   verdictCodes: {
     approve: "approved",

--- a/projects/monolith/frontend/src/routes/private/agents/run-view.css
+++ b/projects/monolith/frontend/src/routes/private/agents/run-view.css
@@ -219,8 +219,7 @@
   border-top: 1px solid var(--line);
   padding-top: 12px;
 }
-.disposition,
-.narrative-rail {
+.disposition {
   margin-top: 14px;
   border-top: 1px solid var(--line);
   padding-top: 10px;
@@ -238,29 +237,6 @@
 .disposition-next {
   color: var(--muted);
   margin-top: 4px;
-}
-.narrative-event {
-  border-left: 2px solid var(--line-strong);
-  margin: 0 0 8px 4px;
-  padding: 6px 0 6px 10px;
-  color: var(--text-soft);
-  font-size: var(--size-detail);
-}
-.narrative-event.register-testimony {
-  border-left-color: var(--attn);
-}
-.narrative-meta {
-  color: var(--muted);
-  display: flex;
-  gap: 8px;
-  font: var(--size-meta) var(--font-mono);
-  margin-bottom: 3px;
-}
-.narrative-event blockquote {
-  border-left: 0;
-  color: var(--text);
-  margin: 0;
-  white-space: pre-wrap;
 }
 .verdict-text {
   color: var(--text-soft);

--- a/projects/monolith/swarm/deviations.py
+++ b/projects/monolith/swarm/deviations.py
@@ -55,20 +55,6 @@ def compute_deviations(run: dict) -> list[dict]:
             )
         deviations.append(_deviation("retry_taken", node["key"], evidence, text))
 
-    review = by_key.get("review") or {}
-    verdict = review.get("verdict")
-    if isinstance(verdict, dict) and verdict.get("value") is not None:
-        value = verdict["value"]
-        if value != "approve":
-            deviations.append(
-                _deviation(
-                    "verdict_not_approve",
-                    "review",
-                    f"recorded review verdict: {value}",
-                    f"review returned a {value} verdict.",
-                )
-            )
-
     if pinned:
         expected_models = {
             "implement": plan.get("implementer_model"),

--- a/projects/monolith/swarm/deviations_test.py
+++ b/projects/monolith/swarm/deviations_test.py
@@ -54,14 +54,6 @@ def test_retry_taken_includes_recorded_finding_code():
     assert "head_unchanged" in deviation["evidence"]
 
 
-def test_verdict_not_approve_includes_unparseable():
-    run = {
-        "plan": plan(),
-        "nodes": [node("review", verdict={"value": "unparseable"})],
-    }
-    assert compute_deviations(run)[0]["code"] == "verdict_not_approve"
-
-
 def test_model_mismatch():
     run = {
         "plan": plan(),
@@ -99,3 +91,17 @@ def test_pin_dependent_deviations_are_absent_when_plan_is_unpinned():
     assert "model_mismatch" not in codes
     assert "budget_exceeded" not in codes
     assert "retry_taken" in codes
+
+
+def test_non_approve_verdict_is_not_a_deviation():
+    """A deviation is a departure from what the pinned plan promised.
+
+    A reviewer asking for changes departs from nothing the plan promised, so
+    it is the run's outcome, not a deviation. It is already stated by the
+    disposition; a third restatement here was a category error.
+    """
+    run = {
+        "plan": plan(),
+        "nodes": [node("review", verdict={"value": "unparseable"})],
+    }
+    assert [d["code"] for d in compute_deviations(run)] == []

--- a/projects/monolith/swarm/view.py
+++ b/projects/monolith/swarm/view.py
@@ -308,127 +308,6 @@ def _structured_verdict(output: dict, repo: str | None) -> dict | None:
     }
 
 
-def _event_stream(
-    workflow_id,
-    dbos_status,
-    created_at,
-    implement_attempts,
-    review_attempts,
-    output,
-    repo,
-    stranded,
-):
-    events = []
-
-    def add(at, register, text, refs):
-        timestamp = _iso(at)
-        if timestamp:
-            events.append(
-                {"at": timestamp, "register": register, "text": text, "refs": refs}
-            )
-
-    add(
-        created_at,
-        "fact",
-        f"started run {_short_sha(workflow_id)}",
-        {"workflow_id": workflow_id},
-    )
-    for attempt in implement_attempts:
-        if attempt.get("started_at"):
-            add(
-                attempt["started_at"],
-                "fact",
-                f"implement attempt {attempt['n']} started with {attempt['model']}",
-                {
-                    "node": "implement",
-                    "attempt": attempt["n"],
-                    "session_id": attempt["session_id"],
-                },
-            )
-        rationale = attempt.get("rationale") or {}
-        if rationale.get("raw"):
-            add(
-                attempt.get("ended_at") or attempt.get("started_at"),
-                "testimony",
-                f"implementer reported (attempt {attempt['n']})",
-                {
-                    "node": "implement",
-                    "attempt": attempt["n"],
-                    "session_id": attempt["session_id"],
-                    "rationale_key": "paths",
-                },
-            )
-        if attempt.get("ended_at"):
-            if attempt.get("state") == "gated":
-                add(
-                    attempt["ended_at"],
-                    "fact",
-                    f"attempt {attempt['n']} head did not move, passed to gate for decision",
-                    {
-                        "node": "implement",
-                        "attempt": attempt["n"],
-                        "prior_head": attempt.get("prior_head"),
-                    },
-                )
-            elif attempt.get("state") in ("completed", "failed"):
-                observed = (attempt.get("finding") or {}).get("observed_head")
-                text = (
-                    f"attempt {attempt['n']} advanced to {observed}"
-                    if observed
-                    else f"attempt {attempt['n']} complete"
-                )
-                add(
-                    attempt["ended_at"],
-                    "fact",
-                    text,
-                    {
-                        "node": "implement",
-                        "attempt": attempt["n"],
-                        "session_id": attempt["session_id"],
-                        "sha": observed,
-                    },
-                )
-    for attempt in review_attempts:
-        if attempt.get("started_at"):
-            add(
-                attempt["started_at"],
-                "fact",
-                f"review attempt {attempt['n']} started with {attempt['model']}",
-                {
-                    "node": "review",
-                    "attempt": attempt["n"],
-                    "session_id": attempt["session_id"],
-                },
-            )
-    verdict = _structured_verdict(output, repo)
-    if verdict and review_attempts:
-        attempt = review_attempts[-1]
-        add(
-            attempt.get("ended_at") or attempt.get("started_at"),
-            "testimony",
-            f"reviewer {verdict['summary_plain']}",
-            {
-                "node": "review",
-                "attempt": attempt["n"],
-                "session_id": attempt["session_id"],
-                "verdict_value": verdict["value"],
-                "commit_sha": verdict["commit_sha"],
-                "commit_url": verdict["commit_url"],
-            },
-        )
-    if dbos_status == "CANCELLED":
-        add(
-            output.get("completed_at") or created_at,
-            "fact",
-            "run cancelled",
-            {"workflow_id": workflow_id},
-        )
-    indexed = enumerate(events)
-    return [
-        event for _, event in sorted(indexed, key=lambda item: (item[1]["at"], item[0]))
-    ]
-
-
 def _disposition(dbos_status, state, output, nodes, plan):
     if dbos_status == "CANCELLED":
         return {"state": "cancelled", "reason": "this run was cancelled", "next": None}
@@ -621,23 +500,12 @@ def compose_run(dbos, workflow_id, session_rows, server_app_version) -> dict | N
     )
     state = _derived_state(raw, output, nodes, stranded)
     disposition = _disposition(raw, state, output, nodes, plan)
-    events = _event_stream(
-        workflow_id,
-        raw,
-        _value(status, "created_at"),
-        implement_attempts,
-        review_attempts,
-        output,
-        inp.get("repo"),
-        stranded,
-    )
     work_branch = output.get("work_branch") or f"claude/swarm-{workflow_id}"
     return {
         "workflow_id": workflow_id,
         "dbos_status": raw,
         "state": state,
         "disposition": disposition,
-        "events": events,
         "task": {
             "text": inp.get("task", ""),
             "repo": inp.get("repo"),

--- a/projects/monolith/swarm/view_test.py
+++ b/projects/monolith/swarm/view_test.py
@@ -1,8 +1,8 @@
+import re
 from datetime import datetime, timezone
 
 from swarm.view import (
     _disposition,
-    _event_stream,
     _structured_verdict,
     compose_master,
     compose_run,
@@ -389,31 +389,6 @@ def test_structured_verdict_handles_unparseable():
     assert verdict["summary_plain"] == "verdict could not be parsed"
 
 
-def test_event_stream_orders_chronologically():
-    events = _event_stream(
-        "workflow-123456",
-        "SUCCESS",
-        datetime(2026, 8, 10, 4, 6, 45, tzinfo=timezone.utc),
-        [
-            {
-                "n": 1,
-                "started_at": "2026-08-10T04:08:00Z",
-                "ended_at": "2026-08-10T04:09:00Z",
-                "state": "completed",
-                "model": "luna",
-                "session_id": 1,
-                "rationale": {},
-                "finding": {"observed_head": "12345678"},
-            }
-        ],
-        [],
-        {},
-        "repo",
-        False,
-    )
-    assert [event["at"] for event in events] == sorted(event["at"] for event in events)
-
-
 def test_disposition_shows_changes_requested():
     disposition = _disposition("SUCCESS", "changes_requested", {}, [], {})
     assert disposition["state"] == "changes_requested"
@@ -479,10 +454,6 @@ def test_compose_run_events_full_sequence():
         session(2, status="completed", node="review"),
     ]
     run = compose_run(DBOS(Workflow(status)), status.workflow_id, rows, "unknown")
-    assert run["events"]
-    assert {event["register"] for event in run["events"]} == {"fact", "testimony"}
-    assert any("started" in event["text"] for event in run["events"])
-    assert any("approved" in event["text"] for event in run["events"])
 
 
 def test_attempt_carries_prior_head_alongside_finding():
@@ -600,3 +571,63 @@ def test_master_row_includes_dbos_status():
         ListingDBOS(Workflow(status)), True, {"wf-master-status": []}, "unknown"
     )
     assert result["runs"][0]["dbos_status"] == "CANCELLED"
+
+
+def _composed_prose(run: dict) -> list[tuple[str, str]]:
+    """Every string this payload composes for a human to read.
+
+    Deliberately NOT the whole payload. Identifiers, SHAs, branch names and
+    internal enums are legitimate data; the contract is only that nothing
+    *composed for display* carries machine formatting. Quoted testimony is
+    excluded for the same reason: it is the agent's own words, and ADR 056
+    decision 7's no-filename rule governs system-composed walkthrough text,
+    not what an agent said.
+    """
+    found: list[tuple[str, str]] = []
+    disposition = run.get("disposition") or {}
+    for key in ("reason", "next"):
+        if isinstance(disposition.get(key), str):
+            found.append((f"disposition.{key}", disposition[key]))
+    for node in run.get("nodes") or []:
+        current = node.get("current") or {}
+        if isinstance(current.get("label"), str):
+            found.append((f"nodes[{node.get('key')}].current.label", current["label"]))
+        verdict = node.get("verdict") or {}
+        if isinstance(verdict.get("summary_plain"), str):
+            found.append(
+                (f"nodes[{node.get('key')}].verdict", verdict["summary_plain"])
+            )
+    for deviation in run.get("deviations") or []:
+        if isinstance(deviation.get("text"), str):
+            found.append((f"deviations[{deviation.get('code')}]", deviation["text"]))
+    return found
+
+
+def test_composed_prose_carries_no_machine_formatting():
+    """Pins three presentation defects shut at once.
+
+    A raw ISO timestamp and a raw enum are both internal vocabulary reaching
+    the reader. Fixing the three known instances would not stop a fourth, so
+    the class is asserted rather than the instances.
+    """
+    iso = re.compile(r"\d{4}-\d{2}-\d{2}T")
+    enum = re.compile(r"^[A-Z][A-Z_]+$")
+    for status, output in (
+        (
+            Status("wf-a", "SUCCESS", ["task", "repo", "main"]),
+            {"review_verdict": "approve"},
+        ),
+        (
+            Status("wf-b", "SUCCESS", ["task", "repo", "main"]),
+            {"review_verdict": "request_changes"},
+        ),
+        (Status("wf-c", "CANCELLED", ["task", "repo", "main"]), {}),
+    ):
+        run = compose_run(
+            DBOS(Workflow(status, output)), status.workflow_id, [], "unknown"
+        )
+        if run is None:
+            continue
+        for where, value in _composed_prose(run):
+            assert not iso.search(value), f"{where} carries a raw timestamp: {value}"
+            assert not enum.fullmatch(value.strip()), f"{where} is a raw enum: {value}"


### PR DESCRIPTION
Joe on the run view: "atm it's a bit of a jumble."

The diagnosis, from a design pass over the shipped surface: the run view
carried **four parallel presentations of one run** (header, staged node rail,
flat narrative rail, standalone deviations) with none clearly primary.
Polishing the narrative rail would have produced a tidier version of the same
confusion.

Addresses four of the six defects in #4806, and applies the rule in #4796.

## The rail restated what the node rail already said better

Its testimony event composed `f"implementer reported (attempt {n})"`, an
announcement that testimony exists. Immediately below it, `RunView.svelte`
already renders the parsed rationale properly: each `path · why`, plus
deviation chips. **The rail announced what the card showed.**

Removed: `run.events` from the payload, `_event_stream` from `view.py`, the
rendering, its CSS, and the tests that exercised it. Verified consumers were
only `view.py`, `view_test.py` and `RunView.svelte`, so the deletion is
contained.

**Kept from PR #4792**: the `disposition` field and the structured
`verdict {value, summary_plain, text_md}`. Those answer "how did this end" and
"what did the reviewer actually say", and nothing else on the screen does.
This is not a revert of that PR, it is removing the one part of it that
competed with an existing surface.

It is also the presentation that would have aged worst. Under #4781 the
conductor generates and reshapes the DAG, and the rank-ordered node rail is
already the timeline; a second flat timeline would have had to be rebuilt or
deleted then anyway.

## Internal vocabulary no longer reaches the reader

- Deleting the rail removes the `register-tag` chip that printed the raw
  `fact` / `testimony` enum. **ADR 054 decision 3 says the client maps
  register to style, never names it.** The engine-belief banner keeps its
  lexicon phrase, which is the correct form of the same idea.
- `disposition.state` now goes through `run-lexicon.js` instead of printing
  `CHANGES_REQUESTED`. The `dispositionStates` table already existed and was
  simply never used; the missing `gated` entry is added.

## `verdict_not_approve` was a category error

A deviation is a departure from **what the pinned plan promised**. A reviewer
asking for changes departs from nothing the plan promised: it is the run's
outcome, which the disposition already states. It was also the third
restatement of the same fact.

Removed from `compute_deviations`, and its test replaced by the inverse
assertion so the category error cannot come back. Every other deviation type
is untouched; `budget_exceeded` and the mechanical shape deviations are real.

## One test pins the class, not the instances

Three of #4806's defects are the same failure: internal vocabulary reaching
the surface. Fixing three instances would not stop a fourth, so the new test
asserts that **no server-composed prose field** contains a raw ISO timestamp
(`/\d{4}-\d{2}-\d{2}T/`) or a bare enum (`/^[A-Z][A-Z_]+$/`).

It asserts over composed fields specifically (`disposition.reason`,
`disposition.next`, node `current.label`, `verdict.summary_plain`, deviation
`text`), not the whole payload: identifiers, SHAs and internal enums are
legitimate **data**. Quoted testimony is deliberately excluded, because it is
the agent's own words, and ADR 056 decision 7's no-filename rule governs
system-composed walkthrough text rather than what an agent said.

## Verification

`ci test //projects/monolith:view_test //projects/monolith:deviations_test //projects/monolith/frontend:test -- --nocache_test_results`
-> `Executed 3 out of 3 tests: 3 tests pass.` Forced uncached, since a cached
green cannot distinguish a real pass from a run that never happened.

Not verified: how it reads. That is the point of the change and no test here
can judge it.

## Still open from #4806

The outcome band treatment, folding deviations into their node cards, and a
three-level weight pass are judgment work, deliberately not in this PR. The
per-attempt change summary needs the compare endpoint from #4805, now merged.

No chart version or `targetRevision` touched.