### PR TITLE
fix(embervm): resolve the trace writer through a scopeable name

### DIFF
--- a/projects/embervm/control/lib/embervm/spec_trace.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace.ex
@@ -5,6 +5,7 @@ defmodule Embervm.SpecTrace do
   @enabled_key {__MODULE__, :enabled}
   @dropped_key {__MODULE__, :dropped}
   @run_id_key {__MODULE__, :run_id}
+  @writer_key {__MODULE__, :writer_name}
   # Mailbox depth past which emitters stop enqueueing. Generous relative to any
   # real burst (a sweep emits one Checkpoint), small enough that a stalled
   # writer cannot accumulate meaningful heap.
@@ -56,7 +57,7 @@ defmodule Embervm.SpecTrace do
       mono = System.monotonic_time(:nanosecond)
       ts = System.system_time(:millisecond)
 
-      case Process.whereis(@writer) do
+      case Process.whereis(writer_name()) do
         pid when is_pid(pid) -> maybe_send(pid, {:emit, spec, action, vars, mono, ts})
         _ -> :ok
       end
@@ -94,6 +95,34 @@ defmodule Embervm.SpecTrace do
   defp put_dropped(msg, 0), do: msg
   defp put_dropped({:emit, spec, action, vars, mono, ts}, n),
     do: {:emit, spec, action, Map.put(vars, :spec_trace_dropped_before, n), mono, ts}
+
+  @doc """
+  The registered name `emit/3` resolves the writer through.
+
+  Defaults to the module, which is production's only shape. A test can point
+  emissions at ITS OWN writer via `scope_writer/1`, which matters because the
+  writer was a single global name: a scenario that started a writer captured
+  emissions from every other test in the same BEAM, so its store was per-test
+  while its TRACE was not.
+
+  That is not a cosmetic test concern. The restart-wedge scenario asserted on its
+  own trace and caught `health_monotonic` failing for a node it never created,
+  and the same mixing can just as easily SUPPLY the record that satisfies an
+  invariant's precondition, so a passing run is not evidence either. #4833.
+
+  Still one `:persistent_term.get/2` on the emit path, and the disabled path short
+  circuits before reaching it, so the hot path cost is unchanged.
+  """
+  @spec writer_name() :: atom()
+  def writer_name, do: :persistent_term.get(@writer_key, @writer)
+
+  @doc """
+  Point `emit/3` at `name` for the rest of this BEAM, or back at the default with
+  `nil`. Test-only: production never calls this, and the default is the module.
+  """
+  @spec scope_writer(atom() | nil) :: :ok
+  def scope_writer(nil), do: :persistent_term.put(@writer_key, @writer)
+  def scope_writer(name) when is_atom(name), do: :persistent_term.put(@writer_key, name)
 
   @doc "Wait until all events already sent to the named writer are written."
   @spec drain(GenServer.server()) :: :ok

--- a/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
+++ b/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
@@ -24,10 +24,26 @@ defmodule Embervm.RestartWedgeScenarioTest do
     # what the checker can see is a conclusion about an empty store.
     {:ok, trace_store} = TraceSQLite.start_link(name: nil, path: ":memory:")
 
+    # A SCOPED writer name, so this scenario's trace contains only this
+    # scenario's emissions.
+    #
+    # The writer used to be one global name resolved by Process.whereis, so
+    # whichever test happened to have started a writer captured emissions from
+    # every other test in the BEAM. The store was per-test; the trace was not.
+    # This scenario caught it by asserting on its own trace and finding
+    # health_monotonic failing for a node it never created, and the mixing cuts
+    # both ways: a foreign record can just as easily supply the precondition an
+    # invariant needs, so a green run was not evidence either. #4833.
+    writer_name = :"wedge_trace_writer_#{System.unique_integer([:positive])}"
+
     trace_writer =
       start_supervised!(
-        {SpecTrace.Writer, store_mod: TraceSQLite, store: trace_store, batch_size: 1, flush_ms: 5}
+        {SpecTrace.Writer,
+         name: writer_name, store_mod: TraceSQLite, store: trace_store, batch_size: 1, flush_ms: 5}
       )
+
+    SpecTrace.scope_writer(writer_name)
+    on_exit(fn -> SpecTrace.scope_writer(nil) end)
 
     context = [trace_store: trace_store, trace_writer: trace_writer]
 

--- a/projects/embervm/control/test/embervm/spec_trace_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_test.exs
@@ -121,6 +121,43 @@ defmodule Embervm.SpecTraceTest do
     assert seqs == Enum.uniq(seqs), "duplicate seq values: #{inspect(seqs)}"
   end
 
