### PR TITLE
test(ci): assert ci test mirrors the pr-checks resource requests

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -50,6 +50,11 @@ exports_files(
     visibility = ["//:__subpackages__"],
 )
 
+exports_files(
+    ["buildbuddy.yaml"],
+    visibility = ["//bazel/tools/ci:__pkg__"],
+)
+
 # Produce aspect_rules_py targets rather than rules_python
 # gazelle:map_kind py_binary py_venv_binary @aspect_rules_py//py/private/py_venv:defs.bzl
 # gazelle:map_kind py_library py_library @aspect_rules_py//py:defs.bzl

--- a/bazel/tools/ci/BUILD
+++ b/bazel/tools/ci/BUILD
@@ -8,5 +8,8 @@ exports_files(["ci"])
 sh_test(
     name = "ci_test",
     srcs = ["ci_test.sh"],
-    data = ["ci", "//:buildbuddy.yaml"],
+    data = [
+        "ci",
+        "//:buildbuddy.yaml",
+    ],
 )

--- a/bazel/tools/ci/BUILD
+++ b/bazel/tools/ci/BUILD
@@ -8,5 +8,5 @@ exports_files(["ci"])
 sh_test(
     name = "ci_test",
     srcs = ["ci_test.sh"],
-    data = ["ci"],
+    data = ["ci", "//:buildbuddy.yaml"],
 )

--- a/bazel/tools/ci/ci_test.sh
+++ b/bazel/tools/ci/ci_test.sh
@@ -18,6 +18,21 @@ if [[ -z "$CI" ]]; then
 	exit 1
 fi
 
