### PR TITLE
fix(helm): let a dev Application opt into the chart version write-back

### DIFF
--- a/bazel/helm/write-back-versions.sh
+++ b/bazel/helm/write-back-versions.sh
@@ -84,6 +84,67 @@ _app_yaml_for() {
 	echo ""
 }
 
+# Further Applications whose chart pin this bot maintains, beyond the production
+# one _app_yaml_for finds. One per line, empty if none.
+#
+# OPT-IN BY MARKER, NOT BY PATH CONVENTION, and the distinction is the whole
+# point. `projects/<svc>/dev/deploy/application.yaml` is not uniformly ours to
+# write: Kargo owns monolith-dev's targetRevision at runtime (#4744), and the
+# value committed there is a deliberately frozen bootstrap floor that drifts
+# from the live one on purpose. A path rule matching `*/dev/deploy/` would
+# rewrite that floor on every publish, fighting the promotion pipeline and
+# destroying the revert lever the committed value exists to be. So an
+# Application joins the write-back only by saying so in its own file.
+#
+# A dev Application that opts in catches up in ONE jump the next time its chart
+# publishes, rather than walking forward one version at a time, because the
+# version written is whatever main just published.
+MANAGED_MARKER='chart-version-bot: manage-target-revision'
+
+_opted_in_app_yamls_for() {
+	local chart_dir="$1" svc_dir candidate
+	svc_dir="$(dirname "$chart_dir")"
+	shopt -s nullglob
+	for candidate in "${svc_dir}"/*/deploy/application.yaml; do
+		if [[ -f "$candidate" ]] && grep -qF "$MANAGED_MARKER" "$candidate"; then
+			echo "$candidate"
+		fi
+	done
+	shopt -u nullglob
+	return 0
+}
+
+# Point one Application's semver targetRevision at `version`, staging it if it
+# moved. Split out of the main loop so production and every opted-in
+# Application go through the SAME anchoring and verification, rather than the
+# dev path getting a looser copy of it.
+_rewrite_target_revision() {
+	local app_yaml="$1" version="$2" tr_count old_tr
+	# Match ONLY a semver targetRevision. deploy/application.yaml is a
+	# multi-source Application: the chart source is pinned to a version,
+	# and the $values source is a GIT REF (`targetRevision: HEAD`).
+	# A loose `grep targetRevision: | head -1` would eventually rewrite
+	# that git ref into a chart version and break the values source, so
+	# the pattern is anchored to a semver and the count is asserted.
+	# This mirrors bump-chart.sh, which got it right first.
+	tr_count=$(grep -cE "$SEMVER_TR_RE" "$app_yaml" || true)
+	if [[ "$tr_count" -ne 1 ]]; then
+		echo "WARNING: ${app_yaml} has ${tr_count} semver targetRevision line(s), expected 1; leaving it alone." >&2
+		return 0
+	fi
+	old_tr=$(grep -E "$SEMVER_TR_RE" "$app_yaml" | head -1 | awk '{print $2}' | tr -d '"')
+	if [[ "$old_tr" == "$version" ]]; then
+		return 0
+	fi
+	sed "s/targetRevision: ${old_tr}\$/targetRevision: ${version}/" "$app_yaml" >"${app_yaml}.tmp"
+	mv "${app_yaml}.tmp" "$app_yaml"
+	if ! grep -qF "targetRevision: ${version}" "$app_yaml"; then
+		echo "ERROR: failed to rewrite targetRevision in ${app_yaml} (unusual formatting?)." >&2
+		exit 1
+	fi
+	git add "$app_yaml"
+}
+
 git config user.name "chart-version-bot"
 git config user.email "chart-version-bot@users.noreply.github.com"
 
@@ -124,29 +185,20 @@ while [[ "$attempt" -le "$TRIES" ]]; do
 
 		APP_YAML="$(_app_yaml_for "$CHART_DIR")"
 		if [[ -n "$APP_YAML" ]]; then
-			# Match ONLY a semver targetRevision. deploy/application.yaml is a
-			# multi-source Application: the chart source is pinned to a version,
-			# and the $values source is a GIT REF (`targetRevision: HEAD`).
-			# A loose `grep targetRevision: | head -1` would eventually rewrite
-			# that git ref into a chart version and break the values source, so
-			# the pattern is anchored to a semver and the count is asserted.
-			# This mirrors bump-chart.sh, which got it right first.
-			TR_COUNT=$(grep -cE "$SEMVER_TR_RE" "$APP_YAML" || true)
-			if [[ "$TR_COUNT" -ne 1 ]]; then
-				echo "WARNING: ${APP_YAML} has ${TR_COUNT} semver targetRevision line(s), expected 1; leaving it alone." >&2
-			else
-				OLD_TR=$(grep -E "$SEMVER_TR_RE" "$APP_YAML" | head -1 | awk '{print $2}' | tr -d '"')
-				if [[ "$OLD_TR" != "$VERSION" ]]; then
-					sed "s/targetRevision: ${OLD_TR}\$/targetRevision: ${VERSION}/" "$APP_YAML" >"${APP_YAML}.tmp"
-					mv "${APP_YAML}.tmp" "$APP_YAML"
-					if ! grep -qF "targetRevision: ${VERSION}" "$APP_YAML"; then
-						echo "ERROR: failed to rewrite targetRevision in ${APP_YAML} (unusual formatting?)." >&2
-						exit 1
-					fi
-					git add "$APP_YAML"
-				fi
-			fi
+			_rewrite_target_revision "$APP_YAML" "$VERSION"
 		fi
+
+		# Opted-in Applications (a dev environment tracking the same chart).
+		# Read into an array first: _rewrite_target_revision runs `git add`, and
+		# piping the loop's input from a process substitution while git writes
+		# the index has bitten this repo before.
+		OPTED_IN=()
+		while IFS= read -r extra_yaml; do
+			[[ -n "$extra_yaml" ]] && OPTED_IN+=("$extra_yaml")
+		done < <(_opted_in_app_yamls_for "$CHART_DIR")
+		for extra_yaml in "${OPTED_IN[@]+"${OPTED_IN[@]}"}"; do
+			_rewrite_target_revision "$extra_yaml" "$VERSION"
+		done
 
 		SUMMARY+=("${CHART_DIR}: ${ON_MAIN} -> ${VERSION}")
 		CHANGED=$((CHANGED + 1))

--- a/bazel/helm/write-back-versions_test.sh
+++ b/bazel/helm/write-back-versions_test.sh
@@ -212,6 +212,59 @@ else
 	FAILURES=$((FAILURES + 1))
 fi
 
+# Add a dev-environment Application beside the production one, pinned BEHIND it,
+# with or without the opt-in marker. Committed through the clone so origin/main
+# carries it before the script runs.
+add_dev_app() {
+	local clone="$1" version="$2" marker="$3" path="$clone/projects/demo/dev/deploy"
+	mkdir -p "$path"
+	{
+		echo "spec:"
+		echo "  sources:"
+		echo "    - repoURL: oci://ghcr.io/jomcgi/homelab/charts"
+		echo "      chart: demo"
+		if [[ "$marker" == "marked" ]]; then
+			echo "      # chart-version-bot: manage-target-revision"
+		fi
+		echo "      targetRevision: ${version}"
+		echo "    - repoURL: https://github.com/jomcgi/homelab"
+		echo "      targetRevision: HEAD"
+		echo "      ref: values"
+	} >"$path/application.yaml"
+	git -C "$clone" add -A
+	git -C "$clone" commit --quiet -m "chore: seed dev application"
+	git -C "$clone" push --quiet origin main
+}
+
+# 7. An opted-in dev Application advances with the chart, in one jump. Without
+# this the dev pin freezes at whatever bootstrapped it and drifts further from
+# production on every publish, which is what #4832 recorded.
+clone=$(new_env devopt 0.1.0)
+add_dev_app "$clone" 0.0.9 marked
+record "$TMP/rec-devopt" demo projects/demo/chart 0.2.0
+(cd "$clone" && bash "$SCRIPT" "$TMP/rec-devopt" >/dev/null 2>&1)
+git -C "$clone" fetch --quiet origin main
+expect "opted-in dev pin advances" "0.2.0" \
+	"$(version_on_main "$clone" projects/demo/dev/deploy/application.yaml)" "marker present"
+expect "dev \$values ref survives" "1" \
+	"$(git -C "$clone" show origin/main:projects/demo/dev/deploy/application.yaml |
+		grep -c 'targetRevision: HEAD')" "same anchored pattern as production"
+
+# 8. THE ONE THAT MATTERS. A dev Application with no marker is not ours to
+# write. This is monolith-dev: Kargo owns its targetRevision at runtime (#4744),
+# and the committed value is a deliberately frozen bootstrap floor kept as the
+# revert lever. A path-based rule matching */dev/deploy/ would rewrite it on
+# every publish, fight the promotion pipeline, and destroy the lever silently.
+clone=$(new_env devunmarked 0.1.0)
+add_dev_app "$clone" 0.0.9 plain
+record "$TMP/rec-devplain" demo projects/demo/chart 0.2.0
+(cd "$clone" && bash "$SCRIPT" "$TMP/rec-devplain" >/dev/null 2>&1)
+git -C "$clone" fetch --quiet origin main
+expect "unmarked dev pin untouched" "0.0.9" \
+	"$(version_on_main "$clone" projects/demo/dev/deploy/application.yaml)" "no marker, not ours to write"
+expect "production advances regardless" "0.2.0" \
+	"$(version_on_main "$clone" projects/demo/deploy/application.yaml)" "dev opt-in does not gate production"
+
 if [[ "$FAILURES" -gt 0 ]]; then
 	echo "${FAILURES} test(s) failed"
 	exit 1

--- a/projects/embervm/dev/deploy/application.yaml
+++ b/projects/embervm/dev/deploy/application.yaml
@@ -7,6 +7,16 @@ spec:
   project: default
   sources:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
+    #
+    # chart-version-bot: manage-target-revision
+    #
+    # Opts this pin into the post-merge write-back, so dev advances with the
+    # chart instead of freezing at whatever it was bootstrapped to (#4832).
+    # The marker is required rather than implied by the path: monolith-dev's
+    # equivalent is Kargo-owned (#4744) and its committed value is a frozen
+    # revert lever, so the bot must never assume a dev Application is its to
+    # write. EmberVM has no promotion pipeline yet (#4762 deferred it), which
+    # is exactly why this one wants the bot.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
       targetRevision: 0.12.2


### PR DESCRIPTION
Closes #4832 item 2.

## The bug

`_app_yaml_for` resolves exactly one Application per chart, production's:

```bash
candidate="$(dirname "$chart_dir")/deploy/application.yaml"
```

So `projects/embervm/dev/deploy/application.yaml` is never written. embervm-dev's pin froze at whatever bootstrapped it and drifts further from production on every publish. Three manual bumps in one evening is what surfaced it.

## Why the obvious fix is wrong

A path rule for `*/dev/deploy/application.yaml` would have shipped in five lines and broken production.

`monolith-dev`'s `targetRevision` is **Kargo-owned at runtime** (#4744). The value committed in git is a deliberately frozen bootstrap floor (`0.293.0`), kept as the revert lever, and `git != live` there is correct rather than a stuck deploy. A path rule rewrites that floor on every publish: it fights the promotion pipeline, and it destroys the lever silently, because rewriting a value nobody reads produces no error.

Two dev Applications, the same path shape, opposite ownership. So ownership has to be stated, not inferred:

```yaml
# chart-version-bot: manage-target-revision
```

embervm carries it, because #4762 deferred Kargo for embervm deliberately ("standing up an environment and a promotion pipeline at once means a failure in either looks like a failure in the other"). monolith-dev does not, and is untouched. Verified against the real tree:

```
embervm  -> [projects/embervm/dev/deploy/application.yaml]
monolith -> []
```

## Shared rewrite path

The rewrite moves out of the loop body into `_rewrite_target_revision`, so production and every opted-in Application go through the **same** anchored semver pattern and the same post-write verification. The alternative, a second rewrite for the dev path, is how a `$values` git ref eventually gets rewritten into a chart version: the anchoring comment in this file exists because that class of bug already happened once.

## Verification

`Executed 1 out of 1 test: 1 test passes.`

Four new assertions, and the load-bearing one was run red first. Against a path-based implementation (marker check removed):

```
FAIL: unmarked dev pin untouched: want '0.0.9', got '0.2.0'
```

which is precisely the monolith-dev regression, reproduced on demand.

## Note on catch-up

An opted-in dev pin advances in one jump on the next publish of its chart, not one version at a time, because the version written is whatever main just published. embervm-dev will go from `0.12.2` to current the first time the embervm chart publishes after this lands. That is the intent, and it is worth knowing before it happens rather than after.