### PR TITLE
fix(monolith): merge the duplicate chat block so the API token key renders

### DIFF
--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -965,6 +965,10 @@ chat:
   llamaCppUrl: ""
   embeddingUrl: ""
   searxngUrl: ""
+  # Discord attachment bytes are stored in SeaweedFS (content-addressed at
+  # blobs/<sha256>) rather than inline in Postgres. Reuses the shared SeaweedFS
+  # S3 endpoint/creds emitted alongside the stars block.
+  blobBucket: "chat"
   onepassword:
     itemPath: ""
 
@@ -1227,12 +1231,6 @@ stars:
   historyMapKey: "history-map.json"
   s3AccessKeyId: "duckdb"
   s3SecretAccessKey: "duckdb"
-
-# Chat: Discord attachment bytes are stored in SeaweedFS (content-addressed at
-# blobs/<sha256>) rather than inline in Postgres. Reuses the shared SeaweedFS S3
-# endpoint/creds emitted alongside the stars block.
-chat:
-  blobBucket: "chat"
 
 # goosecracker artifact store (ADR 024). The full monolith writes agent-built
 # HTML to s3://<bucket>/<id>/index.html (reusing the shared SeaweedFS S3


### PR DESCRIPTION
## What was actually broken

`chart/values.yaml` declared `chat:` twice, at line 961 and line 1234. YAML keeps the **last** mapping for a duplicate key, so the second block

```yaml
chat:
  blobBucket: "chat"
```

replaced the first one wholesale. `chat.githubApiTokenSecretKey` did not exist at render time.

The compare endpoint (b8a09ed44, PR #4805) wires `GITHUB_API_TOKEN` from exactly that field, with no default and no `optional: true`:

```yaml
key: {{ .Values.chat.githubApiTokenSecretKey }}
```

which rendered as a bare `key:`. `helm template` accepts it, because it is valid YAML. The API server does not:

```
Deployment.apps "monolith-dev" is invalid:
spec.template.spec.containers[0].env[37].valueFrom.secretKeyRef.key: Required value
```

## Why this matters beyond the one field

This is what has had `monolith-dev` stuck `OutOfSync` and four consecutive Kargo dev promotions erroring in `argocd-wait` at the 5m timeout, which in turn stranded prod on `0.304.9` while `0.305.4` sat published and discovered.

#4821 (`RespectIgnoreDifferences=true`) fixed a real and separate problem: `ignoreDifferences` suppresses diffing, not applying. That option is correct and stays. It was not the cause of this outage, and the sync failure message only became legible once it landed.

Note that prod is exposed to the same bug the moment it is promoted past `0.304.9`: `chat.enabled` is true in `projects/monolith/deploy/values.yaml` for both environments. Dev is the gate that caught it.

## Verification

Rendered both value stacks off this branch:

| stack | `GITHUB_API_TOKEN` key | `CHAT_BLOB_S3_BUCKET` |
|---|---|---|
| prod | `GITHUB_TOKEN` | `"chat"` |
| prod + dev overlay | `GITHUB_TOKEN` | `"chat"` |

Both `monolith-chat-secrets` and `monolith-dev-chat-secrets` already carry a `GITHUB_TOKEN` key, so the reference resolves rather than trading a sync failure for a `CreateContainerConfigError`.

Swept every top-level key in all four monolith values files for the same defect; `chat` was the only duplicate.

**Not verified: that this unsticks the pipeline.** That is only observable after merge, when the write-back publishes and the next Kargo dev promotion runs: `monolith-dev` should reach `Synced` and prod should advance past `0.304.9`.

## Gap this exposes

Nothing in CI renders the chart and asks the API server whether the result is admissible. `helm template` passing is not the same check. A `--dry-run=server` pass over the rendered manifests would have caught this at PR time rather than as a six-hour deploy outage that alerted nobody.