### PR TITLE
fix(embervm): stop router_test's node registration leaking into other tests

### DIFF
--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -228,6 +228,18 @@ defmodule Embervm.NodeRegistry do
     GenServer.call(server, {:register, reg})
   end
 
+  @doc """
+  Removes one dial-home instance and synchronously tears down its streamer.
+
+  This is primarily useful to callers that own the lifetime of a registration,
+  such as request-level test fixtures. The removal goes through the registry so
+  a pending reconnect cannot outlive the registration owner.
+  """
+  @spec unregister(GenServer.server(), String.t(), String.t()) :: :ok
+  def unregister(server \\ __MODULE__, node, pod_uid) do
+    GenServer.call(server, {:unregister, node, pod_uid})
+  end
+
   # -- GenServer callbacks ---------------------------------------------------
 
   @impl true
@@ -533,6 +545,19 @@ defmodule Embervm.NodeRegistry do
       {:ok, norm} -> {:reply, :ok, apply_registration(state, norm)}
       :error -> {:reply, {:error, :invalid}, state}
     end
+  end
+
+  def handle_call({:unregister, node, pod_uid}, _from, state) do
+    instance_id = instance_id_of(to_trimmed(node), to_trimmed(pod_uid))
+
+    state =
+      if Map.has_key?(state.node_runtime, instance_id) do
+        expire_instance(state, instance_id)
+      else
+        state
+      end
+
+    {:reply, :ok, state}
   end
 
   # Best-effort: stop orphaned streamers from outliving the GenServer holding

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -227,7 +227,21 @@ defmodule Embervm.BaseBuilderTest do
       end
     end)
 
