### PR TITLE
fix(ci): seed the pr-checks fallback snapshot, and align clone depth across both actions

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -35,9 +35,14 @@ actions:
       # pr-checks on every push to every feature branch, on top of the
       # pull_request run, which is the opposite of why the queue is being
       # enabled.
+      #
+      # `main` is here to seed this action's fallback snapshot, NOT to gate or
+      # publish anything: see the main-only stage at the top of the steps below
+      # for why, and for what it deliberately does not run.
       push:
         branches:
           - "gh-readonly-queue/*"
+          - "main"
     steps:
       - run: |
           # errexit is LOAD-BEARING. A BuildBuddy step is one shell script and
@@ -68,6 +73,49 @@ actions:
           # anonymous ~100-pull/6h quota, which 429s and aborts the build.
           if [ -n "${DOCKERHUB_TOKEN:-}" ]; then
             echo "$DOCKERHUB_TOKEN" | docker login docker.io -u "${DOCKERHUB_USERNAME:-}" --password-stdin
+          fi
+
+          # ---- 0. main: seed this action's fallback snapshot ---------------
+          # A runner snapshot's key is (repo URL, ACTION NAME, instance suffix,
+          # git_clean_exclude), so pr-checks and deploy occupy DISJOINT snapshot
+          # namespaces even though their container_image and resource_requests
+          # are identical. A run with no snapshot for its own branch falls back
+          # to the PR's base branch and then to the repo's default branch, but
+          # pr-checks had never once run on main, so that fallback found nothing
+          # and every new branch booted a VM from scratch.
+          #
+          # Measured over the 7 days to 2026-08-14: 128 of 647 CI `test //...`
+          # invocations were cold, median 413s against 68s warm, about 736
+          # minutes of wall clock a week. 62 of 94 new branches started cold.
+          #
+          # The save policy compounds it. The default, first-non-default-ref,
+          # saves a snapshot only on the FIRST run of a non-default ref but on
+          # EVERY run of a default one. So a branch's snapshot is frozen at its
+          # first push and never refreshed, which is why 30% of later pushes to
+          # an already-seen branch were cold too. main saving on every push is
+          # what turns the fallback from one-shot into continuously refreshed.
+          #
+          # This stage exists ONLY to leave that warm snapshot behind. It runs
+          # the tests and stops: deploy owns publishing on main, and running the
+          # stages below here would double a chart publish and push a
+          # ci-format-bot commit straight to main. GIT_BRANCH and
+          # GIT_REPO_DEFAULT_BRANCH are set by the workflow service on every
+          # run; compare them rather than hardcoding "main" so this keeps
+          # working if the default branch is ever renamed.
+          #
+          # GIT_PR_NUMBER is in the condition to close a hole, not for tidiness.
+          # On a pull_request event GIT_BRANCH is the PR's HEAD branch, so a PR
+          # opened from a fork's own `main` would match a branch-name-only test
+          # and skip every gate below while still reporting the required check
+          # green. The workflow service formats that variable with %d, so a push
+          # is exactly "0" and any PR is non-zero.
+          if [ -n "${GIT_BRANCH:-}" ] &&
+             [ "${GIT_BRANCH:-}" = "${GIT_REPO_DEFAULT_BRANCH:-}" ] &&
+             [ "${GIT_PR_NUMBER:-0}" = "0" ]; then
+            echo "On ${GIT_BRANCH}: seeding the pr-checks fallback snapshot, tests only."
+            bazel test //... --config=ci --deleted_packages=bazel/tools/python --test_tag_filters=-external,-future
+            echo "DISK pr-checks seed end:"; df -h /
+            exit 0
           fi
 
           # ORDER IS LOAD-BEARING: everything that analyses //... runs BEFORE the

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -19,6 +19,34 @@ actions:
       cpu: "6"
       memory: "10GB"
       disk: "120GB"