+  # Emissions follow the SCOPED writer, so one test's trace cannot contain
+  # another's records.
+  #
+  # emit/3 resolved the writer through a single global name, so whichever test
+  # had started a writer captured every other test's emissions in the same BEAM:
+  # per-test store, shared trace. A scenario could not make a clean claim about
+  # what its own actions produced, and the mixing cuts both ways, since a foreign
+  # record can supply the precondition an invariant needs. #4833.
+  test "emissions go to the scoped writer, not the default one", %{writer: default_writer, store: default_store} do
+    {:ok, other_store} = SQLite.start_link(name: nil, path: ":memory:")
+    other_name = :"scoped_writer_#{System.unique_integer([:positive])}"
+
+    other_writer =
+      start_supervised!(
+        {SpecTrace.Writer,
+         name: other_name, store_mod: SQLite, store: other_store, batch_size: 1, flush_ms: 5},
+        id: :other_writer
+      )
+
+    SpecTrace.scope_writer(other_name)
+    on_exit(fn -> SpecTrace.scope_writer(nil) end)
+
+    SpecTrace.emit(:adoption, :prime, %{"vm_id" => "vm-scoped"})
+    :ok = SpecTrace.drain(other_writer)
+    :ok = SpecTrace.drain(default_writer)
+
+    assert {:ok, scoped} = SQLite.read_window(other_store, spec: "adoption")
+    assert "vm-scoped" in Enum.map(scoped, & &1["vars"]["vm_id"]),
+           "the scoped writer did not receive the emission: #{inspect(scoped)}"
+
+    assert {:ok, leaked} = SQLite.read_window(default_store, spec: "adoption")
+
+    refute "vm-scoped" in Enum.map(leaked, & &1["vars"]["vm_id"]),
+           "the emission ALSO landed in the default writer's store, so scoping does " <>
+             "not isolate and a scenario's trace can still contain foreign records"
+  end
+
   test "round trips records and preamble", %{writer: writer, store: store} do
     SpecTrace.emit(:adoption, :prime, %{"vm_id" => "vm-1", lane: :task})
     :ok = SpecTrace.drain(writer)


### PR DESCRIPTION
Closes #4833.

`emit/3` resolved the writer through a single compile-time module name via `Process.whereis`, so whichever test had started a writer captured emissions from **every other test in the same BEAM**. The store was per-test; the trace was not.

## How it surfaced, and why it is not cosmetic

The restart-wedge scenario asserted on its own trace and caught `health_monotonic` failing:

```
node node-4/uid-210 has age_to_down without preceding age_to_unknown
```

`uid-210` is a node that scenario never created. It came from another test's `NodeRegistry` losing a stream to an unreachable address, emitted into whichever writer happened to be registered.

The mixing cuts **both ways**, which is the part that matters. A foreign record can just as easily SUPPLY the precondition an invariant needs, so a passing run was not evidence either. The hermetic lane (#4761) exists so exact interleavings can be forced rather than hoped for, and a trace that silently absorbs another test's events is the opposite property: no scenario can make a clean claim about what its own actions produced.

## The fix

`writer_name/0` reads the name from a `:persistent_term` defaulting to the module, which is production's only shape. `scope_writer/1` points emissions at a named writer for the rest of the BEAM.

**Hot path unchanged.** Still one `:persistent_term.get/2` on the emit path, and the disabled path short-circuits on the enabled check before reaching it. No per-call lookup added to the case that matters in production.

The wedge scenario now starts a uniquely-named writer, scopes to it, and restores the default in `on_exit`.

## The test asserts BOTH directions

```elixir
assert "vm-scoped" in scoped_store    # the scoped writer received it
refute "vm-scoped" in default_store   # and the default one did NOT
```

The first is satisfied by a broken implementation that sends to both writers. The second is what proves `scope_writer/1` **replaces** rather than **supplements**, which is the only interesting assertion for anything described as scoping or isolation.

## Verification

```
1288 tests, 0 failures, 6 skipped
2 processes: 1 internal, 1 remote
```

Executed remotely, not a cache replay.

## Follow-up

With contamination fixed, the wedge scenario's assertion can be widened back from three named invariants to the whole verdict list. Left for a follow-up so this does not conflict with #4840, which is editing those same lines.

Auto-merge deliberately not armed: concurrent auto-merges bounce each other `BEHIND` on a repo with no merge queue, so this queues behind #4844.