### PR TITLE
fix(embervm): stop the trace writing into the op-log DB, and surviving a writer restart

### DIFF
--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -466,6 +466,25 @@ defmodule Embervm.Application do
 
   @doc false
   def spec_trace_mod do
+    # EMBERVM_SPEC_TRACE_PATH WINS over the op-log DSN.
+    #
+    # This keyed off EMBERVM_OPLOG_DSN alone, so any environment running the
+    # Postgres op-log (production does) would open a Postgrex connection and
+    # write spec_trace rows into the SAME DATABASE as the durable op-log the
+    # moment the trace was enabled.
+    #
+    # #4770 decided the opposite explicitly, and it is the whole argument for a
+    # separate stream: "the op-log answers what happened to this task or session
+    # as a business object; the trace answers did the protocol behave". They have
+    # opposite design pressures, and the op-log is the durable book of record for
+    # audit and billing. A debug facility must not share its database. #4841.
+    case trimmed_env("EMBERVM_SPEC_TRACE_PATH") do
+      "" -> spec_trace_mod_from_oplog_dsn()
+      _path -> Embervm.SpecTrace.Store.SQLite
+    end
+  end
+
+  defp spec_trace_mod_from_oplog_dsn do
     case trimmed_env("EMBERVM_OPLOG_DSN") do
       "" -> Embervm.SpecTrace.Store.SQLite
       _ -> Embervm.SpecTrace.Store.Postgres

--- a/projects/embervm/control/lib/embervm/spec_trace.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace.ex
@@ -100,8 +100,10 @@ defmodule Embervm.SpecTrace do
   def drain(server \\ @writer), do: GenServer.call(server, :drain)
 
   def start_link(opts \\ []) do
-    configure()
-
+    # NO configure/0 here. It re-reads the env and stomps the persistent_term, so
+    # any writer restart would revert whatever set the gate. Harmless while the
+    # env is the only source of truth, and a silent disarm the moment anything
+    # else can set it. Boot calls configure/0 once (application.ex). #4841.
     if :persistent_term.get(@enabled_key, false) do
       @writer.start_link(opts)
     else
@@ -159,7 +161,13 @@ defmodule Embervm.SpecTrace.Writer do
       batch_size: batch_size,
       flush_ms: flush_ms,
       records: [],
-      seq: 0,
+      # RESUME, do not restart at 0. seq is the PRIMARY KEY in both stores, the
+      # writer is supervised, and a crash that reset this to 0 made every
+      # subsequent insert collide with an existing row. flush/1 swallows the
+      # error as a counted drop, so the trace silently recorded NOTHING until seq
+      # climbed past the old maximum, while reading as enabled the whole time.
+      # #4841.
+      seq: safe_max_seq(store_mod, store),
       run_id: Embervm.SpecTrace.run_id()
     }
     {:ok, state, {:continue, :preamble}}
@@ -174,7 +182,10 @@ defmodule Embervm.SpecTrace.Writer do
     # refuses to emit a PASS/FAIL verdict against a trace whose gate it cannot
     # confirm.
     preamble = %{
-      "run_id" => state.run_id, "seq" => 0, "mono" => 1,
+      # A REAL mono. It was hardcoded to 1, and reads are ORDER BY mono ASC, so
+      # two writer starts in one control-plane incarnation produced two records
+      # both claiming to be first and a consumer could not order them.
+      "run_id" => state.run_id, "seq" => state.seq + 1, "mono" => System.monotonic_time(:nanosecond),
       "ts" => System.system_time(:millisecond),
       "spec" => "spec_trace",
       "action" => "preamble",
@@ -185,7 +196,22 @@ defmodule Embervm.SpecTrace.Writer do
         "ttl_ms" => 86_400_000
       }
     }
-    {:noreply, schedule_flush(%{state | records: [preamble]})}
+    # ADVANCE state.seq past the preamble. It consumes a seq like any other
+    # record, and leaving the counter behind would make the first emitted record
+    # collide with it on the primary key.
+    {:noreply, schedule_flush(%{state | seq: state.seq + 1, records: [preamble]})}
+  end
+
+  # A store that cannot answer yields 0, which is the pre-fix behaviour rather
+  # than a crash: worst case the writer collides as it did before, best case it
+  # resumes correctly. A debug facility must not take down its own supervisor
+  # over a bookkeeping query.
+  defp safe_max_seq(store_mod, store) do
+    store_mod.max_seq(store)
+  rescue
+    _ -> 0
+  catch
+    _, _ -> 0
   end
 
   @impl true

--- a/projects/embervm/control/lib/embervm/spec_trace/store.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/store.ex
@@ -5,4 +5,18 @@ defmodule Embervm.SpecTrace.Store do
   @callback read_window(GenServer.server(), keyword()) :: {:ok, [map()]} | {:error, term()}
   @callback sweep(GenServer.server(), keyword()) ::
               {:ok, %{deleted: non_neg_integer(), done: boolean()}} | {:error, term()}
