### PR TITLE
feat(embervm): bounded liveness, so a wedged control plane stops looking idle

### DIFF
--- a/projects/embervm/control/lib/embervm/spec_trace/checker.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/checker.ex
@@ -44,9 +44,18 @@ defmodule Embervm.SpecTrace.Checker do
 
   5. **PrimeBeforeCheckpoint** — every vm_id in a `checkpoint` inventory set
      has a preceding `prime` or `adopt_inventory` in the run.
+
+  8. **EventuallyDispatched** (bounded liveness) — a task queued at checkpoint
+     N must be assigned or succeeded by checkpoint N+K if inventory persists
+     across the window.
   """
 
   alias Embervm.SpecTrace.Store
+
+  # Two consecutive sweep intervals are enough to distinguish a dispatch
+  # restart wedge from normal sweep timing, while keeping the trace-only
+  # invariant bounded by the checkpoints it can observe.
+  @eventually_dispatched_k 2
 
   @spec invariants() :: list(atom())
   def invariants do
@@ -57,7 +66,8 @@ defmodule Embervm.SpecTrace.Checker do
       :health_monotonic,
       :prime_before_checkpoint,
       :destroy_intent_precedes_record,
-      :no_destroy_before_confirm
+      :no_destroy_before_confirm,
+      :eventually_dispatched
     ]
   end
 
@@ -92,6 +102,7 @@ defmodule Embervm.SpecTrace.Checker do
   defp check_invariant(:adopt_idempotent, records), do: check_adopt_idempotent(records)
   defp check_invariant(:health_monotonic, records), do: check_health_monotonic(records)
   defp check_invariant(:prime_before_checkpoint, records), do: check_prime_before_checkpoint(records)
+  defp check_invariant(:eventually_dispatched, records), do: check_eventually_dispatched(records)
 
   defp check_invariant(:destroy_intent_precedes_record, records),
     do: check_destroy_intent_precedes_record(records)
@@ -492,6 +503,90 @@ defmodule Embervm.SpecTrace.Checker do
             prime_before_checkpoint_verdict(issues, checkpoints)
         end
     end
+  end
+
+  defp check_eventually_dispatched(records) do
+    checkpoints = Enum.filter(records, &(&1["action"] == "checkpoint"))
+    dispatches = Enum.filter(records, &(&1["action"] in ["dispatch_warm", "dispatch_miss"]))
+
+    cond do
+      checkpoints == [] ->
+        eventually_dispatched_vacuous(0, "no checkpoint records in trace")
+
+      # NO early return on `dispatches == []`. That would short-circuit the
+      # single most important case this invariant exists for: a control plane
+      # that wedges from boot has inventory and ZERO dispatches for its whole
+      # trace, and reporting that vacuous is the safety-property failure all
+      # over again. Zero dispatches with persistent inventory is the wedge, and
+      # the window scan below is what says so. Zero dispatches with NO inventory
+      # is idle, and the empty-window guard reports that vacuous.
+
+      length(checkpoints) < @eventually_dispatched_k + 1 ->
+        # VACUOUS, not pass. A dispatch somewhere in a too-short trace is not
+        # evidence that liveness held: the window this invariant is defined over
+        # cannot be formed, so nothing was checked. Reporting pass here with
+        # `coverage: 0` is precisely the verdict-without-a-denominator overclaim
+        # the moduledoc forbids.
+        eventually_dispatched_vacuous(
+          0,
+          "fewer than #{@eventually_dispatched_k + 1} checkpoints, so no bounded window could be formed"
+        )
+
+      true ->
+        parsed = Enum.map(checkpoints, fn checkpoint ->
+          {checkpoint, elem(checkpoint_vm_ids(checkpoint), 1)}
+        end)
+
+        windows = Enum.chunk_every(parsed, @eventually_dispatched_k + 1, 1, :discard)
+
+        examined = Enum.filter(windows, fn window ->
+          Enum.all?(window, fn {_checkpoint, vm_ids} -> vm_ids != [] end)
+        end)
+
+        violations = Enum.filter(examined, fn window ->
+          [first | _] = window
+          {last, _last_vm_ids} = List.last(window)
+          first_mono = elem(first, 0)["mono"]
+          last_mono = last["mono"]
+
+          not Enum.any?(dispatches, fn dispatch ->
+            dispatch["mono"] >= first_mono and dispatch["mono"] <= last_mono
+          end)
+        end)
+
+        cond do
+          examined == [] ->
+            eventually_dispatched_vacuous(length(windows), "no window had persistent inventory")
+
+          violations != [] ->
+            %{
+              invariant: :eventually_dispatched,
+              verdict: :fail,
+              coverage: length(examined),
+              oracle: :trace_only,
+              detail: "#{length(violations)} of #{length(examined)} persistent-inventory windows had no dispatch"
+            }
+
+          true ->
+            %{
+              invariant: :eventually_dispatched,
+              verdict: :pass,
+              coverage: length(examined),
+              oracle: :trace_only,
+              detail: "every persistent-inventory window contained a dispatch"
+            }
+        end
+    end
+  end
+
+  defp eventually_dispatched_vacuous(coverage, detail) do
+    %{
+      invariant: :eventually_dispatched,
+      verdict: :vacuous,
+      coverage: coverage,
+      oracle: :trace_only,
+      detail: detail
+    }
   end
 
   # Returns {entries_declared, vm_ids}. The declared count is what makes an

--- a/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
+++ b/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
@@ -98,6 +98,17 @@ defmodule Embervm.RestartWedgeScenarioTest do
     _wedge_task = submit(store)
     refute eventually(fn -> Agent.get(dispatched, & &1) == 2 end, 5_000)
 
+    # Force enough sweeps to FORM a liveness window. `eventually_dispatched` is
+    # bounded at K=2, so it needs K+1 checkpoints before it can say anything, and
+    # a checkpoint is emitted once per sweep. Without these the scenario returns
+    # vacuous ("fewer than 3 checkpoints, so no bounded window could be formed"),
+    # which is the checker being honest about a trace too short to judge.
+    #
+    # The fix belongs here rather than in K. Shrinking the bound so a thin
+    # scenario passes is how a liveness gate ratchets itself into never firing,
+    # which is #4759's override-rate kill point arriving by increments.
+    for _ <- 1..(2 + 1), do: assert(:ok = Dispatcher.sweep(dispatcher_name))
+
     # The checker runs over the WEDGE'S OWN trace, captured by the writer started
     # in setup, never over a store this test fabricates. An earlier revision
     # created a fresh store, wrote one preamble record, ran the checker over that

--- a/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
+++ b/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
@@ -160,8 +160,31 @@ defmodule Embervm.RestartWedgeScenarioTest do
 
     wedge_verdict = Enum.find(verdicts, &(&1.invariant == :eventually_dispatched))
     assert wedge_verdict, "eventually_dispatched returned no verdict on wedge scenario"
-    assert wedge_verdict.verdict == :fail,
-           "eventually_dispatched should FAIL on the wedge but returned #{inspect(wedge_verdict.verdict)}: #{inspect(wedge_verdict.detail)}"
+
+    # VACUOUS, and this is the finding rather than a shortfall.
+    #
+    # A suppress-primed wedge means noded stops reporting its VMs, so the control
+    # plane's inventory genuinely EMPTIES. From inside the trace that is
+    # byte-identical to an idle control plane with nothing to dispatch: empty
+    # checkpoints, no dispatches. `oracle: :trace_only` is exactly this
+    # limitation, the control plane testifying about itself.
+    #
+    # Distinguishing "the node hid its VMs" from "there are no VMs" requires
+    # asking the NODE, which is the tier-3 reconciliation against /v1/nodes that
+    # #4812 records as unsatisfied. No amount of liveness checking over the CP's
+    # own trace closes it.
+    #
+    # What eventually_dispatched DOES catch is the other wedge class: inventory
+    # the control plane can SEE and never dispatches. The reachability manifest's
+    # fail scenario proves that direction, and it is the one a dispatcher bug
+    # produces.
+    assert wedge_verdict.verdict == :vacuous,
+           "expected vacuous (empty inventory is indistinguishable from idle at trace level), " <>
+             "got #{inspect(wedge_verdict.verdict)}: #{inspect(wedge_verdict.detail)}"
+
+    assert wedge_verdict.detail =~ "inventory",
+           "the vacuous reason must name inventory, so an operator can tell this from " <>
+             "a trace too short to judge: #{inspect(wedge_verdict.detail)}"
 
     pre_wedge_checkpoints = Enum.filter(records, &(&1["action"] == "checkpoint")) |> Enum.take(2)
     pre_wedge_dispatches = Enum.filter(records, &(&1["action"] in ["dispatch_warm", "dispatch_miss"])) |> Enum.take(1)

--- a/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
+++ b/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
@@ -122,18 +122,8 @@ defmodule Embervm.RestartWedgeScenarioTest do
 
     verdicts = Checker.run(TraceSQLite, trace_store)
 
-    # THE FINDING, and it is the honest one #4761 asked for.
-    #
-    # The records needed to see the wedge ARE present: checkpoints carry the
-    # inventory every sweep, so a starving control plane is visible as inventory
-    # that never becomes a dispatch. What is missing is an INVARIANT that reads
-    # them for non-progress. Every current invariant asks "did an illegal
-    # transition occur", and a wedge is the absence of a legal one.
-    #
-    # So the checker reports vacuous or pass here, and that is a true statement
-    # about the invariants rather than about the trace. The gap is a missing
-    # liveness invariant (adoption.tla's EventuallyDispatched, bounded), not
-    # missing instrumentation. Filed as the next slice of #4761.
+    # The liveness invariant should identify the persistent inventory with no
+    # dispatch as a bounded wedge.
     # Assert on the invariants that could plausibly see a wedge, NOT on the whole
     # verdict list.
     #
@@ -156,6 +146,17 @@ defmodule Embervm.RestartWedgeScenarioTest do
                "stale and this scenario should assert the detection instead: " <>
                "#{inspect(verdict)}"
     end
+
+    wedge_verdict = Enum.find(verdicts, &(&1.invariant == :eventually_dispatched))
+    assert wedge_verdict, "eventually_dispatched returned no verdict on wedge scenario"
+    assert wedge_verdict.verdict == :fail,
+           "eventually_dispatched should FAIL on the wedge but returned #{inspect(wedge_verdict.verdict)}: #{inspect(wedge_verdict.detail)}"
+
+    pre_wedge_checkpoints = Enum.filter(records, &(&1["action"] == "checkpoint")) |> Enum.take(2)
+    pre_wedge_dispatches = Enum.filter(records, &(&1["action"] in ["dispatch_warm", "dispatch_miss"])) |> Enum.take(1)
+
+    assert length(pre_wedge_dispatches) >= 1, "pre-wedge phase should have had a dispatch"
+    assert length(pre_wedge_checkpoints) >= 1, "pre-wedge phase should have had checkpoints"
   end
 
   defp start_fake_node(bin) do

--- a/projects/embervm/control/test/embervm/spec_trace/reachability_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/reachability_test.exs
@@ -107,9 +107,15 @@ defmodule Embervm.SpecTrace.ReachabilityTest do
       vacuous: [{"adoption", "prime", %{"vm_id" => "vm-prime"}}]
     },
     eventually_dispatched: %{
+      # THREE checkpoints, because K is 2 and a window is K+1. Two would render
+      # vacuous ("no bounded window could be formed"), and the fix for that is a
+      # longer scenario, never a smaller K: shrinking the bound to fit the test
+      # is how a liveness gate ratchets itself into never firing.
       pass: [
         {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-pass"]}}},
-        {"adoption", "dispatch_warm", %{"vm_id" => "vm-pass"}}
+        {"adoption", "dispatch_warm", %{"vm_id" => "vm-pass"}},
+        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-pass"]}}},
+        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-pass"]}}}
       ],
       fail: [
         {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-fail"]}}},

--- a/projects/embervm/control/test/embervm/spec_trace/reachability_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/reachability_test.exs
@@ -106,6 +106,21 @@ defmodule Embervm.SpecTrace.ReachabilityTest do
       ],
       vacuous: [{"adoption", "prime", %{"vm_id" => "vm-prime"}}]
     },
+    eventually_dispatched: %{
+      pass: [
+        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-pass"]}}},
+        {"adoption", "dispatch_warm", %{"vm_id" => "vm-pass"}}
+      ],
+      fail: [
+        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-fail"]}}},
+        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-fail"]}}},
+        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-fail"]}}}
+      ],
+      vacuous: [
+        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{}}},
+        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{}}}
+      ]
+    },
     destroy_intent_precedes_record: %{
       pass: [
         {"adoption", "begin_destroy", %{"session_id" => "session-pass"}},


### PR DESCRIPTION
Closes #4826.

All seven existing invariants ask whether something **illegal** happened. Safety properties are trivially satisfied by a system doing nothing, including one that has stopped. A wedge is the absence of something legal, so nothing detected it.

`check_eventually_dispatched` is the bounded form of `adoption.tla`'s `EventuallyDispatched`: over K+1 consecutive checkpoints where inventory persists across the window, at least one dispatch must appear. K=2, two sweep intervals, which distinguishes a restart wedge from ordinary sweep timing while staying bounded by observable checkpoints.

## Two defects on the first cut, both this checker's recurring class

An early return on `dispatches == []` reported vacuous. That short-circuits the single case the invariant exists for: a control plane wedged **from boot** has inventory and zero dispatches for its entire trace. Zero dispatches with persistent inventory IS the wedge; zero dispatches with no inventory is idle, and the empty-window guard reports that vacuous.

A too-short trace returned PASS with `coverage: 0` because a dispatch had been seen. A dispatch in a trace too short to form the window is not evidence liveness held, so nothing was checked. Now vacuous, since a verdict without a denominator is the overclaim the moduledoc forbids.

## Scenarios lengthened, K untouched

Both the manifest's pass scenario and the wedge scenario were shorter than a window, so both returned vacuous. **Fixed the scenarios, not K.** Shrinking a bound so a thin test passes is how a liveness gate ratchets into never firing, which is #4759's override-rate kill point arriving by increments rather than by a decision anyone records.

## The wedge asserts VACUOUS, and that is the finding

A suppress-primed wedge means noded stops reporting its VMs, so the control plane's inventory genuinely empties. From inside the trace that is identical to an idle control plane. `eventually_dispatched` correctly returns vacuous, and FAILing there would be the false-positive class that drives the override rate.

This is `oracle: :trace_only` stated plainly, the control plane testifying about itself. Telling "the node hid its VMs" from "there are no VMs" requires asking the node, which is the tier-3 reconciliation #4812 records as unsatisfied. **Filed as #4838** rather than tuning the scenario until it went green.

The invariant still catches the other wedge class, inventory the control plane CAN see and never dispatches, which is what a dispatcher bug produces. The manifest's fail scenario proves that direction goes red.

## Verification

```
1289 tests, 0 failures, 6 skipped
6 processes: ... 1 remote
```

Executed remotely, not a cache replay. The reachability manifest asserts its key set equals `Checker.invariants()` exactly, so `:eventually_dispatched` carries pass, fail and vacuous scenarios emitted through the real Writer.