### PR TITLE
feat(embervm): fault levers on the fake noded, and a restart-wedge scenario that actually runs

### DIFF
--- a/bazel/erlang/BUILD
+++ b/bazel/erlang/BUILD
@@ -106,11 +106,17 @@ genrule(
         # spec_vocabulary_test.exs finds them; absent env leaves behavior unchanged.
         "//projects/embervm/specs:spec_files",
         "//projects/embervm/proto/embervm/node/v1:node_proto",
+        # The stateful fake noded (#4761). The restart-wedge scenario drives a
+        # real Dispatcher against it and suppresses primed_vm_ids to starve
+        # adoption. Without it staged here the scenario SKIPS, which would make
+        # the harness's own proof inert in the lane that runs it.
+        "//projects/embervm/proto/embervm/node/v1/fakenode",
     ],
     outs = ["mix_test_smoke.txt"],
     cmd = "MIX_REBAR3_SRC=\"$$(pwd)/$(location @rebar3//file)\" " +
           "EMBERVM_SPECS_SRCS=\"$(locations //projects/embervm/specs:spec_files)\" " +
           "EMBERVM_NODE_PROTO_SRC=\"$(location //projects/embervm/proto/embervm/node/v1:node_proto)\" " +
+          "EMBERVM_FAKE_NODE_SRC=\"$(location //projects/embervm/proto/embervm/node/v1/fakenode)\" " +
           "$(location mix_test.sh) \"$(location @otp_ubuntu2204_amd64//:Install)\" \"$(location @elixir_1_18_4//:bin/elixir)\" \"$(location //projects/embervm/control:mix.exs)\" \"$@\" \"$(location @hex_archive//file)\" \"$(location //projects/embervm/proto/embervm/node/v1:node_elixir_src)\" $(locations :hex_tarballs)",
     tags = ["no-remote-cache"],
     tools = ["mix_test.sh"],

--- a/bazel/erlang/mix_test.sh
+++ b/bazel/erlang/mix_test.sh
@@ -116,6 +116,21 @@ if [ -n "${EMBERVM_NODE_PROTO_SRC:-}" ]; then
 	cp "$proto_abs" "$work/proto/node.proto"
 	export EMBERVM_NODE_PROTO="$work/proto/node.proto"
 fi
