### PR TITLE
feat(embervm): node-reconciled oracle, so a suppress-primed wedge is not idle

### DIFF
--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -1341,8 +1341,7 @@ defmodule Embervm.Dispatcher do
 
         {instance_id_of(facts), %{
           "live_vms" => Map.get(facts, :live_vms, 0),
-          "primed_count" => length(primed_vm_ids),
-          "connected" => true
+          "primed_count" => length(primed_vm_ids)
         }}
       end
 

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -1332,10 +1332,25 @@ defmodule Embervm.Dispatcher do
       |> Enum.map(&Map.get(&1, :vm_id))
       |> Enum.filter(&is_binary/1)
 
+    node_reported =
+      for facts <- NodeCapacity.all(state.capacity_table), into: %{} do
+        primed_vm_ids =
+          Map.get(facts, :workloads, %{})
+          |> Map.values()
+          |> Enum.flat_map(&(Map.get(&1, :primed_vm_ids, []) || []))
+
+        {instance_id_of(facts), %{
+          "live_vms" => Map.get(facts, :live_vms, 0),
+          "primed_count" => length(primed_vm_ids),
+          "connected" => true
+        }}
+      end
+
     Embervm.SpecTrace.emit(:adoption, :checkpoint, %{
       "node_workload_vm_ids" => node_workload_vm_ids,
       "reserved_vm_ids" => reserved_vm_ids,
-      "node_health" => safe_node_health()
+      "node_health" => safe_node_health(),
+      "node_reported" => node_reported
     })
 
     state

--- a/projects/embervm/control/lib/embervm/spec_trace/checker.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/checker.ex
@@ -20,11 +20,11 @@ defmodule Embervm.SpecTrace.Checker do
   `coverage` is how many instances were actually examined. A verdict without a
   denominator overclaims.
 
-  `oracle` records what the verdict was checked against. Everything in this PR
-  is `:trace_only` (the trace is control-plane testimony). Node reconciliation
-  against `GET /v1/nodes` is later work, and the field exists so a report can
-  never render "the system does what the spec says" and "the log agrees with
-  itself" identically.
+  `oracle` records what the verdict was checked against. Most invariants are
+  `:trace_only` (the trace is control-plane testimony). `:node_reconciled`
+  invariants also use node testimony recorded at checkpoint time, so a report
+  can never render "the system does what the spec says" and "the log agrees
+  with itself" identically.
 
   Invariants (from adoption.tla):
 
@@ -59,6 +59,14 @@ defmodule Embervm.SpecTrace.Checker do
      N must be assigned or succeeded by checkpoint N+K if inventory persists
      across the window.
 
