### PR TITLE
feat(swarm): compose a session walkthrough from the diff and the trailer

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -4435,6 +4435,16 @@ py_test(
 )
 
 py_test(
+    name = "swarm_walkthrough_composer_test",
+    srcs = ["swarm/walkthrough_composer_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_swarm",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "swarm_workflows_test",
     srcs = ["swarm/workflows_test.py"],
     imports = ["."],

--- a/projects/monolith/swarm/router.py
+++ b/projects/monolith/swarm/router.py
@@ -11,11 +11,28 @@ from pydantic import BaseModel
 from goosecracker.api import REPO_CATALOG
 from swarm import config, runtime
 from swarm.compare_router import router as compare_router
+from swarm.compare_router import compare_stats
+from swarm.rationale import parse_rationale
+from swarm.walkthrough_composer import compose_walkthrough
 
 router = APIRouter(prefix="/api/swarm", tags=["swarm"])
 logger = logging.getLogger(__name__)
 
 router.include_router(compare_router)
+
+
+@router.get("/walkthrough/{session_id}/{turn_seq}")
+async def walkthrough(session_id: int, turn_seq: int) -> dict:
+    """Return the composed session-tier walkthrough for one turn."""
+    from swarm.compare_router import _decode, _turn_data
+
+    data = await asyncio.to_thread(_turn_data, session_id, turn_seq)
+    if data is None:
+        raise HTTPException(status_code=404, detail="Agent turn not found")
+    compare = await compare_stats(session_id, turn_seq)
+    rationale = parse_rationale(data["result_text"])
+    usage = _decode(data.get("usage_json"), {})
+    return compose_walkthrough(session_id, turn_seq, compare, rationale, usage)
 
 
 class RunRequest(BaseModel):

--- a/projects/monolith/swarm/walkthrough_composer.py
+++ b/projects/monolith/swarm/walkthrough_composer.py
@@ -1,0 +1,279 @@
+"""Compose the session-tier walkthrough from recorded evidence."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_LARGE_ACTIVITY_COUNT = 12
+
+
+def _activities(value: Any) -> list[dict]:
+    if isinstance(value, dict):
+        value = value.get("activities", [])
+    return (
+        [item for item in value if isinstance(item, dict)]
+        if isinstance(value, list)
+        else []
+    )
+
+
+def _testimony(
+    rationale: dict, turn_seq: int, points: list[dict] | None = None
+) -> dict:
+    return {
+        "turn": rationale.get("turn", turn_seq),
+        "attempt": rationale.get("attempt", 1),
+        "points": points if points is not None else list(rationale.get("paths", [])),
+    }
+
+
+def _file_change(item: dict) -> dict:
+    return {
+        "additions": item.get("additions", 0),
+        "deletions": item.get("deletions", 0),
+        "status": item.get("status"),
+    }
+
+
+def _path_order(activities: list[dict]) -> list[str]:
+    result = []
+    for activity in activities:
+        if activity.get("type") in {"edit", "write"} and isinstance(
+            activity.get("file_path"), str
+        ):
+            if activity["file_path"] not in result:
+                result.append(activity["file_path"])
+    return result
+
+
+def _run_paths(activity: dict) -> set[str]:
+    if isinstance(activity.get("file_path"), str):
+        return {activity["file_path"]}
+    for key in ("file_paths", "files", "output_files", "produced_files"):
+        value = activity.get(key)
+        if isinstance(value, list):
+            return {path for path in value if isinstance(path, str)}
+    return set()
+
+
+def _area(rationale: dict, point: dict) -> str | None:
+    if isinstance(point.get("area"), str):
+        return point["area"]
+    areas = rationale.get("areas")
+    if isinstance(areas, dict) and isinstance(areas.get(point.get("path")), str):
+        return areas[point["path"]]
+    return None
+
+
+def _mechanical_steps(files: list[dict], activities: list[dict]) -> list[dict]:
+    mechanical = [item for item in files if item.get("classification") == "mechanical"]
+    runs = [item for item in activities if item.get("type") == "run"]
+    if not mechanical or not runs:
+        return []
+    remaining = {item.get("path"): item for item in mechanical}
+    groups: list[tuple[dict, list[dict]]] = []
+    for run in runs:
+        explicit = _run_paths(run)
+        selected = [remaining.pop(path) for path in explicit if path in remaining]
+        groups.append((run, selected))
+    # The compare has no per-file producer field. Unclaimed outputs belong to
+    # the last run that preceded them, which is the only defensible ordering
+    # available when the activity ingest omitted generator output paths.
+    if remaining:
+        groups[-1][1].extend(remaining.values())
+    return [
+        {
+            "type": "mechanical",
+            "register": "fact",
+            "count": len(items),
+            "generator_activity": run,
+        }
+        for run, items in groups
+        if items
+    ]
+
+
+def _rung4(activities: list[dict]) -> dict:
+    paths = _path_order(activities)
+    return {
+        "rung": 4,
+        "ephemeral": False,
+        "steps": [],
+        "stats": {
+            "total_files": len(paths),
+            "authored_files": len(paths),
+            "activities": paths,
+        },
+        "message": "Files touched by tools this turn; decline to offer walkthrough without intent structure",
+    }
+
+
+def compose_walkthrough(
+    session_id: int,
+    turn_seq: int,
+    compare_output: dict | None,
+    rationale_output: dict | None,
+    usage_json_activities: dict | list | None,
+) -> dict:
+    """Compose one turn's session walkthrough.
+
+    ``session_id`` is accepted as part of the public contract. It is not
+    copied into steps because the console already has it in the route.
+    """
+    del session_id
+    rationale = rationale_output if isinstance(rationale_output, dict) else {}
+    activities = _activities(usage_json_activities)
+    parsed = rationale.get("parse_status") == "parsed"
+    compare_rung = (
+        compare_output.get("resolution_rung", 1)
+        if isinstance(compare_output, dict)
+        else None
+    )
+    has_compare = compare_rung in (1, 2)
+
+    if not has_compare and not parsed:
+        authored = _path_order(activities)
+        if len(authored) > _LARGE_ACTIVITY_COUNT:
+            return _rung4(activities)
+        return {
+            "rung": 5,
+            "ephemeral": False,
+            "steps": [],
+            "message": "No activity recorded",
+        }
+    if not has_compare and parsed:
+        steps = [
+            {
+                "type": "authored",
+                "register": "testimony",
+                "file_path": item.get("path"),
+                "testimony": _testimony(rationale, turn_seq, [item]),
+            }
+            for item in rationale.get("paths", [])
+            if isinstance(item, dict) and isinstance(item.get("path"), str)
+        ]
+        if steps and rationale.get("deviations"):
+            steps[0]["testimony"]["points"].extend(
+                {"deviation": item} for item in rationale["deviations"]
+            )
+        elif rationale.get("deviations"):
+            steps.append(
+                {
+                    "type": "authored",
+                    "register": "testimony",
+                    "testimony": _testimony(
+                        rationale,
+                        turn_seq,
+                        [{"deviation": item} for item in rationale["deviations"]],
+                    ),
+                }
+            )
+        steps.extend(
+            {
+                "type": "authored",
+                "register": "fact",
+                "file_path": path,
+                "file_change": {"additions": 0, "deletions": 0, "status": "touched"},
+            }
+            for path in _path_order(activities)
+            if path
+            not in {
+                item.get("path")
+                for item in rationale.get("paths", [])
+                if isinstance(item, dict)
+            }
+        )
+        return {
+            "rung": 3,
+            "ephemeral": False,
+            "steps": steps,
+            "stats": {"authored_files": len(_path_order(activities))},
+            "message": "Limited walkthrough: testimony and activities only",
+        }
+
+    compare = compare_output
+    files = [
+        item
+        for item in compare.get("files", [])
+        if isinstance(item, dict) and isinstance(item.get("path"), str)
+    ]
+    by_path = {item["path"]: item for item in files}
+    authored_paths = {
+        item["path"] for item in files if item.get("classification") == "authored"
+    }
+    point_by_path = {
+        item.get("path"): item
+        for item in rationale.get("paths", [])
+        if isinstance(item, dict)
+    }
+    ordered = [
+        item["path"]
+        for item in rationale.get("paths", [])
+        if isinstance(item, dict) and item.get("path") in authored_paths
+    ]
+    for path in _path_order(activities) + [item["path"] for item in files]:
+        if path in authored_paths and path not in ordered:
+            ordered.append(path)
+    steps = []
+    for path in ordered:
+        item = by_path[path]
+        step = {
+            "type": "authored",
+            "register": "fact",
+            "file_path": path,
+            "file_change": _file_change(item),
+        }
+        point = point_by_path.get(path)
+        if point is not None:
+            if _area(rationale, point) is not None:
+                step["area"] = _area(rationale, point)
+            step["testimony"] = _testimony(rationale, turn_seq, [point])
+        steps.append(step)
+    steps.extend(_mechanical_steps(files, activities))
+    for path in sorted(set(compare.get("unexplained_files", []))):
+        if path in by_path:
+            steps.append(
+                {
+                    "type": "unexplained",
+                    "register": "fact",
+                    "file_path": path,
+                    "file_change": _file_change(by_path[path]),
+                    "label": "Unexplained file",
+                }
+            )
+    for path in sorted(set(compare.get("contradicted_paths", []))):
+        point = point_by_path.get(path, {"path": path})
+        steps.append(
+            {
+                "type": "contradiction",
+                "register": "testimony",
+                "label": "Contradicted path",
+                "testimony": _testimony(rationale, turn_seq, [point]),
+            }
+        )
+    if compare.get("stats", {}).get("truncated_at") or compare.get("truncated"):
+        steps.append(
+            {
+                "type": "truncation",
+                "register": "fact",
+                "label": "GitHub files truncated",
+            }
+        )
+    if compare.get("activities_truncated"):
+        steps.append(
+            {"type": "truncation", "register": "fact", "label": "activities truncated"}
+        )
+    return {
+        "rung": compare_rung,
+        "ephemeral": compare_rung == 2,
+        "steps": steps,
+        "stats": compare.get("stats", {}),
+        **(
+            {
+                "message": "This walkthrough becomes unavailable once this branch is deleted"
+            }
+            if compare_rung == 2
+            else {}
+        ),
+    }

--- a/projects/monolith/swarm/walkthrough_composer_test.py
+++ b/projects/monolith/swarm/walkthrough_composer_test.py
@@ -1,0 +1,148 @@
+import json
+
+from swarm.walkthrough_composer import compose_walkthrough
+
+
+def _rationale(paths=(), deviations=()):
+    return {
+        "parse_status": "parsed",
+        "paths": [{"path": path, "why": "because"} for path in paths],
+        "deviations": list(deviations),
+        "parser_version": 1,
+    }
+
+
+def _compare(files, rung=1, **extra):
+    stats = extra.pop("stats", {"total_files": len(files)})
+    return {
+        "resolution_rung": rung,
+        "files": files,
+        "stats": stats,
+        "unexplained_files": [],
+        "contradicted_paths": [],
+        **extra,
+    }
+
+
+def _file(path, classification="authored"):
+    return {
+        "path": path,
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "classification": classification,
+    }
+
+
+def test_rungs_one_and_two_are_full_and_two_is_ephemeral():
+    files = [_file("a.py")]
+    one = compose_walkthrough(1, 2, _compare(files), _rationale(["a.py"]), {})
+    assert one["rung"] == 1
+    assert one["ephemeral"] is False
+    two = compose_walkthrough(1, 2, _compare(files, rung=2), _rationale(["a.py"]), {})
+    assert two["rung"] == 2
+    assert two["ephemeral"] is True
+    assert "branch is deleted" in two["message"]
+
+
+def test_rung_three_has_testimony_and_activities_without_diff_stats():
+    result = compose_walkthrough(
+        1,
+        2,
+        None,
+        _rationale(["a.py"], ["used a fallback"]),
+        {
+            "activities": [
+                {"type": "edit", "file_path": "a.py"},
+                {"type": "write", "file_path": "b.py"},
+            ]
+        },
+    )
+    assert result["rung"] == 3
+    assert result["message"].startswith("Limited walkthrough")
+    assert {step.get("file_path") for step in result["steps"]} == {"a.py", "b.py"}
+    assert {
+        point.get("deviation")
+        for point in result["steps"][0]["testimony"]["points"]
+        if "deviation" in point
+    } == {"used a fallback"}
+    assert all(
+        "file_change" not in step
+        for step in result["steps"]
+        if step.get("register") == "testimony"
+    )
+
+
+def test_rungs_four_and_five_decline_or_stop():
+    activities = {
+        "activities": [{"type": "edit", "file_path": f"f{i}.py"} for i in range(20)]
+    }
+    four = compose_walkthrough(1, 1, None, {"parse_status": "none"}, activities)
+    assert four["rung"] == 4
+    assert four["steps"] == []
+    assert "decline" in four["message"]
+    five = compose_walkthrough(1, 1, None, {"parse_status": "none"}, {})
+    assert five["rung"] == 5
+    assert five["message"] == "No activity recorded"
+
+
+def test_mechanical_files_collapse_per_generator_run_and_authored_order_is_retained():
+    files = [
+        _file("a.py"),
+        _file("one.out", "mechanical"),
+        _file("two.out", "mechanical"),
+        _file("three.out", "mechanical"),
+    ]
+    activities = {
+        "activities": [
+            {"type": "edit", "file_path": "a.py"},
+            {
+                "type": "run",
+                "command": "ci regen",
+                "produced_files": ["one.out", "two.out"],
+            },
+            {"type": "run", "command": "asset regen", "produced_files": ["three.out"]},
+        ]
+    }
+    result = compose_walkthrough(1, 1, _compare(files), _rationale(), activities)
+    mechanical = [step for step in result["steps"] if step["type"] == "mechanical"]
+    assert [step["count"] for step in mechanical] == [2, 1]
+    assert [step["generator_activity"]["command"] for step in mechanical] == [
+        "ci regen",
+        "asset regen",
+    ]
+    assert result["steps"][0]["file_path"] == "a.py"
+
+
+def test_truncation_cross_checks_and_register_shape():
+    files = [_file("a.py"), _file("generated.py", "mechanical")]
+    compare = _compare(
+        files,
+        stats={"total_files": 300, "truncated_at": 300},
+        unexplained_files=["a.py", "generated.py"],
+        contradicted_paths=["missing.py"],
+        activities_truncated=True,
+    )
+    result = compose_walkthrough(1, 1, compare, _rationale(["missing.py"]), {})
+    assert [
+        step["label"] for step in result["steps"] if step["type"] == "truncation"
+    ] == ["GitHub files truncated", "activities truncated"]
+    assert any(
+        step["type"] == "unexplained" and step["file_path"] == "a.py"
+        for step in result["steps"]
+    )
+    contradiction = next(
+        step for step in result["steps"] if step["type"] == "contradiction"
+    )
+    assert contradiction["register"] == "testimony"
+    assert contradiction["testimony"]["points"][0]["path"] == "missing.py"
+    assert all("T" not in json.dumps(step) for step in result["steps"])
+
+
+def test_composer_has_no_run_tier_filename_representation():
+    result = compose_walkthrough(
+        1, 1, _compare([_file("a.py")]), _rationale(["a.py"]), {}
+    )
+    # The session composer emits only session steps. A run view must link here,
+    # not inline this payload, so no run-tier field is introduced accidentally.
+    assert "run" not in result


### PR DESCRIPTION
Reopens the work from #4815, which I closed in favour of composing client-side in #4816. That call was wrong, and the evidence is that #4816's own rework now fetches `/api/swarm/walkthrough/{session}/{turn}` (`SessionWalkthrough.svelte:91`), an endpoint that does not exist on main. Landing #4816 without this ships a walkthrough that 404s for every session.

ADR 056 decision 5 puts step composition server-side, and ADR 054 decision 3 says the server owns every composed sentence. This is that composition.

## What it does

A turn's compare plus its parsed rationale become an ordered list of steps.

- **Authored files** become steps grouped under the trailer's named areas.
- **Mechanical files** collapse to one step per generator run carrying a count, so a turn that ran `ci regen` is one step saying it produced 143 files rather than 143 steps. That is what keeps a large change legible.
- **Each step carries its register.** The diff's file stats are fact, the agent's trailer points are testimony quoted in the agent's own order, and the mechanical classification is fact.
- **The cross-check is carried through rather than aggregated away.** A changed file no point mentions is surfaced as unexplained in system voice; a point naming a file absent from the diff is marked contradicted. Both flag, neither blocks (ADR 056 decision 4).
- **Both truncation caps are stated rather than swallowed.** GitHub's files array and the activities ingest each cap around 300, and a silent cap turns a large change into a small-looking one.
- **All five degradation rungs are labelled as what they are**, including rung 4, which declines to offer a walk at all when there is no compare, no trailer, and more than a dozen files. Declining is the answer there; a walk over an unstructured diff would be a worse surface wearing an honest label.

## Verification

`ci test //projects/monolith:swarm_walkthrough_composer_test --nocache_test_results` → `Executed 1 out of 1 test: 1 test passes` (forced, not a cache replay).

Checked every field the composer reads against what `compare_router.py` actually emits on main, rather than against the shape it was written for: `resolution_rung`, `unexplained_files`, `contradicted_paths`, `classification`, `activities_truncated`, `truncated_at` all exist. `_decode` and `_turn_data` are importable from `compare_router`, and `router.py` already imports `asyncio` and `HTTPException`.

## Known, deliberately not fixed here

- **#4817 does not reach this surface.** `compare_router` reports every trailer path as contradicted when `paths` is empty, which happens at `resolution_rung == 3`. The composer's `has_compare = compare_rung in (1, 2)` guard means it never reads `contradicted_paths` in that case. It remains reachable at rung 1/2 with a genuinely empty diff, and that is #4817's job, not this PR's.
- **The turn row is read twice per request**: once here for `result_text` and `usage_json`, and again inside `compare_stats`. Two DB round trips where one would do. Worth folding later; it is not worth blocking a 404 fix.

**Not verified: that the composed payload renders correctly.** That is only observable once #4816 lands on top of this and both are deployed.