+    # Full history, and the SAME depth on both actions. 0 means unlimited; the
+    # runner otherwise fetches --depth=1 (ci_runner.go, `fetchDepth := 1`).
+    #
+    # deploy needs it because the publish derives every chart version from a
+    # walk over the conventional commits since the commit that last set that
+    # version (chart-version.sh). In a shallow clone that walk is not merely
+    # short, it is EMPTY: at the graft boundary every file reads as newly
+    # added, so the `-S"version: X"` search matches the boundary commit itself,
+    # and at depth 1 that is HEAD, whose exclusive HEAD..HEAD range contains
+    # nothing. Every chart then computes "no bump needed" and either silently
+    # skips its deploy or fails the action outright, which took main's deploy
+    # down on 2026-08-10 (60ebba4, and inertly on 2000bae before it). A bounded
+    # depth is not a fix either: at depth 10 this repo computes embervm 0.2.8
+    # where full history gives 0.2.30, trading a stuck version for a wrong one.
+    #
+    # pr-checks carries it so the two agree. It is not decoration: a runner
+    # snapshot persists the clone, so once these two share a snapshot (#4824) a
+    # divergent depth would make PR runs deep when restored from main and
+    # shallow when booted cold, and check-commit-msg-ascii.sh --all branches on
+    # exactly that. Aligning also makes CI's git history match a local clone,
+    # which is the assumption most history logic here is written against.
+    #
+    # Cost is a cold-fetch-only ~152MB (12M -> 164M for this repo's 12k commits
+    # under the default blob:none filter), and the snapshot carries it after.
+    # This replaces a hand-rolled `git fetch --unshallow` that used to live in
+    # deploy's steps: the runner does the same thing, including the
+    # sticky-depth check, and does it fatally rather than with a warning.
+    git_fetch_depth: 0
     triggers:
       pull_request:
         branches:
@@ -241,6 +269,8 @@ actions:
       cpu: "6"
       memory: "10GB"
       disk: "120GB"
+    # See pr-checks. Both actions MUST carry the same value.
+    git_fetch_depth: 0
     triggers:
       push:
         branches:
@@ -271,42 +301,9 @@ actions:
           # ---- 1. tests ---------------------------------------------------
           bazel test //... --config=ci --deleted_packages=bazel/tools/python --test_tag_filters=-external,-future
 
-          # ---- 1.5 deepen the clone ---------------------------------------
-          # The publish below derives every chart version from a walk over the
-          # conventional commits since the commit that last set that version
-          # (chart-version.sh). BuildBuddy clones SHALLOW, and in a shallow
-          # clone that walk is not merely short, it is EMPTY: at the graft
-          # boundary every file reads as newly added, so the `-S"version: X"`
-          # search matches the boundary commit itself, and at depth 1 that is
-          # HEAD, whose exclusive HEAD..HEAD range contains nothing.
-          #
-          # The result is that every chart computes "no bump needed" and either
-          # silently skips its deploy or, now that image digests are the
-          # authority on whether to publish, fails the action outright. That is
-          # what took main's deploy down on 2026-08-10 (60ebba4, and inertly on
-          # 2000bae before it): the escalation could not compute a higher
-          # version because the range it walked was empty, not because the
-          # dependency closure was incomplete.
-          #
-          # Deepening restores the assumption the arithmetic is built on, that
-          # the version is a function of the COMMIT. It is not enough to fetch
-          # "some" history: at depth 10 this repo computes embervm 0.2.8 where
-          # the full history gives 0.2.30, so a bounded --deepen would just
-          # trade a stuck version for a wrong one. BuildBuddy reuses the runner
-          # workspace between runs, so the cost is paid per cold runner rather
-          # than per deploy, and the guard is skipped once the repo is complete.
-          # Deliberately NOT fatal, unlike the test step above. `set -e` is
-          # load-bearing there because a failed test must not publish images.
-          # Here the opposite applies: if this fetch cannot run, because the
-          # runner's clone has no remote configured or the network blips,
-          # aborting would skip the image pushes as well and leave main worse
-          # off than the bug being fixed. chart-version.sh refuses to compute a
-          # version in a shallow repo, so a failed deepen surfaces as a precise
-          # per-chart error instead of a raw git failure with nothing attempted.
-          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-            git fetch --unshallow --quiet ||
-              echo "WARNING: could not deepen the clone; chart versions will fail loudly below." >&2
-          fi
+          # The clone is deep because `git_fetch_depth: 0` asks for it, not
+          # because a step deepens it. See that field on both actions above for
+          # why the publish needs full history.
 
           # PUBLISH BEFORE THE FORMAT CHECK, deliberately. Under `set -e` a
           # formatter hiccup aborts everything after it, and on 2026-08-09 that


### PR DESCRIPTION
Two changes to `buildbuddy.yaml`, both about making runner state coherent. Net **+81 / -36**, and the second is a deletion of hand-rolled code the runner already does.

## 1. Seed the `pr-checks` fallback snapshot

`pr-checks` had never once run on `main`, so it had no default-branch snapshot for new PR branches to fall back to, and every new branch booted a VM from scratch.

The runner snapshot key is `(repo URL, action name, instance suffix, git_clean_exclude)` (`enterprise/server/workflow/service/service.go:169-195`), so `pr-checks` and `deploy` occupy **disjoint** snapshot namespaces despite identical `container_image` and `resource_requests`. The fallback order is own branch, then PR base branch, then repo default branch, and for `pr-checks` all three were empty. This also rules out a separate lightweight "seeder" action: a new action name gets a new, empty namespace.

