### PR TITLE
fix(swarm): stop reporting contradictions the compare never checked

### DIFF
--- a/projects/monolith/swarm/compare_router.py
+++ b/projects/monolith/swarm/compare_router.py
@@ -167,8 +167,17 @@ async def compare_stats(session_id: int, turn_seq: int) -> dict:
             compare = await _compare(repo, "main", branch, f"branch:{branch}")
 
     paths = {item["path"] for item in compare["files"]}
+    # The cross-check is only meaningful against a diff we actually resolved.
+    # At rung 3 there is no compare, so `paths` is empty because nothing was
+    # fetched, not because the agent changed nothing. Differencing against it
+    # would report every path the agent named as contradicted and every
+    # changed file as explained, which states the opposite of the truth in
+    # both directions (issue #4817). Absence of evidence is not a finding:
+    # omit both halves and let `cross_checked` say the check did not run.
+    cross_checked = resolution_rung in (1, 2)
     result = {
         "resolution_rung": resolution_rung,
+        "cross_checked": cross_checked,
         "diff_type": diff_type,
         "base_sha": base_sha,
         "commit_sha": commit_sha,
@@ -187,8 +196,14 @@ async def compare_stats(session_id: int, turn_seq: int) -> dict:
         },
         "trailer_parsed": rationale.get("parse_status") == "parsed",
         "authored_file_paths": sorted(authored),
-        "unexplained_files": sorted(paths - trailer_paths),
-        "contradicted_paths": sorted(trailer_paths - paths),
+        **(
+            {
+                "unexplained_files": sorted(paths - trailer_paths),
+                "contradicted_paths": sorted(trailer_paths - paths),
+            }
+            if cross_checked
+            else {}
+        ),
     }
     if activities_truncated:
         result["activities_truncated"] = True

--- a/projects/monolith/swarm/compare_router_test.py
+++ b/projects/monolith/swarm/compare_router_test.py
@@ -100,6 +100,13 @@ async def test_branch_and_absence_resolution(monkeypatch):
     result = await mod.compare_stats(1, 1)
     assert result["resolution_rung"] == 3
     assert result["error"] == "no_compare_available"
+    # Issue #4817. This turn's trailer names a.py and no diff was fetched, so
+    # the old set difference reported a.py as contradicted: the agent accused
+    # of describing work it did not do, on the strength of no evidence at all.
+    # The cross-check has to be absent here, not empty and not populated.
+    assert result["cross_checked"] is False
+    assert "contradicted_paths" not in result
+    assert "unexplained_files" not in result
 
 
 @pytest.mark.asyncio
@@ -121,6 +128,7 @@ async def test_truncation_activities_and_cross_checks(monkeypatch):
     result = await mod.compare_stats(1, 1)
     assert result["activities_truncated"] is True
     assert result["stats"]["truncated_at"] == 300
+    assert result["cross_checked"] is True
     assert result["unexplained_files"] == ["a.py", "generated.py"]
     assert result["contradicted_paths"] == ["missing.py"]
 


### PR DESCRIPTION
Closes #4817.

## The defect

`compare_stats` computed its cross-check as a pair of set differences against the paths in the fetched diff:

```python
"unexplained_files": sorted(paths - trailer_paths),
"contradicted_paths": sorted(trailer_paths - paths),
```

At resolution rung 3 no diff is fetched at all, so `paths` is empty because nothing was looked at, not because the agent changed nothing. The difference then reported **every path the agent's trailer named as contradicted**: an accusation that it described work it did not do, resting on no evidence whatsoever.

The mirror error rode along silently. `unexplained_files` came out empty, which reads as "nothing unexplained" when it means "nothing checked". Same category error in the opposite direction, and harder to notice because empty looks like good news.

## The fix

Both halves are emitted only when the diff actually resolved. A `cross_checked` boolean states which of the two conditions the payload is in, so a reader does not have to infer it from a rung number.

The cross-check exists to make a self-authored narrative safe to show (ADR 056 decision 3). A false contradiction is worse than no cross-check: it discredits accurate rationale exactly when the system knows least.

## Blast radius

Checked every consumer rather than assuming:

| consumer | reads | safe? |
|---|---|---|
| `walkthrough_composer.py` | `.get("unexplained_files", [])`, `.get("contradicted_paths", [])` | yes, defaults |
| `compare_router_test.py` | both, asserted | updated |
| frontend | neither, reads composer step shapes | yes |

The composer's `has_compare = compare_rung in (1, 2)` guard already kept rung 3 out of the contradiction branch, which is why the console was correct before this. The endpoint is the shared surface, though, so any other reader inherited the false accusation.

## Verification

`ci test //projects/monolith:swarm_compare_router_test //projects/monolith:swarm_walkthrough_composer_test --nocache_test_results` → `Executed 2 out of 2 tests: 2 tests pass`. Forced, not a cache replay.

The rung-3 test now asserts the absence directly. That turn's trailer names `a.py` and no diff is fetched, so before this change the assertion `"contradicted_paths" not in result` failed with `["a.py"]` present, which is the bug reproduced rather than described.