### PR TITLE
fix(embervm): stop dev building five base images for workloads it never runs

### DIFF
--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -229,3 +229,39 @@ workloads:
 # unready until something is actually being served.
 servingEnvoy:
   enabled: false
+
+# Skip the base builders for workloads dev does not run.
+#
+# The Workload CR and its base BUILDER are two separate switches, and turning
+# off the one you can see leaves the expensive one running.
+# `claudeRuntimeWorkload.enabled: false` removes the CR; the builder loop in
+# _noded-pod.tpl gates on `.Values.runtimeClaude.guestImage.repository`, a
+# different key entirely.
+#
+# So dev was building all six bases on every brick start, including
+# runtime-claude, the 4 GiB image #4762 explicitly excluded ("tiny echo guest,
+# not claude-runtime"), for a workload no session can ever use. Measured: the
+# first dev brick spent roughly three of its four minutes on that one builder.
+#
+# Only `sandbox` keeps its builder, because it is the only Workload CR dev
+# enables. Emptying the repository is what the loop's `if` tests, so the init
+# container is not rendered at all.
+semgrep:
+  guestImage:
+    repository: ""
+
+runtimePython:
+  guestImage:
+    repository: ""
+
+runtimeClaude:
+  guestImage:
+    repository: ""
+
+scratchPostgres:
+  guestImage:
+    repository: ""
+
+bazelQuery:
+  guestImage:
+    repository: ""


### PR DESCRIPTION
The Workload CR and its base **builder** are two separate switches, and turning off the one you can see leaves the expensive one running.

```
claudeRuntimeWorkload.enabled: false   -> removes the Workload CR
runtimeClaude.guestImage.repository    -> gates the base BUILDER
workloads.runtimeClaude.rootfsPath     -> where that builder WRITES
```

Three keys, three different names, one conceptual workload. #4827 turned off the first and #4837 fixed the third; this is the second.

## What it cost

Dev built all six bases on every brick start, including `runtime-claude`, the 4 GiB image #4762 explicitly excluded ("tiny echo guest, not claude-runtime"), for a workload no session can ever use. The first dev brick spent roughly three of its four minutes on that one builder, and it repeats on every restart because the idempotency marker lives on the brick's scratch.

## The fix

Emptying `guestImage.repository` is what the builder loop's condition tests (`_noded-pod.tpl`: `if and  .guestImage .guestImage.repository`), so those init containers are not rendered at all.

## Verified by rendering both

```
dev   build-sandbox-rootfs
prod  build-bazel-query-rootfs, build-runtime-claude-rootfs, build-runtime-python-rootfs,
      build-sandbox-rootfs, build-scratch-postgres-rootfs, build-semgrep-rootfs
```

## Verification

```
1286 tests, 0 failures, 6 skipped
Executed 0 out of 712 tests: 712 tests pass
295 processes: ... 5 remote
```

## Worth stating as a rule

Disabling a workload in EmberVM means disabling BOTH its CR and its guest image, because they are gated on different keys and only one of them has the workload's name in it. Folded into #4832.

Auto-merge deliberately NOT armed: three concurrent auto-merges were bouncing each other `BEHIND` (no merge queue on a user-owned repo), so this waits its turn.