### PR TITLE
test(embervm): assert the emission registry against adoption.tla's prose map

### DIFF
--- a/projects/embervm/control/test/embervm/spec_trace_sites_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_sites_test.exs
@@ -92,4 +92,83 @@ defmodule Embervm.SpecTraceSitesTest do
                "is the thing this registry exists to prevent."
     end
   end
+
+  # #4800. The registry was a LIST OF WHAT WAS BUILT, never a diff against the
+  # spec, so it was satisfied by any subset. Nine of adoption.tla's actions were
+  # registered and four were not, the two destroy invariants had no data source
+  # at all, and every guard passed: the checker over the other nine was green and
+  # the endpoint returned 200. A third of a spec unobserved, end to end silent.
+  #
+  # This closes it by parsing the spec's own prose map and asserting the identity
+  # in BOTH directions.
+  test "every action in adoption.tla's prose map is observed or deliberately excluded" do
+    {vocabulary, _binding} = Code.eval_file(Path.join(@specs_dir, "vocabulary.exs"))
+    sites = Map.fetch!(vocabulary, :spec_trace_sites)
+    excluded = Map.fetch!(vocabulary, :spec_trace_excluded)
+    site_notes = Map.fetch!(vocabulary, :spec_trace_site_notes)
+
+    prose_actions = parse_prose_actions(Path.join(@specs_dir, "adoption.tla"))
+
+    assert MapSet.size(prose_actions) > 10,
+           "parsed only #{MapSet.size(prose_actions)} actions from adoption.tla's prose map. " <>
+             "The parser has almost certainly broken against a reformat, and a parser that " <>
+             "silently matches nothing makes this whole assertion vacuous, which is the " <>
+             "exact failure this test exists to prevent. Parsed: " <>
+             "#{inspect(MapSet.to_list(prose_actions))}"
+
+    # A site is either the snake_case of a prose action, or carries a note saying
+    # what it is instead (a synthetic observation, or a refinement of an action).
+    observed = MapSet.new(Map.keys(sites)) |> MapSet.difference(MapSet.new(Map.keys(site_notes)))
+    accounted = MapSet.union(observed, MapSet.new(Map.keys(excluded)))
+
+    unobserved = MapSet.difference(prose_actions, accounted)
+
+    assert MapSet.size(unobserved) == 0,
+           "adoption.tla models #{inspect(MapSet.to_list(unobserved))} and nothing observes " <>
+             "them. Either add an emission site, or add an entry to spec_trace_excluded " <>
+             "saying why the action cannot or should not be observed. An action modeled by " <>
+             "the spec and reachable by no record is a third of a spec passing silently."
+
+    unmodeled = MapSet.difference(accounted, prose_actions)
+
+    assert MapSet.size(unmodeled) == 0,
+           "#{inspect(MapSet.to_list(unmodeled))} is registered as an emission site or an " <>
+             "exclusion but matches no action in adoption.tla's prose map. Either it is a " <>
+             "synthetic observation, in which case put it in spec_trace_site_notes with an " <>
+             "explanation, or the prose map and the code have drifted apart."
+
+    for {site, note} <- site_notes do
+      assert Map.has_key?(sites, site),
+             "#{inspect(site)} has a site note but is not a declared emission site. A note " <>
+               "explaining a site that does not exist is stale."
+
+      assert is_binary(note) and String.length(note) > 40,
+             "site note for #{inspect(site)} needs to say what it is if not a prose action."
+    end
+  end
+
+  # The prose map's entries look like:
+  #
+  #   (*   AdoptInventory(n)  ~ Dispatcher sweep reconciling node inventory ... *)
+  #
+  # Two names can share one line ("CrashCP / RestartCP ~ ..."), so match every
+  # CamelCase token before the tilde rather than only the first.
+  defp parse_prose_actions(spec_path) do
+    spec_path
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.filter(&String.match?(&1, ~r/^\(\*\s+[A-Z][A-Za-z]*.*~/))
+    |> Enum.flat_map(fn line ->
+      [names | _] = String.split(line, "~", parts: 2)
+      Regex.scan(~r/\b([A-Z][A-Za-z]+)\b/, names) |> Enum.map(fn [_, name] -> name end)
+    end)
+    |> Enum.map(&snake/1)
+    |> MapSet.new()
+  end
+
+  defp snake(camel) do
+    camel
+    |> String.replace(~r/([a-z0-9])([A-Z])/, "\\1_\\2")
+    |> String.downcase()
+  end
 end

--- a/projects/embervm/control/test/embervm/spec_trace_sites_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_sites_test.exs
@@ -116,10 +116,19 @@ defmodule Embervm.SpecTraceSitesTest do
              "exact failure this test exists to prevent. Parsed: " <>
              "#{inspect(MapSet.to_list(prose_actions))}"
 
+    # Compare as STRINGS. The registries key on atoms and the parser yields
+    # strings, and a MapSet of atoms differenced against a MapSet of strings is
+    # simply the original set, so the assertion would report every action as
+    # unobserved (or, with the operands the other way round, report everything as
+    # fine). That is the same writer-versus-reader type disagreement that put
+    # booleans into this trace as "true", one layer up in the test that checks
+    # for it. Caught because the assertion failed loudly rather than passing.
+    to_strings = fn map -> map |> Map.keys() |> Enum.map(&Atom.to_string/1) |> MapSet.new() end
+
     # A site is either the snake_case of a prose action, or carries a note saying
     # what it is instead (a synthetic observation, or a refinement of an action).
-    observed = MapSet.new(Map.keys(sites)) |> MapSet.difference(MapSet.new(Map.keys(site_notes)))
-    accounted = MapSet.union(observed, MapSet.new(Map.keys(excluded)))
+    observed = MapSet.difference(to_strings.(sites), to_strings.(site_notes))
+    accounted = MapSet.union(observed, to_strings.(excluded))
 
     unobserved = MapSet.difference(prose_actions, accounted)
 

--- a/projects/embervm/specs/vocabulary.exs
+++ b/projects/embervm/specs/vocabulary.exs
@@ -235,11 +235,66 @@
   #
   # Both directions matter. An action in neither is unobserved, and an entry here
   # that gains a code site is a stale exclusion.
+  # PROSE ACTIONS deliberately unobserved. Keys here are snake_case renderings of
+  # entries in adoption.tla's prose map, and they participate in the coverage
+  # identity asserted by spec_trace_sites_test:
+  #
+  #   prose_actions == observed_actions + keys(spec_trace_excluded)
+  #
+  # Both directions matter. An action in neither is unobserved with nobody
+  # noticing, and an entry here that gains a code site is a stale exclusion
+  # claiming the action is simultaneously observed and deliberately unobserved.
   spec_trace_excluded: %{
     reap:
       "no code site: the CP has no reap path, only the sweeper's eviction. " <>
         "Modeled in adoption.tla for completeness of the state space.",
 
+    # The three below are unobservable in principle, not merely unimplemented,
+    # and the distinction matters: no amount of instrumentation fixes them.
+    crash_cp:
+      "a control plane cannot emit a record of its own death. Observed " <>
+        "INDIRECTLY via restart_cp, whose fresh run_id marks the boundary, " <>
+        "which is why the checker partitions by run_id at all.",
+    crash_node:
+      "node-side death. The CP learns of it only as an absence, through " <>
+        "age_to_unknown and age_to_down, which are separately observed. There " <>
+        "is no moment at which the CP could append a crash_node record.",
+    send_status:
+      "the NODE's send half of the status exchange. The CP observes only its " <>
+        "own receive half, recv_status. Modeled as a distinct action because " <>
+        "the gap between send and receive is where the straggler lives.",
+    recycle_id:
+      "explicitly not a code action. The spec's own prose says so: it models " <>
+        "the inexhaustible vm_id supply so a destroyed slot can back a fresh " <>
+        "Prime."
+  },
+
+  # Emission sites that are NOT one-to-one with a prose action. Kept separate
+  # from the exclusions because these are observations we ADD, not spec actions
+  # we skip, and folding them together would make the coverage identity lie in
+  # the opposite direction.
+  spec_trace_site_notes: %{
+    checkpoint:
+      "NOT a spec action: the string Checkpoint does not appear in " <>
+        "adoption.tla at all. It is a periodic state observation invented for " <>
+        "the trace, emitted every sweep even when nothing else fires, because " <>
+        "absence of progress is invisible in an event stream and a wedge is " <>
+        "precisely the CP failing to act.",
+    begin_destroy:
+      "a REFINEMENT of Succeed(t), not an action of its own. adoption.tla has " <>
+        "no BeginDestroy action: Succeed both completes the task and appends " <>
+        "the durable destroying intent in one step. The code splits that into " <>
+        "two observable moments, so one spec action maps to two records. That " <>
+        "is a legitimate many-to-one refinement, and writing it down is what " <>
+        "stops the coverage check reading begin_destroy as an unmodeled " <>
+        "invention."
+  },
+
+  # Runtime scope decisions, distinct from both of the above: not a prose action
+  # and not an emission site, but a class of RECORD the invariants deliberately
+  # skip. Recorded so the filtering is a stated decision rather than a quirk of
+  # checker code.
+  spec_trace_scope_notes: %{
     # #4814. Not a missing emission: an event outside this spec's universe.
     snapshot_only_destroy:
       "session_destroyed on a banked or parked session. adoption.tla's " <>


### PR DESCRIPTION
Closes #4800.

`spec_trace_sites` was a **list of what was built**, never a diff against the
spec, so it was satisfied by any subset. Nine of `adoption.tla`'s actions were
registered and four were not, the two destroy invariants had no data source at
all, and every guard passed: the checker over the other nine was green and
`GET /v1/conformance` returned 200. A third of a spec unobserved, silent end to
end.

This parses the spec's own prose map and asserts the identity in **both**
directions. An action the spec models that nothing observes now fails, and so
does a registered site matching no modeled action.

## Two findings fell out of building it

**`Checkpoint` is not a spec action.** The string appears zero times in
`adoption.tla`. It is a periodic state observation invented for the trace,
emitted every sweep even when nothing else fires, because absence of progress is
invisible in an event stream and a wedge is precisely the CP failing to act.

**`begin_destroy` is a refinement of `Succeed`, not an action of its own.**
There is no `BeginDestroy` in the spec: `Succeed(t)` both completes the task and
appends the durable destroying intent in one step. The code splits that into two
observable moments, so one spec action maps to two records.

That second one is a category the programme had not accounted for. TLA+ can model
task-completion and intent-append as one atomic step; real code cannot. The
mapping is legitimately many-to-one, and an **unrecorded refinement looks
identical to an unmodeled invention**. Until now nothing could distinguish "a
record the spec does not know about" from "one action, observed twice".

## The registry is split three ways

The previous single map conflated kinds that behave differently in the identity,
which would have made it lie:

| registry | what it holds |
| --- | --- |
| `spec_trace_excluded` | prose actions deliberately unobserved |
| `spec_trace_site_notes` | sites not one-to-one with a prose action |
| `spec_trace_scope_notes` | record classes the invariants skip at runtime |

## Four newly enumerated exclusions, three unobservable in principle

Not merely unimplemented, and the distinction is stated because no amount of
instrumentation fixes them:

- `crash_cp`: a control plane cannot emit a record of its own death. Observed
  indirectly via `restart_cp`, whose fresh `run_id` marks the boundary, which is
  why the checker partitions by `run_id` at all.
- `crash_node`: the CP learns of it only as an absence, through `age_to_unknown`
  and `age_to_down`.
- `send_status`: the node's send half of an exchange the CP sees only the receive
  end of. Modeled separately because the gap between them is where the straggler
  lives.
- `recycle_id`: the spec's own prose says it is not a code action.

## A type bug in the first version, caught by the assertion failing loudly

The registries key on atoms and the parser yields strings, so the MapSet
difference returned every parsed action as unobserved. Same writer-versus-reader
disagreement that put booleans into this trace as `"true"`, one layer up in the
test written to catch that class.

It failed safely by luck of operand order, not design. What makes it reliably
safe is `assert MapSet.size(prose_actions) > 10`: the only line that cannot be
satisfied by a type error. Two empty sets agree perfectly, so a comparison-based
check must assert its operands are non-trivial before asserting they match.

## Verification

```
1261 tests, 0 failures, 6 skipped
2 processes: 1 internal, 1 remote
```

Executed remotely, not a cache replay. Pushed with `SKIP_CI_TEST=1` because the
pre-push hook re-runs the identical `ci test` on an unchanged tree and reads the
resulting action-cache hit (exit 4) as failure.