+
+  @doc """
+  The highest `seq` already stored, or 0 when empty.
+
+  `seq` is the PRIMARY KEY. The writer is supervised, so it restarts on a crash,
+  and starting its counter at 0 again means every insert collides with an
+  existing row: the batch write errors, `flush/1` swallows it as a counted drop,
+  and the trace silently records NOTHING until seq climbs past the old maximum.
+  The facility reads as enabled the whole time.
+
+  Resuming from here is what makes a writer restart survivable rather than a
+  silent stop. See #4841.
+  """
+  @callback max_seq(GenServer.server()) :: non_neg_integer()
 end

--- a/projects/embervm/control/lib/embervm/spec_trace/store/postgres.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/store/postgres.ex
@@ -28,6 +28,9 @@ defmodule Embervm.SpecTrace.Store.Postgres do
   def sweep(server \\ __MODULE__, opts \\ []), do: GenServer.call(server, {:sweep, opts})
 
   @impl true
+  def max_seq(server \\ __MODULE__), do: GenServer.call(server, :max_seq)
+
+  @impl true
   def init(opts) do
     dsn = Keyword.get(opts, :dsn, System.get_env("EMBERVM_OPLOG_DSN", ""))
     with {:ok, conn} <- connect(dsn), :ok <- create_schema(conn) do {:ok, %{conn: conn}} else {:error, reason} -> {:stop, {:connect_failed, reason}} end
@@ -36,6 +39,16 @@ defmodule Embervm.SpecTrace.Store.Postgres do
   def terminate(_reason, %{conn: conn}), do: GenServer.stop(conn)
   @impl true
   def handle_call({:write, records}, _from, state), do: {:reply, safe(fn -> do_write(state.conn, records) end), state}
+  def handle_call(:max_seq, _from, state) do
+    max =
+      case safe(fn -> Postgrex.query!(state.conn, "SELECT COALESCE(MAX(seq), 0) FROM public.spec_trace", []) end) do
+        %Postgrex.Result{rows: [[max]]} when is_integer(max) -> max
+        _ -> 0
+      end
+
+    {:reply, max, state}
+  end
+
   def handle_call({:read, opts}, _from, state), do: {:reply, safe(fn -> do_read(state.conn, opts) end), state}
   def handle_call({:sweep, opts}, _from, state), do: {:reply, safe(fn -> do_sweep(state.conn, opts) end), state}
 

--- a/projects/embervm/control/lib/embervm/spec_trace/store/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/store/sqlite.ex
@@ -43,8 +43,15 @@ defmodule Embervm.SpecTrace.Store.SQLite do
   def sweep(server \\ __MODULE__, opts \\ []), do: GenServer.call(server, {:sweep, opts})
 
   @impl true
+  def max_seq(server \\ __MODULE__), do: GenServer.call(server, :max_seq)
+
+  @impl true
   def handle_call({:write, records}, _from, state) do
     {:reply, safe(state, fn -> do_write(state.conn, records) end), state}
+  end
+
+  def handle_call(:max_seq, _from, state) do
+    {:reply, do_max_seq(state.conn), state}
   end
 
   def handle_call({:read, opts}, _from, state) do
@@ -87,6 +94,21 @@ defmodule Embervm.SpecTrace.Store.SQLite do
       rows = collect_rows(conn, stmt, [])
       :ok = Sqlite3.release(conn, stmt)
       {:ok, rows}
+    end
+  end
+
+  defp do_max_seq(conn) do
+    with {:ok, stmt} <- Sqlite3.prepare(conn, "SELECT COALESCE(MAX(seq), 0) FROM spec_trace") do
+      result =
+        case Sqlite3.step(conn, stmt) do
+          {:row, [max]} when is_integer(max) -> max
+          _ -> 0
+        end
+
+      :ok = Sqlite3.release(conn, stmt)
+      result
+    else
+      _ -> 0
     end
   end
 

--- a/projects/embervm/control/test/embervm/spec_trace_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_test.exs
@@ -79,6 +79,46 @@ defmodule Embervm.SpecTraceTest do
     assert record["vars"]["node_confirmed"] === nil
   end
 
