### PR TITLE
perf(ci): mirror the Test action's cpu and memory on the bb remote runner

### DIFF
--- a/bazel/tools/ci/ci
+++ b/bazel/tools/ci/ci
@@ -273,7 +273,9 @@ cmd_test() {
 	dim "  bb remote --os=linux --arch=amd64 ${bazel_args[*]}"
 	dim "  (include-secrets=true: runner may receive org secrets; treat as CI)"
 
-	# Match the Test action's `resource_requests.disk` in buildbuddy.yaml (120GB).
+	# Match the Test action's `resource_requests` in buildbuddy.yaml: disk 120GB,
+	# cpu 8, memory 10GB.
+	#
 	# Parity with CI was previously argv-only: targets, --config, --deleted_packages
 	# and --test_tag_filters all matched, but resource requests live in the YAML
 	# rather than the bazel command line, so they were never mirrored and this path
@@ -284,6 +286,23 @@ cmd_test() {
 	# the failing target moves between runs, and it is never the target you changed.
 	# Confirmed not to be runner-recycling debris; a fresh runner
 	# (recycle-runner=false) ran out of disk the same way.
+	#
+	# CPU and memory are the same omission, one step further on. The images apko
+	# builds are `no-remote-exec` (rules_apko sets it), so they run ON the runner
+	# rather than on RBE and their concurrency is capped by its cores, not by
+	# --jobs. A default-sized runner therefore serialises the slowest part of a
+	# cold //... here while CI runs it 8-wide, which is the opposite of what "1:1
+	# with the Test action" claims.
+	#
+	# Memory is raised alongside deliberately, not for its own sake: 8 concurrent
+	# apko builds on a default memory allowance is how you trade a slow run for an
+	# OOM. The pair matches buildbuddy.yaml rather than being tuned independently.
+	#
+	# Property names are exact and case-insensitive on lookup: EstimatedCPU takes
+	# cores or an `m` suffix, EstimatedMemory takes an IEC string. A typo here does
+	# NOT fail, it silently falls back to the default (milliCPUProp/iecBytesProp
+	# return defaultValue on a parse error), so changing these means re-reading the
+	# runner's actual size rather than trusting the flag went through.
 	local out
 	out="$(mktemp)"
 	trap 'rm -f "${out:-}"' RETURN INT TERM
@@ -292,6 +311,8 @@ cmd_test() {
 	bb remote --os=linux --arch=amd64 \
 		--runner_exec_properties=include-secrets=true \
 		--runner_exec_properties=EstimatedFreeDiskBytes=120GB \
+		--runner_exec_properties=EstimatedCPU=8 \
+		--runner_exec_properties=EstimatedMemory=10GB \
 		"${bazel_args[@]}" 2>&1 | tee "$out" || bb_status=$?
 
 	# bb remote exits 0 when the remote ACTION fails, so require positive evidence


### PR DESCRIPTION
Completes a parity fix that was already half done, and already documented as half done.

## The existing comment says it

`bazel/tools/ci/ci` already mirrors one resource request, with this rationale:

> Parity with CI was previously argv-only: targets, `--config`, `--deleted_packages` and `--test_tag_filters` all matched, but resource requests live in the YAML rather than the bazel command line, so they were never mirrored and this path silently took the much smaller default runner disk.

cpu and memory are the same omission, one step further on.

```diff
 bb remote --os=linux --arch=amd64 \
 	--runner_exec_properties=include-secrets=true \
 	--runner_exec_properties=EstimatedFreeDiskBytes=120GB \
+	--runner_exec_properties=EstimatedCPU=8 \
+	--runner_exec_properties=EstimatedMemory=10GB \
```

## Why it matters here specifically

The images apko builds are `no-remote-exec` (`rules_apko` sets it), so they run **on the runner** rather than on RBE, and their concurrency is capped by its cores rather than by `--jobs`. A default-sized runner serialises the slowest part of a cold `//...` here while CI runs it 8-wide, which is the opposite of what "1:1 with the Test action" claims.

Memory is raised alongside deliberately rather than for its own sake: 8 concurrent apko builds on a default memory allowance trades a slow run for an OOM. The pair matches `buildbuddy.yaml` rather than being tuned independently.

## Names verified, not guessed

A typo here does **not** fail. `milliCPUProp` and `iecBytesProp` both return the default on a parse error, so a wrong name or format is silently the old behaviour, which is the "declared but unwired" shape. Checked against BuildBuddy's `server/util/platform/platform.go`:

```go
EstimatedComputeUnitsPropertyName = "EstimatedComputeUnits"
EstimatedFreeDiskPropertyName     = "EstimatedFreeDiskBytes"   // matches what is already here
EstimatedCPUPropertyName          = "EstimatedCPU"
EstimatedMemoryPropertyName       = "EstimatedMemory"
```

`milliCPUProp` accepts bare cores or an `m` suffix, so `8` is 8 cores.

## Separate namespace from #4829

Worth recording because it is not obvious: this runner does **not** share `pr-checks`' snapshot. The workflow instance name hashes the workflow **action name** (`workflow/service/service.go:169`), and `bb remote` is not a workflow action. So the `resource_requests` change in #4829 neither disturbs nor is disturbed by this, and #4823's seeding did nothing for `ci test` either.

That `ci test` snapshots at all is visible in its own numbers, since 20k local action-cache hits needs a persistent output_base:

```
537 processes: 21508 action cache hit, ...    warm
713 processes: 20580 action cache hit, ...    warm
287 processes:  3401 action cache hit, ...    cold
```

## Verification

`ci test` green on this branch, on a cold runner (it recompiled embervm from scratch), judged by summary rather than exit code:

```
1286 tests, 0 failures, 6 skipped
287 processes: 3401 action cache hit, 97 remote cache hit, 119 internal, 77 remote.
Executed 4 out of 712 tests: 712 tests pass.
```

That confirms the flags are accepted and the loop still works end to end. It does **not** independently confirm the runner came up at 8 cores, since neither bazel nor `bb remote` prints the runner's size. Given a wrong value fails silently, that is worth a follow-up probe rather than an assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)