### PR TITLE
fix(swarm): let a run honour the model the console picked

### DIFF
--- a/projects/monolith/swarm/router.py
+++ b/projects/monolith/swarm/router.py
@@ -41,6 +41,7 @@ class RunRequest(BaseModel):
     branch: str
     idempotency_key: str | None = None
     budget_usd: float | None = None
+    model: str | None = None
 
 
 class ClassifyAndStartRequest(BaseModel):
@@ -126,6 +127,13 @@ def start_run(request: RunRequest) -> dict:
         raise HTTPException(status_code=400, detail=f"unknown repo {request.repo}")
     if request.budget_usd is not None and request.budget_usd <= 0:
         raise HTTPException(status_code=400, detail="budget_usd must be positive")
+    if request.model is not None:
+        from agent_sessions import model_family
+
+        try:
+            model_family(request.model)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
     from swarm.workflows import implement_then_review
 
     dbos = _dbos()
@@ -142,6 +150,7 @@ def start_run(request: RunRequest) -> dict:
                 request.repo,
                 request.branch,
                 request.budget_usd,
+                request.model,
             )
     else:
         handle = dbos.start_workflow(
@@ -150,6 +159,7 @@ def start_run(request: RunRequest) -> dict:
             request.repo,
             request.branch,
             request.budget_usd,
+            request.model,
         )
     return {"workflow_id": handle.workflow_id}
 
@@ -280,6 +290,7 @@ async def classify_and_start(request: Request, body: ClassifyAndStartRequest):
                     repo=body.repo,
                     branch=body.branch,
                     budget_usd=body.budget_usd,
+                    model=model,
                 )
             )
         except HTTPException:
@@ -352,7 +363,7 @@ def promote_session(request: Request, body: PromoteSessionRequest):
         repo, branch, model = row.repo, row.branch, row.model or "luna"
     if not repo or not branch:
         raise HTTPException(status_code=400, detail="session has no repo and branch")
-    result = start_run(RunRequest(task=task, repo=repo, branch=branch))
+    result = start_run(RunRequest(task=task, repo=repo, branch=branch, model=model))
     task_id = models.mint_task_id()
     models.create_task(
         task_id,

--- a/projects/monolith/swarm/router_test.py
+++ b/projects/monolith/swarm/router_test.py
@@ -96,7 +96,120 @@ def test_start_run_passes_budget(monkeypatch):
         },
     )
     assert response.status_code == 200
