### PR TITLE
fix(embervm): put dev scratch under node-4's NVMe so it inherits a capacity bound

### DIFF
--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -469,7 +469,17 @@ volumes:
   - name: nvme
     hostPath:
       path: {{ $ctx.Values.noded.firecracker.nvmeRoot }}
-      type: Directory
+      # Directory (the default) is a GUARD, not a formality: if the NVMe is not
+      # mounted, the pod fails to start rather than silently creating the path on
+      # the node's ROOT filesystem and filling it with multi-GB base images.
+      # Production must keep it.
+      #
+      # DirectoryOrCreate is for a path UNDER an already-mounted parent, where
+      # the mount is guaranteed by the parent's existence and only the leaf needs
+      # creating. embervm-dev uses that shape: scratch/dev under node-4's NVMe,
+      # so it inherits the NVMe's capacity rather than living uncapped on root
+      # (ADR 012's uniform cap, and #4832).
+      type: {{ $ctx.Values.noded.firecracker.nvmeRootHostPathType | default "Directory" }}
   {{- if $ctx.Values.workloads }}
   - name: rootfs-builder-script
     configMap:

--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -57,11 +57,30 @@ noded:
   store:
     bucket: embervm-dev
 
-# nvmeRoot split. Dev bricks use /var/lib/embervm/scratch-dev, separate from
+# nvmeRoot lives UNDER node-4's NVMe mount so it inherits that capacity bound,
 # production's shared node-4 NVMe scratch. Scratch is shared metal; the split
 # prevents prod GC and dev artifacts from colliding.
   firecracker:
-    nvmeRoot: /var/lib/embervm/scratch-dev
+    # UNDER node-4's NVMe mount, not a sibling of it.
+    #
+    # scratch-dev was /var/lib/embervm/scratch-dev, a sibling of the NVMe mount
+    # point and therefore a plain directory on the node's ROOT filesystem. That
+    # made it the ONLY scratch path in this system with no capacity bound: node-4's
+    # NVMe is mounted at /var/lib/embervm/scratch and the masters carry a 35 GiB
+    # loop cap on the same path. Six base builders writing multi-GB images to an
+    # uncapped root filesystem, on the node that also runs production's
+    # brick-16gi-node-4 and brick-2gi, is a DiskPressure eviction of production
+    # waiting to happen. ADR 012's uniform cap exists for exactly this.
+    #
+    # A subdirectory gives up "separate metal", which was never the load-bearing
+    # property: the split existed so production GC and dev artifacts do not
+    # collide, and a distinct subdirectory achieves that. It buys the capacity
+    # bound, which is. See #4832.
+    nvmeRoot: /var/lib/embervm/scratch/dev
+    # The leaf needs creating; the MOUNT is still guarded by its parent existing.
+    # Production keeps the default Directory, which fails loudly if the NVMe is
+    # absent instead of filling root.
+    nvmeRootHostPathType: DirectoryOrCreate
 
   # Node capacity. Dev runs one tiny brick, so use the smaller default.
   maxLiveVMs: 8
@@ -183,17 +202,17 @@ nodeConfirmedDestroy: true
 # gated separately from the Workload CRs.
 workloads:
   sandbox:
-    rootfsPath: /var/lib/embervm/scratch-dev/embervm-noded/sandbox/rootfs.ext4
+    rootfsPath: /var/lib/embervm/scratch/dev/embervm-noded/sandbox/rootfs.ext4
   semgrep:
-    rootfsPath: /var/lib/embervm/scratch-dev/embervm-noded/semgrep/rootfs.ext4
+    rootfsPath: /var/lib/embervm/scratch/dev/embervm-noded/semgrep/rootfs.ext4
   runtimePython:
-    rootfsPath: /var/lib/embervm/scratch-dev/embervm-noded/runtime-python/rootfs.ext4
+    rootfsPath: /var/lib/embervm/scratch/dev/embervm-noded/runtime-python/rootfs.ext4
   runtimeClaude:
-    rootfsPath: /var/lib/embervm/scratch-dev/embervm-noded/runtime-claude/rootfs.ext4
+    rootfsPath: /var/lib/embervm/scratch/dev/embervm-noded/runtime-claude/rootfs.ext4
   scratchPostgres:
-    rootfsPath: /var/lib/embervm/scratch-dev/embervm-noded/scratch-postgres/rootfs.ext4
+    rootfsPath: /var/lib/embervm/scratch/dev/embervm-noded/scratch-postgres/rootfs.ext4
   bazelQuery:
-    rootfsPath: /var/lib/embervm/scratch-dev/embervm-noded/bazel-query/rootfs.ext4
+    rootfsPath: /var/lib/embervm/scratch/dev/embervm-noded/bazel-query/rootfs.ext4
 
 # The serving lane, off. Dev exercises task-class lifecycle for the conformance
 # harness, not serving or stateful workloads.


### PR DESCRIPTION
Implements #4832's headline decision (option 2), which blocks everything downstream in #4762.

## The problem

`scratch-dev` was `/var/lib/embervm/scratch-dev`, a **sibling** of the NVMe mount point and therefore a plain directory on node-4's ROOT filesystem. That made it the only scratch path in this system with **no capacity bound**: node-4's NVMe is mounted at `/var/lib/embervm/scratch`, and the masters carry a 35 GiB loop cap on that same path. ADR 012's uniform cap exists for exactly this.

Six base builders writing multi-GB images to an uncapped root filesystem, on the node that also runs production's `brick-16gi-node-4` and `brick-2gi`, is a DiskPressure eviction of production waiting on one `mkdir`.

It has been held back only by a hostPath type check failing since the first sync:

```
FailedMount (x8): hostPath type check failed:
  /var/lib/embervm/scratch-dev is not a directory
```

**An absent prerequisite is not a gate.** A gate is something someone must act to open; an absent prerequisite is something someone helpfully fills in.

## The fix

Dev moves to `/var/lib/embervm/scratch/dev`, under the mount. This gives up "separate metal", which was never the load-bearing property: the split existed so production GC and dev artifacts do not collide, and a distinct subdirectory achieves that. It buys the capacity bound, which is.

## Why the hostPath type is configurable rather than just changed

`type: Directory` on a mount point is a **guard**: if the NVMe is not mounted, the pod fails to start rather than silently creating the path on root and filling it with base images. Flipping it globally would trade one uncapped-path bug for a worse one.

Under a path whose parent IS the mount, the semantics differ: the parent existing is the mount check, so creating only the leaf is safe. Same flag, opposite risk profile, decided by where in the path you point it.

The default stays `Directory` and dev opts in, so the safe choice is the one you get by not thinking about it.

## Verified by rendering both

```
dev    /var/lib/embervm/scratch/dev   DirectoryOrCreate
prod   /var/lib/embervm/scratch       Directory          (unchanged)
```

Zero stale `scratch-dev` references and zero DaemonSets in the dev render, confirming the rebase kept main's `servingEnvoy: false`.

## Verification

```
1286 tests, 0 failures, 6 skipped
Executed 1 out of 712 tests: 712 tests pass
```

## Follow-up

Dev's chart pin needs bumping again once this publishes, since `nvmeRootHostPathType` is not in `0.11.12`. That double round-trip is #4832's second item: the write-back maintains only production's `application.yaml`, so dev's pin never advances on its own.