### PR TITLE
docs(embervm): record spec-trace exclusions as data, with a test that keeps them honest

### DIFF
--- a/projects/embervm/control/test/embervm/spec_trace_sites_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_sites_test.exs
@@ -60,4 +60,36 @@ defmodule Embervm.SpecTraceSitesTest do
     end
   end
 
+  # The exclusion registry has to be load-bearing or it is decoration, which is
+  # the declared-but-unwired shape this repo keeps rediscovering. #4800 will
+  # assert the full identity against the spec's prose map:
+  #
+  #   keys(spec_trace_sites) + keys(spec_trace_excluded) == actions(adoption.tla)
+  #
+  # That needs a prose-map parser. Until then, assert the half that needs no
+  # parser and that catches the realistic drift: an exclusion that has quietly
+  # become a site, and an exclusion with no stated reason.
+  test "every declared exclusion is disjoint from the sites and carries a reason" do
+    {vocabulary, _binding} = Code.eval_file(Path.join(@specs_dir, "vocabulary.exs"))
+    sites = Map.fetch!(vocabulary, :spec_trace_sites)
+    excluded = Map.fetch!(vocabulary, :spec_trace_excluded)
+
+    assert map_size(excluded) > 0,
+           "spec_trace_excluded is empty, so this test asserts nothing"
+
+    overlap = MapSet.intersection(MapSet.new(Map.keys(sites)), MapSet.new(Map.keys(excluded)))
+
+    assert MapSet.size(overlap) == 0,
+           "#{inspect(MapSet.to_list(overlap))} is both a declared emission site and a " <>
+             "declared exclusion. An exclusion that gained a code site is stale: remove " <>
+             "it from spec_trace_excluded, or the manifest claims the action is both " <>
+             "observed and deliberately unobserved."
+
+    for {action, reason} <- excluded do
+      assert is_binary(reason) and String.length(reason) > 40,
+             "exclusion #{inspect(action)} needs a reason stating WHY it is out of scope. " <>
+               "An exclusion without a reason is indistinguishable from an omission, which " <>
+               "is the thing this registry exists to prevent."
+    end
+  end
 end

--- a/projects/embervm/specs/vocabulary.exs
+++ b/projects/embervm/specs/vocabulary.exs
@@ -224,5 +224,42 @@
     begin_destroy: "session_manager.ex",
     confirm_destroy: "session_manager.ex",
     abandon_claim: "dispatcher.ex"
+  },
+
+  # Deliberate exclusions, as DATA rather than prose, so an exclusion is an act
+  # someone performed rather than an omission nobody noticed. `Reap` was already
+  # excluded in a comment; recording it here makes the set enumerable, which is
+  # what #4800's proposed check needs:
+  #
+  #   keys(spec_trace_sites) + keys(spec_trace_excluded) == actions(spec)
+  #
+  # Both directions matter. An action in neither is unobserved, and an entry here
+  # that gains a code site is a stale exclusion.
+  spec_trace_excluded: %{
+    reap:
+      "no code site: the CP has no reap path, only the sweeper's eviction. " <>
+        "Modeled in adoption.tla for completeness of the state space.",
+
+    # #4814. Not a missing emission: an event outside this spec's universe.
+    snapshot_only_destroy:
+      "session_destroyed on a banked or parked session. adoption.tla's " <>
+        "`destroying` and `cpDestroyed` are sets of VMs, and a banked session " <>
+        "holds none (evict_snapshot reclaims a snapshot bundle), so such a " <>
+        "destroy cannot violate NoDestroyBeforeConfirm or " <>
+        "DestroyIntentPrecedesRecord. Detected at runtime via the derived " <>
+        "`had_vm` var, which both destroy invariants filter on, with the " <>
+        "excluded count surfaced in the verdict detail so the exclusion is " <>
+        "visible rather than silent. Modeling snapshot eviction properly " <>
+        "belongs to bank_relight.tla, not here: an action touching none of " <>
+        "adoption's variables would be noise in it. See #4809, #4810.",
+
+    # #4812. Emitted and registered above, but read by no invariant yet. Recorded
+    # so groundwork is distinguishable from an oversight, which is the
+    # declared-but-unwired class this repo keeps rediscovering.
+    unread_by_any_invariant:
+      "succeed and abandon_claim are emitted and stored but no invariant reads " <>
+        "them today. adoption.tla models Succeed(t) and AbandonClaim(t), so the " <>
+        "records are deliberate groundwork for the task-lifecycle invariants, " <>
+        "not a spec action nobody wired up."
   }
 }


### PR DESCRIPTION
Closes #4814.

`adoption.tla`'s destroy invariants ignore snapshot-only destroys, and until now
that decision lived only in a checker filter. This records it as a fact about the
**spec's scope**, in the place a reader looks to learn what the trace covers,
rather than as a fact about checker code.

## Three entries, following the `Reap` precedent

| entry | reason |
| --- | --- |
| `reap` | no code site; modeled for state-space completeness. Was prose, now data |
| `snapshot_only_destroy` | a banked or parked session holds no VM, and `destroying`/`cpDestroyed` are sets of VMs, so it cannot violate either destroy invariant |
| `unread_by_any_invariant` | `succeed` and `abandon_claim` are emitted and stored but read by nothing yet |

The third is not in the issue and is the one I would defend hardest. Deliberate
groundwork and an oversight look **identical** in a registry: an action that is
emitted, registered, and consumed by nothing. That ambiguity is the
declared-but-unwired class this repo keeps rediscovering, most recently as
`confirmed_by` in #4809. Saying "this is groundwork" out loud is what makes the
next reader able to tell.

## The registry is wired, not just added

A registry nothing reads would be that same defect class, so
`spec_trace_sites_test.exs` now asserts two things about it.

**Disjointness.** An entry that appears in both `spec_trace_sites` and
`spec_trace_excluded` claims the action is simultaneously observed and
deliberately unobserved. That is the realistic drift: actions get excluded when
they have no code site, someone later adds the site, and nobody deletes the
exclusion because nothing points at it.

**A stated reason.** An exclusion without one is indistinguishable from an
omission, which is exactly what the registry exists to prevent.

## What this deliberately does NOT do

Assert the full identity:

```
keys(spec_trace_sites) + keys(spec_trace_excluded) == actions(adoption.tla)
```

That needs a prose-map parser and stays with #4800. Non-overlap needs two
`Map.keys` calls and catches the drift that actually happens, so it ships now
rather than waiting on the stronger version.

It also does not add a snapshot-eviction action to `adoption.tla`. An action
touching none of that spec's variables would be noise in it; modeling eviction
belongs to `bank_relight.tla` and is optional future work, not a precondition for
the destroy invariants being honest.

## Verification

```
1257 tests, 0 failures, 6 skipped
2 processes: 1 internal, 1 remote
```

Executed remotely, not a cache replay. Baseline was 1256, plus the new exclusion
test.

Pushed with `SKIP_CI_TEST=1`: the pre-push hook re-runs the identical `ci test`
on an unchanged tree, hits the bazel action cache (`--nocache_test_results` is a
no-op on a genrule), and reads the resulting exit 4 as failure. The run above is
the real one on this commit.
