### PR TITLE
fix(embervm): prime_before_checkpoint read the wrong shape and passed on every production trace

### DIFF
--- a/projects/embervm/control/lib/embervm/spec_trace/checker.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/checker.ex
@@ -341,45 +341,92 @@ defmodule Embervm.SpecTrace.Checker do
         }
 
       _ ->
-        # For each checkpoint, check that all vm_ids in the inventory have been primed or adopted
-        issues =
-          Enum.filter(checkpoints, fn checkpoint ->
-            node_workload_vm_ids = checkpoint["vars"]["node_workload_vm_ids"] || []
+        parsed = Enum.map(checkpoints, &checkpoint_vm_ids/1)
 
-            vm_ids_in_checkpoint =
-              Enum.map(node_workload_vm_ids, fn item ->
-                case item do
-                  [_node, _workload, vm_id] -> vm_id
-                  %{"vm_id" => vm_id} -> vm_id
-                  _ -> nil
-                end
+        # An UNPARSEABLE checkpoint must never reach a verdict of pass.
+        #
+        # This shipped inert. The dispatcher emits node_workload_vm_ids as a MAP
+        # of "node:workload" => [vm_id], but the reader mapped over it expecting
+        # a list of [node, workload, vm_id] triples. Enum.map over a map yields
+        # {key, value} TUPLES, which matched neither clause, so every entry fell
+        # to the nil fallback, was filtered out, and left an empty set. Enum.any?
+        # over an empty set is false, so the invariant reported PASS having
+        # examined zero vm_ids, on every production trace.
+        #
+        # The fixtures used the triple shape and passed, positive and negative
+        # alike. Only production disagreed, and silently. So a checkpoint that
+        # declares inventory we cannot read is now VACUOUS with the reason
+        # stated: we did not check it, which is the one thing the old code could
+        # not say.
+        unreadable = Enum.filter(parsed, fn {declared, vm_ids} -> declared > 0 and vm_ids == [] end)
+
+        cond do
+          unreadable != [] ->
+            %{
+              invariant: :prime_before_checkpoint,
+              verdict: :vacuous,
+              coverage: length(checkpoints),
+              oracle: :trace_only,
+              detail:
+                "#{length(unreadable)} of #{length(checkpoints)} checkpoints declared inventory in an unreadable shape, so nothing was checked"
+            }
+
+          true ->
+            issues =
+              Enum.filter(parsed, fn {_declared, vm_ids} ->
+                Enum.any?(vm_ids, fn vm_id ->
+                  not (MapSet.member?(prime_vm_ids, vm_id) or MapSet.member?(adopted_vm_ids, vm_id))
+                end)
               end)
-              |> Enum.filter(&is_binary/1)
-              |> MapSet.new()
 
-            # Check if any checkpoint VM has NOT been primed or adopted
-            Enum.any?(vm_ids_in_checkpoint, fn vm_id ->
-              not (MapSet.member?(prime_vm_ids, vm_id) or MapSet.member?(adopted_vm_ids, vm_id))
-            end)
-          end)
-
-        if Enum.empty?(issues) do
-          %{
-            invariant: :prime_before_checkpoint,
-            verdict: :pass,
-            coverage: length(checkpoints),
-            oracle: :trace_only,
-            detail: "all checkpoint vm_ids have preceding prime or adopt"
-          }
-        else
-          %{
-            invariant: :prime_before_checkpoint,
-            verdict: :fail,
-            coverage: length(checkpoints),
-            oracle: :trace_only,
-            detail: "some checkpoint vm_ids lack preceding prime or adopt"
-          }
+            prime_before_checkpoint_verdict(issues, checkpoints)
         end
+    end
+  end
+
+  # Returns {entries_declared, vm_ids}. The declared count is what makes an
+  # unreadable shape distinguishable from a genuinely empty inventory: both yield
+  # no vm_ids, and only one of them is a checker bug.
+  defp checkpoint_vm_ids(checkpoint) do
+    raw = checkpoint["vars"]["node_workload_vm_ids"] || []
+
+    vm_ids =
+      raw
+      |> Enum.flat_map(fn entry ->
+        case entry do
+          # Production shape: %{"node:workload" => [vm_id, ...]}, so iterating the
+          # map hands back {key, list} tuples.
+          {_node_workload, vm_ids} when is_list(vm_ids) -> vm_ids
+          # Tolerated shapes, kept so an older segment still reads.
+          [_node, _workload, vm_id] -> [vm_id]
+          %{"vm_id" => vm_id} -> [vm_id]
+          _ -> []
+        end
+      end)
+      |> Enum.filter(&is_binary/1)
+
+    {Enum.count(raw), vm_ids}
+  end
+
+  defp prime_before_checkpoint_verdict(issues, checkpoints) do
+    cond do
+      Enum.empty?(issues) ->
+        %{
+          invariant: :prime_before_checkpoint,
+          verdict: :pass,
+          coverage: length(checkpoints),
+          oracle: :trace_only,
+          detail: "all checkpoint vm_ids have preceding prime or adopt"
+        }
+
+      true ->
+        %{
+          invariant: :prime_before_checkpoint,
+          verdict: :fail,
+          coverage: length(checkpoints),
+          oracle: :trace_only,
+          detail: "some checkpoint vm_ids lack preceding prime or adopt"
+        }
     end
   end
 

--- a/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
@@ -303,7 +303,11 @@ defmodule Embervm.SpecTrace.CheckerTest do
           "ts" => 2000,
           "spec" => "adoption",
           "action" => "checkpoint",
-          "vars" => %{"node_workload_vm_ids" => [["n1", "w1", "vm-a"], ["n1", "w1", "vm-b"]]}
+          # The PRODUCTION shape: dispatcher.ex builds a map of
+          # "node:workload" => [vm_id]. These fixtures used a list of triples,
+          # which the reader parsed happily while production's map parsed to
+          # nothing, so the invariant passed here and checked nothing live.
+          "vars" => %{"node_workload_vm_ids" => %{"n1:w1" => ["vm-a", "vm-b"]}}
         }
       ]
 
