### PR TITLE
perf(ci): stop building every image base twice, and give the runner 8 CPUs

### DIFF
--- a/bazel/tools/oci/apko_image.bzl
+++ b/bazel/tools/oci/apko_image.bzl
@@ -113,12 +113,31 @@ def apko_image(
     # no-tars case is just the general path with tars = [].
 
     # Create the amd64 base image (always built).
+    #
+    # tags = ["manual"] is load-bearing, not tidiness. This target and the
+    # transitioned filegroup below wrap the SAME apko action in two different
+    # configurations (`k8-fastbuild` here, `linux_amd64` after the transition),
+    # and the action key includes the output root, so they are two distinct
+    # actions doing byte-identical work. Only the transitioned one is reachable
+    # from :{name}, but `bazel test //...` expands to this target too, so every
+    # apko base was being built TWICE per arch on every run: same label, same
+    # layer digest, overlapping wall clock. Observed in invocation
+    # e687c0c6 on 2026-08-14, where semgrep/guest/image_base_amd64 ran at
+    # 04:14:41 and again at 04:14:56, both emitting sha256:19aaf6a6...
+    #
+    # This is expensive rather than merely wasteful: rules_apko sets
+    # `no-remote-exec`, so these run on the workflow runner's 6 vCPUs rather
+    # than on RBE, and they own the critical path of a cold run. `manual` only
+    # removes a target from wildcard EXPANSION, so the transitioned filegroup
+    # still pulls it in as a dependency and :{name} is unaffected.
+    # domain_images.bzl already does this for the same reason.
     _apko_image(
         name = name + "_base_amd64",
         architecture = "x86_64",
         config = config,
         contents = contents,
         tag = "latest",
+        tags = ["manual"],
     )
 
     # Transition the base image to its target platform
@@ -130,12 +149,14 @@ def apko_image(
     )
 
     if arm64:
+        # See the amd64 base above for why this is manual.
         _apko_image(
             name = name + "_base_arm64",
             architecture = "aarch64",
             config = config,
             contents = contents,
             tag = "latest",
+            tags = ["manual"],
         )
 
         platform_transition_filegroup(

--- a/bazel/tools/oci/py3_image.bzl
+++ b/bazel/tools/oci/py3_image.bzl
@@ -78,9 +78,17 @@ def py3_image(name, binary, main = None, root = "/", layer_groups = {}, env = {}
         extra_tars_arm64.append(tar_base + "_arm64")
 
     if multi_platform:
-        # Build AMD64 image
+        # Build AMD64 image.
+        #
+        # tags = ["manual"]: this target and the transitioned filegroup below
+        # are the same work in two configurations, and `bazel test //...`
+        # expands to both, so each base was assembled twice. `manual` removes
+        # it from wildcard expansion only; the filegroup still depends on it.
+        # Same defect as apko_image.bzl, though cheaper here because oci_image
+        # is remotely executable where the apko action is `no-remote-exec`.
         oci_image(
             name = name + "_base_amd64",
+            tags = ["manual"],
             base = base,
             tars = py_image_layer(
                 name = name + "_layers_amd64",
@@ -98,9 +106,10 @@ def py3_image(name, binary, main = None, root = "/", layer_groups = {}, env = {}
             target_platform = "//bazel/tools/platforms:linux_x86_64",
         )
 
-        # Build ARM64 image
+        # Build ARM64 image. See the amd64 base above for why this is manual.
         oci_image(
             name = name + "_base_arm64",
+            tags = ["manual"],
             base = base,
             tars = py_image_layer(
                 name = name + "_layers_arm64",

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -16,7 +16,20 @@ actions:
     container_image: "ubuntu-24.04"
     max_retries: 1
     resource_requests:
-      cpu: "6"
+      # 8, not 6, because the images apko builds are `no-remote-exec`
+      # (rules_apko sets it), so they run HERE rather than on RBE and their
+      # concurrency is capped by this number, not by --jobs=80. They own the
+      # critical path of a cold run: in invocation e687c0c6 only 75 of 21988
+      # actions executed and 68 of those were apko, spanning 04:10:49 to
+      # 04:16:13 of a 04:10:45 to 04:16:15 execution phase.
+      #
+      # Raising this INVALIDATES EVERY EXISTING SNAPSHOT for the action:
+      # resource_requests becomes the EstimatedCPU / EstimatedMemory /
+      # EstimatedFreeDisk / EstimatedComputeUnits platform properties
+      # (workflow service createActionForWorkflow), and the snapshot key hashes
+      # the platform properties. So change it deliberately and rarely, never as
+      # iterative tuning: each edit costs one cold run on every active branch.
+      cpu: "8"
       memory: "10GB"
       disk: "120GB"
     # Full history, and the SAME depth on both actions. 0 means unlimited; the
@@ -266,7 +279,8 @@ actions:
     container_image: "ubuntu-24.04"
     max_retries: 1
     resource_requests:
-      cpu: "6"
+      # See pr-checks for why 8 and for the snapshot-invalidation cost.
+      cpu: "8"
       memory: "10GB"
       disk: "120GB"
     # See pr-checks. Both actions MUST carry the same value.


### PR DESCRIPTION
Follows #4823. Two changes, both aimed at the part of a cold run that is real work rather than cache lookups.

## 1. Every image base was built twice per arch

`apko_image.bzl` and `py3_image.bzl` each declare a base image target **and** a `platform_transition_filegroup` over it. Only the transitioned one is reachable from `:{name}`, but the untransitioned target is still a target, so `bazel test //...` expands to both. Same work, two configurations, and the action key includes the output root, so Bazel runs two distinct actions producing byte-identical output.

Caught in [invocation e687c0c6](https://jomcgi.buildbuddy.io/invocation/e687c0c6-24e4-4dcc-bb55-ee9c8d85d73b):

```
(04:16:11) INFO: From Action projects/firecracker/semgrep/guest/image_base_amd64:   # started 04:14:41
  layer digest: sha256:19aaf6a64f3528c3b0a41dd5ce555ff9d34b92c248815a2c875a6cdcc9f717c9
(04:16:14) INFO: From Action projects/firecracker/semgrep/guest/image_base_amd64:   # started 04:14:56
  layer digest: sha256:19aaf6a64f3528c3b0a41dd5ce555ff9d34b92c248815a2c875a6cdcc9f717c9
```

Same label, same digest, overlapping wall clock. Same for `_arm64` (`aa11c1b5...` twice).

This is expensive rather than merely wasteful, because `rules_apko` sets `execution_requirements = {"no-remote-exec": "1"}` (`apko/private/apko_image.bzl:112`), so these run on the workflow runner instead of RBE. In that invocation **only 75 of 21,988 actions executed at all, and 68 of them were apko**, spanning 04:10:49 to 04:16:13 of a 04:10:45 to 04:16:15 execution phase. They are the critical path of a cold run.

`tags = ["manual"]` removes a target from wildcard **expansion** only; the transitioned filegroup still depends on it and `:{name}` is unaffected. `domain_images.bzl` already does exactly this and says why: *"Tagged manual (like each image target) so `bazel test //...` on every PR does not build 18 domains x 2 arches of image nobody consumes in CI"*. This just applies the same fix to the two macros that were missed.

`py3_image` has the identical defect but a cheaper one, since `oci_image` is remotely executable. Fixed for consistency.

## 2. `cpu: 6` to `cpu: 8`

apko concurrency is capped by the runner's cores, not by `--jobs=80`, precisely because those actions cannot go to RBE. 68 of them queued on 6 vCPUs is why the tail is wide.

Recorded on the field itself, because it is not a tuning dial: `resource_requests` becomes the `EstimatedCPU` / `EstimatedMemory` / `EstimatedFreeDisk` / `EstimatedComputeUnits` platform properties (workflow service `createActionForWorkflow`), and **the snapshot key hashes the platform properties**. So every edit to this value invalidates every existing snapshot for the action and costs one cold run on every active branch. Deliberately sequenced after #4823 so a `main` snapshot exists to fall back to.

## Verification

`ci test` green on this branch, judged by its summary rather than exit code:

```
1284 tests, 0 failures, 6 skipped
537 processes: 21508 action cache hit, 270 remote cache hit, 274 internal, 4 remote.
Executed 0 out of 712 tests: 712 tests pass.
```

That proves nothing broke. It does not prove the duplicate is gone, because that run was warm. **The proof is this PR's own CI run**: compare its `processes:` line against the 68 `linux-sandbox` baseline in e687c0c6.

## Note on the flake

#4823's first run went red on `Embervm.RestartWedgeScenarioTest` / `health_monotonic`. A re-run on the identical tree passed, and the `ci test` above ran the same 1284-test corpus clean. Filed as #4828 with a diagnosis: the test dials `10.0.0.9:9090` and `:enetunreach` fails the dial instantly, so the node reaches `age_to_down` without ever passing through `age_to_unknown`. Runner-dependent, not diff-dependent.

## Not in this PR

Dropping `arm64` has a larger blast radius than it looks: with `arm64 = False` the macro's `else` branch makes `:{name}` an `oci_image` directly rather than an `oci_image_index`, so the pinned digest changes and every affected chart rolls its workload. That deserves its own PR and its own revert point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)