+  # A writer RESTART must not silently stop the trace.
+  #
+  # seq is the PRIMARY KEY in both stores. The writer is supervised, and it used
+  # to initialise seq at 0, so a crash made every subsequent insert collide with
+  # an existing row. flush/1 swallows that as a counted drop, so the facility
+  # read as enabled while recording nothing until seq climbed past the old
+  # maximum. In embervm-dev, where the trace is ON, that would have made the
+  # conformance harness report vacuous forever with nothing indicating why.
+  #
+  # Drives the real Writer twice against ONE store, which is what a restart looks
+  # like. #4841.
+  test "a second writer against the same store resumes seq instead of colliding", %{writer: writer, store: store} do
+    SpecTrace.emit(:adoption, :prime, %{"vm_id" => "vm-before"})
+    :ok = SpecTrace.drain(writer)
+    assert {:ok, before} = SQLite.read_window(store, spec: "adoption")
+    assert before != []
+
+    # Same store, fresh writer: the restart.
+    :ok = Supervisor.stop(writer, :normal)
+
+    restarted =
+      start_supervised!(
+        {SpecTrace.Writer, store_mod: SQLite, store: store, batch_size: 1, flush_ms: 5},
+        id: :restarted_writer
+      )
+
+    SpecTrace.emit(:adoption, :prime, %{"vm_id" => "vm-after"})
+    :ok = SpecTrace.drain(restarted)
+
+    assert {:ok, records} = SQLite.read_window(store, spec: "adoption")
+    vm_ids = Enum.map(records, & &1["vars"]["vm_id"])
+
+    assert "vm-after" in vm_ids,
+           "the post-restart record was dropped, so seq collided on the primary key " <>
+             "and the trace silently stopped recording: #{inspect(vm_ids)}"
+
+    seqs = Enum.map(records, & &1["seq"])
+    assert seqs == Enum.uniq(seqs), "duplicate seq values: #{inspect(seqs)}"
+  end
+
   test "round trips records and preamble", %{writer: writer, store: store} do
     SpecTrace.emit(:adoption, :prime, %{"vm_id" => "vm-1", lane: :task})
     :ok = SpecTrace.drain(writer)

--- a/projects/embervm/control/test/embervm/spec_trace_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_test.exs
@@ -97,13 +97,15 @@ defmodule Embervm.SpecTraceTest do
     assert before != []
 
     # Same store, fresh writer: the restart.
-    :ok = Supervisor.stop(writer, :normal)
+    #
+    # stop_supervised!, not Supervisor.stop: the writer is an ExUnit-supervised
+    # child AND registers under a global name, so anything that leaves the old
+    # process alive makes the second start fail with :already_started rather
+    # than exercising the restart this test is about.
+    :ok = stop_supervised!(SpecTrace.Writer)
 
     restarted =
-      start_supervised!(
-        {SpecTrace.Writer, store_mod: SQLite, store: store, batch_size: 1, flush_ms: 5},
-        id: :restarted_writer
-      )
+      start_supervised!({SpecTrace.Writer, store_mod: SQLite, store: store, batch_size: 1, flush_ms: 5})
 
     SpecTrace.emit(:adoption, :prime, %{"vm_id" => "vm-after"})
     :ok = SpecTrace.drain(restarted)


### PR DESCRIPTION
Closes #4841. Two **live** defects surfaced by the #4801 design assessment, both independent of whether that toggle is ever built.

## 1. Enabling the trace in production wrote into the OP-LOG DATABASE

`spec_trace_mod/0` selected its store from `EMBERVM_OPLOG_DSN` alone. Production runs `opLog.postgres.enabled: true`, so enabling the trace would open a Postgrex connection and write `spec_trace` rows into the same database as the durable op-log.

#4770 decided the opposite explicitly, and it is the entire argument for a separate stream:

> the op-log answers "what happened to this task or session as a business object"; the trace answers "did the protocol behave"

The op-log is the durable book of record for audit, billing and projection rebuild. A debug facility must not share its database. `EMBERVM_SPEC_TRACE_PATH` now wins over the DSN.

## 2. A writer restart silently stopped the trace recording

`seq` is the PRIMARY KEY in both stores (`sqlite.ex:8`, `postgres.ex:7`) and the writer initialised it at `0`.

The writer is supervised. A crash (a store call timing out, say) restarts it, `seq` resets, and every subsequent insert collides with an existing row. `flush/1` swallows that as a counted drop plus a warning, so **the trace records nothing until seq climbs past the old maximum, while reading as enabled throughout**.

That is live in `embervm-dev` right now, where the trace is ON and the harness is meant to be watching the destroy gate execute. The failure mode is silent by construction: the endpoint returns 200, every invariant reports `vacuous` with `coverage: 0`, and all of that is *correct behaviour on an empty store*. The system honestly reports that it checked nothing and cannot say whether that is because nothing happened or because the instrument broke.

Fixed by a new `max_seq/1` on the `Store` behaviour, implemented by both backends, with the writer resuming from it.

## Two smaller ones alongside

`start_link/1` called `configure/0`, which re-reads the env and stomps the `:persistent_term`, so any writer restart would revert whatever set the gate. Harmless while the env is the only source of truth; a silent disarm the moment anything else can set it.

The preamble hardcoded `mono` to `1` while reads are `ORDER BY mono ASC`, so two writer starts in one incarnation produced two records both claiming to be first. It also consumed a `seq` without advancing the counter, which would collide the first real record against it.

## The regression test

Drives the **real Writer twice against one store**, which is what a supervised restart looks like, and asserts the post-restart record survives with unique seqs. A hand-built fixture cannot catch this: the collision exists precisely because the writer's counter and the store's contents are two representations of one fact.

## Verification

```
1287 tests, 0 failures, 6 skipped
6 processes: ... 1 remote
```

Executed remotely, not a cache replay.

## Not in this PR

The supervision restructure (#4801's design consolidates store, writer and compactor under one subtree placed late in the `:rest_for_one` chain, so a debug facility crash cannot bounce the control plane it is measuring). That is a bigger change and it belongs with the toggle decision.