-    assert captured[0][1:] == ("fix", "jomcgi/homelab", "main", 2.0)
+    assert captured[0][1:] == ("fix", "jomcgi/homelab", "main", 2.0, None)
+
+
+def test_planned_run_with_explicit_model(monkeypatch):
+    monkeypatch.setenv("SWARM_ENABLED", "true")
+    captured = []
+
+    class Handle:
+        workflow_id = "wf-planned"
+
+    class FakeDBOS:
+        def start_workflow(self, *args):
+            captured.append(args)
+            return Handle()
+
+    async def classify(_task):
+        return "planned", 1, "success", None
+
+    monkeypatch.setattr(swarm_router.runtime, "init_dbos", lambda: FakeDBOS())
+    monkeypatch.setattr(swarm_router.runtime, "is_launched", lambda: True)
+    monkeypatch.setattr("swarm.classifier.classify_task_with_outcome", classify)
+    monkeypatch.setattr(swarm_router, "_create_task_sync", lambda *args: None)
+    monkeypatch.setattr(swarm_router, "_record_classification_sync", lambda *args: None)
+    monkeypatch.setattr(
+        swarm_router, "_set_task_link_sync", lambda *args, **kwargs: None
+    )
+
+    response = client().post(
+        "/api/swarm/classify-and-start",
+        json={
+            "task": "fix",
+            "repo": "jomcgi/homelab",
+            "branch": "main",
+            "model": "terra",
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured[0][1:] == ("fix", "jomcgi/homelab", "main", None, "terra")
+
+
+def test_planned_run_rejects_unknown_model(monkeypatch):
+    monkeypatch.setenv("SWARM_ENABLED", "true")
+
+    async def classify(_task):
+        return "planned", 1, "success", None
+
+    monkeypatch.setattr("swarm.classifier.classify_task_with_outcome", classify)
+    monkeypatch.setattr(swarm_router, "_create_task_sync", lambda *args: None)
+    monkeypatch.setattr(swarm_router, "_record_classification_sync", lambda *args: None)
+
+    response = client().post(
+        "/api/swarm/classify-and-start",
+        json={
+            "task": "fix",
+            "repo": "jomcgi/homelab",
+            "branch": "main",
+            "model": "invalid",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "Unknown model" in response.json()["detail"]
+
+
+def test_promote_session_carries_model(monkeypatch):
+    captured = []
+    row = type(
+        "Row",
+        (),
+        {"id": 7, "repo": "jomcgi/homelab", "branch": "main", "model": "qwen"},
+    )()
+    turn = type("Turn", (), {"prompt": "fix"})()
+
+    class Result:
+        def first(self):
+            return turn
+
+    class FakeSession:
+        def __init__(self, _engine):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def get(self, _model, _session_id):
+            return row
+
+        def exec(self, _statement):
+            return Result()
+
+    monkeypatch.setattr("core.db.get_engine", lambda: object())
+    monkeypatch.setattr("sqlmodel.Session", FakeSession)
+    monkeypatch.setattr(
+        swarm_router,
+        "start_run",
+        lambda request: captured.append(request) or {"workflow_id": "wf-promoted"},
+    )
+    monkeypatch.setattr("swarm.models.mint_task_id", lambda: "task-1")
+    monkeypatch.setattr("swarm.models.create_task", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "swarm.models.append_plan_version", lambda *args, **kwargs: None
+    )
+
+    response = client().put(
+        "/api/swarm/promote-session",
+        json={"session_id": 7},
+    )
+
+    assert response.status_code == 200
+    assert captured[0].model == "qwen"
 
 
 def test_follower_replica_returns_503(monkeypatch):

--- a/projects/monolith/swarm/steps.py
+++ b/projects/monolith/swarm/steps.py
@@ -7,7 +7,7 @@ from dbos import DBOS
 
 
 @DBOS.step()
-def pin_plan(budget_usd: float | None = None) -> dict:
+def pin_plan(budget_usd: float | None = None, model: str | None = None) -> dict:
     """Resolve run config ONCE and checkpoint it.
 
     The workflow body must never read config.* directly: recovery re-executes
@@ -20,7 +20,7 @@ def pin_plan(budget_usd: float | None = None) -> dict:
         "version": 1,
         "max_attempts": max(1, config.max_attempts()),
         "max_review_cycles": max(1, config.max_review_cycles()),
-        "implementer_model": config.implementer_model(),
+        "implementer_model": model or config.implementer_model(),
         "reviewer_model": config.reviewer_model(),
         "turn_timeout_seconds": config.turn_timeout_seconds(),
         "budget_usd": budget_usd,

--- a/projects/monolith/swarm/steps_test.py
+++ b/projects/monolith/swarm/steps_test.py
@@ -40,6 +40,16 @@ def test_pin_plan_resolves_config_once(monkeypatch):
     }
 
 
+def test_pin_plan_uses_implementer_override(monkeypatch):
+    monkeypatch.setenv("SWARM_IMPLEMENTER_MODEL", "implementer")
+    monkeypatch.setenv("SWARM_REVIEWER_MODEL", "reviewer")
+
+    plan = steps.pin_plan.__wrapped__(2.0, "terra")
+
+    assert plan["implementer_model"] == "terra"
+    assert plan["reviewer_model"] == "reviewer"
+
+
 @pytest.mark.parametrize(
     ("status", "payload", "expected"),
     [(200, {"object": {"sha": "deadbeef"}}, "deadbeef"), (404, {}, None)],

--- a/projects/monolith/swarm/workflows.py
+++ b/projects/monolith/swarm/workflows.py
@@ -141,9 +141,13 @@ def _escalated(
 
 @DBOS.workflow()
 def implement_then_review(
-    task: str, repo: str, branch: str, budget_usd: float | None = None
+    task: str,
+    repo: str,
+    branch: str,
+    budget_usd: float | None = None,
+    model: str | None = None,
 ) -> dict:
-    plan = pin_plan(budget_usd)
+    plan = pin_plan(budget_usd, model)
     try:
         workflow_id = DBOS.workflow_id
     except Exception:  # noqa: BLE001 - no workflow context

--- a/projects/monolith/swarm/workflows_test.py
+++ b/projects/monolith/swarm/workflows_test.py
@@ -11,11 +11,11 @@ class Queue:
         return Handle()
 
 
-def workflow(*args):
+def workflow(*args, **kwargs):
     # DBOS requires an initialized runtime to invoke the decorated entrypoint.
     # The wrapped function is the deterministic control flow under test, while
     # the decorator remains on the production entrypoint.
-    return workflows.implement_then_review.__wrapped__(*args)
+    return workflows.implement_then_review.__wrapped__(*args, **kwargs)
 
 
 def run(monkeypatch, turns, heads=None):
@@ -31,11 +31,11 @@ def run(monkeypatch, turns, heads=None):
     monkeypatch.setattr(
         workflows,
         "pin_plan",
-        lambda budget_usd=None: {
+        lambda budget_usd=None, model=None: {
             "version": 1,
             "max_attempts": max(1, config.max_attempts()),
             "max_review_cycles": max(1, config.max_review_cycles()),
-            "implementer_model": config.implementer_model(),
+            "implementer_model": model or config.implementer_model(),
             "reviewer_model": config.reviewer_model(),
             "turn_timeout_seconds": config.turn_timeout_seconds(),
             "budget_usd": budget_usd,
@@ -88,6 +88,20 @@ def test_commit_on_first_attempt_goes_to_review(monkeypatch):
     assert calls[1][-2:] == ("review", 1)
 
 
+def test_explicit_model_is_used_by_implementer(monkeypatch):
+    calls = run(
+        monkeypatch,
+        {
+            101: {"commit_sha": None, "result_text": "no", "cost_usd": 1},
+            102: {"commit_sha": None, "result_text": "no", "cost_usd": 1},
+        },
+    )
+
+    workflow("task", "jomcgi/homelab", "main", model="terra")
+
+    assert calls[0][2] == "terra"
+
+
 def test_no_commit_retries(monkeypatch):
     calls = run(
         monkeypatch,
@@ -115,7 +129,7 @@ def test_pinned_attempt_bound_survives_config_change(monkeypatch):
     monkeypatch.setattr(
         workflows,
         "pin_plan",
-        lambda budget_usd=None: {
+        lambda budget_usd=None, model=None: {
             "version": 1,
             "max_attempts": max(1, config.max_attempts()),
             "max_review_cycles": max(1, config.max_review_cycles()),


### PR DESCRIPTION
Closes #4858.

## The defect

The agents console shows a model picker on every submission path. Only plain sessions honoured it.

**Planned runs.** `classify_and_start` required `model` and validated only that it was non-empty, then on the `planned` branch called `start_run(RunRequest(...))`. `RunRequest` had no `model` field, so the pick was dropped and `pin_plan` resolved `implementer_model` from `SWARM_IMPLEMENTER_MODEL`. Every run executed on the env default regardless of selection.

**Session promotion.** Worse in a quieter way: `promote_session` read

```python
repo, branch, model = row.repo, row.branch, row.model or "luna"
```

and then never passed `model` anywhere. A session running on `qwen` promoted into a run on the default implementer.

## The change

`model` now rides `RunRequest` through `start_run` and `implement_then_review` into `pin_plan`, which pins it as the implementer override.

**The reviewer model deliberately stays on the env default.** ADR 038 decision 5 floors review at Opus, and the picker chooses who implements, not who reviews.

The run branch also resolves the name through `agent_sessions.model_family`, the way the session branch already did, so an unroutable name fails at submit with the valid model list in the message rather than somewhere inside the workflow.

`swarm/deviations.py` and `swarm/view.py:246,376` read `plan["implementer_model"]` to narrate what ran, so pinning the override into the plan keeps that narration truthful with no further change. Verified rather than assumed.

## Verification

`ci test //projects/monolith:swarm_router_test //projects/monolith:swarm_steps_test //projects/monolith:swarm_workflows_test //projects/monolith:deviations_test --nocache_test_results` → **`Executed 4 out of 4 tests: 4 tests pass`**. Forced, not a cache replay.

New coverage:

| test | asserts |
|---|---|
| `test_planned_run_with_explicit_model` | the picked model reaches the workflow args |
| `test_planned_run_rejects_unknown_model` | 400 with the model list, at submit |
| `test_promote_session_carries_model` | the session's model reaches the run |

`test_start_run_passes_budget` updated for the new trailing arg.

## Deploy note

The workflow signature gains a trailing optional parameter, so the DBOS `app_version` hash moves on deploy. That is expected for a workflow source change, not a defect. Existing in-flight workflows recover against their recorded args.

## Not fixed here

The console's offered list is still a bundle literal, so "dev shows only Qwen" remains #4859. This PR makes the picked value actually drive runs, which #4859 assumes.