### PR TITLE
fix(embervm): pin dev to 0.11.13, the chart that renders the capped scratch path

### DIFF
--- a/projects/embervm/dev/deploy/application.yaml
+++ b/projects/embervm/dev/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.11.12
+      targetRevision: 0.11.13
       helm:
         valueFiles:
           - $values/projects/embervm/dev/deploy/values.yaml


### PR DESCRIPTION
Unblocks the `embervm-dev` brick, which has sat in `ContainerCreating` since the first sync.

## Why it was blocked

`0.11.12` predates the `nvmeRootHostPathType` template that #4837 added, so dev's values asked for `DirectoryOrCreate` under the NVMe and got a chart with nothing that reads it:

```
FailedMount: hostPath type check failed:
  /var/lib/embervm/scratch-dev is not a directory
```

## Verified against the PULLED artifact

Not against the working tree. That distinction is what caused the previous round trip (#4835): `helm template <repo>/chart/` answers "what would this chart render", and the cluster renders the pinned artifact.

```
/var/lib/embervm/scratch/dev -> DirectoryOrCreate
EMBERVM_NODE_CONFIRMED_DESTROY = true
```

So after this syncs, kubelet creates the leaf under node-4's NVMe mount, the brick starts, and its six base builders write to a path that inherits the NVMe's capacity rather than filling the root filesystem (#4832, ADR 012).

## Second manual bump tonight, same structural reason

`write-back-versions.sh`'s `_app_yaml_for` looks only at `$(dirname chart_dir)/deploy/application.yaml`, i.e. production's copy. Dev's pin never advances on its own, so every chart change dev needs costs a merge, a publish, and a hand-written bump PR.

That is #4832's second item and the real argument for the Kargo stage #4762 defers: not promotion elegance, but that the write-back is the wrong shape for a second environment and the workaround is a human remembering a number.