+BUILD_BUDDY=""
+for candidate in \
+	"${RUNFILES_DIR:-}/_main/buildbuddy.yaml" \
+	"${TEST_SRCDIR:-}/_main/buildbuddy.yaml" \
+	"${BASH_SOURCE[0]%/*}/../../..//buildbuddy.yaml"; do
+	if [[ -f "$candidate" ]]; then
+		BUILD_BUDDY="$(cd "${candidate%/*}" && pwd)/${candidate##*/}"
+		break
+	fi
+done
+if [[ -z "$BUILD_BUDDY" ]]; then
+	echo "ERROR: cannot locate buildbuddy.yaml" >&2
+	exit 1
+fi
+
 PASS=0
 FAIL=0
 pass() {
@@ -28,6 +43,82 @@ fail() {
 	echo "FAIL [$1]: $2"
 	FAIL=$((FAIL + 1))
 }
+
+resource_requests="$(awk '
+	$0 ~ /^  - name: "pr-checks"$/ { in_pr_checks = 1; next }
+	in_pr_checks && $0 ~ /^  - name: / { exit }
+	in_pr_checks && $0 ~ /^    resource_requests:$/ { in_resources = 1; next }
+	in_resources && $0 ~ /^      [a-z]+:/ { parse_resource = 1 }
+	in_resources && $0 ~ /^[[:space:]]*(#|$)/ { next }
+	in_resources && !parse_resource { exit }
+	in_resources {
+		key = $1
+		sub(/:$/, "", key)
+		value = $2
+		sub(/^"/, "", value)
+		sub(/"$/, "", value)
+		print key "=" value
+		parse_resource = 0
+	}
+' "$BUILD_BUDDY")"
+
+resource_properties=()
+while IFS= read -r property; do
+	[[ -n "$property" ]] && resource_properties+=("$property")
+done < <(grep -oE -- '--runner_exec_properties=[^[:space:]\\]+=[^[:space:]\\]+' "$CI" |
+	sed 's/.*--runner_exec_properties=//')
+
+# Record each drift with its specific cause, and do not stop at the first one.
+# The whole reason this test exists is that the drift is otherwise silent, so a
+# failure that only says "they do not match" leaves the reader doing by hand the
+# comparison the test just did.
+drift=()
+
+while IFS='=' read -r yaml_key _; do
+	case "$yaml_key" in
+	'') ;;
+	cpu | memory | disk) ;;
+	*) drift+=("buildbuddy.yaml pr-checks declares resource_requests key '$yaml_key', which this test has no mapping for: add it here and pass it in cmd_test") ;;
+	esac
+done <<<"$resource_requests"
+
+for yaml_key in cpu memory disk; do
+	case "$yaml_key" in
+	cpu) property="EstimatedCPU" ;;
+	memory) property="EstimatedMemory" ;;
+	disk) property="EstimatedFreeDiskBytes" ;;
+	esac
+	yaml_value="$(printf '%s\n' "$resource_requests" | awk -F= -v key="$yaml_key" '$1 == key { print $2 }')"
+	ci_value=""
+	for candidate in "${resource_properties[@]}"; do
+		if [[ "${candidate%%=*}" == "$property" ]]; then
+			ci_value="${candidate#*=}"
+		fi
+	done
+	if [[ -z "$yaml_value" ]]; then
+		drift+=("buildbuddy.yaml pr-checks declares no '$yaml_key' under resource_requests (parse failure, or the key was removed)")
+	elif [[ -z "$ci_value" ]]; then
+		drift+=("ci cmd_test passes no $property, but buildbuddy.yaml pr-checks declares $yaml_key: $yaml_value")
+	elif [[ "$yaml_value" != "$ci_value" ]]; then
+		drift+=("ci cmd_test passes $property=$ci_value, but buildbuddy.yaml pr-checks declares $yaml_key: $yaml_value")
+	fi
+done
+
+for property in "${resource_properties[@]}"; do
+	property_name="${property%%=*}"
+	case "$property_name" in
+	EstimatedCPU | EstimatedMemory | EstimatedFreeDiskBytes | EstimatedComputeUnits) ;;
+	Estimated*)
+		drift+=("ci cmd_test passes $property_name, which BuildBuddy does not recognise: it will silently fall back to the default rather than fail")
+		;;
+	esac
+done
+
+if [[ ${#drift[@]} -eq 0 ]]; then
+	pass "buildbuddy_resource_parity"
+else
+	fail "buildbuddy_resource_parity" "$(printf '%s | ' "${drift[@]}")"
+fi
 
 if grep -q 'local feedback loop' "$CI" &&
 	grep -q 'SKIP_REMOTE=1' "$CI" &&


### PR DESCRIPTION
Closes #4850.

`cmd_test` hand-copies the `resource_requests` declared for the `pr-checks` action in `buildbuddy.yaml`, passing them to `bb remote` as `--runner_exec_properties`. That duplication is what makes `ci test` 1:1 with CI, and nothing checked it.

It has drifted twice:

- `disk` was missing, so local runs hit a disk exhaustion CI did not.
- `cpu` and `memory` were missing (#4836), so a local run serialised the `no-remote-exec` apko builds while CI ran them 8 wide.

Both were caught by a person reading the two files side by side, which is not a mechanism.

The drift is silent in **both** directions. BuildBuddy looks these property names up case-insensitively and returns `defaultValue` on a parse error (`milliCPUProp` / `iecBytesProp`), so a typo does not fail the run, it quietly hands you a smaller runner.

## What the test does

Parses the `pr-checks` action's `resource_requests` and `cmd_test`'s `--runner_exec_properties`, then asserts `cpu -> EstimatedCPU`, `memory -> EstimatedMemory`, `disk -> EstimatedFreeDiskBytes`.

It parses `pr-checks` specifically, because `deploy` carries its own `resource_requests` block with currently identical values, so a naive grep would match twice and mask a real drift.

Values are not hardcoded, so the test keeps working when a value is deliberately changed in both places. It reports every drift it finds with the specific cause rather than a single "they do not match", since the whole premise is that the drift is otherwise invisible.

It also flags an `Estimated*` property name BuildBuddy does not recognise, which is the silent-typo case.

## Verification

Hermetic, matching the existing `ci_test.sh` header (no git repo, no bb CLI, no network). Both inputs are files in the repo.

```
PASS [buildbuddy_resource_parity]
--- 17 passed, 0 failed ---
Executed 1 out of 1 test: 1 test passes.
```

Run with `--nocache_test_results` so that is a real execution, not a cache hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CVxWW96h5c9Ybhu4bxBzr