+  9. **InventoryReconciled**: at a checkpoint, a dispatchable node instance
+     reporting `live_vms > 0` must not have an empty control-plane inventory.
+     The only invariant whose oracle is not the trace alone: the node's own
+     count is recorded into the checkpoint, so a suppress-primed wedge (the
+     node stops reporting its pool, the CP's inventory genuinely empties) is
+     distinguishable from an idle control plane, which no trace-only invariant
+     can do (#4838).
+
   This list is the fourth copy of the invariant set (#4802): `invariants/0` is
   the source, `check_invariant/2` dispatches on it, and the router reads it. The
   prose here drifted first, documenting 6 of 8 while numbering the last one 8,
@@ -83,7 +91,8 @@ defmodule Embervm.SpecTrace.Checker do
       :prime_before_checkpoint,
       :destroy_intent_precedes_record,
       :no_destroy_before_confirm,
-      :eventually_dispatched
+      :eventually_dispatched,
+      :inventory_reconciled
     ]
   end
 
@@ -119,6 +128,7 @@ defmodule Embervm.SpecTrace.Checker do
   defp check_invariant(:health_monotonic, records), do: check_health_monotonic(records)
   defp check_invariant(:prime_before_checkpoint, records), do: check_prime_before_checkpoint(records)
   defp check_invariant(:eventually_dispatched, records), do: check_eventually_dispatched(records)
+  defp check_invariant(:inventory_reconciled, records), do: check_inventory_reconciled(records)
 
   defp check_invariant(:destroy_intent_precedes_record, records),
     do: check_destroy_intent_precedes_record(records)
@@ -593,6 +603,107 @@ defmodule Embervm.SpecTrace.Checker do
             }
         end
     end
+  end
+
+  defp check_inventory_reconciled(records) do
+    checkpoints = Enum.filter(records, &(&1["action"] == "checkpoint"))
+    reported = Enum.map(checkpoints, &get_in(&1, ["vars", "node_reported"]))
+
+    cond do
+      checkpoints == [] ->
+        inventory_reconciled_vacuous("no checkpoint records in trace")
+
+      Enum.all?(reported, &(not is_map(&1))) ->
+        inventory_reconciled_vacuous("node_reconciled oracle input is absent from every checkpoint")
+
+      true ->
+        observations =
+          Enum.flat_map(checkpoints, fn checkpoint ->
+            node_reported = get_in(checkpoint, ["vars", "node_reported"])
+
+            if is_map(node_reported) do
+              Enum.map(node_reported, fn {instance_id, report} ->
+                {checkpoint, instance_id, report}
+              end)
+            else
+              []
+            end
+          end)
+
+        missing_live_vms = Enum.filter(observations, fn {_checkpoint, _instance_id, report} ->
+          not is_map(report) or not Map.has_key?(report, "live_vms")
+        end)
+
+        connected = Enum.filter(observations, fn {_checkpoint, _instance_id, report} ->
+          is_map(report) and Map.get(report, "connected", false) == true
+        end)
+
+        cond do
+          missing_live_vms != [] ->
+            inventory_reconciled_vacuous("node_reconciled oracle input is missing live_vms")
+
+          connected == [] ->
+            inventory_reconciled_vacuous("every examined node instance is disconnected")
+
+          true ->
+            violations = Enum.filter(connected, fn {checkpoint, instance_id, report} ->
+              live_vms = Map.get(report, "live_vms", 0)
+              live_vms > 0 and checkpoint_inventory_empty?(checkpoint, instance_id)
+            end)
+
+            case violations do
+              [{checkpoint, instance_id, report} | _] ->
+                %{
+                  invariant: :inventory_reconciled,
+                  verdict: :fail,
+                  coverage: connected_instance_count(connected),
+                  oracle: :node_reconciled,
+                  detail:
+                    "instance #{instance_id} reports #{report["live_vms"]} live_vms with empty checkpoint inventory at mono #{checkpoint["mono"]}"
+                }
+
+              [] ->
+                %{
+                  invariant: :inventory_reconciled,
+                  verdict: :pass,
+                  coverage: connected_instance_count(connected),
+                  oracle: :node_reconciled,
+                  detail: "every connected instance with live_vms had checkpoint inventory"
+                }
+            end
+        end
+    end
+  end
+
+  defp checkpoint_inventory_empty?(checkpoint, instance_id) do
+    checkpoint
+    |> get_in(["vars", "node_workload_vm_ids"])
+    |> case do
+      inventory when is_map(inventory) ->
+        inventory
+        |> Enum.filter(fn {key, _vm_ids} -> String.starts_with?(to_string(key), "#{instance_id}:") end)
+        |> Enum.all?(fn {_key, vm_ids} -> not is_list(vm_ids) or vm_ids == [] end)
+
+      _ ->
+        true
+    end
+  end
+
+  defp connected_instance_count(observations) do
+    observations
+    |> Enum.map(fn {_checkpoint, instance_id, _report} -> instance_id end)
+    |> MapSet.new()
+    |> MapSet.size()
+  end
+
+  defp inventory_reconciled_vacuous(detail) do
+    %{
+      invariant: :inventory_reconciled,
+      verdict: :vacuous,
+      coverage: 0,
+      oracle: :node_reconciled,
+      detail: detail
+    }
   end
 
   defp eventually_dispatched_vacuous(coverage, detail) do

--- a/projects/embervm/control/lib/embervm/spec_trace/checker.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/checker.ex
@@ -630,46 +630,52 @@ defmodule Embervm.SpecTrace.Checker do
             end
           end)
 
