### PR TITLE
fix(monolith): let ignoreDifferences actually hold on the app deployments

### DIFF
--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -34,6 +34,14 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      # The ignoreDifferences above suppresses DIFFING, not APPLYING.
+      # Without this option a sync still writes the chart's version of
+      # those fields, stripping the env Kyverno injects; Kyverno
+      # re-injects, and the Deployment never settles. `canada` already
+      # carries this option one level up so Kargo's targetRevision patch
+      # on Application resources survives; the child apps declared
+      # ignoreDifferences without it.
+      - RespectIgnoreDifferences=true
     retry:
       limit: 5
       backoff:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -73,6 +73,14 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      # The ignoreDifferences above suppresses DIFFING, not APPLYING.
+      # Without this option a sync still writes the chart's version of
+      # those fields, stripping the env Kyverno injects; Kyverno
+      # re-injects, and the Deployment never settles. `canada` already
+      # carries this option one level up so Kargo's targetRevision patch
+      # on Application resources survives; the child apps declared
+      # ignoreDifferences without it.
+      - RespectIgnoreDifferences=true
     retry:
       limit: 5
       backoff:

--- a/projects/monolith/dev/deploy/application.yaml
+++ b/projects/monolith/dev/deploy/application.yaml
@@ -113,6 +113,14 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      # The ignoreDifferences above suppresses DIFFING, not APPLYING.
+      # Without this option a sync still writes the chart's version of
+      # those fields, stripping the env Kyverno injects; Kyverno
+      # re-injects, and the Deployment never settles. `canada` already
+      # carries this option one level up so Kargo's targetRevision patch
+      # on Application resources survives; the child apps declared
+      # ignoreDifferences without it.
+      - RespectIgnoreDifferences=true
     retry:
       limit: 5
       backoff:


### PR DESCRIPTION
**The deploy pipeline has been stuck for roughly two hours and nothing
alerted.** Every merge since is stranded behind it, including the run view
work Joe is waiting on.

## What is happening

Kargo's dev stage runs `argocd-update` then `argocd-wait`. `monolith-dev` sits
`OutOfSync` on `Deployment/monolith-dev`, so `argocd-wait` times out at 5m and
the promotion errors. The last three dev promotions errored (106m, 69m and 16m
before this was found). Prod promotes from dev, so prod is stranded on freight
from over two hours ago.

```
dev    ... Unknown  False  step "step-1" timed out after 5m0s
prod   ... Healthy  True   Freight has been verified        (old freight)
```

`0.305.3` is published and Kargo has discovered it. The chart is fine. The
Deployment is fine: 1/1 ready, `Available=True`, `Progressing=True
NewReplicaSetAvailable`, generation observed. **The sync simply cannot
converge.**

## Why

Kyverno injects OTEL env vars (`otel.injected-by: kyverno/inject-otel-env-vars`).
Each Application already declares `ignoreDifferences` covering exactly those
fields.

But **`ignoreDifferences` suppresses DIFFING, not APPLYING.** Without
`RespectIgnoreDifferences=true`, a sync still writes the chart's version of
those fields, stripping what Kyverno injected. Kyverno re-injects. The
Deployment never settles.

Normally that oscillation is invisible, which is why it survived unnoticed. It
became visible the moment something waited on a **stable** Synced, and
`argocd-wait` is exactly that.

## The repo already knew

`canada` carries `RespectIgnoreDifferences=true` one level up so Kargo's
`targetRevision` patch on Application resources survives, and the comments in
these very files describe the mechanism:

> ignoreDifferences alone suppresses DIFFING, not APPLYING, so the field
> survives idle reconciliation and is stamped back by the next real sync.

The child apps declared `ignoreDifferences` and never got the matching option.
Same trap, one level down, on Deployments rather than Applications.

## Scope

Applied to **all three** Applications, not only the one currently stuck.
`monolith`, `monolith-dev` and `monolith-public` carry the same
`ignoreDifferences` and the same gap, and prod would fail identically the first
time it is asked to wait on a converging sync. Fixing only dev would leave a
loaded gun.

**Three functional lines, one per Application.** Everything else in the diff is
comment explaining the mechanism so the next reader does not remove it.

## Verification

`ci test` -> `Executed 1 out of 712 tests: 712 tests pass.`

**Not verified: that this unsticks the pipeline.** That is only observable
after this merges and ArgoCD reconciles the Applications: `monolith-dev` should
reach `Synced`, the next dev promotion should succeed rather than time out, and
prod should then advance to `0.305.3` or later. If it does not, the diff is
something other than the Kyverno injection and this narrows it rather than
fixing it.

No chart version or `targetRevision` touched.