+
+# The stateful fake noded (#4761). Without it the restart-wedge scenario SKIPS,
+# and a scenario that never runs is the defect class this whole harness exists to
+# catch: it would report green while asserting nothing. Copied rather than
+# referenced so the sandbox owns an executable copy.
+if [ -n "${EMBERVM_FAKE_NODE_SRC:-}" ]; then
+	case "$EMBERVM_FAKE_NODE_SRC" in
+	/*) fake_abs="$EMBERVM_FAKE_NODE_SRC" ;;
+	*) fake_abs="$(pwd)/$EMBERVM_FAKE_NODE_SRC" ;;
+	esac
+	mkdir -p "$work/bin"
+	cp "$fake_abs" "$work/bin/fakenode"
+	chmod +x "$work/bin/fakenode"
+	export EMBERVM_FAKE_NODE_BIN="$work/bin/fakenode"
+fi
 export HOME="$work" # mix/hex write under $HOME (~/.mix); keep it in the sandbox
 export MIX_ENV=test
 # The executor env is stripped, so force UTF-8 filename handling (avoids the

--- a/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
+++ b/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
@@ -181,10 +181,21 @@ defmodule Embervm.RestartWedgeScenarioTest do
     end
   end
 
+  # :httpc wants a FOUR-tuple for methods that carry a body and a two-tuple for
+  # those that do not. Passing the two-tuple form for :post returns
+  # {:error, :invalid_request} before anything reaches the network, which reads
+  # like the control port rejecting the lever rather than the client refusing to
+  # send it.
   defp control(port, method, path) do
-    {:ok, {{_, status, _}, _headers, _body}} =
-      :httpc.request(method, {~c"http://127.0.0.1:#{port}#{path}", []}, [], [])
+    url = ~c"http://127.0.0.1:#{port}#{path}"
 
+    request =
+      case method do
+        :post -> {url, [], ~c"application/json", ~c""}
+        _ -> {url, []}
+      end
+
+    {:ok, {{_, status, _}, _headers, _body}} = :httpc.request(method, request, [], [])
     status
   end
 

--- a/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
+++ b/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
@@ -91,7 +91,7 @@ defmodule Embervm.RestartWedgeScenarioTest do
     assert control(fake.control_port, :post, "/fault/suppress-primed") == 204
     {:ok, stream} = NodeService.Stub.watch_node(fake.channel, %Embervm.Node.V1.WatchNodeRequest{node_id: "node-4"})
     assert Enum.all?(stream, fn {:ok, status} -> status.workloads == [] end)
-    Process.exit(Process.whereis(dispatcher_name), :normal)
+    crash_dispatcher(dispatcher_name)
     put_capacity(cap_table, [])
     start_dispatcher(dispatcher_name, store, cap_table, catalog_table, depth_table, dispatched)
 
@@ -178,6 +178,28 @@ defmodule Embervm.RestartWedgeScenarioTest do
         })
 
       response.vm_id
+    end
+  end
+
+  # A CRASH, and it must be observed to have happened before restarting.
+  #
+  # `Process.exit(pid, :normal)` from another process is IGNORED unless the
+  # target traps exits, so the dispatcher survived and the restart failed with
+  # {:error, {:already_started, pid}}. It also modelled the wrong thing:
+  # adoption.tla's CrashCP is a crash, not an orderly shutdown, and the whole
+  # point of this scenario is what the control plane does after dying.
+  #
+  # Monitoring and waiting for the :DOWN is what makes the restart deterministic
+  # rather than a race against process teardown.
+  defp crash_dispatcher(name) do
+    pid = Process.whereis(name)
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+    after
+      5_000 -> flunk("dispatcher #{name} did not die within 5s")
     end
   end
 

--- a/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
+++ b/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
@@ -41,16 +41,23 @@ defmodule Embervm.RestartWedgeScenarioTest do
     end
   end
 
-  test "dispatch restart wedge is caught by SpecTrace checker", %{skip: skip, fake: fake} do
-    if skip do
-      # The round-trip genrule supplies the fake binary; ordinary Mix runs do not.
-      IO.puts("restart wedge scenario skipped: #{skip}")
-    else
-      run_wedge_scenario(fake)
-    end
+  test "dispatch restart wedge starves adoption and the trace records it", ctx do
+    # NOT a silent skip. mix_test.sh now stages the fake noded (bazel/erlang/BUILD
+    # plus the EMBERVM_FAKE_NODE_SRC block), so an absent binary means that
+    # staging broke, not that the environment is legitimately without it.
+    #
+    # The previous revision printed "skipped" and passed, so this scenario never
+    # ran in CI once, while the suite reported green. A harness proof that can
+    # excuse itself is the exact defect class this harness exists to catch.
+    refute ctx[:skip],
+           "the fake noded is not staged: #{ctx[:skip]}. mix_test.sh is supposed to " <>
+             "export EMBERVM_FAKE_NODE_BIN from EMBERVM_FAKE_NODE_SRC. This scenario " <>
+             "must not silently skip."
+
+    run_wedge_scenario(ctx.fake, ctx.trace_store, ctx.trace_writer)
   end
 
-  defp run_wedge_scenario(fake) do
+  defp run_wedge_scenario(fake, trace_store, trace_writer) do
     vm_ids = prime(fake.channel, 3)
     assert Enum.count(vm_ids) == 3
 

--- a/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
+++ b/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
@@ -193,6 +193,12 @@ defmodule Embervm.RestartWedgeScenarioTest do
   # rather than a race against process teardown.
   defp crash_dispatcher(name) do
     pid = Process.whereis(name)
+
+    # UNLINK first. The dispatcher is started with start_link, so it is linked to
+    # this test process, and a :kill exit propagates down the link and takes the
+    # test with it (** (EXIT from #PID<...>) killed). Monitoring is what we want
+    # here instead: observe the death without sharing it.
+    Process.unlink(pid)
     ref = Process.monitor(pid)
     Process.exit(pid, :kill)
 

--- a/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
+++ b/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
@@ -18,9 +18,26 @@ defmodule Embervm.RestartWedgeScenarioTest do
       SpecTrace.configure()
     end)
 
+    # A REGISTERED writer, because SpecTrace.emit/3 resolves it via
+    # Process.whereis/1. An unnamed writer means every emission silently finds
+    # nothing, the scenario records zero events, and any conclusion drawn about
+    # what the checker can see is a conclusion about an empty store.
+    {:ok, trace_store} = TraceSQLite.start_link(name: nil, path: ":memory:")
+
+    trace_writer =
+      start_supervised!(
+        {SpecTrace.Writer, store_mod: TraceSQLite, store: trace_store, batch_size: 1, flush_ms: 5}
+      )
+
+    context = [trace_store: trace_store, trace_writer: trace_writer]
+
     case System.get_env("EMBERVM_FAKE_NODE_BIN") do
-      nil -> {:ok, skip: "EMBERVM_FAKE_NODE_BIN is not staged in the ordinary Mix test", fake: nil}
-      bin -> start_fake_node(bin)
+      nil ->
+        {:ok, [skip: "EMBERVM_FAKE_NODE_BIN is not staged", fake: nil] ++ context}
+
+      bin ->
+        {:ok, fake_ctx} = start_fake_node(bin)
+        {:ok, Keyword.merge(context, Enum.to_list(fake_ctx))}
     end
   end
 
@@ -74,26 +91,50 @@ defmodule Embervm.RestartWedgeScenarioTest do
     _wedge_task = submit(store)
     refute eventually(fn -> Agent.get(dispatched, & &1) == 2 end, 5_000)
 
-    {:ok, trace_store} = TraceSQLite.start_link(name: nil, path: ":memory:")
-    :ok =
-      TraceSQLite.write(trace_store, [
-        %{
-          "run_id" => "restart-wedge",
-          "seq" => 1,
-          "mono" => 1,
-          "ts" => 1,
-          "spec" => "adoption",
-          "action" => "preamble",
-          "vars" => %{}
-        }
-      ])
+    # The checker runs over the WEDGE'S OWN trace, captured by the writer started
+    # in setup, never over a store this test fabricates. An earlier revision
+    # created a fresh store, wrote one preamble record, ran the checker over that
+    # and concluded "the checker cannot see the wedge". It could not see
+    # anything: there was nothing there. Testing the wrong artifact produces a
+    # finding about the wrong artifact.
+    :ok = SpecTrace.drain(trace_writer)
+    {:ok, records} = TraceSQLite.read_window(trace_store, spec: "adoption")
+
+    assert records != [],
+           "the wedge produced NO trace records, so any conclusion about what the " <>
+             "checker can or cannot see is unfounded. Check the writer is running and " <>
+             "the gate is on."
+
+    checkpoints = Enum.filter(records, &(&1["action"] == "checkpoint"))
+
+    assert checkpoints != [],
+           "no checkpoint records. Checkpoint is emitted every sweep EVEN WHEN NOTHING " <>
+             "ELSE FIRES precisely so that non-progress is observable, and a wedge is " <>
+             "non-progress. Without it this scenario cannot be distinguished from a quiet " <>
+             "healthy run by any means."
 
     verdicts = Checker.run(TraceSQLite, trace_store)
 
-    # The current checker is trace-only. A quiet run has no illegal transition,
-    # so it reports vacuous coverage rather than proving that adoption happened.
-    assert Enum.any?(verdicts, &(&1.verdict == :vacuous))
-    refute Enum.any?(verdicts, &(&1.verdict == :fail))
+    # THE FINDING, and it is the honest one #4761 asked for.
+    #
+    # The records needed to see the wedge ARE present: checkpoints carry the
+    # inventory every sweep, so a starving control plane is visible as inventory
+    # that never becomes a dispatch. What is missing is an INVARIANT that reads
+    # them for non-progress. Every current invariant asks "did an illegal
+    # transition occur", and a wedge is the absence of a legal one.
+    #
+    # So the checker reports vacuous or pass here, and that is a true statement
+    # about the invariants rather than about the trace. The gap is a missing
+    # liveness invariant (adoption.tla's EventuallyDispatched, bounded), not
+    # missing instrumentation. Filed as the next slice of #4761.
+    refute Enum.any?(verdicts, &(&1.verdict == :fail)),
+           "a FAIL here would mean an invariant already detects the wedge, which would " <>
+             "make this comment wrong and is worth knowing: #{inspect(verdicts)}"
+
+    dispatch_verdict = Enum.find(verdicts, &(&1.invariant == :dispatch_provenance))
+
+    assert dispatch_verdict.verdict in [:pass, :vacuous],
+           "unexpected verdict shape: #{inspect(dispatch_verdict)}"
   end
 
   defp start_fake_node(bin) do

--- a/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
+++ b/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
@@ -1,0 +1,233 @@
+defmodule Embervm.RestartWedgeScenarioTest do
+  use ExUnit.Case, async: false
+
+  alias Embervm.{Dispatcher, NodeCapacity, TaskStore, WorkloadCatalog}
+  alias Embervm.OpLog.SQLite
+  alias Embervm.SpecTrace
+  alias Embervm.SpecTrace.Checker
+  alias Embervm.SpecTrace.Store.SQLite, as: TraceSQLite
+  alias Embervm.Node.V1.{NodeService, PrimeRequest, Trace}
+
+  setup do
+    :inets.start()
+    System.put_env("EMBERVM_SPEC_TRACE", "on")
+    SpecTrace.configure()
+
+    on_exit(fn ->
+      System.put_env("EMBERVM_SPEC_TRACE", "off")
+      SpecTrace.configure()
+    end)
+
+    case System.get_env("EMBERVM_FAKE_NODE_BIN") do
+      nil -> {:ok, skip: "EMBERVM_FAKE_NODE_BIN is not staged in the ordinary Mix test", fake: nil}
+      bin -> start_fake_node(bin)
+    end
+  end
+
+  test "dispatch restart wedge is caught by SpecTrace checker", %{skip: skip, fake: fake} do
+    if skip do
+      # The round-trip genrule supplies the fake binary; ordinary Mix runs do not.
+      IO.puts("restart wedge scenario skipped: #{skip}")
+    else
+      run_wedge_scenario(fake)
+    end
+  end
+
+  defp run_wedge_scenario(fake) do
+    vm_ids = prime(fake.channel, 3)
+    assert Enum.count(vm_ids) == 3
+
+    suffix = System.unique_integer([:positive])
+    cap_table = String.to_atom("wedge_cap_#{suffix}")
+    catalog_table = String.to_atom("wedge_catalog_#{suffix}")
+    depth_table = String.to_atom("wedge_depth_#{suffix}")
+    dispatcher_name = String.to_atom("wedge_dispatcher_#{suffix}")
+    db_path = Path.join(System.tmp_dir!(), "embervm_restart_wedge_#{suffix}.db")
+
+    NodeCapacity.create(cap_table)
+    WorkloadCatalog.create(catalog_table)
+    put_catalog(catalog_table)
+    put_capacity(cap_table, vm_ids)
+    {:ok, op_log} = SQLite.start_link(name: nil, path: db_path)
+
+    dispatched = Agent.start_link(fn -> 0 end) |> elem(1)
+    {:ok, store} =
+      TaskStore.start_link(
+        name: nil,
+        op_log: op_log,
+        on_queued: fn task -> Dispatcher.enqueue(dispatcher_name, task) end
+      )
+
+    start_dispatcher(dispatcher_name, store, cap_table, catalog_table, depth_table, dispatched)
+    assert :ok = Dispatcher.sweep(dispatcher_name)
+    task_id = submit(store)
+    assert eventually(fn -> Agent.get(dispatched, & &1) == 1 end)
+    assert {:ok, %{id: ^task_id}} = TaskStore.get(store, task_id)
+
+    assert control(fake.control_port, :post, "/fault/suppress-primed") == 204
+    {:ok, stream} = NodeService.Stub.watch_node(fake.channel, %Embervm.Node.V1.WatchNodeRequest{node_id: "node-4"})
+    assert Enum.all?(stream, fn {:ok, status} -> status.workloads == [] end)
+    Process.exit(Process.whereis(dispatcher_name), :normal)
+    put_capacity(cap_table, [])
+    start_dispatcher(dispatcher_name, store, cap_table, catalog_table, depth_table, dispatched)
+
+    _wedge_task = submit(store)
+    refute eventually(fn -> Agent.get(dispatched, & &1) == 2 end, 5_000)
+
+    {:ok, trace_store} = TraceSQLite.start_link(name: nil, path: ":memory:")
+    :ok =
+      TraceSQLite.write(trace_store, [
+        %{
+          "run_id" => "restart-wedge",
+          "seq" => 1,
+          "mono" => 1,
+          "ts" => 1,
+          "spec" => "adoption",
+          "action" => "preamble",
+          "vars" => %{}
+        }
+      ])
+
+    verdicts = Checker.run(TraceSQLite, trace_store)
+
+    # The current checker is trace-only. A quiet run has no illegal transition,
+    # so it reports vacuous coverage rather than proving that adoption happened.
+    assert Enum.any?(verdicts, &(&1.verdict == :vacuous))
+    refute Enum.any?(verdicts, &(&1.verdict == :fail))
+  end
+
+  defp start_fake_node(bin) do
+    proc = Port.open({:spawn_executable, bin}, [:binary, :exit_status, {:line, 1024}, {:args, ["--control-addr", "127.0.0.1:0"]}])
+    grpc_port = read_port(proc, "PORT=", 5_000)
+    control_port = read_port(proc, "CONTROL_PORT=", 5_000)
+    {:ok, channel} = GRPC.Stub.connect("127.0.0.1:#{grpc_port}", adapter: GRPC.Client.Adapters.Mint)
+
+    on_exit(fn ->
+      _ = GRPC.Stub.disconnect(channel)
+      if Port.info(proc), do: Port.close(proc)
+    end)
+
+    {:ok, fake: %{channel: channel, control_port: control_port}}
+  end
+
+  defp read_port(proc, prefix, timeout) do
+    receive do
+      {^proc, {:data, {:eol, line}}} ->
+        if String.starts_with?(line, prefix), do: String.to_integer(String.replace_prefix(line, prefix, "")), else: read_port(proc, prefix, timeout)
+      {^proc, {:exit_status, code}} -> flunk("fake node exited early with status #{code}")
+    after
+      timeout -> flunk("timed out waiting for fake node #{prefix} line")
+    end
+  end
+
+  defp prime(channel, count) do
+    for n <- 1..count do
+      {:ok, response} =
+        NodeService.Stub.prime(channel, %PrimeRequest{
+          trace: %Trace{workload: "test-workload"},
+          lineage_id: "scenario-#{n}",
+          volume_mount: "/workspace"
+        })
+
+      response.vm_id
+    end
+  end
+
+  defp control(port, method, path) do
+    {:ok, {{_, status, _}, _headers, _body}} =
+      :httpc.request(method, {~c"http://127.0.0.1:#{port}#{path}", []}, [], [])
+
+    status
+  end
+
+  defp put_catalog(table) do
+    WorkloadCatalog.upsert(table, "test-workload", %{
+      name: "test-workload",
+      namespace: "embervm",
+      cap: 10,
+      floor: 0,
+      mem_mib: 0,
+      invoke_path: "/",
+      timeout_ms: 5_000,
+      result_ttl_ms: 60_000,
+      result_max_bytes: 1_048_576,
+      retry: %{max_attempts: 1, backoff_ms: 1, backoff_cap_ms: 1, retry_on: []},
+      triggers: []
+    })
+  end
+
+  defp put_capacity(table, vm_ids) do
+    NodeCapacity.put(table, "node-4", %{
+      node_id: "node-4",
+      configured_id: "node-4",
+      instance_id: "node-4",
+      workloads: %{
+        "test-workload" => %{
+          free_primed_slots: length(vm_ids),
+          snapshot_ref: "snap-test-workload",
+          base_state: :BASE_BUILD_STATE_READY,
+          primed_vm_ids: vm_ids
+        }
+      },
+      mem_headroom_mib: 4096,
+      mem_budget_mib: 0,
+      cpu_headroom_millicores: 4000,
+      live_vms: 0,
+      max_live_vms: 10,
+      draining: false,
+      updated_at: System.monotonic_time(:millisecond)
+    })
+  end
+
+  defp start_dispatcher(name, store, cap_table, catalog_table, depth_table, dispatched) do
+    {:ok, _pid} =
+      Dispatcher.start_link(
+        name: name,
+        task_store: store,
+        capacity_table: cap_table,
+        catalog_table: catalog_table,
+        depth_table: depth_table,
+        channel_fun: fn _ -> {:ok, :channel} end,
+        assign_fun: fn _channel, _request -> Agent.update(dispatched, &(&1 + 1)); {:ok, assign_response()} end,
+        prime_fun: fn _channel, _request -> {:error, :not_expected} end,
+        start_sweep: false
+      )
+  end
+
+  defp assign_response do
+    %Embervm.Node.V1.AssignResponse{
+      response: %Embervm.Node.V1.GuestResponse{status_code: 200, headers: %{}, body: "ok"},
+      usage: %Embervm.Node.V1.UsageStats{cpu_ms: 1, peak_rss_mib: 1, wall_ms: 1}
+    }
+  end
+
+  defp submit(store) do
+    {:ok, :created, task_id} =
+      TaskStore.submit(store, %{
+        tenant: "test",
+        principal: "scenario",
+        workload: "test-workload",
+        request: %{path: "/", headers: %{}, body_b64: Base.encode64("")}
+      })
+
+    task_id
+  end
+
+  defp eventually(fun, timeout \\ 1_000, interval \\ 10) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_eventually(fun, deadline, interval)
+  end
+
+  defp do_eventually(fun, deadline, interval) do
+    if fun.() do
+      true
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        false
+      else
+        Process.sleep(interval)
+        do_eventually(fun, deadline, interval)
+      end
+    end
+  end
+end

--- a/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
+++ b/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
@@ -86,7 +86,7 @@ defmodule Embervm.RestartWedgeScenarioTest do
     assert :ok = Dispatcher.sweep(dispatcher_name)
     task_id = submit(store)
     assert eventually(fn -> Agent.get(dispatched, & &1) == 1 end)
-    assert {:ok, %{id: ^task_id}} = TaskStore.get(store, task_id)
+    assert {:ok, %{task_id: ^task_id, state: :succeeded}} = TaskStore.get(store, task_id)
 
     assert control(fake.control_port, :post, "/fault/suppress-primed") == 204
     {:ok, stream} = NodeService.Stub.watch_node(fake.channel, %Embervm.Node.V1.WatchNodeRequest{node_id: "node-4"})

--- a/projects/embervm/proto/embervm/node/v1/fakenode/BUILD
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/BUILD
@@ -21,5 +21,12 @@ go_library(
 go_binary(
     name = "fakenode",
     embed = [":fakenode_lib"],
-    visibility = ["//projects/embervm:__subpackages__"],
+    visibility = [
+        "//projects/embervm:__subpackages__",
+        # The Elixir test lane stages this binary so the restart-wedge scenario
+        # (#4761) can drive a real Dispatcher against a fault-injectable node.
+        # Without it the scenario skips, and a harness proof that never runs is
+        # the defect class the harness exists to catch.
+        "//bazel/erlang:__pkg__",
+    ],
 )

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -611,7 +611,6 @@ func (s *fakeServer) WatchNode(req *nodev1.WatchNodeRequest, stream grpc.ServerS
 			return nil
 		}
 	}
-	return nil
 }
 
 func main() {

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -13,11 +13,14 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
 	"google.golang.org/grpc"
@@ -35,8 +38,14 @@ type fakeServer struct {
 	// ExportArtifact records a key, a repeat export short-circuits skipped, and
 	// EvictArtifact removes it, so the round-trip test proves the verbs cross the
 	// wire and observe each other's effect within one test's fresh server.
-	mu    sync.Mutex
-	store map[string]bool
+	mu             sync.Mutex
+	store          map[string]bool
+	vmState        map[string]bool
+	vmWorkload     map[string]string
+	suppressPrimed bool
+	dropStatus     bool
+	closeStream    bool
+	streamActive   bool
 }
 
 // storeKey mirrors the Fork-3 layout <kind>/<workload>/<ref> so the fake's
@@ -57,8 +66,13 @@ func (*fakeServer) BuildBase(_ context.Context, req *nodev1.BuildBaseRequest) (*
 	}, nil
 }
 
-func (*fakeServer) Prime(_ context.Context, req *nodev1.PrimeRequest) (*nodev1.PrimeResponse, error) {
-	return &nodev1.PrimeResponse{VmId: "vm:" + req.GetLineageId() + ":" + req.GetVolumeMount()}, nil
+func (s *fakeServer) Prime(_ context.Context, req *nodev1.PrimeRequest) (*nodev1.PrimeResponse, error) {
+	vmID := "vm:" + req.GetLineageId() + ":" + req.GetVolumeMount()
+	s.mu.Lock()
+	s.vmState[vmID] = true
+	s.vmWorkload[vmID] = req.GetTrace().GetWorkload()
+	s.mu.Unlock()
+	return &nodev1.PrimeResponse{VmId: vmID}, nil
 }
 
 func (*fakeServer) Assign(_ context.Context, req *nodev1.AssignRequest) (*nodev1.AssignResponse, error) {
@@ -74,7 +88,11 @@ func (*fakeServer) Assign(_ context.Context, req *nodev1.AssignRequest) (*nodev1
 	}, nil
 }
 
-func (*fakeServer) Destroy(_ context.Context, _ *nodev1.DestroyRequest) (*nodev1.DestroyResponse, error) {
+func (s *fakeServer) Destroy(_ context.Context, req *nodev1.DestroyRequest) (*nodev1.DestroyResponse, error) {
+	s.mu.Lock()
+	delete(s.vmState, req.GetVmId())
+	delete(s.vmWorkload, req.GetVmId())
+	s.mu.Unlock()
 	return &nodev1.DestroyResponse{}, nil
 }
 
@@ -547,28 +565,106 @@ func (s *fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusR
 	}, nil
 }
 
-func (*fakeServer) WatchNode(req *nodev1.WatchNodeRequest, stream grpc.ServerStreamingServer[nodev1.NodeStatus]) error {
-	// Stream a fixed number of heartbeats with an incrementing live_vms counter so
-	// the client can assert both the count and the ordering, then complete.
-	for i := uint32(0); i < watchNodeHeartbeats; i++ {
-		if err := stream.Send(&nodev1.NodeStatus{NodeId: req.GetNodeId(), LiveVms: i}); err != nil {
+func (s *fakeServer) WatchNode(req *nodev1.WatchNodeRequest, stream grpc.ServerStreamingServer[nodev1.NodeStatus]) error {
+	s.mu.Lock()
+	s.streamActive = true
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.streamActive = false
+		s.mu.Unlock()
+	}()
+
+	for i := uint32(0); ; i++ {
+		s.mu.Lock()
+		dropStatus := s.dropStatus
+		closeStream := s.closeStream
+		if closeStream {
+			s.closeStream = false
+		}
+		primed := make(map[string][]string)
+		if !s.suppressPrimed {
+			for vmID := range s.vmState {
+				workload := s.vmWorkload[vmID]
+				primed[workload] = append(primed[workload], vmID)
+			}
+		}
+		s.mu.Unlock()
+
+		if closeStream && dropStatus {
+			return nil
+		}
+		if dropStatus {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		workloads := make([]*nodev1.WorkloadCapacity, 0, len(primed))
+		for workload, vmIDs := range primed {
+			workloads = append(workloads, &nodev1.WorkloadCapacity{
+				Workload: workload, FreePrimedSlots: uint32(len(vmIDs)), PrimedVmIds: vmIDs,
+			})
+		}
+		if err := stream.Send(&nodev1.NodeStatus{NodeId: req.GetNodeId(), LiveVms: i, Workloads: workloads}); err != nil {
 			return err
+		}
+		if closeStream || i+1 == watchNodeHeartbeats {
+			return nil
 		}
 	}
 	return nil
 }
 
 func main() {
+	controlAddr := flag.String("control-addr", "", "HTTP fault-control listener address")
+	flag.Parse()
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "fakenode: listen: %v\n", err)
 		os.Exit(1)
 	}
 	srv := grpc.NewServer()
-	nodev1.RegisterNodeServiceServer(srv, &fakeServer{store: map[string]bool{}})
+	fake := &fakeServer{store: map[string]bool{}, vmState: map[string]bool{}, vmWorkload: map[string]string{}}
+	nodev1.RegisterNodeServiceServer(srv, fake)
 
 	// Announce the chosen port on stdout (unbuffered) so the harness can connect.
 	fmt.Printf("PORT=%d\n", lis.Addr().(*net.TCPAddr).Port)
+	if *controlAddr != "" {
+		controlLis, err := net.Listen("tcp", *controlAddr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fakenode: control listen: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("CONTROL_PORT=%d\n", controlLis.Addr().(*net.TCPAddr).Port)
+		go http.Serve(controlLis, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			set := r.Method == http.MethodPost
+			unset := r.Method == http.MethodDelete
+			if !set && !unset {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			fake.mu.Lock()
+			switch r.URL.Path {
+			case "/fault/suppress-primed":
+				fake.suppressPrimed = set
+			case "/fault/drop-status":
+				fake.dropStatus = set
+			case "/fault/close-stream":
+				if set {
+					fake.closeStream = true
+				} else {
+					fake.mu.Unlock()
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+			default:
+				fake.mu.Unlock()
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			fake.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		}))
+	}
 
 	if err := srv.Serve(lis); err != nil {
 		fmt.Fprintf(os.Stderr, "fakenode: serve: %v\n", err)


### PR DESCRIPTION
First slice of #4761. Fault levers on the fake noded, plus the restart-wedge
scenario that #4761 names as the harness's own proof:

> Reproduce the dispatch restart wedge: the fake suppresses `primed_vm_ids`
> after a CP restart, adoption starves, and the harness must go red. **If that
> scenario cannot go red, the harness is decoration.**

## What landed

**Fault levers.** `fakenode/main.go` gains in-memory VM state (it was 577 lines
of stateless stubs) and an HTTP control port with three levers:
`suppress-primed` (report an empty set while the VMs remain live),
`drop-status` (stop sending frames without closing the stream), and
`close-stream` (force the CP's reconnect path). Existing behaviour is unchanged
with no fault set, so the round-trip test is unaffected.

**The scenario.** Primes VMs against the real fake noded, drives a real
`Dispatcher` with a real SQLite op-log, confirms normal dispatch, sets
`suppress-primed`, crashes and restarts the control plane, and asserts the next
task does NOT dispatch. Then runs the real `Checker` over the trace the wedge
itself produced.

## The honest finding, which is what #4761 asked for

**No current invariant detects the wedge, and the reason is not missing
instrumentation.**

The records are all there. `checkpoint` is emitted every sweep precisely so that
non-progress is observable, and the scenario asserts they are present before
drawing any conclusion. What is missing is an invariant that READS them for
non-progress: every current invariant asks "did an illegal transition occur",
and a wedge is the absence of a legal one. The gap is a bounded-liveness check,
`adoption.tla`'s `EventuallyDispatched`, and that is the next slice.

## Nine bugs found by making the test actually run

The slice arrived with the scenario **skipping in every CI run**:
`EMBERVM_FAKE_NODE_BIN` is staged only for the round-trip genrule, so it printed
"skipped" and the suite reported green while it asserted nothing.

Wiring it up surfaced, in order: a Bazel visibility error, a `nogo` unreachable
`return` (nothing outside the round-trip target had ever compiled this file), a
compile error in the plumbing, a pattern matching `id` where `TaskStore` returns
`task_id`, an `:httpc` two-tuple where POST needs four, `Process.exit(:normal)`
being ignored by a non-trapping process, and an untrappable `:kill` propagating
down the `start_link` link and killing the test itself.

Every one produces an immediate legible failure the moment the code executes.
They accumulated to nine because nothing ever ran it.

Two are worth more than the fix:

- The checker step originally created a **fresh empty store**, wrote one
  `preamble` record, ran the checker over that, and concluded "the checker
  cannot see the wedge". It could not see anything. That produced a **false
  finding**, not just a false pass, and a false finding propagates into issues
  and designs. The scenario now asserts `records != []` before concluding
  anything about what the checker saw.
- `Process.exit(pid, :normal)` would have modelled an orderly shutdown, not
  `CrashCP`. Had BEAM happened to kill on `:normal`, the test would be green and
  exercising the wrong event, and the invariants this programme cares most about
  are specifically about crashes.

## The skip is now a hard failure

`refute ctx[:skip]` with a message naming the staging path. A test that can
excuse itself will eventually excuse itself permanently with nothing noticing,
which is exactly what happened here.

## Verification

```
1261 tests, 0 failures, 6 skipped
6 processes: 357 action cache hit, 4 remote cache hit, 1 internal, 1 remote
```

Executed remotely, not a cache replay. Zero occurrences of "restart wedge
scenario skipped" in the log, and the `refute ctx[:skip]` guard means a
non-staged binary fails rather than passes, so the scenario body demonstrably
ran.

## Not in this slice

The general scenario runner from #4761's scope, and the bounded-liveness
invariant that would make this wedge go red. A narrower thing that genuinely
runs beats a framework that does not.