-        missing_live_vms = Enum.filter(observations, fn {_checkpoint, _instance_id, report} ->
-          not is_map(report) or not Map.has_key?(report, "live_vms")
-        end)
-
-        connected = Enum.filter(observations, fn {_checkpoint, _instance_id, report} ->
-          is_map(report) and Map.get(report, "connected", false) == true
+        readable_observations = Enum.filter(observations, fn {checkpoint, _instance_id, _report} ->
+          is_map(get_in(checkpoint, ["vars", "node_workload_vm_ids"]))
         end)
 
         cond do
-          missing_live_vms != [] ->
-            inventory_reconciled_vacuous("node_reconciled oracle input is missing live_vms")
+          observations == [] ->
+            inventory_reconciled_vacuous("no dispatchable node instance in the checkpoint testimony")
 
-          connected == [] ->
-            inventory_reconciled_vacuous("every examined node instance is disconnected")
+          readable_observations == [] ->
+            inventory_reconciled_vacuous("no checkpoint carried a readable inventory")
 
           true ->
-            violations = Enum.filter(connected, fn {checkpoint, instance_id, report} ->
-              live_vms = Map.get(report, "live_vms", 0)
-              live_vms > 0 and checkpoint_inventory_empty?(checkpoint, instance_id)
+            missing_live_vms = Enum.filter(readable_observations, fn {_checkpoint, _instance_id, report} ->
+              not is_map(report) or not Map.has_key?(report, "live_vms")
             end)
 
-            case violations do
-              [{checkpoint, instance_id, report} | _] ->
-                %{
-                  invariant: :inventory_reconciled,
-                  verdict: :fail,
-                  coverage: connected_instance_count(connected),
-                  oracle: :node_reconciled,
-                  detail:
-                    "instance #{instance_id} reports #{report["live_vms"]} live_vms with empty checkpoint inventory at mono #{checkpoint["mono"]}"
-                }
+            cond do
+              missing_live_vms != [] ->
+                inventory_reconciled_vacuous("node_reconciled oracle input is missing live_vms")
 
-              [] ->
-                %{
-                  invariant: :inventory_reconciled,
-                  verdict: :pass,
-                  coverage: connected_instance_count(connected),
-                  oracle: :node_reconciled,
-                  detail: "every connected instance with live_vms had checkpoint inventory"
-                }
+              true ->
+                violations = Enum.filter(readable_observations, fn {checkpoint, instance_id, report} ->
+                  live_vms = Map.get(report, "live_vms", 0)
+                  live_vms > 0 and checkpoint_inventory_empty?(checkpoint, instance_id)
+                end)
+
+                case violations do
+                  [{checkpoint, instance_id, report} | _] ->
+                    %{
+                      invariant: :inventory_reconciled,
+                      verdict: :fail,
+                      coverage: examined_instance_count(readable_observations),
+                      oracle: :node_reconciled,
+                      detail:
+                        "instance #{instance_id} reports #{report["live_vms"]} live_vms with empty checkpoint inventory at mono #{checkpoint["mono"]}"
+                    }
+
+                  [] ->
+                    %{
+                      invariant: :inventory_reconciled,
+                      verdict: :pass,
+                      coverage: examined_instance_count(readable_observations),
+                      oracle: :node_reconciled,
+                      detail: "every examined node instance with live_vms had checkpoint inventory"
+                    }
+                end
             end
         end
     end
@@ -685,11 +691,11 @@ defmodule Embervm.SpecTrace.Checker do
         |> Enum.all?(fn {_key, vm_ids} -> not is_list(vm_ids) or vm_ids == [] end)
 
       _ ->
-        true
+        false
     end
   end
 
-  defp connected_instance_count(observations) do
+  defp examined_instance_count(observations) do
     observations
     |> Enum.map(fn {_checkpoint, instance_id, _report} -> instance_id end)
     |> MapSet.new()

--- a/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
@@ -496,6 +496,47 @@ defmodule Embervm.SpecTrace.CheckerTest do
     end
   end
 
+  describe "inventory reconciliation" do
+    test "inventory_reconciled fails on a suppress-primed wedge", %{store: store} do
+      :ok = SQLite.write(store, [inventory_checkpoint("wedge", 100, %{"node-1:wl" => []}, %{"node-1" => %{"live_vms" => 1, "primed_count" => 0, "connected" => true}})])
+
+      verdict = inventory_verdict(Checker.run(SQLite, store))
+
+      assert verdict[:verdict] == :fail
+      assert verdict[:oracle] == :node_reconciled
+      assert verdict[:coverage] == 1
+      assert verdict[:detail] =~ "node-1"
+      assert verdict[:detail] =~ "1"
+      assert verdict[:detail] =~ "100"
+    end
+
+    test "inventory_reconciled does not fail for an idle node", %{store: store} do
+      :ok = SQLite.write(store, [inventory_checkpoint("idle", 200, %{"node-1:wl" => []}, %{"node-1" => %{"live_vms" => 0, "primed_count" => 0, "connected" => true}})])
+
+      assert inventory_verdict(Checker.run(SQLite, store))[:verdict] == :pass
+    end
+
+    test "inventory_reconciled is vacuous when node_reported is absent", %{store: store} do
+      record = inventory_checkpoint("absent", 300, %{"node-1:wl" => []}, nil)
+      record = update_in(record, ["vars"], &Map.delete(&1, "node_reported"))
+      :ok = SQLite.write(store, [record])
+
+      verdict = inventory_verdict(Checker.run(SQLite, store))
+
+      assert verdict[:verdict] == :vacuous
+      assert verdict[:detail] =~ "absent"
+    end
+
+    test "inventory_reconciled is vacuous for disconnected-only nodes", %{store: store} do
+      :ok = SQLite.write(store, [inventory_checkpoint("disconnected", 400, %{"node-1:wl" => []}, %{"node-1" => %{"live_vms" => 1, "primed_count" => 0, "connected" => false}})])
+
+      verdict = inventory_verdict(Checker.run(SQLite, store))
+
+      assert verdict[:verdict] == :vacuous
+      assert verdict[:detail] =~ "disconnected"
+    end
+  end
+
   describe "destroy invariants" do
     test "destroy_intent_precedes_record passes when gate on and begin precedes confirm", %{store: store} do
       :ok = SQLite.write(store, destroy_records(true, true, true, 100, 200))
@@ -673,6 +714,25 @@ defmodule Embervm.SpecTrace.CheckerTest do
 
   defp destroy_verdict(verdicts, invariant) do
     Enum.find(verdicts, &(&1[:invariant] == invariant))
+  end
+
+  defp inventory_verdict(verdicts) do
+    Enum.find(verdicts, &(&1[:invariant] == :inventory_reconciled))
+  end
+
+  defp inventory_checkpoint(run_id, mono, inventory, node_reported) do
+    vars = %{"node_workload_vm_ids" => inventory}
+    vars = if is_nil(node_reported), do: vars, else: Map.put(vars, "node_reported", node_reported)
+
+    %{
+      "run_id" => "test-run-#{run_id}",
+      "seq" => mono,
+      "mono" => mono,
+      "ts" => mono * 10,
+      "spec" => "adoption",
+      "action" => "checkpoint",
+      "vars" => vars
+    }
   end
 
   defp destroy_records(gate, node_confirmed, _begin_gate, begin_mono, confirm_mono) do

--- a/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
@@ -498,7 +498,7 @@ defmodule Embervm.SpecTrace.CheckerTest do
 
   describe "inventory reconciliation" do
     test "inventory_reconciled fails on a suppress-primed wedge", %{store: store} do
-      :ok = SQLite.write(store, [inventory_checkpoint("wedge", 100, %{"node-1:wl" => []}, %{"node-1" => %{"live_vms" => 1, "primed_count" => 0, "connected" => true}})])
+      :ok = SQLite.write(store, [inventory_checkpoint("wedge", 100, %{"node-1:wl" => []}, %{"node-1" => %{"live_vms" => 1, "primed_count" => 0}})])
 
       verdict = inventory_verdict(Checker.run(SQLite, store))
 
@@ -511,7 +511,7 @@ defmodule Embervm.SpecTrace.CheckerTest do
     end
 
     test "inventory_reconciled does not fail for an idle node", %{store: store} do
-      :ok = SQLite.write(store, [inventory_checkpoint("idle", 200, %{"node-1:wl" => []}, %{"node-1" => %{"live_vms" => 0, "primed_count" => 0, "connected" => true}})])
+      :ok = SQLite.write(store, [inventory_checkpoint("idle", 200, %{"node-1:wl" => []}, %{"node-1" => %{"live_vms" => 0, "primed_count" => 0}})])
 
       assert inventory_verdict(Checker.run(SQLite, store))[:verdict] == :pass
     end
@@ -527,13 +527,24 @@ defmodule Embervm.SpecTrace.CheckerTest do
       assert verdict[:detail] =~ "absent"
     end
 
-    test "inventory_reconciled is vacuous for disconnected-only nodes", %{store: store} do
-      :ok = SQLite.write(store, [inventory_checkpoint("disconnected", 400, %{"node-1:wl" => []}, %{"node-1" => %{"live_vms" => 1, "primed_count" => 0, "connected" => false}})])
+    test "inventory_reconciled is vacuous for an empty node_reported map", %{store: store} do
+      :ok = SQLite.write(store, [inventory_checkpoint("empty", 400, %{"node-1:wl" => []}, %{})])
 
       verdict = inventory_verdict(Checker.run(SQLite, store))
 
       assert verdict[:verdict] == :vacuous
-      assert verdict[:detail] =~ "disconnected"
+      assert verdict[:detail] =~ "no dispatchable node instance in the checkpoint testimony"
+    end
+
+    test "inventory_reconciled is vacuous when checkpoint inventory is unreadable", %{store: store} do
+      record = inventory_checkpoint("missing-inventory", 500, %{}, %{"node-1" => %{"live_vms" => 1, "primed_count" => 0}})
+      record = put_in(record, ["vars", "node_workload_vm_ids"], nil)
+      :ok = SQLite.write(store, [record])
+
+      verdict = inventory_verdict(Checker.run(SQLite, store))
+
+      assert verdict[:verdict] == :vacuous
+      assert verdict[:detail] =~ "no checkpoint carried a readable inventory"
     end
   end
 

--- a/projects/embervm/control/test/embervm/spec_trace/reachability_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/reachability_test.exs
@@ -127,6 +127,21 @@ defmodule Embervm.SpecTrace.ReachabilityTest do
         {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{}}}
       ]
     },
