### PR TITLE
docs(embervm): document the two destroy invariants and guard the list

### DIFF
--- a/projects/embervm/control/lib/embervm/spec_trace/checker.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/checker.ex
@@ -45,9 +45,25 @@ defmodule Embervm.SpecTrace.Checker do
   5. **PrimeBeforeCheckpoint** — every vm_id in a `checkpoint` inventory set
      has a preceding `prime` or `adopt_inventory` in the run.
 
+  6. **DestroyIntentPrecedesRecord**: every `confirm_destroy` for a live VM
+     (`had_vm: true`) has a `begin_destroy` for the same session_id earlier in
+     the run. Vacuous when the window holds no live-VM confirmations, because a
+     run that destroyed nothing cannot evidence the destroy ordering.
+
+  7. **NoDestroyBeforeConfirm**: a gated `confirm_destroy` (`gate: true`)
+     always carries `node_confirmed: true`, so the control plane records a
+     destroy only after the node confirmed it by teardown or by absence.
+     Vacuous when every confirmation took the gate-off path.
+
   8. **EventuallyDispatched** (bounded liveness) — a task queued at checkpoint
      N must be assigned or succeeded by checkpoint N+K if inventory persists
      across the window.
+
+  This list is the fourth copy of the invariant set (#4802): `invariants/0` is
+  the source, `check_invariant/2` dispatches on it, and the router reads it. The
+  prose here drifted first, documenting 6 of 8 while numbering the last one 8,
+  so `documents every invariant it evaluates` in the test suite now holds it to
+  `invariants/0` rather than to review.
   """
 
   alias Embervm.SpecTrace.Store

--- a/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
@@ -616,6 +616,61 @@ defmodule Embervm.SpecTrace.CheckerTest do
     end
   end
 
+  describe "the moduledoc and invariants/0 agree" do
+    # #4802 is about lists that must agree and are kept in sync by hand, where
+    # disagreement reports green rather than erroring. Both router sites now read
+    # `invariants/0`, so the code copies are gone, but the prose copy in the
+    # moduledoc survived and immediately drifted: it documented 6 of the 8 and
+    # numbered the last one 8, which is what a reader consults to learn what the
+    # endpoint covers. An operator reading it during an incident would conclude
+    # the destroy ordering is not checked at all.
+    #
+    # Deriving the expected heading from the atom is the point. A hand-written
+    # list of expected headings here would be a FIFTH copy, drifting the same way.
+    test "every invariant in invariants/0 has a moduledoc entry" do
+      {:docs_v1, _, _, _, %{"en" => moduledoc}, _, _} = Code.fetch_docs(Checker)
+
+      undocumented =
+        Enum.reject(Checker.invariants(), fn invariant ->
+          heading =
+            invariant
+            |> Atom.to_string()
+            |> String.split("_")
+            |> Enum.map_join(&String.capitalize/1)
+
+          String.contains?(moduledoc, "**#{heading}**")
+        end)
+
+      assert undocumented == [],
+             "invariants evaluated but not documented: #{inspect(undocumented)}"
+    end
+
+    # The other direction. A heading with no invariant behind it is the same
+    # defect read backwards: the moduledoc promises a check the endpoint never
+    # runs, and nothing fails because prose cannot fail.
+    test "every moduledoc entry is an invariant invariants/0 evaluates" do
+      {:docs_v1, _, _, _, %{"en" => moduledoc}, _, _} = Code.fetch_docs(Checker)
+
+      documented =
+        Regex.scan(~r/^\s*\d+\. \*\*(\w+)\*\*/m, moduledoc, capture: :all_but_first)
+        |> List.flatten()
+
+      evaluated =
+        Enum.map(Checker.invariants(), fn invariant ->
+          invariant
+          |> Atom.to_string()
+          |> String.split("_")
+          |> Enum.map_join(&String.capitalize/1)
+        end)
+
+      # Positive control: a regex that matches nothing would make the assertion
+      # below pass over an empty list, which is the empty-collection false PASS
+      # this whole module exists to refuse.
+      assert length(documented) == length(evaluated)
+      assert documented -- evaluated == []
+    end
+  end
+
   defp destroy_verdict(verdicts, invariant) do
     Enum.find(verdicts, &(&1[:invariant] == invariant))
   end


### PR DESCRIPTION
Closes #4802 by removing the copy that outlived its fix.

## The finding

`Checker`'s moduledoc enumerated **6 of the 8** invariants `invariants/0` evaluates, and numbered the last one `8` where `6.` and `7.` should have been. The gap is not cosmetic: the two it omitted are `destroy_intent_precedes_record` and `no_destroy_before_confirm`, the pair that landed with the destroy gate.

```
invariants/0:  no_double_assign dispatch_provenance adopt_idempotent health_monotonic
               prime_before_checkpoint destroy_intent_precedes_record
               no_destroy_before_confirm eventually_dispatched   (8)
moduledoc:     1. 2. 3. 4. 5. 8.                                 (6)
```

## Why this is #4802's own pattern

#4802 is about two or more lists that must agree, kept in sync by hand, where disagreement produces a green report rather than an error. Its fix replaced the two hardcoded lists in `router.ex` with `Checker.invariants()`, which is why the endpoint is correct today.

The prose copy was not counted, and it is the one a human reads. An operator opening this module during an incident to learn what `GET /v1/conformance` covers would conclude the destroy ordering is not checked at all. It is checked. The docs stopped tracking it.

## The fix, and why the test is the load-bearing half

Entries 6 and 7 are written, so the numbering is contiguous again.

More importantly, a test now derives each expected heading from `invariants/0` rather than restating it:

```elixir
heading = invariant |> Atom.to_string() |> String.split("_") |> Enum.map_join(&String.capitalize/1)
String.contains?(moduledoc, "**#{heading}**")
```

Deriving is the point. A hand-written list of expected headings in the test would have been a **fifth** copy, drifting the same way, and the failure mode would again be silence. Both directions are asserted: an invariant with no entry (the bug found here), and an entry with no invariant (prose promising a check the endpoint never runs).

## Verification

Both tests were run red before green, because a guard that has never failed is not yet evidence. Removing entry 6 from the moduledoc:

```
1) test ... every moduledoc entry is an invariant invariants/0 evaluates
   code: assert length(documented) == length(evaluated)
2) test ... every invariant in invariants/0 has a moduledoc entry
   invariants evaluated but not documented: [:destroy_intent_precedes_record]
1293 tests, 2 failures, 6 skipped
```

Restored: `1293 tests, 0 failures, 6 skipped`. Same count both runs, so the two tests ran in the green run rather than being silently uncollected.

The second test also carries an explicit `length(documented) == length(evaluated)` control, because a regex that matched nothing would otherwise make `documented -- evaluated == []` pass over an empty list. That is the empty-collection false PASS this module exists to refuse, and it is worth not reintroducing in the test that guards it.