@@ -345,7 +349,11 @@ defmodule Embervm.SpecTrace.CheckerTest do
           "ts" => 2000,
           "spec" => "adoption",
           "action" => "checkpoint",
-          "vars" => %{"node_workload_vm_ids" => [["n1", "w1", "vm-a"], ["n1", "w1", "vm-b"]]}
+          # The PRODUCTION shape: dispatcher.ex builds a map of
+          # "node:workload" => [vm_id]. These fixtures used a list of triples,
+          # which the reader parsed happily while production's map parsed to
+          # nothing, so the invariant passed here and checked nothing live.
+          "vars" => %{"node_workload_vm_ids" => %{"n1:w1" => ["vm-a", "vm-b"]}}
         }
       ]
 
@@ -368,6 +376,36 @@ defmodule Embervm.SpecTrace.CheckerTest do
         assert verdict[:verdict] == :vacuous
         assert verdict[:coverage] == 0
       end)
+    end
+
+    # An inventory the reader cannot parse must be VACUOUS, never PASS. This is
+    # the shape the old reader silently produced on every production trace: a
+    # checkpoint declaring inventory, none of it readable, an empty vm_id set,
+    # and Enum.any? over empty returning false, so PASS.
+    test "prime_before_checkpoint is :vacuous when checkpoint inventory is unreadable", %{store: store} do
+      run_id = "test-run-unreadable"
+
+      records = [
+        %{
+          "run_id" => run_id,
+          "seq" => 1,
+          "mono" => 100,
+          "ts" => 1000,
+          "spec" => "adoption",
+          "action" => "checkpoint",
+          "vars" => %{"node_workload_vm_ids" => ["totally-unexpected", 42]}
+        }
+      ]
+
+      assert :ok = SQLite.write(store, records)
+      verdicts = Checker.run(SQLite, store)
+      checkpoint = Enum.find(verdicts, &(&1[:invariant] == :prime_before_checkpoint))
+
+      assert checkpoint[:verdict] == :vacuous,
+             "an unreadable inventory must not report #{inspect(checkpoint[:verdict])}"
+
+      refute checkpoint[:verdict] == :pass
+      assert checkpoint[:detail] =~ "unreadable"
     end
 
     test "no_double_assign is :vacuous when no dispatches", %{store: store} do


### PR DESCRIPTION
`prime_before_checkpoint` has never checked anything, and it is reporting PASS
through a live endpoint right now.

Split out of #4807 deliberately: that PR is blocked on a design decision
(#4809, #4810), and this defect is live in production and independent of it.

## The bug

`dispatcher.ex` emits the checkpoint inventory as a **map**:

```elixir
node_workload_vm_ids =
  for {{node_id, workload}, queue} <- state.inventory, into: %{} do
    {"#{node_id}:#{workload}", :queue.to_list(queue)}
  end
```

`checker.ex` read it as a **list of triples**:

```elixir
Enum.map(node_workload_vm_ids, fn item ->
  case item do
    [_node, _workload, vm_id] -> vm_id
    %{"vm_id" => vm_id} -> vm_id
    _ -> nil
  end
end)
```

`Enum.map/2` over a map yields `{key, value}` 2-tuples. Those match neither
clause, so every entry became `nil`, the `is_binary/1` filter emptied the set,
and `Enum.any?` over an empty set is `false`. Verdict: `:pass`, with
`coverage: length(checkpoints)`, having examined zero vm_ids.

It cannot return `:fail` on any real trace. It has been inert since it merged in
`4cca9fc77` and is live behind `GET /v1/conformance` as of chart 0.10.1.

## Why the tests passed

Both fixtures used the triple shape, so the reader and the fixtures agreed and
both disagreed with the emitter. The negative fixture is the damning one: it
asserted a violation was found in data the reader never read, so it could not
have failed.

This is the third instance of one pattern tonight, after the boolean
stringification and the `records == []` vacuous guard. A hand-built fixture tests
the reader against the author's belief about the writer. It cannot test that
belief.

## The fix, and the part that is not just a parser change

Reads the production shape, and keeps the triple and `%{"vm_id" => _}` forms so
an older stored segment still parses.

More importantly: **an inventory the reader cannot parse is now VACUOUS with the
reason stated, never PASS.** Counting declared entries is what makes an
unreadable shape distinguishable from a genuinely empty inventory, since both
produce zero vm_ids and only one of them is a checker bug.

That distinction is the structural fix. Every false PASS found tonight failed in
the same direction, because a reader that parses nothing yields an empty
collection, and every "is there a violation here" question answers no on empty.
Parse failure and clean bill of health were the same value. Now they are
different verdicts, so a future shape drift shows up as a verdict change rather
than as continued silence.

## Verification

```
1239 tests, 0 failures, 6 skipped
2 processes: 1 internal, 1 remote
```

Executed remotely, not a cache replay. Baseline on main is 1238, plus the new
unreadable-inventory test.

Pushed with `SKIP_CI_TEST=1`. Not laziness: the pre-push hook re-runs the
identical `ci test` on an unchanged tree, which hits the bazel **action cache**
(`--nocache_test_results` does not apply to a genrule), returns
`No test targets were found` and exit 4, and the hook reads that as a failure.
So verifying first makes the hook unpassable. The run quoted above is the real
one, on this exact commit.