-    failed = latest(agent, "w")
+    # The retry is deliberately only 5ms later. It can publish BaseBuilding or
+    # BaseBuilt before this test process gets scheduled again, so latest/2 does
+    # not identify the failure that satisfied the wait above. Read the recorded
+    # failure event itself, preserving the assertion about the daemon error
+    # rather than racing the retry state.
+    failed =
+      recorded(agent)
+      |> Enum.reverse()
+      |> Enum.find_value(fn {_namespace, name, status_map} ->
+        if name == "w" and
+             match?(%{"reason" => "BuildFailed"}, condition(status_map, "BaseBuilt")),
+           do: status_map
+      end)
+
+    refute is_nil(failed), "the failed build status was not recorded"
     assert %{"status" => "False", "message" => "no image source for imgA"} = condition(failed, "BaseBuilt")
     assert %{"status" => "False", "reason" => "BaseNotBuilt"} = condition(failed, "Ready")
 

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -9,7 +9,7 @@ defmodule Embervm.RouterTest do
   """
   use ExUnit.Case, async: false
 
-  alias Embervm.TaskStore
+  alias Embervm.{NodeRegistry, TaskStore}
 
   @allowed "system:serviceaccount:embervm:embervm"
 
@@ -236,6 +236,14 @@ defmodule Embervm.RouterTest do
     Application.put_env(:embervm, :authenticator, FakeAuth)
 
     on_exit(fn ->
+      # Only the two registers that return 200 actually create an instance; the
+      # 401/403 cases are rejected before the registry sees them. Unregister is
+      # synchronous, so the streamer and its pending reconnect are gone before
+      # the next test file opens its trace store. Without this the retry loop
+      # outlives the test (async: false means the same VM) and writes health
+      # records into someone else's trace.
+      NodeRegistry.unregister("node-4", "router-test-sa")
+      NodeRegistry.unregister("node-4", "router-test-node-token")
       Application.delete_env(:embervm, :authenticator)
       Application.delete_env(:embervm, :sync_park_cap)
       Application.delete_env(:embervm, :sync_timeout_ms)
@@ -299,7 +307,20 @@ defmodule Embervm.RouterTest do
 
   defp reg_body(overrides \\ %{}) do
     Map.merge(
-      %{"node" => "node-4", "pod_uid" => unique("uid"), "address" => "10.0.0.9:9090", "boot_id" => "boot-1"},
+      # The address must be a port that is REFUSED identically on every host, not
+      # merely one that happens to be unreachable. This used to advertise
+      # 10.0.0.9:9090, which the registry then dialled for real: on a runner with
+      # a route the dial hung and the node aged unknown -> down, while on one
+      # without a route it failed instantly with :enetunreach and went straight
+      # to down, tripping the health_monotonic spec-trace invariant in whichever
+      # test happened to own the trace store by then (#4828). 127.0.0.1:1 is
+      # refused the same way everywhere.
+      #
+      # pod_uid stays unique per registration. Collapsing it to a constant would
+      # turn the second successful register in this file into a re-registration
+      # of the same (node, pod_uid), which is a distinct code path and the one
+      # #4707 is about. Teardown names the uids explicitly instead.
+      %{"node" => "node-4", "pod_uid" => unique("uid"), "address" => "127.0.0.1:1", "boot_id" => "boot-1"},
       overrides
     )
     |> :json.encode()
@@ -308,7 +329,7 @@ defmodule Embervm.RouterTest do
 
   test "POST /v1/nodes/register with the noded SA token is 200" do
     Application.put_env(:embervm, :noded_service_account, @allowed)
-    resp = req(:post, "/v1/nodes/register", auth("good"), reg_body())
+    resp = req(:post, "/v1/nodes/register", auth("good"), reg_body(%{"pod_uid" => "router-test-sa"}))
     assert resp.status == 200
     assert json(resp.body)["registered"] == true
   end
@@ -337,7 +358,7 @@ defmodule Embervm.RouterTest do
     end
 
     Application.put_env(:embervm, :authenticator, NodeAuth)
-    resp = req(:post, "/v1/nodes/register", auth("node-token"), reg_body())
+    resp = req(:post, "/v1/nodes/register", auth("node-token"), reg_body(%{"pod_uid" => "router-test-node-token"}))
     assert resp.status == 200
   end
 


### PR DESCRIPTION
Closes #4828. This is the one blocking everything else: PR CI has been failing roughly half its runs on causes unrelated to the diff under test.

## Root cause

`router_test.exs` registered `node-4` at **`10.0.0.9:9090`**, and `NodeRegistry` dialled that address for real. The registration outlived the test: its streamer kept retrying on a backoff timer, and because `async: false` files share one VM it was still running when a later test opened its SpecTrace store. Its health records landed there, and the checker reported a node reaching `age_to_down` with no preceding `age_to_unknown`.

The foreign node ids in the failures are this file's own `unique("uid")` values:

```
node node-4/uid-206 has age_to_down without preceding age_to_unknown
```

Whether it failed depended on the **runner's routing table**, which is why it was intermittent. With a route the dial hung and the node aged normally; without one it failed instantly with `:enetunreach` and went straight to `down`:

```
[error]   unable to establish a connection to http://10.0.0.9:9090. reason: :enetunreach
[warning] node node-4/uid-206 stream ended (:enetunreach), reconnect in 16000ms
[warning] node node-4/uid-206 is DOWN (stream silent > 15000ms)
```

## Fix, and which half matters

```
address -> 127.0.0.1:1
NodeRegistry.unregister/3, synchronous, from on_exit
```

The **unregister is the load-bearing half**. The address change alone would have made things worse, not better: a refused dial is also instant, so it produces the same straight-to-`down` record, just reliably rather than flakily. What the address buys is that the outcome no longer depends on the host. What the unregister buys is that the streamer and its pending reconnect are gone before the next file runs.

`pod_uid` stays **unique** per registration. Pinning it to a constant would make teardown simpler but would turn the second successful register in this file into a re-registration of the same `(node, pod_uid)`, which is a distinct code path and the one #4707 is about. The two registering tests name their uids explicitly instead, so teardown is exact without collapsing the identity. (The 401 and 403 cases never reach the registry.)

`base_builder_test.exs` is a separate race: the retry fires 5ms after the failure, so `latest/2` could read the retry's state rather than the failure the wait had just observed. It now reads the recorded failure event. **The assertions are unchanged**; only which status is read changed, plus a `refute is_nil` so it cannot pass vacuously.

## Verification

Five seeded runs, because one green run proves nothing about a flake. `EXUNIT_SEED` 1 through 5, each a real execution rather than a cache replay (`--action_env` re-keys the genrule):

| seed | result | processes |
|---|---|---|
| 1 | `1286 tests, 0 failures, 6 skipped` | 4 processes, 3 remote |
| 2 | `1286 tests, 0 failures, 6 skipped` | 4 processes, 3 remote |
| 3 | `1286 tests, 0 failures, 6 skipped` | 8 processes, 3 remote |
| 4 | `1286 tests, 0 failures, 6 skipped` | 8 processes, 3 remote |
| 5 | `1286 tests, 0 failures, 6 skipped` | 4 processes, 3 remote |

Mechanism check, which is stronger than the green runs. Across all five:

```
10.0.0.9:      0 occurrences   (was the dial target)
:enetunreach:  0 occurrences   (4 in an earlier failing run)
"is DOWN (stream silent > ...)": 0 occurrences   (this is the record that trips the invariant)
```

One `:econnrefused` with a 1s reconnect remains in seed 5, inside `router_test`'s own lifetime. That is expected and bounded: the synchronous unregister lands long before the 15s silence threshold that produces a DOWN record, and `router_test` asserts on HTTP status codes rather than trace invariants.

## What was not done

- `health_monotonic` is untouched. It was catching a real ordering property and correctly reported a node that genuinely went to `down` without `unknown`.
- Neither test is skipped, tagged flaky, or excluded, and no `Process.sleep` was added.
- The Bazel downloader transient (`Multiple entries with same key: Range=[bytes=...]` fetching a Wolfi `.apk`) is a different class and is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)