### PR TITLE
feat(agents): session walkthrough UI for turn-level diffs

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -26,6 +26,7 @@
   import { crumbTrail, sessionLineage } from "./lineage.js";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
   import PaneHeader from "./PaneHeader.svelte";
+  import SessionWalkthrough from "./SessionWalkthrough.svelte";
 
   const MOBILE_MEDIA_QUERY = "(max-width: 760px)";
 
@@ -1156,7 +1157,21 @@
       aria-label={P.labels.backToSessions}
       onclick={returnToSessionList}>{P.labels.mobileBack}</button
     >
-    {#if fixture && !fixture.home}
+    {#if fixture?.walkthrough}
+      <!-- Walkthrough visual states are reviewed via ?fixture=walk-*; the
+           component gets its payload inline and never fetches. -->
+      <div class="turns">
+        <div class="turns-inner">
+          <article class="turn">
+            <SessionWalkthrough
+              turnSeq={fixture.walkthrough.turnSeq}
+              model={fixture.walkthrough.model}
+              fixture={fixture.walkthrough}
+            />
+          </article>
+        </div>
+      </div>
+    {:else if fixture && !fixture.home}
       <RunView
         run={fixture.run}
         view={fixture.view}
@@ -1253,6 +1268,13 @@
                 <div class="result-md">
                   {@html renderAgentMarkdown(turn.result_text)}
                 </div>
+              {/if}
+              {#if selectedSession.repo}
+                <SessionWalkthrough
+                  sessionId={selectedSession.id}
+                  turnSeq={turn.seq}
+                  model={turn.model || selectedSession.model || "luna"}
+                />
               {/if}
               <div class="turn-meta mono">
                 <span>{turn.model || selectedSession.model || "luna"}</span>

--- a/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.svelte
@@ -1,0 +1,544 @@
+<script>
+  // Session-tier walkthrough (ADR 056): what did this turn change, and why.
+  // The diff is fact, the agent's points are testimony, and the two are
+  // juxtaposed, never merged. Collapsed by default; the compare is fetched
+  // once on first open (the console polls, so nothing here polls), and
+  // per-step patches are fetched lazily and only for authored steps.
+  import { RUN_LEXICON as P } from "./run-lexicon.js";
+  import { joinMeta } from "./run-format.js";
+  import { composeWalkthrough, parsePatch } from "./walkthrough.js";
+
+  let {
+    sessionId = null,
+    turnSeq = null,
+    model = "",
+    // Fixture preview (?fixture=walk-*): compare/rationale/patches supplied
+    // inline, so the preview never fetches.
+    fixture = null,
+  } = $props();
+
+  let compare = $state(fixture?.compare ?? null);
+  let rationale = $state(fixture?.rationale ?? null);
+  let loading = $state(false);
+  let failed = $state(false);
+  let focus = $state(0);
+  let diffOpen = $state({});
+  let patches = $state({});
+
+  const walk = $derived(
+    compare ? composeWalkthrough(compare, rationale) : null,
+  );
+  const total = $derived(walk?.steps.length ?? 0);
+  const attribution = $derived(
+    joinMeta(`${P.labels.turn} ${turnSeq ?? ""}`.trim(), model),
+  );
+
+  async function load() {
+    if (compare || loading || fixture) return;
+    loading = true;
+    failed = false;
+    try {
+      const response = await fetch(
+        `/api/swarm/compare/${encodeURIComponent(sessionId)}/${encodeURIComponent(turnSeq)}`,
+      );
+      if (!response.ok) throw new Error("compare unavailable");
+      compare = await response.json();
+    } catch {
+      failed = true;
+    } finally {
+      loading = false;
+    }
+  }
+
+  function onToggle(event) {
+    if (event.currentTarget.open) load();
+  }
+
+  function focusStep(index) {
+    if (total === 0) return;
+    focus = Math.max(0, Math.min(index, total - 1));
+  }
+
+  // Left/right arrows walk the steps, the OpenChamber guided-tour motion.
+  // Up/down stay untouched so the transcript keeps scrolling normally.
+  function onKeydown(event) {
+    if (total < 2) return;
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      focusStep(focus - 1);
+    } else if (event.key === "ArrowRight") {
+      event.preventDefault();
+      focusStep(focus + 1);
+    }
+  }
+
+  async function toggleDiff(step) {
+    const path = step.path;
+    diffOpen[path] = !diffOpen[path];
+    if (!diffOpen[path] || patches[path]) return;
+    if (fixture?.patches?.[path] !== undefined) {
+      patches[path] = { lines: parsePatch(fixture.patches[path]) };
+      return;
+    }
+    if (!step.patchUrl) {
+      patches[path] = { failed: true };
+      return;
+    }
+    patches[path] = { loading: true };
+    try {
+      const response = await fetch(step.patchUrl);
+      if (!response.ok) throw new Error("patch unavailable");
+      const body = await response.json();
+      patches[path] = { lines: parsePatch(body.patch) };
+    } catch {
+      patches[path] = { failed: true };
+    }
+  }
+
+  function retry() {
+    compare = null;
+    load();
+  }
+</script>
+
+<details class="walk" open={Boolean(fixture)} ontoggle={onToggle}>
+  <summary class="walk-summary mono">
+    <span>{P.labels.walkSummary}</span>
+    {#if walk && walk.rung <= 2}
+      <span class="walk-stats">
+        {walk.stats.totalFiles}
+        {walk.stats.totalFiles === 1
+          ? P.labels.walkFileWord
+          : P.labels.walkFilesWord}
+        <span class="add">+{walk.stats.additions}</span>
+        <span class="del">&minus;{walk.stats.deletions}</span>
+      </span>
+    {/if}
+  </summary>
+
+  {#if loading}
+    <div class="walk-fact">{P.labels.walkLoading}</div>
+  {:else if failed}
+    <div class="walk-fact">
+      {P.labels.walkUnavailable}
+      <button class="walk-retry mono" type="button" onclick={retry}
+        >{P.labels.walkRetry}</button
+      >
+    </div>
+  {:else if walk}
+    {#if walk.ephemeral}
+      <div class="walk-fact">{P.labels.walkEphemeralNote}</div>
+    {/if}
+    {#each walk.truncation as reason}
+      <div class="walk-fact">
+        <span class="walk-flag">{P.labels.walkTruncatedWord}</span>
+        {reason}
+      </div>
+    {/each}
+
+    {#if walk.rung <= 2}
+      {#if !walk.trailer}
+        <div class="walk-fact">{P.labels.walkNoTrailerNote}</div>
+      {/if}
+      {#if total > 0}
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+        <div
+          class="walk-tour"
+          role="group"
+          aria-label={P.labels.walkSummary}
+          onkeydown={onKeydown}
+        >
+          {#if total > 1}
+            <div class="walk-nav">
+              <span class="walk-progress"
+                >{P.labels.walkStepWord} {focus + 1} {P.labels.of} {total}</span
+              >
+              <button
+                class="walk-nav-btn"
+                type="button"
+                aria-label={P.labels.walkPrevStep}
+                disabled={focus === 0}
+                onclick={() => focusStep(focus - 1)}>&larr;</button
+              >
+              <button
+                class="walk-nav-btn"
+                type="button"
+                aria-label={P.labels.walkNextStep}
+                disabled={focus === total - 1}
+                onclick={() => focusStep(focus + 1)}>&rarr;</button
+              >
+              <span class="walk-phone-note">{P.labels.walkDiffsDesktop}</span>
+            </div>
+          {/if}
+          <ol class="walk-steps">
+            {#each walk.steps as step, index (step.path)}
+              <li class="walk-step" class:focused={index === focus}>
+                <button
+                  class="walk-step-head"
+                  type="button"
+                  aria-expanded={index === focus}
+                  onclick={() => focusStep(index)}
+                >
+                  <span class="walk-idx">{index + 1}</span>
+                  <span class="walk-path">{step.path}</span>
+                  {#if step.unexplained}
+                    <span class="walk-flag" title={P.labels.walkUnexplainedNote}
+                      >{P.labels.walkUnexplained}</span
+                    >
+                  {/if}
+                  <span class="walk-file-stats">
+                    <span class="add">+{step.additions}</span>
+                    <span class="del">&minus;{step.deletions}</span>
+                  </span>
+                </button>
+                {#if index === focus}
+                  <div class="walk-step-body">
+                    {#if step.why}
+                      <div class="testimony" data-register="testimony">
+                        <div class="testimony-attribution">{attribution}</div>
+                        <div class="testimony-line">{step.why}</div>
+                      </div>
+                    {:else if step.unexplained}
+                      <div class="walk-fact">
+                        {P.labels.walkUnexplainedNote}
+                      </div>
+                    {/if}
+                    {#if step.patchUrl || fixture?.patches?.[step.path] !== undefined}
+                      <button
+                        class="walk-diff-btn"
+                        type="button"
+                        onclick={() => toggleDiff(step)}
+                        >{diffOpen[step.path]
+                          ? P.labels.walkHideDiff
+                          : P.labels.walkShowDiff}</button
+                      >
+                      {#if diffOpen[step.path]}
+                        {#if patches[step.path]?.loading}
+                          <div class="walk-fact">
+                            {P.labels.walkDiffLoading}
+                          </div>
+                        {:else if patches[step.path]?.failed}
+                          <div class="walk-fact">
+                            {P.labels.walkDiffUnavailable}
+                          </div>
+                        {:else if patches[step.path]?.lines}
+                          <!-- A div of block spans, not a pre: template
+                               whitespace inside a pre would render as blank
+                               lines between every patch line. -->
+                          <div class="walk-patch">
+                            {#each patches[step.path].lines as line, lineIndex (lineIndex)}
+                              <span class={`pl pl-${line.kind}`}
+                                >{line.text}</span
+                              >
+                            {/each}
+                          </div>
+                        {/if}
+                      {/if}
+                    {/if}
+                  </div>
+                {/if}
+              </li>
+            {/each}
+          </ol>
+        </div>
+      {/if}
+      {#if walk.mechanical}
+        <details class="walk-mech">
+          <summary class="walk-mech-summary"
+            >{P.labels.walkMechanicalStep}{P.punct.colon}
+            {walk.mechanical.count}
+            {walk.mechanical.count === 1
+              ? P.labels.walkFileWord
+              : P.labels.walkFilesWord}</summary
+          >
+          <ul class="walk-list">
+            {#each walk.mechanical.files as path (path)}
+              <li>{path}</li>
+            {/each}
+          </ul>
+        </details>
+      {/if}
+      {#each walk.contradicted as claim (claim.path)}
+        <div class="walk-contradicted">
+          <span class="walk-path">{claim.path}</span>
+          {#if claim.why}
+            <div class="testimony" data-register="testimony">
+              <div class="testimony-attribution">{attribution}</div>
+              <div class="testimony-line">{claim.why}</div>
+            </div>
+          {/if}
+          <div class="conflict" data-register="fact">
+            {P.labels.walkContradictedNote}
+          </div>
+        </div>
+      {/each}
+    {:else if walk.rung === 3}
+      <div class="walk-fact">{P.labels.walkNoCompareNote}</div>
+      <ol class="walk-steps">
+        {#each walk.steps as step, index (step.path)}
+          <li class="walk-step focused">
+            <div class="walk-step-head static">
+              <span class="walk-idx">{index + 1}</span>
+              <span class="walk-path">{step.path}</span>
+            </div>
+            {#if step.why}
+              <div class="walk-step-body">
+                <div class="testimony" data-register="testimony">
+                  <div class="testimony-attribution">{attribution}</div>
+                  <div class="testimony-line">{step.why}</div>
+                </div>
+              </div>
+            {/if}
+          </li>
+        {/each}
+      </ol>
+      {#if walk.touched.length > 0}
+        <div class="walk-fact">{P.labels.walkTouchedLabel}</div>
+        <ul class="walk-list">
+          {#each walk.touched as path (path)}
+            <li>{path}</li>
+          {/each}
+        </ul>
+      {/if}
+    {:else if walk.rung === 4}
+      <!-- Rung 4 declines to offer a walk (ADR 056 decision 6): stats and
+           the touched list, each labelled as what it is, and nothing walks. -->
+      <div class="walk-fact">{P.labels.walkDeclinedNote}</div>
+      <div class="walk-fact">
+        {P.labels.walkTouchedLabel}{P.punct.colon}
+        {walk.touched.length}
+      </div>
+      <ul class="walk-list">
+        {#each walk.touched as path (path)}
+          <li>{path}</li>
+        {/each}
+      </ul>
+    {:else}
+      <div class="walk-fact">{P.labels.walkNothingNote}</div>
+    {/if}
+
+    {#if walk.deviations.length > 0}
+      <div class="testimony" data-register="testimony">
+        <div class="testimony-attribution">{attribution}</div>
+        {#each walk.deviations as deviation (deviation)}
+          <div class="testimony-line">
+            <span class="dev-chip">{P.labels.deviationWord}</span><span
+              >{deviation}</span
+            >
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</details>
+
+<style>
+  /* Colors, sizes, and radii come from agents-theme.css tokens only; spacing
+     follows run-view.css's 4/8/16 rhythm. */
+  .walk {
+    margin-top: 8px;
+    border-top: 1px solid var(--line);
+    padding-top: 4px;
+  }
+  .walk-summary {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    color: var(--muted);
+    font: var(--size-meta) var(--font-mono);
+    cursor: pointer;
+    user-select: none;
+    width: fit-content;
+  }
+  .walk-summary:hover {
+    color: var(--text-soft);
+  }
+  .walk-stats {
+    color: var(--text-soft);
+  }
+  .add {
+    color: var(--ok);
+  }
+  .del {
+    color: var(--err);
+  }
+  .walk-fact {
+    margin-top: 8px;
+    color: var(--muted);
+    font-size: var(--size-detail);
+  }
+  .walk-flag {
+    display: inline-block;
+    margin-right: 4px;
+    padding: 0 4px;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-sm);
+    color: var(--text-soft);
+    font: var(--size-meta) var(--font-mono);
+  }
+  .walk-nav {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .walk-progress {
+    color: var(--text-soft);
+    font: var(--size-meta) var(--font-mono);
+  }
+  .walk-nav-btn {
+    padding: 0 8px;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--text-soft);
+    font: var(--size-body-mono) var(--font-mono);
+    cursor: pointer;
+  }
+  .walk-nav-btn:disabled {
+    color: var(--dot-idle);
+    border-color: var(--line);
+    cursor: default;
+  }
+  .walk-nav-btn:not(:disabled):hover {
+    background: var(--hover);
+  }
+  /* The phone reader gets intent, counts, and quoted rationale; patch
+     reading is deferred to a desktop by design (ADR 056), so the note only
+     exists where the diff controls are hidden. */
+  .walk-phone-note {
+    display: none;
+    margin-left: auto;
+    color: var(--muted);
+    font-size: var(--size-meta);
+  }
+  .walk-steps {
+    list-style: none;
+    margin: 8px 0 0;
+    padding: 0;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+  }
+  .walk-step + .walk-step {
+    border-top: 1px solid var(--line);
+  }
+  .walk-step-head {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    width: 100%;
+    padding: 4px 8px;
+    border: 0;
+    background: transparent;
+    text-align: left;
+    font: var(--size-body-mono) var(--font-mono);
+    color: var(--text);
+    cursor: pointer;
+  }
+  .walk-step-head.static {
+    cursor: default;
+  }
+  button.walk-step-head:hover {
+    background: var(--hover);
+  }
+  .walk-step.focused > .walk-step-head {
+    background: var(--code-bg);
+  }
+  .walk-idx {
+    color: var(--muted);
+    min-width: 16px;
+  }
+  .walk-path {
+    font-family: var(--font-mono);
+    font-size: var(--size-body-mono);
+    overflow-wrap: anywhere;
+  }
+  .walk-file-stats {
+    margin-left: auto;
+    white-space: nowrap;
+    font-size: var(--size-meta);
+  }
+  .walk-step-body {
+    padding: 4px 8px 8px 32px;
+  }
+  .walk-diff-btn {
+    margin-top: 8px;
+    padding: 0 8px;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--text-soft);
+    font: var(--size-meta) var(--font-mono);
+    cursor: pointer;
+  }
+  .walk-diff-btn:hover {
+    background: var(--hover);
+  }
+  .walk-patch {
+    margin: 8px 0 0;
+    padding: 8px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    background: var(--panel-bg);
+    font: var(--size-body-mono) var(--font-mono);
+    line-height: 1.5;
+    overflow-x: auto;
+  }
+  .pl {
+    display: block;
+    white-space: pre;
+    min-height: 1em;
+  }
+  .pl-add {
+    background: var(--ok-soft);
+  }
+  .pl-del {
+    background: var(--err-bg);
+  }
+  .pl-hunk {
+    color: var(--info);
+  }
+  .walk-retry {
+    margin-left: 8px;
+    padding: 0 8px;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--text-soft);
+    font: var(--size-meta) var(--font-mono);
+    cursor: pointer;
+  }
+  .walk-mech {
+    margin-top: 8px;
+  }
+  .walk-mech-summary {
+    color: var(--muted);
+    font: var(--size-meta) var(--font-mono);
+    cursor: pointer;
+    user-select: none;
+    width: fit-content;
+  }
+  .walk-mech-summary:hover {
+    color: var(--text-soft);
+  }
+  .walk-list {
+    list-style: none;
+    margin: 4px 0 0;
+    padding: 0 0 0 16px;
+    color: var(--text-soft);
+    font: var(--size-body-mono) var(--font-mono);
+  }
+  .walk-contradicted {
+    margin-top: 8px;
+  }
+  @media (max-width: 760px) {
+    .walk-diff-btn,
+    .walk-patch {
+      display: none;
+    }
+    .walk-phone-note {
+      display: inline;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.svelte
@@ -1,48 +1,97 @@
 <script>
   // Session-tier walkthrough (ADR 056): what did this turn change, and why.
-  // The diff is fact, the agent's points are testimony, and the two are
-  // juxtaposed, never merged. Collapsed by default; the compare is fetched
-  // once on first open (the console polls, so nothing here polls), and
-  // per-step patches are fetched lazily and only for authored steps.
+  // Layout follows the agents-console walkthrough mock: a provenance banner,
+  // a points list beside a detail pane, unexplained files as points in the
+  // same list, a WHY block over a filebar and diff hunks. Two channels,
+  // deliberately not merged: the points are the agent's own account, the
+  // diff is the artifact, and the registers are expressed as style only.
+  //
+  // Collapsed by default; the composed payload is fetched once on first
+  // open (the console polls, this never does), and per-point patches are
+  // fetched lazily, on selection, desktop only.
   import { RUN_LEXICON as P } from "./run-lexicon.js";
   import { joinMeta } from "./run-format.js";
-  import { composeWalkthrough, parsePatch } from "./walkthrough.js";
+  import { walkthroughView, parsePatchHunks } from "./walkthrough.js";
 
   let {
     sessionId = null,
     turnSeq = null,
     model = "",
-    // Fixture preview (?fixture=walk-*): compare/rationale/patches supplied
-    // inline, so the preview never fetches.
+    // Fixture preview (?fixture=walk-*): payload/patches supplied inline,
+    // so the preview never fetches.
     fixture = null,
   } = $props();
 
-  let compare = $state(fixture?.compare ?? null);
-  let rationale = $state(fixture?.rationale ?? null);
+  let payload = $state(fixture?.payload ?? null);
   let loading = $state(false);
   let failed = $state(false);
-  let focus = $state(0);
-  let diffOpen = $state({});
+  let opened = $state(Boolean(fixture));
+  let selected = $state(0);
+  // Mobile pane swap: the points list and the detail pane are one column
+  // under the console's 760px breakpoint, and selecting a point drills in.
+  let drilled = $state(false);
   let patches = $state({});
 
   const walk = $derived(
-    compare ? composeWalkthrough(compare, rationale) : null,
+    payload ? walkthroughView(payload, { sessionId, turnSeq }) : null,
   );
-  const total = $derived(walk?.steps.length ?? 0);
-  const attribution = $derived(
-    joinMeta(`${P.labels.turn} ${turnSeq ?? ""}`.trim(), model),
+  const items = $derived(
+    walk
+      ? [
+          ...walk.points,
+          ...walk.contradictions.map((claim) => ({
+            kind: "contradiction",
+            path: claim.path,
+            why: claim.why,
+            attribution: claim.attribution,
+            deviations: [],
+            additions: 0,
+            deletions: 0,
+            touched: false,
+            patchUrl: null,
+          })),
+        ]
+      : [],
   );
+  const point = $derived(items[selected] ?? null);
+
+  function basename(path) {
+    return String(path || "")
+      .split("/")
+      .pop();
+  }
+
+  function attributionLine(index, item) {
+    return joinMeta(
+      `${P.labels.walkPointWord} ${index + 1}`,
+      P.labels.walkAccountLabel,
+      item.attribution?.turn != null
+        ? `${P.labels.turn} ${item.attribution.turn}`
+        : "",
+      item.attribution?.attempt != null
+        ? `${P.labels.attempt} ${item.attribution.attempt}`
+        : "",
+      model,
+    );
+  }
+
+  function isDesktop() {
+    return (
+      typeof window !== "undefined" &&
+      window.matchMedia("(min-width: 761px)").matches
+    );
+  }
 
   async function load() {
-    if (compare || loading || fixture) return;
+    if (payload || loading || fixture) return;
     loading = true;
     failed = false;
     try {
       const response = await fetch(
-        `/api/swarm/compare/${encodeURIComponent(sessionId)}/${encodeURIComponent(turnSeq)}`,
+        `/api/swarm/walkthrough/${encodeURIComponent(sessionId)}/${encodeURIComponent(turnSeq)}`,
       );
-      if (!response.ok) throw new Error("compare unavailable");
-      compare = await response.json();
+      if (!response.ok) throw new Error("walkthrough unavailable");
+      payload = await response.json();
     } catch {
       failed = true;
     } finally {
@@ -51,68 +100,74 @@
   }
 
   function onToggle(event) {
-    if (event.currentTarget.open) load();
+    opened = event.currentTarget.open;
+    if (opened) load();
   }
 
-  function focusStep(index) {
-    if (total === 0) return;
-    focus = Math.max(0, Math.min(index, total - 1));
+  function selectItem(index) {
+    selected = Math.max(0, Math.min(index, items.length - 1));
+    drilled = true;
   }
 
-  // Left/right arrows walk the steps, the OpenChamber guided-tour motion.
-  // Up/down stay untouched so the transcript keeps scrolling normally.
+  // Left/right arrows walk the points; up/down stay untouched so the
+  // transcript keeps scrolling normally.
   function onKeydown(event) {
-    if (total < 2) return;
+    if (items.length < 2) return;
     if (event.key === "ArrowLeft") {
       event.preventDefault();
-      focusStep(focus - 1);
+      selectItem(selected - 1);
     } else if (event.key === "ArrowRight") {
       event.preventDefault();
-      focusStep(focus + 1);
+      selectItem(selected + 1);
     }
   }
 
-  async function toggleDiff(step) {
-    const path = step.path;
-    diffOpen[path] = !diffOpen[path];
-    if (!diffOpen[path] || patches[path]) return;
+  async function loadPatch(item) {
+    const path = item?.path;
+    if (!path || patches[path]) return;
     if (fixture?.patches?.[path] !== undefined) {
-      patches[path] = { lines: parsePatch(fixture.patches[path]) };
+      patches[path] = { hunks: parsePatchHunks(fixture.patches[path]) };
       return;
     }
-    if (!step.patchUrl) {
-      patches[path] = { failed: true };
-      return;
-    }
+    if (!item.patchUrl) return;
     patches[path] = { loading: true };
     try {
-      const response = await fetch(step.patchUrl);
+      const response = await fetch(item.patchUrl);
       if (!response.ok) throw new Error("patch unavailable");
       const body = await response.json();
-      patches[path] = { lines: parsePatch(body.patch) };
+      patches[path] = { hunks: parsePatchHunks(body.patch) };
     } catch {
       patches[path] = { failed: true };
     }
   }
 
+  // The phone reader gets intent, counts, and quoted rationale; patch
+  // reading is deferred to a desktop by design (ADR 056), so a phone never
+  // fetches what it will not render.
+  $effect(() => {
+    if (opened && point && isDesktop()) loadPatch(point);
+  });
+
   function retry() {
-    compare = null;
+    payload = null;
     load();
   }
+
+  const showDiff = $derived(
+    Boolean(point?.patchUrl || fixture?.patches?.[point?.path] !== undefined),
+  );
 </script>
 
 <details class="walk" open={Boolean(fixture)} ontoggle={onToggle}>
-  <summary class="walk-summary mono">
+  <summary class="walk-summary">
     <span>{P.labels.walkSummary}</span>
-    {#if walk && walk.rung <= 2}
-      <span class="walk-stats">
-        {walk.stats.totalFiles}
-        {walk.stats.totalFiles === 1
-          ? P.labels.walkFileWord
-          : P.labels.walkFilesWord}
-        <span class="add">+{walk.stats.additions}</span>
-        <span class="del">&minus;{walk.stats.deletions}</span>
-      </span>
+    {#if walk}
+      <span class="walk-count"
+        >{joinMeta(
+          `${walk.counts.points} ${walk.counts.points === 1 ? P.labels.walkPointWord : P.labels.walkPointsWord}`,
+          `${walk.counts.files} ${walk.counts.files === 1 ? P.labels.walkFileChanged : P.labels.walkFilesChanged}`,
+        )}</span
+      >
     {/if}
   </summary>
 
@@ -121,220 +176,173 @@
   {:else if failed}
     <div class="walk-fact">
       {P.labels.walkUnavailable}
-      <button class="walk-retry mono" type="button" onclick={retry}
+      <button class="walk-retry" type="button" onclick={retry}
         >{P.labels.walkRetry}</button
       >
     </div>
   {:else if walk}
-    {#if walk.ephemeral}
-      <div class="walk-fact">{P.labels.walkEphemeralNote}</div>
+    {#if walk.message}
+      <div class="walk-fact">{walk.message}</div>
     {/if}
-    {#each walk.truncation as reason}
-      <div class="walk-fact">
-        <span class="walk-flag">{P.labels.walkTruncatedWord}</span>
-        {reason}
-      </div>
+    {#each walk.truncations as reason (reason)}
+      <div class="walk-fact">{reason}</div>
     {/each}
 
-    {#if walk.rung <= 2}
-      {#if !walk.trailer}
-        <div class="walk-fact">{P.labels.walkNoTrailerNote}</div>
-      {/if}
-      {#if total > 0}
-        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-        <div
-          class="walk-tour"
-          role="group"
-          aria-label={P.labels.walkSummary}
-          onkeydown={onKeydown}
-        >
-          {#if total > 1}
-            <div class="walk-nav">
-              <span class="walk-progress"
-                >{P.labels.walkStepWord} {focus + 1} {P.labels.of} {total}</span
-              >
-              <button
-                class="walk-nav-btn"
-                type="button"
-                aria-label={P.labels.walkPrevStep}
-                disabled={focus === 0}
-                onclick={() => focusStep(focus - 1)}>&larr;</button
-              >
-              <button
-                class="walk-nav-btn"
-                type="button"
-                aria-label={P.labels.walkNextStep}
-                disabled={focus === total - 1}
-                onclick={() => focusStep(focus + 1)}>&rarr;</button
-              >
-              <span class="walk-phone-note">{P.labels.walkDiffsDesktop}</span>
+    {#if items.length > 0 || walk.mechanical.length > 0}
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+      <div
+        class="walk-frame"
+        role="group"
+        aria-label={P.labels.walkSummary}
+        onkeydown={onKeydown}
+      >
+        {#if walk.hasTestimony}
+          <div class="provenance">
+            <b>{P.labels.walkProvenanceLead}</b>
+            <span>{P.labels.walkProvenanceBody}</span>
+          </div>
+        {/if}
+        <div class="wbody" class:drilled>
+          <div class="points">
+            <div class="pbband">
+              {joinMeta(
+                `${walk.counts.points} ${walk.counts.points === 1 ? P.labels.walkPointWord : P.labels.walkPointsWord}`,
+                `${walk.counts.files} ${walk.counts.files === 1 ? P.labels.walkFileChanged : P.labels.walkFilesChanged}`,
+              )}
             </div>
-          {/if}
-          <ol class="walk-steps">
-            {#each walk.steps as step, index (step.path)}
-              <li class="walk-step" class:focused={index === focus}>
-                <button
-                  class="walk-step-head"
-                  type="button"
-                  aria-expanded={index === focus}
-                  onclick={() => focusStep(index)}
-                >
-                  <span class="walk-idx">{index + 1}</span>
-                  <span class="walk-path">{step.path}</span>
-                  {#if step.unexplained}
-                    <span class="walk-flag" title={P.labels.walkUnexplainedNote}
-                      >{P.labels.walkUnexplained}</span
-                    >
-                  {/if}
-                  <span class="walk-file-stats">
-                    <span class="add">+{step.additions}</span>
-                    <span class="del">&minus;{step.deletions}</span>
-                  </span>
-                </button>
-                {#if index === focus}
-                  <div class="walk-step-body">
-                    {#if step.why}
-                      <div class="testimony" data-register="testimony">
-                        <div class="testimony-attribution">{attribution}</div>
-                        <div class="testimony-line">{step.why}</div>
-                      </div>
-                    {:else if step.unexplained}
-                      <div class="walk-fact">
-                        {P.labels.walkUnexplainedNote}
-                      </div>
-                    {/if}
-                    {#if step.patchUrl || fixture?.patches?.[step.path] !== undefined}
-                      <button
-                        class="walk-diff-btn"
-                        type="button"
-                        onclick={() => toggleDiff(step)}
-                        >{diffOpen[step.path]
-                          ? P.labels.walkHideDiff
-                          : P.labels.walkShowDiff}</button
-                      >
-                      {#if diffOpen[step.path]}
-                        {#if patches[step.path]?.loading}
-                          <div class="walk-fact">
-                            {P.labels.walkDiffLoading}
-                          </div>
-                        {:else if patches[step.path]?.failed}
-                          <div class="walk-fact">
-                            {P.labels.walkDiffUnavailable}
-                          </div>
-                        {:else if patches[step.path]?.lines}
-                          <!-- A div of block spans, not a pre: template
-                               whitespace inside a pre would render as blank
-                               lines between every patch line. -->
-                          <div class="walk-patch">
-                            {#each patches[step.path].lines as line, lineIndex (lineIndex)}
-                              <span class={`pl pl-${line.kind}`}
-                                >{line.text}</span
-                              >
-                            {/each}
-                          </div>
-                        {/if}
-                      {/if}
-                    {/if}
+            {#each items as item, index (`${item.kind}:${item.path}`)}
+              <button
+                class="point"
+                class:on={index === selected}
+                class:unexplained={item.kind === "unexplained"}
+                class:conflicted={item.kind === "contradiction"}
+                type="button"
+                aria-current={index === selected}
+                onclick={() => selectItem(index)}
+              >
+                <span class="point-top">
+                  <span class="point-n"
+                    >{item.kind === "unexplained"
+                      ? P.labels.walkUnexplainedMark
+                      : item.kind === "contradiction"
+                        ? P.labels.walkContradictedMark
+                        : index + 1}</span
+                  >
+                  <span class="point-t">{basename(item.path)}</span>
+                </span>
+                <span class="point-f" dir="rtl">{item.path}</span>
+              </button>
+            {/each}
+            {#each walk.mechanical as mech, index (index)}
+              <div class="mech-row">
+                {P.labels.walkMechanicalStep}{P.punct.colon}
+                {mech.count}
+                {mech.count === 1
+                  ? P.labels.walkFileWord
+                  : P.labels.walkFilesWord}
+                {#if mech.generator}<span class="mech-gen"
+                    >{mech.generator}</span
+                  >{/if}
+              </div>
+            {/each}
+          </div>
+
+          <div class="detail">
+            <button
+              class="walk-back"
+              type="button"
+              onclick={() => (drilled = false)}>{P.labels.mobileBack}</button
+            >
+            {#if point}
+              {#if point.kind === "unexplained"}
+                <div class="nowhy">
+                  <b>{P.labels.walkUnexplainedTitle}</b>
+                  {P.labels.walkUnexplainedBody}
+                </div>
+              {:else if point.kind === "contradiction"}
+                {#if point.why}
+                  <div class="why">
+                    <div class="why-lbl">
+                      {attributionLine(selected, point)}
+                    </div>
+                    <div class="why-txt">{point.why}</div>
                   </div>
                 {/if}
-              </li>
-            {/each}
-          </ol>
-        </div>
-      {/if}
-      {#if walk.mechanical}
-        <details class="walk-mech">
-          <summary class="walk-mech-summary"
-            >{P.labels.walkMechanicalStep}{P.punct.colon}
-            {walk.mechanical.count}
-            {walk.mechanical.count === 1
-              ? P.labels.walkFileWord
-              : P.labels.walkFilesWord}</summary
-          >
-          <ul class="walk-list">
-            {#each walk.mechanical.files as path (path)}
-              <li>{path}</li>
-            {/each}
-          </ul>
-        </details>
-      {/if}
-      {#each walk.contradicted as claim (claim.path)}
-        <div class="walk-contradicted">
-          <span class="walk-path">{claim.path}</span>
-          {#if claim.why}
-            <div class="testimony" data-register="testimony">
-              <div class="testimony-attribution">{attribution}</div>
-              <div class="testimony-line">{claim.why}</div>
-            </div>
-          {/if}
-          <div class="conflict" data-register="fact">
-            {P.labels.walkContradictedNote}
+                <div class="nowhy">
+                  <b>{P.labels.walkContradictedTitle}</b>
+                  {P.labels.walkContradictedBody}
+                </div>
+              {:else if point.why}
+                <div class="why">
+                  <div class="why-lbl">{attributionLine(selected, point)}</div>
+                  <div class="why-txt">{point.why}</div>
+                </div>
+              {/if}
+              {#each point.deviations as deviation (deviation)}
+                <div class="why-dev">
+                  <span class="dev-chip">{P.labels.deviationWord}</span><span
+                    >{deviation}</span
+                  >
+                </div>
+              {/each}
+              {#if showDiff}
+                <div class="filebar">
+                  <span class="filebar-path">{point.path}</span>
+                  <span class="filebar-stat">
+                    <span class="plus">+{point.additions}</span>
+                    <span class="minus">&minus;{point.deletions}</span>
+                  </span>
+                </div>
+                <div class="walk-phone-note">{P.labels.walkDiffsDesktop}</div>
+                <div class="hunks">
+                  {#if patches[point.path]?.loading}
+                    <div class="walk-fact pad16">
+                      {P.labels.walkDiffLoading}
+                    </div>
+                  {:else if patches[point.path]?.failed}
+                    <div class="walk-fact pad16">
+                      {P.labels.walkDiffUnavailable}
+                    </div>
+                  {:else if patches[point.path]?.hunks}
+                    {#each patches[point.path].hunks as hunk, hunkIndex (hunkIndex)}
+                      <div class="hunk">
+                        <div class="hunk-inner">
+                          {#if hunk.header}
+                            <div class="hunk-head">{hunk.header}</div>
+                          {/if}
+                          {#each hunk.lines as line, lineIndex (lineIndex)}
+                            <span class={`dl ${line.kind}`}
+                              ><span class="g">{line.gutter}</span
+                              >{line.text}</span
+                            >
+                          {/each}
+                        </div>
+                      </div>
+                    {/each}
+                  {/if}
+                </div>
+              {/if}
+            {/if}
           </div>
         </div>
-      {/each}
-    {:else if walk.rung === 3}
-      <div class="walk-fact">{P.labels.walkNoCompareNote}</div>
-      <ol class="walk-steps">
-        {#each walk.steps as step, index (step.path)}
-          <li class="walk-step focused">
-            <div class="walk-step-head static">
-              <span class="walk-idx">{index + 1}</span>
-              <span class="walk-path">{step.path}</span>
-            </div>
-            {#if step.why}
-              <div class="walk-step-body">
-                <div class="testimony" data-register="testimony">
-                  <div class="testimony-attribution">{attribution}</div>
-                  <div class="testimony-line">{step.why}</div>
-                </div>
-              </div>
-            {/if}
-          </li>
-        {/each}
-      </ol>
-      {#if walk.touched.length > 0}
-        <div class="walk-fact">{P.labels.walkTouchedLabel}</div>
-        <ul class="walk-list">
-          {#each walk.touched as path (path)}
-            <li>{path}</li>
-          {/each}
-        </ul>
-      {/if}
-    {:else if walk.rung === 4}
-      <!-- Rung 4 declines to offer a walk (ADR 056 decision 6): stats and
-           the touched list, each labelled as what it is, and nothing walks. -->
-      <div class="walk-fact">{P.labels.walkDeclinedNote}</div>
-      <div class="walk-fact">
-        {P.labels.walkTouchedLabel}{P.punct.colon}
-        {walk.touched.length}
       </div>
+    {/if}
+
+    {#if walk.rung === 4 && walk.touched.length > 0}
+      <div class="walk-fact">{P.labels.walkTouchedLabel}</div>
       <ul class="walk-list">
         {#each walk.touched as path (path)}
           <li>{path}</li>
         {/each}
       </ul>
-    {:else}
-      <div class="walk-fact">{P.labels.walkNothingNote}</div>
-    {/if}
-
-    {#if walk.deviations.length > 0}
-      <div class="testimony" data-register="testimony">
-        <div class="testimony-attribution">{attribution}</div>
-        {#each walk.deviations as deviation (deviation)}
-          <div class="testimony-line">
-            <span class="dev-chip">{P.labels.deviationWord}</span><span
-              >{deviation}</span
-            >
-          </div>
-        {/each}
-      </div>
     {/if}
   {/if}
 </details>
 
 <style>
-  /* Colors, sizes, and radii come from agents-theme.css tokens only; spacing
-     follows run-view.css's 4/8/16 rhythm. */
+  /* Colors, sizes, and radii come from agents-theme.css tokens (including
+     the diff tokens added for this surface); spacing follows the console's
+     existing 4/8/16 rhythm. */
   .walk {
     margin-top: 8px;
     border-top: 1px solid var(--line);
@@ -344,160 +352,25 @@
     display: flex;
     align-items: baseline;
     gap: 8px;
+    width: fit-content;
     color: var(--muted);
     font: var(--size-meta) var(--font-mono);
     cursor: pointer;
     user-select: none;
-    width: fit-content;
   }
   .walk-summary:hover {
     color: var(--text-soft);
   }
-  .walk-stats {
+  .walk-count {
     color: var(--text-soft);
-  }
-  .add {
-    color: var(--ok);
-  }
-  .del {
-    color: var(--err);
   }
   .walk-fact {
     margin-top: 8px;
     color: var(--muted);
     font-size: var(--size-detail);
   }
-  .walk-flag {
-    display: inline-block;
-    margin-right: 4px;
-    padding: 0 4px;
-    border: 1px solid var(--line-strong);
-    border-radius: var(--radius-sm);
-    color: var(--text-soft);
-    font: var(--size-meta) var(--font-mono);
-  }
-  .walk-nav {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-top: 8px;
-  }
-  .walk-progress {
-    color: var(--text-soft);
-    font: var(--size-meta) var(--font-mono);
-  }
-  .walk-nav-btn {
-    padding: 0 8px;
-    border: 1px solid var(--line-strong);
-    border-radius: var(--radius-md);
-    background: transparent;
-    color: var(--text-soft);
-    font: var(--size-body-mono) var(--font-mono);
-    cursor: pointer;
-  }
-  .walk-nav-btn:disabled {
-    color: var(--dot-idle);
-    border-color: var(--line);
-    cursor: default;
-  }
-  .walk-nav-btn:not(:disabled):hover {
-    background: var(--hover);
-  }
-  /* The phone reader gets intent, counts, and quoted rationale; patch
-     reading is deferred to a desktop by design (ADR 056), so the note only
-     exists where the diff controls are hidden. */
-  .walk-phone-note {
-    display: none;
-    margin-left: auto;
-    color: var(--muted);
-    font-size: var(--size-meta);
-  }
-  .walk-steps {
-    list-style: none;
-    margin: 8px 0 0;
-    padding: 0;
-    border: 1px solid var(--line);
-    border-radius: var(--radius-lg);
-    overflow: hidden;
-  }
-  .walk-step + .walk-step {
-    border-top: 1px solid var(--line);
-  }
-  .walk-step-head {
-    display: flex;
-    align-items: baseline;
-    gap: 8px;
-    width: 100%;
-    padding: 4px 8px;
-    border: 0;
-    background: transparent;
-    text-align: left;
-    font: var(--size-body-mono) var(--font-mono);
-    color: var(--text);
-    cursor: pointer;
-  }
-  .walk-step-head.static {
-    cursor: default;
-  }
-  button.walk-step-head:hover {
-    background: var(--hover);
-  }
-  .walk-step.focused > .walk-step-head {
-    background: var(--code-bg);
-  }
-  .walk-idx {
-    color: var(--muted);
-    min-width: 16px;
-  }
-  .walk-path {
-    font-family: var(--font-mono);
-    font-size: var(--size-body-mono);
-    overflow-wrap: anywhere;
-  }
-  .walk-file-stats {
-    margin-left: auto;
-    white-space: nowrap;
-    font-size: var(--size-meta);
-  }
-  .walk-step-body {
-    padding: 4px 8px 8px 32px;
-  }
-  .walk-diff-btn {
-    margin-top: 8px;
-    padding: 0 8px;
-    border: 1px solid var(--line-strong);
-    border-radius: var(--radius-md);
-    background: transparent;
-    color: var(--text-soft);
-    font: var(--size-meta) var(--font-mono);
-    cursor: pointer;
-  }
-  .walk-diff-btn:hover {
-    background: var(--hover);
-  }
-  .walk-patch {
-    margin: 8px 0 0;
-    padding: 8px;
-    border: 1px solid var(--line);
-    border-radius: var(--radius-md);
-    background: var(--panel-bg);
-    font: var(--size-body-mono) var(--font-mono);
-    line-height: 1.5;
-    overflow-x: auto;
-  }
-  .pl {
-    display: block;
-    white-space: pre;
-    min-height: 1em;
-  }
-  .pl-add {
-    background: var(--ok-soft);
-  }
-  .pl-del {
-    background: var(--err-bg);
-  }
-  .pl-hunk {
-    color: var(--info);
+  .walk-fact.pad16 {
+    margin: 12px 16px;
   }
   .walk-retry {
     margin-left: 8px;
@@ -509,18 +382,234 @@
     font: var(--size-meta) var(--font-mono);
     cursor: pointer;
   }
-  .walk-mech {
+  .walk-frame {
     margin-top: 8px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
   }
-  .walk-mech-summary {
+  /* The provenance banner is the register statement for the whole surface:
+     amber ground marks the agent's-account channel, once, instead of a
+     per-element chip naming the register. */
+  .provenance {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--attn-soft);
+    border-bottom: 1px solid var(--line);
+    font-size: var(--size-meta);
+    color: var(--text);
+  }
+  .provenance b {
+    color: var(--attn-text);
+  }
+  .wbody {
+    display: grid;
+    grid-template-columns: 290px minmax(0, 1fr);
+  }
+  .points {
+    border-right: 1px solid var(--line);
+    background: var(--page-bg);
+    max-height: 420px;
+    overflow: auto;
+  }
+  .pbband {
+    position: sticky;
+    top: 0;
+    padding: 8px 12px 6px;
+    background: var(--page-bg);
+    border-bottom: 1px solid var(--line);
+    font: var(--size-meta) var(--font-mono);
     color: var(--muted);
+  }
+  .point {
+    display: grid;
+    gap: 3px;
+    width: 100%;
+    padding: 8px 12px;
+    border: 0;
+    border-bottom: 1px solid var(--line);
+    background: transparent;
+    text-align: left;
+    font: inherit;
+    cursor: pointer;
+  }
+  .point:hover {
+    background: var(--hover);
+  }
+  /* Selection is an inset ink edge, not a background swap, so the
+     unexplained red ground survives selection. */
+  .point.on {
+    background: var(--panel-bg);
+    box-shadow: inset 2px 0 0 var(--ink);
+  }
+  .point-top {
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+  }
+  .point-n {
+    flex: none;
+    font: var(--size-meta) var(--font-mono);
+    color: var(--muted);
+  }
+  .point-t {
+    font-size: var(--size-detail);
+    font-weight: 600;
+    letter-spacing: -0.004em;
+  }
+  /* rtl so a long path keeps its end, the part that identifies the file. */
+  .point-f {
+    font: var(--size-meta) var(--font-mono);
+    color: var(--muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
+  }
+  .point.unexplained {
+    background: var(--err-bg);
+  }
+  .point.unexplained .point-t {
+    color: var(--err);
+  }
+  .point.unexplained.on {
+    background: var(--err-bg);
+  }
+  .point.conflicted .point-t {
+    color: var(--attn-text);
+  }
+  .mech-row {
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--line);
+    font: var(--size-meta) var(--font-mono);
+    color: var(--muted);
+  }
+  .mech-gen {
+    display: block;
+    margin-top: 2px;
+    color: var(--text-soft);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .detail {
+    min-width: 0;
+    max-height: 420px;
+    overflow: auto;
+    background: var(--panel-bg);
+  }
+  .walk-back {
+    display: none;
+    margin: 8px 12px 0;
+    padding: 0 8px;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--text-soft);
     font: var(--size-meta) var(--font-mono);
     cursor: pointer;
-    user-select: none;
-    width: fit-content;
   }
-  .walk-mech-summary:hover {
+  .why {
+    margin: 12px 16px;
+    display: grid;
+    gap: 6px;
+  }
+  .why-lbl {
+    font: var(--size-meta) var(--font-mono);
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  /* The agent's words, quoted: amber edge for the account channel, never
+     restated in system voice. */
+  .why-txt {
+    font-size: var(--size-detail);
+    border-left: 2px solid var(--attn);
+    padding-left: 12px;
+    text-wrap: pretty;
+  }
+  .why-dev {
+    margin: 0 16px 12px;
+    font-size: var(--size-detail);
+  }
+  .nowhy {
+    margin: 12px 16px;
+    padding: 10px 12px;
+    background: var(--err-bg);
+    border-radius: var(--radius-md);
+    font-size: var(--size-detail);
+  }
+  .nowhy b {
+    color: var(--err);
+  }
+  .filebar {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 8px 16px;
+    border-block: 1px solid var(--line);
+    background: var(--page-bg);
+    font: var(--size-body-mono) var(--font-mono);
+  }
+  .filebar-path {
+    overflow-wrap: anywhere;
+  }
+  .filebar-stat {
+    margin-left: auto;
+    flex: none;
+    font-variant-numeric: tabular-nums;
+  }
+  .plus {
+    color: var(--diff-add-mark);
+  }
+  .minus {
+    color: var(--diff-del-mark);
+  }
+  .hunk {
+    border-bottom: 1px solid var(--line);
+    overflow-x: auto;
+  }
+  .hunk-inner {
+    width: max-content;
+    min-width: 100%;
+  }
+  .hunk-head {
+    position: sticky;
+    left: 0;
+    padding: 4px 16px;
+    background: var(--code-bg);
+    color: var(--muted);
+    font: var(--size-meta) var(--font-mono);
+  }
+  .dl {
+    display: block;
+    padding: 1px 16px 1px 30px;
+    text-indent: -14px;
+    font: var(--size-body-mono) var(--font-mono);
+    line-height: 1.6;
+    white-space: pre;
     color: var(--text-soft);
+  }
+  .dl.add {
+    background: var(--diff-add-bg);
+    color: var(--text);
+  }
+  .dl.del {
+    background: var(--diff-del-bg);
+    color: var(--text);
+  }
+  .g {
+    display: inline-block;
+    width: 14px;
+    color: var(--muted);
+  }
+  .dl.add .g {
+    color: var(--diff-add-mark);
+  }
+  .dl.del .g {
+    color: var(--diff-del-mark);
   }
   .walk-list {
     list-style: none;
@@ -529,16 +618,33 @@
     color: var(--text-soft);
     font: var(--size-body-mono) var(--font-mono);
   }
-  .walk-contradicted {
-    margin-top: 8px;
+  .walk-phone-note {
+    display: none;
+    margin: 8px 16px 0;
+    color: var(--muted);
+    font-size: var(--size-meta);
   }
   @media (max-width: 760px) {
-    .walk-diff-btn,
-    .walk-patch {
+    .wbody {
+      grid-template-columns: 1fr;
+    }
+    .points {
+      border-right: 0;
+    }
+    .wbody:not(.drilled) .detail {
+      display: none;
+    }
+    .wbody.drilled .points {
+      display: none;
+    }
+    .walk-back {
+      display: inline-flex;
+    }
+    .hunks {
       display: none;
     }
     .walk-phone-note {
-      display: inline;
+      display: block;
     }
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
+++ b/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
@@ -36,6 +36,15 @@
   /* State tokens: period-invariant, never overridden. */
   --ok: #0a7c3c;
   --ok-soft: #dcf2e5;
+  /* Diff panes (walkthrough): added/removed lines are fact register, so
+     these sit with the state tokens. Backgrounds are one tier lighter than
+     the ok/err soft fills so a full hunk of additions stays readable text
+     on tint rather than a solid block; the gutter marks reuse the state
+     inks themselves. */
+  --diff-add-bg: #e9f6ee;
+  --diff-del-bg: #fdf1ee;
+  --diff-add-mark: var(--ok);
+  --diff-del-mark: var(--err);
   --attn: #b25e00;
   /* Before 4.09:1 on --attn-soft, after 6.01:1 on --attn-soft and
      6.86:1 on white. */

--- a/projects/monolith/frontend/src/routes/private/agents/lexicon.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/lexicon.test.js
@@ -14,6 +14,7 @@ const SURFACES = [
   "RunView.svelte",
   "MasterView.svelte",
   "PaneHeader.svelte",
+  "SessionWalkthrough.svelte",
 ];
 
 function allValues(section) {

--- a/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
@@ -571,6 +571,126 @@ const wide = run("wide", "running", {
   ],
 });
 
+// --- Session walkthrough fixtures (ADR 056) -------------------------------
+// One fixture per degradation-ladder rung, plus the cross-check and scale
+// cases. Shapes mirror GET /api/swarm/compare/{session}/{turn}
+// (swarm/compare_router.py) and swarm/rationale.py's parsed trailer; patches
+// are embedded so previews never fetch.
+
+function walkFile(
+  path,
+  classification,
+  additions,
+  deletions,
+  status = "modified",
+) {
+  return {
+    path,
+    status,
+    additions,
+    deletions,
+    changes: additions + deletions,
+    classification,
+    patch_url:
+      classification === "authored"
+        ? `/api/swarm/compare/301/2/patch?path=${encodeURIComponent(path)}`
+        : null,
+  };
+}
+
+function walkRationale(paths, deviations = []) {
+  return {
+    raw: "RATIONALE",
+    parse_status: "parsed",
+    paths,
+    deviations,
+    parser_version: 1,
+  };
+}
+
+function walkEntry(compare, rationale = null, patches = {}) {
+  return {
+    walkthrough: { turnSeq: 2, model: "luna", compare, rationale, patches },
+  };
+}
+
+const walkPatchRows = [
+  "@@ -41,7 +41,9 @@ def read_turn(session_id, seq):",
+  "     turn = store.get_turn(db, session_id, seq)",
+  "     if turn is None:",
+  "-        return None",
+  "+        raise HTTPException(status_code=404)",
+  "+    if turn.result_text is None:",
+  "+        return empty_turn(turn)",
+  "     return turn",
+].join("\n");
+
+const walkPatchView = [
+  "@@ -12,6 +12,8 @@ export function turnView(turn) {",
+  "   return {",
+  "     seq: turn.seq,",
+  "+    // The walkthrough needs the recorded head to resolve a compare.",
+  "+    commit_sha: turn.commit_sha,",
+  "     model: turn.model,",
+  "   };",
+  " }",
+].join("\n");
+
+const walkFullCompare = {
+  resolution_rung: 1,
+  diff_type: "sha",
+  base_sha: "9f2c11ab",
+  commit_sha: "86dcbf41",
+  branch: "claude/fixture-walk",
+  trailer_parsed: true,
+  files: [
+    walkFile("swarm/rows.py", "authored", 12, 3),
+    walkFile("swarm/view.py", "authored", 8, 2),
+    walkFile("swarm/view_test.py", "authored", 31, 0),
+    walkFile("swarm/quiet.py", "authored", 2, 2),
+    walkFile("charts/monolith/index.yaml", "mechanical", 4, 4),
+    walkFile("charts/monolith/lock.json", "mechanical", 40, 40),
+    walkFile("projects/home-cluster/kustomization.yaml", "mechanical", 1, 1),
+  ],
+  stats: { total_files: 7 },
+  authored_file_paths: [
+    "swarm/quiet.py",
+    "swarm/rows.py",
+    "swarm/view.py",
+    "swarm/view_test.py",
+  ],
+  unexplained_files: [
+    "charts/monolith/index.yaml",
+    "charts/monolith/lock.json",
+    "projects/home-cluster/kustomization.yaml",
+    "swarm/quiet.py",
+  ],
+  contradicted_paths: ["swarm/legacy_rollup.py"],
+};
+
+const walkFullRationale = walkRationale(
+  [
+    { path: "swarm/view.py", why: "serves the recorded head to the console" },
+    {
+      path: "swarm/view_test.py",
+      why: "locks the new field into the contract",
+    },
+    { path: "swarm/rows.py", why: "404s a missing turn instead of nulling" },
+    {
+      path: "swarm/legacy_rollup.py",
+      why: "deleted the rollup the run view replaced",
+    },
+  ],
+  ["left the sidebar rollup untouched; it is owned by another change"],
+);
+
+const walkFullPatches = {
+  "swarm/rows.py": walkPatchRows,
+  "swarm/view.py": walkPatchView,
+  "swarm/view_test.py": walkPatchView,
+  "swarm/quiet.py": walkPatchRows,
+};
+
 export const RUN_FIXTURES = {
   running: entry(running, [
     {
@@ -623,4 +743,148 @@ export const RUN_FIXTURES = {
     engine_tier: "absent",
     snapshot_age_seconds: 0,
   }),
+  // Ladder rung 1: SHAs recorded, trailer parsed. Also carries the two
+  // cross-check states: swarm/quiet.py is authored but unexplained, and
+  // swarm/legacy_rollup.py is claimed but absent from the diff.
+  "walk-full": walkEntry(walkFullCompare, walkFullRationale, walkFullPatches),
+  // Rung 2: no SHAs, branch still resolvable; same walk labelled ephemeral.
+  "walk-ephemeral": walkEntry(
+    {
+      ...walkFullCompare,
+      resolution_rung: 2,
+      diff_type: "branch_ephemeral",
+      base_sha: null,
+      commit_sha: null,
+    },
+    walkFullRationale,
+    walkFullPatches,
+  ),
+  // Rung 3: no compare resolves; quoted testimony plus the touched list,
+  // no diff panes. contradicted_paths deliberately carries every trailer
+  // path (the server set-difference against an empty diff) to prove the
+  // client does not render phantom contradictions.
+  "walk-testimony-only": walkEntry(
+    {
+      resolution_rung: 3,
+      diff_type: null,
+      base_sha: null,
+      commit_sha: null,
+      branch: null,
+      trailer_parsed: true,
+      files: [],
+      stats: { total_files: 0 },
+      authored_file_paths: ["swarm/rows.py", "swarm/view.py"],
+      unexplained_files: [],
+      contradicted_paths: ["swarm/rows.py", "swarm/view.py"],
+      error: "no_compare_available",
+    },
+    walkRationale([
+      { path: "swarm/rows.py", why: "404s a missing turn instead of nulling" },
+      { path: "swarm/view.py", why: "serves the recorded head to the console" },
+    ]),
+  ),
+  // Rung 4: no compare, no trailer, many files: declines to walk and shows
+  // stats plus the touched list, labelled. A requirement, not a shortfall.
+  "walk-stats-only": walkEntry({
+    resolution_rung: 3,
+    diff_type: null,
+    base_sha: null,
+    commit_sha: null,
+    branch: null,
+    trailer_parsed: false,
+    files: [],
+    stats: { total_files: 0 },
+    authored_file_paths: Array.from(
+      { length: 23 },
+      (_, i) => `pkg/generated/module_${String(i).padStart(2, "0")}.py`,
+    ),
+    unexplained_files: [],
+    contradicted_paths: [],
+    error: "no_compare_available",
+  }),
+  // Rung 5: nothing at all; the section says so and stops.
+  "walk-empty": walkEntry({
+    resolution_rung: 3,
+    diff_type: null,
+    base_sha: null,
+    commit_sha: null,
+    branch: null,
+    trailer_parsed: false,
+    files: [],
+    stats: { total_files: 0 },
+    authored_file_paths: [],
+    unexplained_files: [],
+    contradicted_paths: [],
+    error: "no_compare_available",
+  }),
+  // A generator-dominated turn: 143 mechanical files collapse to one step
+  // with a count, and the GitHub files cap renders as a labelled fact.
+  "walk-mechanical-large": walkEntry(
+    {
+      ...walkFullCompare,
+      files: [
+        walkFile("bazel/tools/regen.bzl", "authored", 6, 1),
+        ...Array.from({ length: 143 }, (_, i) =>
+          walkFile(
+            `projects/charts/rendered/out_${String(i).padStart(3, "0")}.yaml`,
+            "mechanical",
+            3,
+            3,
+          ),
+        ),
+      ],
+      stats: {
+        total_files: 144,
+        truncated_at: 300,
+        truncated_reason: "GitHub files array capped at 300",
+      },
+      activities_truncated: true,
+      activities_truncated_reason: "activities ingest capped at 300",
+      authored_file_paths: ["bazel/tools/regen.bzl"],
+      unexplained_files: [],
+      contradicted_paths: [],
+    },
+    walkRationale([
+      { path: "bazel/tools/regen.bzl", why: "widened the regen glob" },
+    ]),
+    { "bazel/tools/regen.bzl": walkPatchRows },
+  ),
+  // A changed file no point mentions: flagged in system voice, never blocking.
+  "walk-unexplained": walkEntry(
+    {
+      ...walkFullCompare,
+      files: [
+        walkFile("swarm/rows.py", "authored", 12, 3),
+        walkFile("swarm/quiet.py", "authored", 2, 2),
+      ],
+      stats: { total_files: 2 },
+      authored_file_paths: ["swarm/quiet.py", "swarm/rows.py"],
+      unexplained_files: ["swarm/quiet.py"],
+      contradicted_paths: [],
+    },
+    walkRationale([
+      { path: "swarm/rows.py", why: "404s a missing turn instead of nulling" },
+    ]),
+    { "swarm/rows.py": walkPatchRows, "swarm/quiet.py": walkPatchRows },
+  ),
+  // A point naming a file absent from the diff: juxtaposed with the claim,
+  // never merged and never dropped.
+  "walk-contradicted": walkEntry(
+    {
+      ...walkFullCompare,
+      files: [walkFile("swarm/rows.py", "authored", 12, 3)],
+      stats: { total_files: 1 },
+      authored_file_paths: ["swarm/rows.py"],
+      unexplained_files: [],
+      contradicted_paths: ["swarm/legacy_rollup.py"],
+    },
+    walkRationale([
+      { path: "swarm/rows.py", why: "404s a missing turn instead of nulling" },
+      {
+        path: "swarm/legacy_rollup.py",
+        why: "deleted the rollup the run view replaced",
+      },
+    ]),
+    { "swarm/rows.py": walkPatchRows },
+  ),
 };

--- a/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
@@ -573,122 +573,126 @@ const wide = run("wide", "running", {
 
 // --- Session walkthrough fixtures (ADR 056) -------------------------------
 // One fixture per degradation-ladder rung, plus the cross-check and scale
-// cases. Shapes mirror GET /api/swarm/compare/{session}/{turn}
-// (swarm/compare_router.py) and swarm/rationale.py's parsed trailer; patches
-// are embedded so previews never fetch.
+// cases. Payload shapes mirror GET /api/swarm/walkthrough/{session}/{turn}
+// (swarm/walkthrough_composer.py); patches are embedded so previews never
+// fetch.
 
-function walkFile(
-  path,
-  classification,
-  additions,
-  deletions,
-  status = "modified",
-) {
+const WALK_TESTIMONY = { turn: 2, attempt: 1 };
+
+function walkAuthored(path, additions, deletions, why = null) {
   return {
-    path,
-    status,
-    additions,
-    deletions,
-    changes: additions + deletions,
-    classification,
-    patch_url:
-      classification === "authored"
-        ? `/api/swarm/compare/301/2/patch?path=${encodeURIComponent(path)}`
-        : null,
+    type: "authored",
+    register: why ? "testimony" : "fact",
+    file_path: path,
+    file_change: { additions, deletions, status: "modified" },
+    ...(why
+      ? { testimony: { ...WALK_TESTIMONY, points: [{ path, why }] } }
+      : {}),
   };
 }
 
-function walkRationale(paths, deviations = []) {
+function walkUnexplained(path, additions, deletions) {
   return {
-    raw: "RATIONALE",
-    parse_status: "parsed",
-    paths,
-    deviations,
-    parser_version: 1,
+    type: "unexplained",
+    register: "fact",
+    file_path: path,
+    file_change: { additions, deletions, status: "modified" },
+    label: "Unexplained file",
   };
 }
 
-function walkEntry(compare, rationale = null, patches = {}) {
-  return {
-    walkthrough: { turnSeq: 2, model: "luna", compare, rationale, patches },
-  };
+function walkEntry(payload, patches = {}) {
+  return { walkthrough: { turnSeq: 2, model: "luna", payload, patches } };
 }
 
-const walkPatchRows = [
-  "@@ -41,7 +41,9 @@ def read_turn(session_id, seq):",
-  "     turn = store.get_turn(db, session_id, seq)",
-  "     if turn is None:",
-  "-        return None",
-  "+        raise HTTPException(status_code=404)",
-  "+    if turn.result_text is None:",
-  "+        return empty_turn(turn)",
-  "     return turn",
+const walkPatchPolicy = [
+  "@@ -13,14 +15,20 @@",
+  "-def next_action(attempt: int, max_attempts: int, commit_sha: str | None) -> str:",
+  "+def next_action(",
+  "+    attempt: int,",
+  "+    max_attempts: int,",
+  "+    head_sha: str | None,",
+  "+    prior_sha: str | None,",
+  "+) -> str:",
+  "-    if commit_sha:",
+  "+    if head_sha and head_sha != prior_sha:",
+  '         return "review"',
 ].join("\n");
 
-const walkPatchView = [
-  "@@ -12,6 +12,8 @@ export function turnView(turn) {",
-  "   return {",
-  "     seq: turn.seq,",
-  "+    // The walkthrough needs the recorded head to resolve a compare.",
-  "+    commit_sha: turn.commit_sha,",
-  "     model: turn.model,",
-  "   };",
-  " }",
+const walkPatchWorkflows = [
+  "@@ -60,16 +66,27 @@",
+  " def _escalated(",
+  "-    attempt: int, session_id: int | None, turn: dict | None, branch_name: str",
+  "+    attempt: int,",
+  "+    session_id: int | None,",
+  "+    turn: dict | None,",
+  "+    branch_name: str,",
+  "+    branch_head: str | None = None,",
+  " ) -> dict:",
+  "+    # commit_sha stays None on escalation: nothing was verified for",
+  "+    # review. branch_head carries the last observed remote head.",
+  "     return {",
+  '         "status": "escalated",',
 ].join("\n");
 
-const walkFullCompare = {
-  resolution_rung: 1,
-  diff_type: "sha",
-  base_sha: "9f2c11ab",
-  commit_sha: "86dcbf41",
-  branch: "claude/fixture-walk",
-  trailer_parsed: true,
-  files: [
-    walkFile("swarm/rows.py", "authored", 12, 3),
-    walkFile("swarm/view.py", "authored", 8, 2),
-    walkFile("swarm/view_test.py", "authored", 31, 0),
-    walkFile("swarm/quiet.py", "authored", 2, 2),
-    walkFile("charts/monolith/index.yaml", "mechanical", 4, 4),
-    walkFile("charts/monolith/lock.json", "mechanical", 40, 40),
-    walkFile("projects/home-cluster/kustomization.yaml", "mechanical", 1, 1),
-  ],
-  stats: { total_files: 7 },
-  authored_file_paths: [
-    "swarm/quiet.py",
-    "swarm/rows.py",
-    "swarm/view.py",
-    "swarm/view_test.py",
-  ],
-  unexplained_files: [
-    "charts/monolith/index.yaml",
-    "charts/monolith/lock.json",
-    "projects/home-cluster/kustomization.yaml",
-    "swarm/quiet.py",
-  ],
-  contradicted_paths: ["swarm/legacy_rollup.py"],
-};
+const walkPatchQueues = [
+  "@@ -8,6 +8,15 @@",
+  "+def codex_queue_limit() -> int:",
+  '+    return int(os.environ.get("SWARM_CODEX_CONCURRENCY", "2"))',
+  " ",
+].join("\n");
 
-const walkFullRationale = walkRationale(
-  [
-    { path: "swarm/view.py", why: "serves the recorded head to the console" },
-    {
-      path: "swarm/view_test.py",
-      why: "locks the new field into the contract",
+const walkFullSteps = [
+  walkAuthored(
+    "projects/monolith/swarm/policy.py",
+    46,
+    5,
+    "A commit existing anywhere satisfied the old check, so stale work went to review. Comparing head against the prior head makes the signal per-attempt.",
+  ),
+  walkAuthored(
+    "projects/monolith/swarm/workflows.py",
+    42,
+    8,
+    "commit_sha stays unset on escalation because nothing was verified, but discarding the observed head left a triager unable to tell an empty branch from a late push.",
+  ),
+  walkAuthored(
+    "projects/monolith/swarm/policy_test.py",
+    63,
+    7,
+    "Sweeping head and prior independently makes the unchanged-head case a first-class row rather than an assumption.",
+  ),
+  // The twin pair the composer emits for an authored file the trailer
+  // skipped: a bare authored row plus an unexplained row for the same path.
+  // The view dedupes them into one unexplained point.
+  walkAuthored("projects/monolith/swarm/queues.py", 12, 3),
+  {
+    type: "mechanical",
+    register: "fact",
+    count: 3,
+    generator_activity: { type: "run", command: "ci regen" },
+  },
+  walkUnexplained("projects/monolith/swarm/queues.py", 12, 3),
+  {
+    type: "contradiction",
+    register: "testimony",
+    label: "Contradicted path",
+    testimony: {
+      ...WALK_TESTIMONY,
+      points: [
+        {
+          path: "projects/monolith/swarm/legacy_rollup.py",
+          why: "deleted the rollup the run view replaced",
+        },
+      ],
     },
-    { path: "swarm/rows.py", why: "404s a missing turn instead of nulling" },
-    {
-      path: "swarm/legacy_rollup.py",
-      why: "deleted the rollup the run view replaced",
-    },
-  ],
-  ["left the sidebar rollup untouched; it is owned by another change"],
-);
+  },
+];
 
 const walkFullPatches = {
-  "swarm/rows.py": walkPatchRows,
-  "swarm/view.py": walkPatchView,
-  "swarm/view_test.py": walkPatchView,
-  "swarm/quiet.py": walkPatchRows,
+  "projects/monolith/swarm/policy.py": walkPatchPolicy,
+  "projects/monolith/swarm/workflows.py": walkPatchWorkflows,
+  "projects/monolith/swarm/policy_test.py": walkPatchWorkflows,
+  "projects/monolith/swarm/queues.py": walkPatchQueues,
 };
 
 export const RUN_FIXTURES = {
@@ -744,147 +748,178 @@ export const RUN_FIXTURES = {
     snapshot_age_seconds: 0,
   }),
   // Ladder rung 1: SHAs recorded, trailer parsed. Also carries the two
-  // cross-check states: swarm/quiet.py is authored but unexplained, and
-  // swarm/legacy_rollup.py is claimed but absent from the diff.
-  "walk-full": walkEntry(walkFullCompare, walkFullRationale, walkFullPatches),
-  // Rung 2: no SHAs, branch still resolvable; same walk labelled ephemeral.
-  "walk-ephemeral": walkEntry(
+  // cross-check states: queues.py is authored but unexplained (as the twin
+  // pair the composer emits), and legacy_rollup.py is claimed but absent
+  // from the diff.
+  "walk-full": walkEntry(
     {
-      ...walkFullCompare,
-      resolution_rung: 2,
-      diff_type: "branch_ephemeral",
-      base_sha: null,
-      commit_sha: null,
+      rung: 1,
+      ephemeral: false,
+      steps: walkFullSteps,
+      stats: { total_files: 8 },
     },
-    walkFullRationale,
     walkFullPatches,
   ),
-  // Rung 3: no compare resolves; quoted testimony plus the touched list,
-  // no diff panes. contradicted_paths deliberately carries every trailer
-  // path (the server set-difference against an empty diff) to prove the
-  // client does not render phantom contradictions.
-  "walk-testimony-only": walkEntry(
+  // Rung 2: no SHAs, branch still resolvable; same walk, labelled ephemeral
+  // by the server's own message.
+  "walk-ephemeral": walkEntry(
     {
-      resolution_rung: 3,
-      diff_type: null,
-      base_sha: null,
-      commit_sha: null,
-      branch: null,
-      trailer_parsed: true,
-      files: [],
-      stats: { total_files: 0 },
-      authored_file_paths: ["swarm/rows.py", "swarm/view.py"],
-      unexplained_files: [],
-      contradicted_paths: ["swarm/rows.py", "swarm/view.py"],
-      error: "no_compare_available",
+      rung: 2,
+      ephemeral: true,
+      steps: walkFullSteps,
+      stats: { total_files: 8 },
+      message:
+        "This walkthrough becomes unavailable once this branch is deleted",
     },
-    walkRationale([
-      { path: "swarm/rows.py", why: "404s a missing turn instead of nulling" },
-      { path: "swarm/view.py", why: "serves the recorded head to the console" },
-    ]),
+    walkFullPatches,
   ),
-  // Rung 4: no compare, no trailer, many files: declines to walk and shows
-  // stats plus the touched list, labelled. A requirement, not a shortfall.
+  // Rung 3: no compare resolves; quoted testimony plus touched files, no
+  // diff panes, and the server's own message labels the limitation.
+  "walk-testimony-only": walkEntry({
+    rung: 3,
+    ephemeral: false,
+    steps: [
+      {
+        type: "authored",
+        register: "testimony",
+        file_path: "projects/monolith/swarm/rows.py",
+        testimony: {
+          ...WALK_TESTIMONY,
+          points: [
+            {
+              path: "projects/monolith/swarm/rows.py",
+              why: "404s a missing turn instead of nulling",
+            },
+            { deviation: "left the sidebar rollup untouched" },
+          ],
+        },
+      },
+      {
+        type: "authored",
+        register: "testimony",
+        file_path: "projects/monolith/swarm/view.py",
+        testimony: {
+          ...WALK_TESTIMONY,
+          points: [
+            {
+              path: "projects/monolith/swarm/view.py",
+              why: "serves the recorded head to the console",
+            },
+          ],
+        },
+      },
+      {
+        type: "authored",
+        register: "fact",
+        file_path: "projects/monolith/swarm/queues.py",
+        file_change: { additions: 0, deletions: 0, status: "touched" },
+      },
+    ],
+    stats: { authored_files: 3 },
+    message: "Limited walkthrough: testimony and activities only",
+  }),
+  // Rung 4: no compare, no trailer, many files: the server declines to walk
+  // and says so; the console renders the labelled touched list and stops.
   "walk-stats-only": walkEntry({
-    resolution_rung: 3,
-    diff_type: null,
-    base_sha: null,
-    commit_sha: null,
-    branch: null,
-    trailer_parsed: false,
-    files: [],
-    stats: { total_files: 0 },
-    authored_file_paths: Array.from(
-      { length: 23 },
-      (_, i) => `pkg/generated/module_${String(i).padStart(2, "0")}.py`,
-    ),
-    unexplained_files: [],
-    contradicted_paths: [],
-    error: "no_compare_available",
+    rung: 4,
+    ephemeral: false,
+    steps: [],
+    stats: {
+      total_files: 23,
+      authored_files: 23,
+      activities: Array.from(
+        { length: 23 },
+        (_, i) => `pkg/generated/module_${String(i).padStart(2, "0")}.py`,
+      ),
+    },
+    message:
+      "Files touched by tools this turn; decline to offer walkthrough without intent structure",
   }),
   // Rung 5: nothing at all; the section says so and stops.
   "walk-empty": walkEntry({
-    resolution_rung: 3,
-    diff_type: null,
-    base_sha: null,
-    commit_sha: null,
-    branch: null,
-    trailer_parsed: false,
-    files: [],
-    stats: { total_files: 0 },
-    authored_file_paths: [],
-    unexplained_files: [],
-    contradicted_paths: [],
-    error: "no_compare_available",
+    rung: 5,
+    ephemeral: false,
+    steps: [],
+    message: "No activity recorded",
   }),
   // A generator-dominated turn: 143 mechanical files collapse to one step
-  // with a count, and the GitHub files cap renders as a labelled fact.
+  // with a count, and both truncation caps render as labelled facts.
   "walk-mechanical-large": walkEntry(
     {
-      ...walkFullCompare,
-      files: [
-        walkFile("bazel/tools/regen.bzl", "authored", 6, 1),
-        ...Array.from({ length: 143 }, (_, i) =>
-          walkFile(
-            `projects/charts/rendered/out_${String(i).padStart(3, "0")}.yaml`,
-            "mechanical",
-            3,
-            3,
-          ),
-        ),
+      rung: 1,
+      ephemeral: false,
+      steps: [
+        walkAuthored("bazel/tools/regen.bzl", 6, 1, "widened the regen glob"),
+        {
+          type: "mechanical",
+          register: "fact",
+          count: 143,
+          generator_activity: { type: "run", command: "ci regen" },
+        },
+        {
+          type: "truncation",
+          register: "fact",
+          label: "GitHub files truncated",
+        },
+        { type: "truncation", register: "fact", label: "activities truncated" },
       ],
-      stats: {
-        total_files: 144,
-        truncated_at: 300,
-        truncated_reason: "GitHub files array capped at 300",
-      },
-      activities_truncated: true,
-      activities_truncated_reason: "activities ingest capped at 300",
-      authored_file_paths: ["bazel/tools/regen.bzl"],
-      unexplained_files: [],
-      contradicted_paths: [],
+      stats: { total_files: 144, truncated_at: 300 },
     },
-    walkRationale([
-      { path: "bazel/tools/regen.bzl", why: "widened the regen glob" },
-    ]),
-    { "bazel/tools/regen.bzl": walkPatchRows },
+    { "bazel/tools/regen.bzl": walkPatchPolicy },
   ),
-  // A changed file no point mentions: flagged in system voice, never blocking.
+  // A changed file no point mentions: a point in the same list, red, in
+  // system voice, never blocking.
   "walk-unexplained": walkEntry(
     {
-      ...walkFullCompare,
-      files: [
-        walkFile("swarm/rows.py", "authored", 12, 3),
-        walkFile("swarm/quiet.py", "authored", 2, 2),
+      rung: 1,
+      ephemeral: false,
+      steps: [
+        walkAuthored(
+          "projects/monolith/swarm/rows.py",
+          12,
+          3,
+          "404s a missing turn instead of nulling",
+        ),
+        walkAuthored("projects/monolith/swarm/queues.py", 12, 3),
+        walkUnexplained("projects/monolith/swarm/queues.py", 12, 3),
       ],
       stats: { total_files: 2 },
-      authored_file_paths: ["swarm/quiet.py", "swarm/rows.py"],
-      unexplained_files: ["swarm/quiet.py"],
-      contradicted_paths: [],
     },
-    walkRationale([
-      { path: "swarm/rows.py", why: "404s a missing turn instead of nulling" },
-    ]),
-    { "swarm/rows.py": walkPatchRows, "swarm/quiet.py": walkPatchRows },
+    {
+      "projects/monolith/swarm/rows.py": walkPatchPolicy,
+      "projects/monolith/swarm/queues.py": walkPatchQueues,
+    },
   ),
   // A point naming a file absent from the diff: juxtaposed with the claim,
   // never merged and never dropped.
   "walk-contradicted": walkEntry(
     {
-      ...walkFullCompare,
-      files: [walkFile("swarm/rows.py", "authored", 12, 3)],
+      rung: 1,
+      ephemeral: false,
+      steps: [
+        walkAuthored(
+          "projects/monolith/swarm/rows.py",
+          12,
+          3,
+          "404s a missing turn instead of nulling",
+        ),
+        {
+          type: "contradiction",
+          register: "testimony",
+          label: "Contradicted path",
+          testimony: {
+            ...WALK_TESTIMONY,
+            points: [
+              {
+                path: "projects/monolith/swarm/legacy_rollup.py",
+                why: "deleted the rollup the run view replaced",
+              },
+            ],
+          },
+        },
+      ],
       stats: { total_files: 1 },
-      authored_file_paths: ["swarm/rows.py"],
-      unexplained_files: [],
-      contradicted_paths: ["swarm/legacy_rollup.py"],
     },
-    walkRationale([
-      { path: "swarm/rows.py", why: "404s a missing turn instead of nulling" },
-      {
-        path: "swarm/legacy_rollup.py",
-        why: "deleted the rollup the run view replaced",
-      },
-    ]),
-    { "swarm/rows.py": walkPatchRows },
+    { "projects/monolith/swarm/rows.py": walkPatchPolicy },
   ),
 };

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -156,6 +156,37 @@ export const RUN_LEXICON = {
     sessionsRegion: "Agent sessions",
     transcriptRegion: "Agent transcript",
     backToSessions: "Back to agent sessions",
+    // Session walkthrough (ADR 056). Server-composed sentences (truncation
+    // reasons, rationale quotes) are data, not lexicon; these are the
+    // interface's own words only.
+    walkSummary: "what changed",
+    walkStepWord: "step",
+    walkStepsWord: "steps",
+    walkFilesWord: "files",
+    walkFileWord: "file",
+    walkPrevStep: "previous step",
+    walkNextStep: "next step",
+    walkShowDiff: "show diff",
+    walkHideDiff: "hide diff",
+    walkDiffLoading: "loading diff…",
+    walkDiffUnavailable: "diff unavailable",
+    walkDiffsDesktop: "diffs read on a desktop",
+    walkUnexplained: "unexplained",
+    walkUnexplainedNote: "in the diff; no point mentions it",
+    walkContradictedNote: "named by the agent; not in the diff",
+    walkMechanicalStep: "produced by tooling this turn",
+    walkEphemeralNote:
+      "compared by branch name; stops resolving once the branch merges",
+    walkNoCompareNote: "no compare available; showing the agent's account",
+    walkNoTrailerNote: "no rationale recorded for this turn",
+    walkTouchedLabel: "files touched by tools this turn",
+    walkDeclinedNote:
+      "no walk offered: no compare and no recorded rationale to structure one",
+    walkNothingNote: "nothing recorded for this turn",
+    walkUnavailable: "walkthrough unavailable",
+    walkRetry: "retry",
+    walkTruncatedWord: "truncated",
+    walkLoading: "loading…",
   },
   punct: { dot: "·", arrow: "→", colon: ":" },
   deviationCodes: {

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -156,36 +156,35 @@ export const RUN_LEXICON = {
     sessionsRegion: "Agent sessions",
     transcriptRegion: "Agent transcript",
     backToSessions: "Back to agent sessions",
-    // Session walkthrough (ADR 056). Server-composed sentences (truncation
-    // reasons, rationale quotes) are data, not lexicon; these are the
-    // interface's own words only.
+    // Session walkthrough (ADR 056). Server-composed sentences (the payload
+    // `message`, rationale quotes, truncation labels) are data, not lexicon;
+    // these are the interface's own words only.
     walkSummary: "what changed",
-    walkStepWord: "step",
-    walkStepsWord: "steps",
-    walkFilesWord: "files",
+    walkPointWord: "point",
+    walkPointsWord: "points",
     walkFileWord: "file",
-    walkPrevStep: "previous step",
-    walkNextStep: "next step",
-    walkShowDiff: "show diff",
-    walkHideDiff: "hide diff",
+    walkFilesWord: "files",
+    walkFileChanged: "file changed",
+    walkFilesChanged: "files changed",
+    walkProvenanceLead: "Agent-authored.",
+    walkProvenanceBody:
+      "These points are the implementer's account of its own change. The diff beside them is from git.",
+    walkAccountLabel: "agent's account",
+    walkUnexplainedMark: "!",
+    walkContradictedMark: "×",
+    walkUnexplainedTitle: "Unexplained change.",
+    walkUnexplainedBody:
+      "This file is in the diff, but the walkthrough never mentions it. It is surfaced rather than dropped.",
+    walkContradictedTitle: "Contradicted path.",
+    walkContradictedBody:
+      "The agent named this file; the compare does not contain it.",
+    walkMechanicalStep: "produced by tooling this turn",
+    walkTouchedLabel: "files touched by tools this turn",
     walkDiffLoading: "loading diff…",
     walkDiffUnavailable: "diff unavailable",
     walkDiffsDesktop: "diffs read on a desktop",
-    walkUnexplained: "unexplained",
-    walkUnexplainedNote: "in the diff; no point mentions it",
-    walkContradictedNote: "named by the agent; not in the diff",
-    walkMechanicalStep: "produced by tooling this turn",
-    walkEphemeralNote:
-      "compared by branch name; stops resolving once the branch merges",
-    walkNoCompareNote: "no compare available; showing the agent's account",
-    walkNoTrailerNote: "no rationale recorded for this turn",
-    walkTouchedLabel: "files touched by tools this turn",
-    walkDeclinedNote:
-      "no walk offered: no compare and no recorded rationale to structure one",
-    walkNothingNote: "nothing recorded for this turn",
     walkUnavailable: "walkthrough unavailable",
     walkRetry: "retry",
-    walkTruncatedWord: "truncated",
     walkLoading: "loading…",
   },
   punct: { dot: "·", arrow: "→", colon: ":" },

--- a/projects/monolith/frontend/src/routes/private/agents/walkthrough.js
+++ b/projects/monolith/frontend/src/routes/private/agents/walkthrough.js
@@ -1,0 +1,203 @@
+// Client-side composition for the session-tier walkthrough (ADR 056).
+//
+// Inputs are the merged payload of GET /api/swarm/compare/{session}/{turn}
+// (swarm/compare_router.py, real since PR #4805) plus, when available, the
+// parsed rationale trailer in the swarm/rationale.py shape ({parse_status,
+// paths: [{path, why}], deviations, raw}). ADR 056 decision 5 puts step
+// composition server-side; the server composer had not landed when this
+// module was written, so the composition lives here as a pure function with
+// the same three inputs the ADR names (compare stats, trailer, classifier)
+// and moves behind the composer's output unchanged when it ships. Everything
+// here is a view-model transform: no prose is invented, no register is
+// recomputed, and the agent's words pass through verbatim.
+//
+// Output shape (the step shape this surface renders):
+//   {
+//     rung: 1..5,            // ADR 056 decision 6 ladder
+//     trailer: boolean,      // a rationale trailer parsed for this turn
+//     ephemeral: boolean,    // rung 2: compare by branch name, has a shelf life
+//     declined: boolean,     // rung 4: no walk is offered, stats only
+//     steps: [{ path, status, additions, deletions, why, unexplained,
+//               patchUrl }],
+//     mechanical: { count, files } | null,   // ONE collapsed step, never per file
+//     contradicted: [{ path, why }],         // claim without a matching diff file
+//     deviations: [string],                  // trailer deviations, testimony
+//     touched: [string],                     // rungs 3/4: files touched by tools
+//     truncation: [string],                  // server-stated truncation facts
+//     stats: { totalFiles, additions, deletions },
+//   }
+
+// ADR 056 rung 4: "no compare, no trailer, above roughly a dozen authored
+// files" declines to walk. Below the threshold there is still nothing to
+// compose a walk from (no diff, no testimony), so the same stats rendering
+// applies; the threshold only marks where declining is the deliberate answer
+// rather than the vacuous one.
+export const DECLINE_FILE_THRESHOLD = 12;
+
+function trailerParsed(rationale) {
+  return rationale?.parse_status === "parsed";
+}
+
+function truncationFacts(compare) {
+  // Truncation renders as a labelled fact, never silent under-reporting.
+  // The reasons are server-composed sentences: pass them through as data.
+  const facts = [];
+  if (compare?.stats?.truncated_reason)
+    facts.push(compare.stats.truncated_reason);
+  if (compare?.activities_truncated_reason)
+    facts.push(compare.activities_truncated_reason);
+  return facts;
+}
+
+function sumStats(files) {
+  let additions = 0;
+  let deletions = 0;
+  for (const file of files) {
+    additions += Number(file.additions || 0);
+    deletions += Number(file.deletions || 0);
+  }
+  return { totalFiles: files.length, additions, deletions };
+}
+
+export function composeWalkthrough(compare, rationale = null) {
+  // Two distinct facts: the server parsed a trailer for this turn
+  // (compare.trailer_parsed), and this view holds its content (rationale).
+  // The compare endpoint serves the first without the second; the composer
+  // serves both. Cross-check sets key off the first, quoting needs the second.
+  const parsed = trailerParsed(rationale);
+  const trailerFact = compare?.trailer_parsed === true || parsed;
+  const files = Array.isArray(compare?.files) ? compare.files : [];
+  const touched = Array.isArray(compare?.authored_file_paths)
+    ? compare.authored_file_paths
+    : [];
+  const truncation = truncationFacts(compare);
+  const base = {
+    trailer: trailerFact,
+    ephemeral: false,
+    declined: false,
+    steps: [],
+    mechanical: null,
+    contradicted: [],
+    deviations: parsed ? rationale.deviations.filter(Boolean) : [],
+    touched,
+    truncation,
+    stats: sumStats(files),
+  };
+
+  if (compare?.resolution_rung !== 1 && compare?.resolution_rung !== 2) {
+    // No compare. The server's cross-check sets are differences against an
+    // empty diff here (contradicted_paths would be every trailer path), so
+    // no cross-check flag is meaningful and none is shown.
+    if (parsed) {
+      // Rung 3: quoted testimony plus the files tools touched, no diff panes.
+      return {
+        ...base,
+        rung: 3,
+        steps: rationale.paths.map((point) => ({
+          path: point.path,
+          status: null,
+          additions: null,
+          deletions: null,
+          why: point.why || "",
+          unexplained: false,
+          patchUrl: null,
+        })),
+      };
+    }
+    if (touched.length > 0) {
+      // Rung 4: stats only, and no walk is offered. That is the decision,
+      // not a shortfall (#4614: "declining to offer one is the answer").
+      return { ...base, rung: 4, declined: true };
+    }
+    // Rung 5: nothing at all. The section says so and stops.
+    return { ...base, rung: 5 };
+  }
+
+  const authored = files.filter((file) => file.classification === "authored");
+  const mechanicalFiles = files.filter(
+    (file) => file.classification === "mechanical",
+  );
+  // Per-file "unexplained" flags only mean something when a trailer parsed:
+  // with no trailer every file is trivially unmentioned, and that absence is
+  // one labelled fact about the turn, not a flag on each of 40 rows.
+  const unexplainedSet = trailerFact
+    ? new Set(compare.unexplained_files ?? [])
+    : new Set();
+  const byPath = new Map(authored.map((file) => [file.path, file]));
+
+  // Steps follow the agent's own order first (testimony order is part of the
+  // testimony), then remaining authored files in compare order. A mechanical
+  // file is never flagged unexplained: the classifier correctly expects no
+  // point about it (ADR 056 decision 4).
+  const steps = [];
+  const seen = new Set();
+  const contradicted = [];
+  for (const point of parsed ? rationale.paths : []) {
+    const file = byPath.get(point.path);
+    if (!file) {
+      if ((compare.contradicted_paths ?? []).includes(point.path)) {
+        contradicted.push({ path: point.path, why: point.why || "" });
+      }
+      continue;
+    }
+    if (seen.has(point.path)) continue;
+    seen.add(point.path);
+    steps.push(stepOf(file, point.why || "", unexplainedSet));
+  }
+  for (const file of authored) {
+    if (seen.has(file.path)) continue;
+    seen.add(file.path);
+    steps.push(stepOf(file, "", unexplainedSet));
+  }
+  // A contradiction the trailer names but the parse did not carry a why for
+  // (or the trailer is server-parsed only) still renders: juxtaposed, never
+  // silently dropped in either direction.
+  for (const path of compare.contradicted_paths ?? []) {
+    if (!contradicted.some((claim) => claim.path === path)) {
+      contradicted.push({ path, why: "" });
+    }
+  }
+
+  return {
+    ...base,
+    rung: compare.resolution_rung,
+    ephemeral: compare.resolution_rung === 2,
+    steps,
+    mechanical:
+      mechanicalFiles.length > 0
+        ? {
+            count: mechanicalFiles.length,
+            files: mechanicalFiles.map((file) => file.path),
+          }
+        : null,
+    contradicted,
+  };
+}
+
+function stepOf(file, why, unexplainedSet) {
+  return {
+    path: file.path,
+    status: file.status ?? null,
+    additions: Number(file.additions || 0),
+    deletions: Number(file.deletions || 0),
+    why,
+    unexplained: !why && unexplainedSet.has(file.path),
+    patchUrl: file.patch_url ?? null,
+  };
+}
+
+// Splits a GitHub compare `patch` field (unified diff hunks, no file header)
+// into typed lines so the component styles without parsing.
+export function parsePatch(patch) {
+  if (typeof patch !== "string" || patch === "") return [];
+  return patch.split("\n").map((text) => ({
+    kind: text.startsWith("@@")
+      ? "hunk"
+      : text.startsWith("+")
+        ? "add"
+        : text.startsWith("-")
+          ? "del"
+          : "ctx",
+    text,
+  }));
+}

--- a/projects/monolith/frontend/src/routes/private/agents/walkthrough.js
+++ b/projects/monolith/frontend/src/routes/private/agents/walkthrough.js
@@ -1,203 +1,195 @@
-// Client-side composition for the session-tier walkthrough (ADR 056).
+// View-model for the session-tier walkthrough (ADR 056).
 //
-// Inputs are the merged payload of GET /api/swarm/compare/{session}/{turn}
-// (swarm/compare_router.py, real since PR #4805) plus, when available, the
-// parsed rationale trailer in the swarm/rationale.py shape ({parse_status,
-// paths: [{path, why}], deviations, raw}). ADR 056 decision 5 puts step
-// composition server-side; the server composer had not landed when this
-// module was written, so the composition lives here as a pure function with
-// the same three inputs the ADR names (compare stats, trailer, classifier)
-// and moves behind the composer's output unchanged when it ships. Everything
-// here is a view-model transform: no prose is invented, no register is
-// recomputed, and the agent's words pass through verbatim.
+// Input is the composed payload of GET /api/swarm/walkthrough/{session}/{turn}
+// (swarm/walkthrough_composer.py, PR #4815): the server owns composition and
+// epistemics, this module only maps steps to renderable rows. It invents no
+// prose and recomputes no register; every string it surfaces is either
+// payload data or a lexicon key the component resolves.
 //
-// Output shape (the step shape this surface renders):
-//   {
-//     rung: 1..5,            // ADR 056 decision 6 ladder
-//     trailer: boolean,      // a rationale trailer parsed for this turn
-//     ephemeral: boolean,    // rung 2: compare by branch name, has a shelf life
-//     declined: boolean,     // rung 4: no walk is offered, stats only
-//     steps: [{ path, status, additions, deletions, why, unexplained,
-//               patchUrl }],
-//     mechanical: { count, files } | null,   // ONE collapsed step, never per file
-//     contradicted: [{ path, why }],         // claim without a matching diff file
-//     deviations: [string],                  // trailer deviations, testimony
-//     touched: [string],                     // rungs 3/4: files touched by tools
-//     truncation: [string],                  // server-stated truncation facts
-//     stats: { totalFiles, additions, deletions },
-//   }
+// Composer step shapes handled:
+//   authored      {type, register, file_path, file_change?, testimony?, area?}
+//   mechanical    {type, register:"fact", count, generator_activity}
+//   unexplained   {type, register:"fact", file_path, file_change, label}
+//   contradiction {type, register:"testimony", label, testimony}
+//   truncation    {type, register:"fact", label}
+// plus payload-level {rung, ephemeral, stats, message?}.
 
-// ADR 056 rung 4: "no compare, no trailer, above roughly a dozen authored
-// files" declines to walk. Below the threshold there is still nothing to
-// compose a walk from (no diff, no testimony), so the same stats rendering
-// applies; the threshold only marks where declining is the deliberate answer
-// rather than the vacuous one.
-export const DECLINE_FILE_THRESHOLD = 12;
-
-function trailerParsed(rationale) {
-  return rationale?.parse_status === "parsed";
+function testimonyPoints(step) {
+  const points = step?.testimony?.points;
+  return Array.isArray(points) ? points : [];
 }
 
-function truncationFacts(compare) {
-  // Truncation renders as a labelled fact, never silent under-reporting.
-  // The reasons are server-composed sentences: pass them through as data.
-  const facts = [];
-  if (compare?.stats?.truncated_reason)
-    facts.push(compare.stats.truncated_reason);
-  if (compare?.activities_truncated_reason)
-    facts.push(compare.activities_truncated_reason);
-  return facts;
-}
-
-function sumStats(files) {
-  let additions = 0;
-  let deletions = 0;
-  for (const file of files) {
-    additions += Number(file.additions || 0);
-    deletions += Number(file.deletions || 0);
-  }
-  return { totalFiles: files.length, additions, deletions };
-}
-
-export function composeWalkthrough(compare, rationale = null) {
-  // Two distinct facts: the server parsed a trailer for this turn
-  // (compare.trailer_parsed), and this view holds its content (rationale).
-  // The compare endpoint serves the first without the second; the composer
-  // serves both. Cross-check sets key off the first, quoting needs the second.
-  const parsed = trailerParsed(rationale);
-  const trailerFact = compare?.trailer_parsed === true || parsed;
-  const files = Array.isArray(compare?.files) ? compare.files : [];
-  const touched = Array.isArray(compare?.authored_file_paths)
-    ? compare.authored_file_paths
-    : [];
-  const truncation = truncationFacts(compare);
-  const base = {
-    trailer: trailerFact,
-    ephemeral: false,
-    declined: false,
-    steps: [],
-    mechanical: null,
-    contradicted: [],
-    deviations: parsed ? rationale.deviations.filter(Boolean) : [],
-    touched,
-    truncation,
-    stats: sumStats(files),
-  };
-
-  if (compare?.resolution_rung !== 1 && compare?.resolution_rung !== 2) {
-    // No compare. The server's cross-check sets are differences against an
-    // empty diff here (contradicted_paths would be every trailer path), so
-    // no cross-check flag is meaningful and none is shown.
-    if (parsed) {
-      // Rung 3: quoted testimony plus the files tools touched, no diff panes.
-      return {
-        ...base,
-        rung: 3,
-        steps: rationale.paths.map((point) => ({
-          path: point.path,
-          status: null,
-          additions: null,
-          deletions: null,
-          why: point.why || "",
-          unexplained: false,
-          patchUrl: null,
-        })),
-      };
-    }
-    if (touched.length > 0) {
-      // Rung 4: stats only, and no walk is offered. That is the decision,
-      // not a shortfall (#4614: "declining to offer one is the answer").
-      return { ...base, rung: 4, declined: true };
-    }
-    // Rung 5: nothing at all. The section says so and stops.
-    return { ...base, rung: 5 };
-  }
-
-  const authored = files.filter((file) => file.classification === "authored");
-  const mechanicalFiles = files.filter(
-    (file) => file.classification === "mechanical",
+function whyFor(step) {
+  const match = testimonyPoints(step).find(
+    (point) => point?.path === step.file_path && typeof point.why === "string",
   );
-  // Per-file "unexplained" flags only mean something when a trailer parsed:
-  // with no trailer every file is trivially unmentioned, and that absence is
-  // one labelled fact about the turn, not a flag on each of 40 rows.
-  const unexplainedSet = trailerFact
-    ? new Set(compare.unexplained_files ?? [])
-    : new Set();
-  const byPath = new Map(authored.map((file) => [file.path, file]));
+  if (match) return match.why;
+  const first = testimonyPoints(step).find(
+    (point) => typeof point?.why === "string",
+  );
+  return first ? first.why : "";
+}
 
-  // Steps follow the agent's own order first (testimony order is part of the
-  // testimony), then remaining authored files in compare order. A mechanical
-  // file is never flagged unexplained: the classifier correctly expects no
-  // point about it (ADR 056 decision 4).
-  const steps = [];
-  const seen = new Set();
-  const contradicted = [];
-  for (const point of parsed ? rationale.paths : []) {
-    const file = byPath.get(point.path);
-    if (!file) {
-      if ((compare.contradicted_paths ?? []).includes(point.path)) {
-        contradicted.push({ path: point.path, why: point.why || "" });
-      }
+function deviationsFor(step) {
+  return testimonyPoints(step)
+    .map((point) => point?.deviation)
+    .filter((value) => typeof value === "string" && value !== "");
+}
+
+function attributionFor(step) {
+  const testimony = step?.testimony;
+  if (!testimony) return null;
+  return { turn: testimony.turn ?? null, attempt: testimony.attempt ?? null };
+}
+
+function fileChange(step) {
+  const change = step?.file_change ?? {};
+  return {
+    additions: Number(change.additions || 0),
+    deletions: Number(change.deletions || 0),
+    status: change.status ?? null,
+  };
+}
+
+// A generator run activity, compacted for a one-line label. Mirrors the
+// transcript's activity rendering: command first, then input, then type.
+export function generatorLabel(activity) {
+  if (activity == null || typeof activity !== "object") return "";
+  for (const value of ["command", "input", "detail"]
+    .map((name) => activity[name])
+    .filter(Boolean)) {
+    const text = typeof value === "string" ? value : JSON.stringify(value);
+    return text.length > 80 ? `${text.slice(0, 80)}…` : text;
+  }
+  return typeof activity.type === "string" ? activity.type : "";
+}
+
+export function walkthroughView(payload, context = {}) {
+  const { sessionId = null, turnSeq = null } = context;
+  const rung = payload?.rung ?? 5;
+  const steps = Array.isArray(payload?.steps) ? payload.steps : [];
+  const stats = payload?.stats ?? {};
+  const message = typeof payload?.message === "string" ? payload.message : "";
+
+  const authored = steps.filter((step) => step.type === "authored");
+  const unexplained = steps.filter((step) => step.type === "unexplained");
+  const unexplainedPaths = new Set(unexplained.map((step) => step.file_path));
+
+  // Rung 1/2 patches stay lazy (ADR 056 decision 8): the composer emits no
+  // patch URL, so it is derived from the compare patch route (PR #4805),
+  // which exists for authored files only. Mechanical and touched-only rows
+  // never link a patch.
+  const patchPath = (path) =>
+    rung <= 2 && sessionId != null && turnSeq != null
+      ? `/api/swarm/compare/${encodeURIComponent(sessionId)}/${encodeURIComponent(turnSeq)}/patch?path=${encodeURIComponent(path)}`
+      : null;
+
+  const points = [];
+  for (const step of authored) {
+    const why = whyFor(step);
+    // The composer emits an authored row AND an unexplained row for an
+    // authored file the trailer skipped. One file, one point: the
+    // unexplained row carries the treatment, so the bare twin is dropped.
+    // This is presentation dedupe, not a recomputed cross-check.
+    if (!why && step.file_path && unexplainedPaths.has(step.file_path)) {
       continue;
     }
-    if (seen.has(point.path)) continue;
-    seen.add(point.path);
-    steps.push(stepOf(file, point.why || "", unexplainedSet));
+    const change = fileChange(step);
+    points.push({
+      kind: "authored",
+      path: step.file_path ?? "",
+      area: typeof step.area === "string" ? step.area : null,
+      why,
+      deviations: deviationsFor(step),
+      attribution: attributionFor(step),
+      ...change,
+      touched: change.status === "touched",
+      patchUrl: step.file_path ? patchPath(step.file_path) : null,
+    });
   }
-  for (const file of authored) {
-    if (seen.has(file.path)) continue;
-    seen.add(file.path);
-    steps.push(stepOf(file, "", unexplainedSet));
+  for (const step of unexplained) {
+    points.push({
+      kind: "unexplained",
+      path: step.file_path ?? "",
+      area: null,
+      why: "",
+      deviations: [],
+      attribution: null,
+      ...fileChange(step),
+      touched: false,
+      patchUrl: step.file_path ? patchPath(step.file_path) : null,
+    });
   }
-  // A contradiction the trailer names but the parse did not carry a why for
-  // (or the trailer is server-parsed only) still renders: juxtaposed, never
-  // silently dropped in either direction.
-  for (const path of compare.contradicted_paths ?? []) {
-    if (!contradicted.some((claim) => claim.path === path)) {
-      contradicted.push({ path, why: "" });
-    }
+
+  const explained = points.filter(
+    (point) => point.kind === "authored" && point.why !== "",
+  ).length;
+  let additions = 0;
+  let deletions = 0;
+  for (const point of points) {
+    additions += point.additions;
+    deletions += point.deletions;
   }
 
   return {
-    ...base,
-    rung: compare.resolution_rung,
-    ephemeral: compare.resolution_rung === 2,
-    steps,
-    mechanical:
-      mechanicalFiles.length > 0
-        ? {
-            count: mechanicalFiles.length,
-            files: mechanicalFiles.map((file) => file.path),
-          }
-        : null,
-    contradicted,
+    rung,
+    ephemeral: payload?.ephemeral === true,
+    message,
+    points,
+    mechanical: steps
+      .filter((step) => step.type === "mechanical")
+      .map((step) => ({
+        count: Number(step.count || 0),
+        generator: generatorLabel(step.generator_activity),
+      })),
+    contradictions: steps
+      .filter((step) => step.type === "contradiction")
+      .map((step) => {
+        const point = testimonyPoints(step)[0] ?? {};
+        return {
+          path: typeof point.path === "string" ? point.path : "",
+          why: typeof point.why === "string" ? point.why : "",
+          attribution: attributionFor(step),
+        };
+      }),
+    truncations: steps
+      .filter((step) => step.type === "truncation")
+      .map((step) => (typeof step.label === "string" ? step.label : ""))
+      .filter(Boolean),
+    // Rung 4's touched list arrives inside stats, labelled server-side.
+    touched: Array.isArray(stats.activities) ? stats.activities : [],
+    counts: {
+      points: explained,
+      files: Number(stats.total_files ?? stats.authored_files ?? points.length),
+      additions,
+      deletions,
+    },
+    hasTestimony:
+      explained > 0 || steps.some((step) => step.type === "contradiction"),
   };
 }
 
-function stepOf(file, why, unexplainedSet) {
-  return {
-    path: file.path,
-    status: file.status ?? null,
-    additions: Number(file.additions || 0),
-    deletions: Number(file.deletions || 0),
-    why,
-    unexplained: !why && unexplainedSet.has(file.path),
-    patchUrl: file.patch_url ?? null,
-  };
-}
-
-// Splits a GitHub compare `patch` field (unified diff hunks, no file header)
-// into typed lines so the component styles without parsing.
-export function parsePatch(patch) {
+// Splits a GitHub compare `patch` field (unified diff, no file header) into
+// hunks for the filebar-and-hunks rendering: each hunk keeps its @@ header
+// and typed lines with a one-character gutter.
+export function parsePatchHunks(patch) {
   if (typeof patch !== "string" || patch === "") return [];
-  return patch.split("\n").map((text) => ({
-    kind: text.startsWith("@@")
-      ? "hunk"
-      : text.startsWith("+")
-        ? "add"
-        : text.startsWith("-")
-          ? "del"
-          : "ctx",
-    text,
-  }));
+  const hunks = [];
+  for (const raw of patch.split("\n")) {
+    if (raw.startsWith("@@") || hunks.length === 0) {
+      hunks.push({ header: raw.startsWith("@@") ? raw : "", lines: [] });
+      if (raw.startsWith("@@")) continue;
+    }
+    const kind = raw.startsWith("+")
+      ? "add"
+      : raw.startsWith("-")
+        ? "del"
+        : "ctx";
+    hunks[hunks.length - 1].lines.push({
+      kind,
+      gutter: kind === "add" ? "+" : kind === "del" ? "-" : " ",
+      text: raw.slice(kind === "ctx" && !raw.startsWith(" ") ? 0 : 1),
+    });
+  }
+  return hunks;
 }

--- a/projects/monolith/frontend/src/routes/private/agents/walkthrough.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/walkthrough.test.js
@@ -1,271 +1,268 @@
 import { describe, expect, test } from "vitest";
-import { composeWalkthrough, parsePatch } from "./walkthrough.js";
+import {
+  generatorLabel,
+  parsePatchHunks,
+  walkthroughView,
+} from "./walkthrough.js";
 
-function file(path, classification, extra = {}) {
+const CTX = { sessionId: 301, turnSeq: 2 };
+
+function authored(path, additions, deletions, why = null) {
   return {
-    path,
-    status: "modified",
-    additions: 4,
-    deletions: 1,
-    changes: 5,
-    classification,
-    patch_url:
-      classification === "authored"
-        ? `/api/swarm/compare/1/2/patch?path=${path}`
-        : null,
-    ...extra,
+    type: "authored",
+    register: why ? "testimony" : "fact",
+    file_path: path,
+    file_change: { additions, deletions, status: "modified" },
+    ...(why
+      ? { testimony: { turn: 2, attempt: 1, points: [{ path, why }] } }
+      : {}),
   };
 }
 
-function rationaleOf(paths, deviations = []) {
-  return {
-    raw: "RATIONALE",
-    parse_status: "parsed",
-    paths,
-    deviations,
-    parser_version: 1,
-  };
-}
-
-const fullCompare = {
-  resolution_rung: 1,
-  diff_type: "sha",
-  trailer_parsed: true,
-  files: [
-    file("swarm/rows.py", "authored"),
-    file("swarm/view.py", "authored"),
-    file("swarm/quiet.py", "authored"),
-    file("charts/index.yaml", "mechanical"),
-    file("charts/lock.json", "mechanical"),
+const fullPayload = {
+  rung: 1,
+  ephemeral: false,
+  steps: [
+    authored("swarm/policy.py", 46, 5, "routes on branch movement"),
+    authored("swarm/workflows.py", 42, 8, "keeps the observed head"),
+    authored("swarm/queues.py", 12, 3),
+    {
+      type: "mechanical",
+      register: "fact",
+      count: 143,
+      generator_activity: { type: "run", command: "ci regen" },
+    },
+    {
+      type: "unexplained",
+      register: "fact",
+      file_path: "swarm/queues.py",
+      file_change: { additions: 12, deletions: 3, status: "modified" },
+      label: "Unexplained file",
+    },
+    {
+      type: "contradiction",
+      register: "testimony",
+      label: "Contradicted path",
+      testimony: {
+        turn: 2,
+        attempt: 1,
+        points: [{ path: "swarm/gone.py", why: "deleted the dead rollup" }],
+      },
+    },
+    { type: "truncation", register: "fact", label: "GitHub files truncated" },
   ],
-  stats: { total_files: 5 },
-  authored_file_paths: ["swarm/rows.py", "swarm/view.py", "swarm/quiet.py"],
-  unexplained_files: [
-    "swarm/quiet.py",
-    "charts/index.yaml",
-    "charts/lock.json",
-  ],
-  contradicted_paths: ["swarm/gone.py"],
+  stats: { total_files: 146, truncated_at: 300 },
 };
 
-const fullRationale = rationaleOf(
-  [
-    { path: "swarm/view.py", why: "renders the walkthrough" },
-    { path: "swarm/rows.py", why: "carries the final turn" },
-    { path: "swarm/gone.py", why: "removed the dead column" },
-  ],
-  ["kept routing unchanged"],
-);
+describe("walkthroughView rung 1", () => {
+  const walk = walkthroughView(fullPayload, CTX);
 
-describe("composeWalkthrough rung 1", () => {
-  const walk = composeWalkthrough(fullCompare, fullRationale);
-
-  test("authored files become steps in the agent's order first", () => {
+  test("authored steps become points in the composer's order", () => {
     expect(walk.rung).toBe(1);
-    expect(walk.steps.map((step) => step.path)).toEqual([
-      "swarm/view.py",
-      "swarm/rows.py",
-      "swarm/quiet.py",
+    expect(walk.points.map((point) => [point.kind, point.path])).toEqual([
+      ["authored", "swarm/policy.py"],
+      ["authored", "swarm/workflows.py"],
+      ["unexplained", "swarm/queues.py"],
     ]);
-    expect(walk.steps[0].why).toBe("renders the walkthrough");
-    expect(walk.steps[0].patchUrl).toContain("/patch?path=");
+    expect(walk.points[0].why).toBe("routes on branch movement");
+    expect(walk.points[0].attribution).toEqual({ turn: 2, attempt: 1 });
   });
 
-  test("mechanical files collapse to one step with a count, never flagged", () => {
-    expect(walk.mechanical).toEqual({
-      count: 2,
-      files: ["charts/index.yaml", "charts/lock.json"],
-    });
-    // 5 changed files render as 3 steps plus one mechanical group.
-    expect(walk.steps).toHaveLength(3);
+  test("the authored/unexplained twin pair dedupes to one unexplained point", () => {
+    const queues = walk.points.filter(
+      (point) => point.path === "swarm/queues.py",
+    );
+    expect(queues).toHaveLength(1);
+    expect(queues[0].kind).toBe("unexplained");
+    expect(queues[0].additions).toBe(12);
   });
 
-  test("an authored file no point mentions is flagged unexplained", () => {
-    const quiet = walk.steps.find((step) => step.path === "swarm/quiet.py");
-    expect(quiet.unexplained).toBe(true);
-    expect(walk.steps.filter((step) => step.unexplained)).toHaveLength(1);
-  });
-
-  test("a point naming a file absent from the diff is contradicted, with its claim", () => {
-    expect(walk.contradicted).toEqual([
-      { path: "swarm/gone.py", why: "removed the dead column" },
+  test("an authored point with testimony is never dropped by the dedupe", () => {
+    const explained = walkthroughView(
+      {
+        rung: 1,
+        steps: [
+          authored("a.py", 1, 0, "kept on purpose"),
+          {
+            type: "unexplained",
+            register: "fact",
+            file_path: "a.py",
+            file_change: { additions: 1, deletions: 0, status: "modified" },
+            label: "Unexplained file",
+          },
+        ],
+        stats: { total_files: 1 },
+      },
+      CTX,
+    );
+    expect(explained.points.map((point) => point.kind)).toEqual([
+      "authored",
+      "unexplained",
     ]);
   });
 
-  test("deviations pass through as testimony", () => {
-    expect(walk.deviations).toEqual(["kept routing unchanged"]);
+  test("mechanical stays one collapsed row with a count and generator label", () => {
+    expect(walk.mechanical).toEqual([{ count: 143, generator: "ci regen" }]);
   });
 
-  test("stats sum the whole compare", () => {
-    expect(walk.stats).toEqual({ totalFiles: 5, additions: 20, deletions: 5 });
+  test("a contradiction carries the quoted claim and attribution", () => {
+    expect(walk.contradictions).toEqual([
+      {
+        path: "swarm/gone.py",
+        why: "deleted the dead rollup",
+        attribution: { turn: 2, attempt: 1 },
+      },
+    ]);
+    expect(walk.hasTestimony).toBe(true);
+  });
+
+  test("truncation renders as the server's labels, never silently", () => {
+    expect(walk.truncations).toEqual(["GitHub files truncated"]);
+  });
+
+  test("counts: explained points, server file total, summed additions", () => {
+    expect(walk.counts.points).toBe(2);
+    expect(walk.counts.files).toBe(146);
+    expect(walk.counts.additions).toBe(46 + 42 + 12);
+    expect(walk.counts.deletions).toBe(5 + 8 + 3);
+  });
+
+  test("patches stay lazy: rung 1/2 points link the compare patch route", () => {
+    expect(walk.points[0].patchUrl).toBe(
+      "/api/swarm/compare/301/2/patch?path=swarm%2Fpolicy.py",
+    );
+    const uncontexted = walkthroughView(fullPayload, {});
+    expect(uncontexted.points[0].patchUrl).toBeNull();
   });
 });
 
-describe("composeWalkthrough degradation ladder", () => {
-  test("rung 2 is the same walkthrough labelled ephemeral", () => {
-    const walk = composeWalkthrough(
-      { ...fullCompare, resolution_rung: 2, diff_type: "branch_ephemeral" },
-      fullRationale,
+describe("walkthroughView degradation ladder", () => {
+  test("rung 2 is the same walk with the server's ephemeral message", () => {
+    const walk = walkthroughView(
+      { ...fullPayload, rung: 2, ephemeral: true, message: "shelf life" },
+      CTX,
     );
     expect(walk.rung).toBe(2);
     expect(walk.ephemeral).toBe(true);
-    expect(walk.steps).toHaveLength(3);
+    expect(walk.message).toBe("shelf life");
+    expect(walk.points[0].patchUrl).toContain("/patch?path=");
   });
 
-  test("rung 3: no compare, trailer parsed: testimony steps, no diff panes, no cross-check", () => {
-    const walk = composeWalkthrough(
+  test("rung 3: testimony points with no patch links, touched rows marked", () => {
+    const walk = walkthroughView(
       {
-        resolution_rung: 3,
-        trailer_parsed: true,
-        files: [],
-        stats: { total_files: 0 },
-        authored_file_paths: ["swarm/rows.py"],
-        unexplained_files: [],
-        // Against an empty diff the server set-difference names every
-        // trailer path; that is not a contradiction and must not render.
-        contradicted_paths: ["swarm/view.py", "swarm/rows.py"],
-        error: "no_compare_available",
+        rung: 3,
+        ephemeral: false,
+        steps: [
+          {
+            type: "authored",
+            register: "testimony",
+            file_path: "swarm/rows.py",
+            testimony: {
+              turn: 2,
+              attempt: 1,
+              points: [
+                { path: "swarm/rows.py", why: "404s a missing turn" },
+                { deviation: "left the rollup untouched" },
+              ],
+            },
+          },
+          {
+            type: "authored",
+            register: "fact",
+            file_path: "swarm/view.py",
+            file_change: { additions: 0, deletions: 0, status: "touched" },
+          },
+        ],
+        stats: { authored_files: 2 },
+        message: "Limited walkthrough: testimony and activities only",
       },
-      rationaleOf([{ path: "swarm/rows.py", why: "carries the final turn" }]),
+      CTX,
     );
     expect(walk.rung).toBe(3);
-    expect(walk.steps).toEqual([
-      {
-        path: "swarm/rows.py",
-        status: null,
-        additions: null,
-        deletions: null,
-        why: "carries the final turn",
-        unexplained: false,
-        patchUrl: null,
-      },
-    ]);
-    expect(walk.contradicted).toEqual([]);
-    expect(walk.touched).toEqual(["swarm/rows.py"]);
+    expect(walk.points).toHaveLength(2);
+    expect(walk.points[0].why).toBe("404s a missing turn");
+    expect(walk.points[0].deviations).toEqual(["left the rollup untouched"]);
+    expect(walk.points[0].patchUrl).toBeNull();
+    expect(walk.points[1].touched).toBe(true);
+    expect(walk.message).toContain("Limited walkthrough");
   });
 
-  test("rung 4: no compare, no trailer, files touched: declines to walk", () => {
-    const touched = Array.from({ length: 40 }, (_, i) => `pkg/mod_${i}.py`);
-    const walk = composeWalkthrough({
-      resolution_rung: 3,
-      trailer_parsed: false,
-      files: [],
-      stats: { total_files: 0 },
-      authored_file_paths: touched,
-      unexplained_files: [],
-      contradicted_paths: [],
-      error: "no_compare_available",
-    });
+  test("rung 4: no points, the server's decline message, the touched list", () => {
+    const activities = Array.from({ length: 23 }, (_, i) => `pkg/m${i}.py`);
+    const walk = walkthroughView(
+      {
+        rung: 4,
+        ephemeral: false,
+        steps: [],
+        stats: { total_files: 23, authored_files: 23, activities },
+        message: "decline to offer walkthrough",
+      },
+      CTX,
+    );
     expect(walk.rung).toBe(4);
-    expect(walk.declined).toBe(true);
-    expect(walk.steps).toEqual([]);
-    expect(walk.touched).toHaveLength(40);
+    expect(walk.points).toEqual([]);
+    expect(walk.touched).toHaveLength(23);
+    expect(walk.message).toContain("decline");
   });
 
-  test("rung 5: nothing at all", () => {
-    const walk = composeWalkthrough({
-      resolution_rung: 3,
-      trailer_parsed: false,
-      files: [],
-      stats: { total_files: 0 },
-      authored_file_paths: [],
-      unexplained_files: [],
-      contradicted_paths: [],
-      error: "no_compare_available",
-    });
+  test("rung 5: the message is all there is", () => {
+    const walk = walkthroughView(
+      { rung: 5, ephemeral: false, steps: [], message: "No activity recorded" },
+      CTX,
+    );
     expect(walk.rung).toBe(5);
-    expect(walk.declined).toBe(false);
-    expect(walk.steps).toEqual([]);
+    expect(walk.points).toEqual([]);
+    expect(walk.mechanical).toEqual([]);
+    expect(walk.hasTestimony).toBe(false);
+    expect(walk.message).toBe("No activity recorded");
   });
 });
 
-describe("composeWalkthrough edge facts", () => {
-  test("truncation renders as labelled facts from the server, never silently", () => {
-    const walk = composeWalkthrough(
-      {
-        ...fullCompare,
-        stats: {
-          total_files: 300,
-          truncated_at: 300,
-          truncated_reason: "GitHub files array capped at 300",
-        },
-        activities_truncated: true,
-        activities_truncated_reason: "activities ingest capped at 300",
-      },
-      fullRationale,
+describe("generatorLabel", () => {
+  test("prefers the command, truncated", () => {
+    expect(generatorLabel({ type: "run", command: "ci regen" })).toBe(
+      "ci regen",
     );
-    expect(walk.truncation).toEqual([
-      "GitHub files array capped at 300",
-      "activities ingest capped at 300",
-    ]);
+    const long = "x".repeat(120);
+    expect(generatorLabel({ command: long })).toHaveLength(81);
   });
 
-  test("a large mechanical run stays one step", () => {
-    const mech = Array.from({ length: 143 }, (_, i) =>
-      file(`gen/out_${i}.json`, "mechanical"),
+  test("falls back to input then type, and survives junk", () => {
+    expect(generatorLabel({ type: "run", input: { cmd: "make" } })).toBe(
+      '{"cmd":"make"}',
     );
-    const walk = composeWalkthrough(
-      {
-        ...fullCompare,
-        files: [file("swarm/rows.py", "authored"), ...mech],
-        unexplained_files: [],
-        contradicted_paths: [],
-      },
-      rationaleOf([{ path: "swarm/rows.py", why: "carries the final turn" }]),
-    );
-    expect(walk.steps).toHaveLength(1);
-    expect(walk.mechanical.count).toBe(143);
-  });
-
-  test("compare without served rationale content: server cross-check still applies", () => {
-    // trailer_parsed is a server fact; the content arrives only once the
-    // composer serves it. Flags key off the fact, quotes need the content.
-    const walk = composeWalkthrough(fullCompare, null);
-    expect(walk.rung).toBe(1);
-    expect(walk.trailer).toBe(true);
-    expect(walk.steps.map((step) => step.path)).toEqual([
-      "swarm/rows.py",
-      "swarm/view.py",
-      "swarm/quiet.py",
-    ]);
-    const quiet = walk.steps.find((step) => step.path === "swarm/quiet.py");
-    expect(quiet.unexplained).toBe(true);
-    expect(walk.contradicted).toEqual([{ path: "swarm/gone.py", why: "" }]);
-  });
-
-  test("no trailer at all: absence is one fact, not a flag per row", () => {
-    const walk = composeWalkthrough(
-      {
-        ...fullCompare,
-        trailer_parsed: false,
-        unexplained_files: fullCompare.files.map((f) => f.path),
-        contradicted_paths: [],
-      },
-      null,
-    );
-    expect(walk.trailer).toBe(false);
-    expect(walk.steps.every((step) => step.unexplained === false)).toBe(true);
+    expect(generatorLabel({ type: "run" })).toBe("run");
+    expect(generatorLabel(null)).toBe("");
+    expect(generatorLabel("run")).toBe("");
   });
 });
 
-describe("parsePatch", () => {
-  test("types hunk, add, del, and context lines", () => {
-    const lines = parsePatch(
-      "@@ -1,3 +1,4 @@\n context\n-old line\n+new line\n+another",
+describe("parsePatchHunks", () => {
+  test("splits hunks on @@ and types lines with gutters", () => {
+    const hunks = parsePatchHunks(
+      "@@ -1,3 +1,4 @@\n ctx line\n-old\n+new\n@@ -9,2 +10,2 @@\n+tail",
     );
-    expect(lines.map((line) => line.kind)).toEqual([
-      "hunk",
+    expect(hunks).toHaveLength(2);
+    expect(hunks[0].header).toBe("@@ -1,3 +1,4 @@");
+    expect(hunks[0].lines.map((line) => line.kind)).toEqual([
       "ctx",
       "del",
       "add",
-      "add",
     ]);
-    expect(lines[3].text).toBe("+new line");
+    expect(hunks[0].lines[0]).toEqual({
+      kind: "ctx",
+      gutter: " ",
+      text: "ctx line",
+    });
+    expect(hunks[1].lines).toEqual([
+      { kind: "add", gutter: "+", text: "tail" },
+    ]);
   });
 
   test("empty or missing patches parse to nothing", () => {
-    expect(parsePatch("")).toEqual([]);
-    expect(parsePatch(null)).toEqual([]);
-    expect(parsePatch(undefined)).toEqual([]);
+    expect(parsePatchHunks("")).toEqual([]);
+    expect(parsePatchHunks(null)).toEqual([]);
+    expect(parsePatchHunks(undefined)).toEqual([]);
   });
 });

--- a/projects/monolith/frontend/src/routes/private/agents/walkthrough.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/walkthrough.test.js
@@ -1,0 +1,271 @@
+import { describe, expect, test } from "vitest";
+import { composeWalkthrough, parsePatch } from "./walkthrough.js";
+
+function file(path, classification, extra = {}) {
+  return {
+    path,
+    status: "modified",
+    additions: 4,
+    deletions: 1,
+    changes: 5,
+    classification,
+    patch_url:
+      classification === "authored"
+        ? `/api/swarm/compare/1/2/patch?path=${path}`
+        : null,
+    ...extra,
+  };
+}
+
+function rationaleOf(paths, deviations = []) {
+  return {
+    raw: "RATIONALE",
+    parse_status: "parsed",
+    paths,
+    deviations,
+    parser_version: 1,
+  };
+}
+
+const fullCompare = {
+  resolution_rung: 1,
+  diff_type: "sha",
+  trailer_parsed: true,
+  files: [
+    file("swarm/rows.py", "authored"),
+    file("swarm/view.py", "authored"),
+    file("swarm/quiet.py", "authored"),
+    file("charts/index.yaml", "mechanical"),
+    file("charts/lock.json", "mechanical"),
+  ],
+  stats: { total_files: 5 },
+  authored_file_paths: ["swarm/rows.py", "swarm/view.py", "swarm/quiet.py"],
+  unexplained_files: [
+    "swarm/quiet.py",
+    "charts/index.yaml",
+    "charts/lock.json",
+  ],
+  contradicted_paths: ["swarm/gone.py"],
+};
+
+const fullRationale = rationaleOf(
+  [
+    { path: "swarm/view.py", why: "renders the walkthrough" },
+    { path: "swarm/rows.py", why: "carries the final turn" },
+    { path: "swarm/gone.py", why: "removed the dead column" },
+  ],
+  ["kept routing unchanged"],
+);
+
+describe("composeWalkthrough rung 1", () => {
+  const walk = composeWalkthrough(fullCompare, fullRationale);
+
+  test("authored files become steps in the agent's order first", () => {
+    expect(walk.rung).toBe(1);
+    expect(walk.steps.map((step) => step.path)).toEqual([
+      "swarm/view.py",
+      "swarm/rows.py",
+      "swarm/quiet.py",
+    ]);
+    expect(walk.steps[0].why).toBe("renders the walkthrough");
+    expect(walk.steps[0].patchUrl).toContain("/patch?path=");
+  });
+
+  test("mechanical files collapse to one step with a count, never flagged", () => {
+    expect(walk.mechanical).toEqual({
+      count: 2,
+      files: ["charts/index.yaml", "charts/lock.json"],
+    });
+    // 5 changed files render as 3 steps plus one mechanical group.
+    expect(walk.steps).toHaveLength(3);
+  });
+
+  test("an authored file no point mentions is flagged unexplained", () => {
+    const quiet = walk.steps.find((step) => step.path === "swarm/quiet.py");
+    expect(quiet.unexplained).toBe(true);
+    expect(walk.steps.filter((step) => step.unexplained)).toHaveLength(1);
+  });
+
+  test("a point naming a file absent from the diff is contradicted, with its claim", () => {
+    expect(walk.contradicted).toEqual([
+      { path: "swarm/gone.py", why: "removed the dead column" },
+    ]);
+  });
+
+  test("deviations pass through as testimony", () => {
+    expect(walk.deviations).toEqual(["kept routing unchanged"]);
+  });
+
+  test("stats sum the whole compare", () => {
+    expect(walk.stats).toEqual({ totalFiles: 5, additions: 20, deletions: 5 });
+  });
+});
+
+describe("composeWalkthrough degradation ladder", () => {
+  test("rung 2 is the same walkthrough labelled ephemeral", () => {
+    const walk = composeWalkthrough(
+      { ...fullCompare, resolution_rung: 2, diff_type: "branch_ephemeral" },
+      fullRationale,
+    );
+    expect(walk.rung).toBe(2);
+    expect(walk.ephemeral).toBe(true);
+    expect(walk.steps).toHaveLength(3);
+  });
+
+  test("rung 3: no compare, trailer parsed: testimony steps, no diff panes, no cross-check", () => {
+    const walk = composeWalkthrough(
+      {
+        resolution_rung: 3,
+        trailer_parsed: true,
+        files: [],
+        stats: { total_files: 0 },
+        authored_file_paths: ["swarm/rows.py"],
+        unexplained_files: [],
+        // Against an empty diff the server set-difference names every
+        // trailer path; that is not a contradiction and must not render.
+        contradicted_paths: ["swarm/view.py", "swarm/rows.py"],
+        error: "no_compare_available",
+      },
+      rationaleOf([{ path: "swarm/rows.py", why: "carries the final turn" }]),
+    );
+    expect(walk.rung).toBe(3);
+    expect(walk.steps).toEqual([
+      {
+        path: "swarm/rows.py",
+        status: null,
+        additions: null,
+        deletions: null,
+        why: "carries the final turn",
+        unexplained: false,
+        patchUrl: null,
+      },
+    ]);
+    expect(walk.contradicted).toEqual([]);
+    expect(walk.touched).toEqual(["swarm/rows.py"]);
+  });
+
+  test("rung 4: no compare, no trailer, files touched: declines to walk", () => {
+    const touched = Array.from({ length: 40 }, (_, i) => `pkg/mod_${i}.py`);
+    const walk = composeWalkthrough({
+      resolution_rung: 3,
+      trailer_parsed: false,
+      files: [],
+      stats: { total_files: 0 },
+      authored_file_paths: touched,
+      unexplained_files: [],
+      contradicted_paths: [],
+      error: "no_compare_available",
+    });
+    expect(walk.rung).toBe(4);
+    expect(walk.declined).toBe(true);
+    expect(walk.steps).toEqual([]);
+    expect(walk.touched).toHaveLength(40);
+  });
+
+  test("rung 5: nothing at all", () => {
+    const walk = composeWalkthrough({
+      resolution_rung: 3,
+      trailer_parsed: false,
+      files: [],
+      stats: { total_files: 0 },
+      authored_file_paths: [],
+      unexplained_files: [],
+      contradicted_paths: [],
+      error: "no_compare_available",
+    });
+    expect(walk.rung).toBe(5);
+    expect(walk.declined).toBe(false);
+    expect(walk.steps).toEqual([]);
+  });
+});
+
+describe("composeWalkthrough edge facts", () => {
+  test("truncation renders as labelled facts from the server, never silently", () => {
+    const walk = composeWalkthrough(
+      {
+        ...fullCompare,
+        stats: {
+          total_files: 300,
+          truncated_at: 300,
+          truncated_reason: "GitHub files array capped at 300",
+        },
+        activities_truncated: true,
+        activities_truncated_reason: "activities ingest capped at 300",
+      },
+      fullRationale,
+    );
+    expect(walk.truncation).toEqual([
+      "GitHub files array capped at 300",
+      "activities ingest capped at 300",
+    ]);
+  });
+
+  test("a large mechanical run stays one step", () => {
+    const mech = Array.from({ length: 143 }, (_, i) =>
+      file(`gen/out_${i}.json`, "mechanical"),
+    );
+    const walk = composeWalkthrough(
+      {
+        ...fullCompare,
+        files: [file("swarm/rows.py", "authored"), ...mech],
+        unexplained_files: [],
+        contradicted_paths: [],
+      },
+      rationaleOf([{ path: "swarm/rows.py", why: "carries the final turn" }]),
+    );
+    expect(walk.steps).toHaveLength(1);
+    expect(walk.mechanical.count).toBe(143);
+  });
+
+  test("compare without served rationale content: server cross-check still applies", () => {
+    // trailer_parsed is a server fact; the content arrives only once the
+    // composer serves it. Flags key off the fact, quotes need the content.
+    const walk = composeWalkthrough(fullCompare, null);
+    expect(walk.rung).toBe(1);
+    expect(walk.trailer).toBe(true);
+    expect(walk.steps.map((step) => step.path)).toEqual([
+      "swarm/rows.py",
+      "swarm/view.py",
+      "swarm/quiet.py",
+    ]);
+    const quiet = walk.steps.find((step) => step.path === "swarm/quiet.py");
+    expect(quiet.unexplained).toBe(true);
+    expect(walk.contradicted).toEqual([{ path: "swarm/gone.py", why: "" }]);
+  });
+
+  test("no trailer at all: absence is one fact, not a flag per row", () => {
+    const walk = composeWalkthrough(
+      {
+        ...fullCompare,
+        trailer_parsed: false,
+        unexplained_files: fullCompare.files.map((f) => f.path),
+        contradicted_paths: [],
+      },
+      null,
+    );
+    expect(walk.trailer).toBe(false);
+    expect(walk.steps.every((step) => step.unexplained === false)).toBe(true);
+  });
+});
+
+describe("parsePatch", () => {
+  test("types hunk, add, del, and context lines", () => {
+    const lines = parsePatch(
+      "@@ -1,3 +1,4 @@\n context\n-old line\n+new line\n+another",
+    );
+    expect(lines.map((line) => line.kind)).toEqual([
+      "hunk",
+      "ctx",
+      "del",
+      "add",
+      "add",
+    ]);
+    expect(lines[3].text).toBe("+new line");
+  });
+
+  test("empty or missing patches parse to nothing", () => {
+    expect(parsePatch("")).toEqual([]);
+    expect(parsePatch(null)).toEqual([]);
+    expect(parsePatch(undefined)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Renders the ADR 056 session-tier walkthrough inside the session view's
turn card, built to the agents-console walkthrough mock ("Agents console:
desktop, swarm runs, and an agent-authored walkthrough", rev 2) and
consuming the composer that landed in PR #4815.

## What the mock establishes, and this ships

- **A provenance banner** on `--attn-soft`: "Agent-authored. These points
  are the implementer's account of its own change. The diff beside them is
  from git." One register statement for the whole surface instead of
  per-element chips; registers are expressed as style only, never named.
- **Two columns**: a 290px points list beside a detail pane. Each point
  carries an index, the file's basename, and the full path with
  `dir="rtl"` so a long path keeps its end. Selection is an inset
  `2px` ink edge, not a background swap, so the unexplained red ground
  survives selection.
- **Unexplained files are points too**, on `--err-bg` with a red title,
  sitting in the same list under a `!` mark; their detail pane states the
  fact in system voice. Contradicted claims sit in the same list under a
  `×` mark, quoting the agent's claim beside the system-voice fact:
  juxtaposed, never merged.
- **Detail pane**: the WHY block (mono uppercase label carrying point
  number, "agent's account", turn, attempt, model; the agent's words
  behind a 2px `--attn` left border), then a filebar with the path and
  `+N −M`, then diff hunks on the new `--diff-add-bg` / `--diff-del-bg`
  tokens with state-ink gutters.

Two mock additions that postdate it, per ADR 056: mechanical files
collapse to one counted row per generator run ("produced by tooling this
turn: 143 files · ci regen"), and rung 4 declines to offer a walk,
rendering the server's decline message plus the labelled touched list.

## Data source: the composer (PR #4815)

The component fetches `GET /api/swarm/walkthrough/{session}/{turn}` once
on first open, and `walkthrough.js` is a pure view-model adapter over its
actual step shapes (`authored` / `mechanical` / `unexplained` /
`contradiction` / `truncation`, each carrying `register`, plus payload
`rung`, `ephemeral`, `stats`, `message`). Server `message` prose renders
as data. Until #4815 merges, the fetch 404s and the section renders
"walkthrough unavailable" with a retry; the fixtures are the review
surface meanwhile.

Reconciliation notes for the composer, stated rather than invented:

- **Steps carry no patch URL.** Per-point patches stay lazy (ADR 056
  decision 8), so the view derives the existing compare patch route from
  PR #4805 (`/api/swarm/compare/{sid}/{seq}/patch?path=`). If the composer
  would rather own this, a `patch_url` on authored/unexplained steps
  replaces one function.
- **The composer emits a twin pair** for an authored file the trailer
  skipped: a bare `authored` row and an `unexplained` row for the same
  path. The view dedupes them into one unexplained point (presentation
  only; an authored row with testimony is never dropped). It also emits
  `unexplained` rows for mechanical files (`unexplained_files` is a set
  difference over the whole diff); those render as points today and will
  stop appearing if the composer excludes mechanical paths.
- **Trailer deviations are dropped at rungs 1/2** by the composer (only
  the rung 3 branch carries them into testimony points). The view renders
  deviations wherever they arrive; nothing is invented at rungs 1/2.
- **The mock's contract has `title`; the shipped trailer has only `path`
  and `why`** (`swarm/rationale.py`). No title is fabricated client-side:
  the point's identity is its path (basename emphasized, full path
  beneath). If titles are wanted, that is a trailer-contract addition.

## Mobile vs desktop

The mock is desktop-only; mobile is derived from the console's existing
pane-swap idiom at the 760px breakpoint. The two columns become one: the
points list shows first, selecting a point drills into its detail with a
back control, and diff hunks are `display:none` with a quiet "diffs read
on a desktop" note. The patch fetch is gated on a desktop media query, so
a phone never fetches what it will not render: the phone reader gets
intent, counts, ordering, flags, and quoted rationale. Left/right arrow
keys walk the points on desktop.

## OpenChamber (functionality reference only)

Taken: grouped edits as ordered steps, per-step explanation beside the
change, jump-to-step, keyboard advance. Rejected: preview panes,
terminals, multi-run fusion, and AI-generated step explanations (ADR 056
forbids inferred captions; the explanation here is the agent's quoted
testimony or an honest labelled absence). The visual and interaction
identity is the mock's, not OpenChamber's.

## Fixtures (`?fixture=<name>`)

All payloads mirror the composer's output shape; patches are embedded so
previews never fetch. `walk-full` (rung 1: four explained points, the
authored/unexplained twin pair, a mechanical group, a contradiction),
`walk-ephemeral` (rung 2 with the server's shelf-life message),
`walk-testimony-only` (rung 3: testimony points, a deviation, a
touched-only row, no diff panes), `walk-stats-only` (rung 4: declines,
23-file touched list), `walk-empty` (rung 5), `walk-mechanical-large`
(143-file mechanical collapse plus both truncation labels),
`walk-unexplained`, `walk-contradicted`.

## Contention and design system

`+page.svelte` got one import, one fixture branch, and a five-line mount
in the completed-turn card gated on `selectedSession.repo`; RunView and
MasterView are untouched, and nothing file-shaped renders at run grain
(ADR 056 decision 7). Colours, font sizes, and radii are tokens;
`agents-theme.css` gains four diff tokens (`--diff-add-bg`,
`--diff-del-bg`, `--diff-add-mark`, `--diff-del-mark`) in the state group
with a rationale comment; spacing follows the console's existing 4/8/16px
rhythm (the console has no spacing tokens). All interface strings live in
`run-lexicon.js` (scanned by the lexicon test, which now covers
`SessionWalkthrough.svelte`); the payload `message`, truncation labels,
and rationale quotes render as server data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGZjjwBxZc4wYePgE7dzMJ
