### PR TITLE
fix(embervm): pin dev to the chart that has the destroy gate, and drop the serving lane

### DIFF
--- a/projects/embervm/dev/deploy/application.yaml
+++ b/projects/embervm/dev/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.10.13
+      targetRevision: 0.11.12
       helm:
         valueFiles:
           - $values/projects/embervm/dev/deploy/values.yaml

--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -194,3 +194,19 @@ workloads:
     rootfsPath: /var/lib/embervm/scratch-dev/embervm-noded/scratch-postgres/rootfs.ext4
   bazelQuery:
     rootfsPath: /var/lib/embervm/scratch-dev/embervm-noded/bazel-query/rootfs.ext4
+
+# The serving lane, off. Dev exercises task-class lifecycle for the conformance
+# harness, not serving or stateful workloads.
+#
+# It was CrashLoopBackOff on the first sync, and the cause is structural rather
+# than a misconfiguration: envoy's bootstrap subscribes to CDS over ADS and
+# blocks initialisation until its first response. With no live brick and no
+# serving workload the control plane's xds snapshot is empty, so the initial
+# fetch times out ("initial fetch timed out for ...v3.Cluster"), the pod never
+# reports ready, and the probe restarts it. Production does not hit this because
+# it always has serving config to send.
+#
+# Turn this back on if dev ever needs the serving lane, and expect it to stay
+# unready until something is actually being served.
+servingEnvoy:
+  enabled: false


### PR DESCRIPTION
Two fixes from watching the first sync of `embervm-dev` (#4827).

## The destroy gate was NOT armed

Dev pinned `targetRevision: 0.10.13`, which predates the
`EMBERVM_NODE_CONFIRMED_DESTROY` template that #4827 added. So
`nodeConfirmedDestroy: true` in dev's values reached a chart with nothing that
reads it, and the live Deployment carried no such env var.

**This is #4758's defect class reproduced one layer out**, and the reason it got
past me is worth stating: charts deploy from a published OCI artifact, not from
the repo. `helm template projects/embervm/chart/` showed the gate rendering
because the repo has the template. The cluster runs the pinned artifact, which
did not. Every check I ran was correct and every one was on the wrong artifact.

Pinned to `0.11.12`, the first published chart containing the template, and
verified by rendering the **pulled** artifact rather than the working tree:

```
EMBERVM_NODE_CONFIRMED_DESTROY: "true"
```

## servingEnvoy off

It was CrashLoopBackOff on the first sync, for a structural reason rather than a
misconfiguration. Envoy's bootstrap subscribes to CDS over ADS and blocks
initialisation until its first response:

```
gRPC config: initial fetch timed out for type.googleapis.com/envoy.config.cluster.v3.Cluster
caught ENVOY_SIGTERM
```

The xds server IS listening (`ads grpc server listening port=18000`) and the
address is correct. With no live brick and no serving workload the snapshot is
empty, so the initial fetch never completes, the pod never reports ready, and the
probe restarts it. Production never hits this because it always has serving
config to send.

Dev exercises task-class lifecycle for the conformance harness and does not need
the serving lane. An unready pod restarting forever is also noise that would mask
a real failure later.

Render now carries zero DaemonSets.

## Note on `bricks` autoscale 404s

The dev control plane logs `brick autoscale current read failed` /
`brick scale failed` with `{:apiserver_status, 404}` for the 2gi/4gi/8gi/16gi
classes, because `desiredReplicas` is zero for all of them so no Deployment
exists to scale. Harmless (autoscale mode is `observe`) but noisy. Left alone
here; folded into #4832 rather than changed under a sync.