+    inventory_reconciled: %{
+      pass: [
+        {"adoption", "checkpoint", %{
+          "node_workload_vm_ids" => %{"node:workload" => ["vm-pass"]},
+          "node_reported" => %{"node" => %{"live_vms" => 1, "connected" => true}}
+        }}
+      ],
+      fail: [
+        {"adoption", "checkpoint", %{
+          "node_workload_vm_ids" => %{"node:workload" => []},
+          "node_reported" => %{"node" => %{"live_vms" => 1, "connected" => true}}
+        }}
+      ],
+      vacuous: [{"adoption", "prime", %{"vm_id" => "vm-prime"}}]
+    },
     destroy_intent_precedes_record: %{
       pass: [
         {"adoption", "begin_destroy", %{"session_id" => "session-pass"}},


### PR DESCRIPTION
Closes #4838.

## The problem, restated

`eventually_dispatched` correctly returns VACUOUS during a suppress-primed wedge. From inside the trace, a wedge and an idle control plane are byte-identical: the CP's inventory genuinely empties, so there are no dispatches to check and no persistent inventory to check them against.

That is not a gap in an invariant. It is `oracle: :trace_only` stated plainly, the control plane testifying about itself, and it sincerely believed there was no inventory. **No liveness invariant over the CP's own trace can close it.**

## The discriminator was already on the wire

`NodeStatus.live_vms` is reported independently of `WorkloadCapacity.primed_vm_ids`. It counts VMs alive on the node whether primed, assigned or serving:

| | `primed_vm_ids` | `live_vms` |
| --- | --- | --- |
| suppress-primed wedge | empty | **> 0** |
| genuinely idle | empty | 0 |

So this needed no new endpoint. It needed one more key on a record the dispatcher already emits.

**Deliberately NOT a live `GET /v1/nodes` query from the checker.** The checker evaluates a historical window; a live snapshot says nothing about what was true at checkpoint time, and a verdict whose two halves come from different moments is not reconciliation. The node's testimony is recorded INTO the checkpoint.

## `InventoryReconciled`, `oracle: :node_reconciled`

The first verdict here that is not the log agreeing with itself, which is what the `oracle` field was reserved for.

- **VACUOUS** when no checkpoint carries the testimony, when an entry lacks `live_vms`, or when no checkpoint carried a readable inventory
- **VACUOUS** when the testimony is present but empty (no dispatchable instance)
- **FAIL** when an instance reports `live_vms > 0` and the CP's checkpoint inventory for it is empty
- **PASS** otherwise, `coverage` counting instances examined

## Two defects found at review, both fixed here

Worth reading, because both are the class this harness exists to refuse and neither would have failed a test.

**1. `connected` was hardcoded `true`.** The tempting read is "stub, wire it up". The real problem is upstream: `NodeCapacity.all/1` returns ONLY dispatchable instances, its own docs saying "a row's mere presence is the dispatchable signal". A disconnected instance is **dropped from the table**, never present with a false flag. So the field's production domain was a single value, the predicate reading it was decoration, and its `connected == []` arm could only fire for a different condition wearing the wrong name. Presence now IS dispatchability, and the empty case says what it means.

**2. A missing `node_workload_vm_ids` read as "inventory is empty"**, which with `live_vms > 0` produced a FAIL. Every prior instance of this bug in this file was in the PASS direction. This one is worse: it invents a wedge that never happened, on a record it could not read. False positives are how a harness earns the override rate that gets it ignored. Such checkpoints are now excluded as not evaluable, and an empty remainder is vacuous.

## Verification

`1301 tests, 0 failures, 6 skipped`, run independently rather than taken on report. The new fixtures were run red first (`1301 tests, 4 failures`), because a guard that has never failed is not evidence.

The moduledoc entry is required by the guard added in #4851, which derives expected headings from `invariants/0`. That guard's first real customer was this PR: adding the invariant without documenting it fails the build rather than drifting quietly.