Measured over the 7 days to 2026-08-14 via `SearchInvocation`, classifying cold as `actionCount > 5000`:

| | runs | cold | median |
|---|---|---|---|
| CI `test //...` | 647 | 128 (20%) | cold **413s** vs warm **68s** |

+345s per cold run, about **736 minutes of wall clock a week**. Split by whether the branch had been seen before:

```
distinct PR branches: 94
FIRST test //... on branch   n=94    cold=62  (66%)  median=285s
LATER pushes, same branch    n=169   cold=51  (30%)  median=94s
```

The 30% residual is the save policy, not eviction. The default, `first-non-default-ref`, saves a snapshot only on the **first** run of a non-default ref but on **every** run of a default one, so a branch's snapshot is frozen at push #1. `main` is a default ref and pushes ~158 times a week, which turns the fallback from one-shot into continuously refreshed and addresses both figures.

The main-only stage runs the tests and exits. `deploy` owns publishing on main; running the later stages here would double a chart publish and push a `ci-format-bot` commit straight to `main`.

### Guard

```sh
if [ -n "${GIT_BRANCH:-}" ] &&
   [ "${GIT_BRANCH:-}" = "${GIT_REPO_DEFAULT_BRANCH:-}" ] &&
   [ "${GIT_PR_NUMBER:-0}" = "0" ]; then
```

Both variables are set on every run (`service.go:1085-1093`). Comparing them beats hardcoding `main` if the default branch is renamed.

`GIT_PR_NUMBER` closes a hole rather than being tidiness: on a `pull_request` event `GIT_BRANCH` is the PR's **head** branch, so a PR from a fork's own `main` would match a name-only test and skip every gate while still reporting the required check green. The service formats it `%d`, so a push is exactly `"0"`.

```
push to main (want SEED)                       SEED
PR from feature branch (want FULL)             FULL
PR from a fork's main (want FULL)              FULL
merge-queue push (want FULL)                   FULL
default branch renamed to trunk (SEED)         SEED
env vars absent entirely (want FULL)           FULL
```

## 2. `git_fetch_depth: 0` on both actions, replacing `deploy`'s unshallow step

`deploy` hand-rolled `git fetch --unshallow` to undo BuildBuddy's default `--depth=1`, because the chart version walk needs real history. The runner already does precisely this, including the sticky-depth check a snapshot taken at depth 1 needs:

```go
// ci_runner.go
fetchDepth := 1                                    // default
if *gitFetchDepth != smartFetchDepth { fetchDepth = *gitFetchDepth }
...
if fetchDepth == 0 {
    // The --depth option is sticky when fetching the same branch.
    if strings.Contains(output, "true") { fetchArgs = append(fetchArgs, "--unshallow") }
}
```

So the step was a duplicate, and a weaker one: it was deliberately non-fatal and only warned.

Setting it on **both** actions is the point, not decoration. A snapshot persists the clone, so once these two share one (#4824) a divergent depth would make PR runs deep when restored from `main` and shallow when booted cold. `check-commit-msg-ascii.sh --all` branches on exactly that: its `git merge-base HEAD origin/main` (line 162) returns empty in a shallow clone, so the range degenerates and the check is close to vacuous today. Aligning makes it check the PR's real commits, bounded by the fork point, so it does not start scanning history. `check_doc_links.py` is already a working-tree check and is unaffected.

Cost is cold-fetch-only, **12M to 164M** for this repo's 12,025 commits under the default `blob:none` filter, and the snapshot carries it afterwards. `deploy` already paid this via the unshallow. Note `git_fetch_depth` is not part of the snapshot key, so this does not invalidate existing snapshots; the sticky-depth branch above converts them on first use.

**Behaviour change worth naming:** a failed deep fetch now fails the action instead of warning and publishing anyway. That is the runner's normal fetch path rather than a supplementary one, so there is no half-deployed state left to degrade into.

## Risk

- **Concurrency**: none. Cancellation is per branch (`AllowsConcurrentRunsOnBranch`) and the default branch is exempt, so this cannot cancel or serialize PR runs.
- **Required check**: name unchanged, and main pushes are not PRs.
- **Cost**: one extra warm `bazel test //...` per main push, against 736 min/week recovered.

## Follow-up

#4824 folds `deploy` into `pr-checks` for a single namespace and no duplicated main run. Change 2 removes what was blocking it.

Verified: `bash -n` on both extracted steps, YAML parse of both actions' triggers and depth, guard table above, clone sizes measured, `ci lint` clean, pre-push `ci test` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)