### PR TITLE
fix(embervm): bump dev to 0.12.2, the chart carrying the eight-invariant checker

### DIFF
--- a/projects/embervm/dev/deploy/application.yaml
+++ b/projects/embervm/dev/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.11.13
+      targetRevision: 0.12.2
       helm:
         valueFiles:
           - $values/projects/embervm/dev/deploy/values.yaml


### PR DESCRIPTION
Batched pin bump, closing out the dev environment work.

## Batched deliberately

Three reactive bumps tonight (#4835 destroy gate, #4839 capped scratch, and this). The pin is one number pointing at one artifact, so N changes cost **one** bump if you wait and **N** if you do not.

The rule that emerged: bump when dev needs a change to **function**, batch when it only needs to be **current**. The destroy gate and the scratch path were blocking a non-working environment. The eighth invariant is not.

## What this picks up, and what needed no bump

`0.12.2`'s image tag is `2026.08.14.06.37.49-87eeacb19`, and that commit's `checker.ex` carries `eventually_dispatched`. Verified by grepping the commit, not by assuming version ordering implied it.

Two things needed no bump at all, which is worth recording:

- **#4844's builder skip**: dev's values ship through the `$values` source pinned at `HEAD`, so values-only changes apply on merge. Only chart **content** sits behind `targetRevision`. That halves the tax for a whole class of change.
- **#4845's writer scoping**: test-isolation only. `writer_name/0` defaults to the module, so runtime behaviour is identical.

## Verified against the PULLED artifact

Not the working tree, per the lesson that cost #4835:

```
EMBERVM_NODE_CONFIRMED_DESTROY = true
EMBERVM_SPEC_TRACE             = on
init containers                build-sandbox-rootfs only
scratch                        /var/lib/embervm/scratch/dev  DirectoryOrCreate
```

## After this

Dev's `/v1/conformance` reports **eight** invariants, including the first liveness check in the system: one that can fail on a control plane doing nothing wrong, because doing nothing is the failure.