### PR TITLE
fix(embervm): authorize the Kargo stages on both Applications

### DIFF
--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -3,6 +3,17 @@ kind: Application
 metadata:
   name: embervm
   namespace: argocd
+  annotations:
+    # Opts production in to Kargo promotion. See the equivalent comment in
+    # dev/deploy/application.yaml for why this guard exists and what its
+    # absence looks like (an Errored Promotion and nothing else complaining).
+    #
+    # Carrying this is NOT what makes production promote automatically. The
+    # embervm prod Stage sets autoPromotion: false, so promotion here is a
+    # deliberate click: every prod roll rebuilds each brick's guest rootfs and
+    # spends unreclaimed master scratch (#4364). This annotation only says the
+    # click is allowed to take effect.
+    kargo.akuity.io/authorized-stage: kargo-embervm:prod
 spec:
   project: default
   sources:

--- a/projects/embervm/dev/deploy/application.yaml
+++ b/projects/embervm/dev/deploy/application.yaml
@@ -3,6 +3,25 @@ kind: Application
 metadata:
   name: embervm-dev
   namespace: argocd
+  annotations:
+    # Kargo will not touch an Application that has not opted in. Without this
+    # the promotion fails with:
+    #
+    #   Argo CD Application "embervm-dev" in namespace "argocd" is not authorized
+    #
+    # which is exactly how #4863 shipped: the Warehouse discovered Freight
+    # within seconds, the dev Promotion ran, and it Errored on step-1. Nothing
+    # else reported a problem, because an unauthorized Promotion is Kargo
+    # declining rather than anything being broken.
+    #
+    # That is a deliberate guard, not an obstacle: installing Kargo cannot
+    # silently give it write access to every Application in the cluster, and an
+    # Application is protected by simply never carrying this.
+    #
+    # Format is <kargo project>:<stage>. The project is kargo-embervm rather
+    # than embervm because a Kargo Project OWNS a namespace of its own name and
+    # both embervm and embervm-dev already exist holding live workloads.
+    kargo.akuity.io/authorized-stage: kargo-embervm:dev
 spec:
   project: default
   sources:


### PR DESCRIPTION
Follow-up to #4863, found by verifying the rollout rather than trusting the merge.

## What happened

#4863 merged, Kargo created `kargo-embervm` with its Warehouse and both Stages, and the Warehouse discovered Freight (chart `0.12.9`) within seconds. The dev Promotion then ran and **Errored**:

```
step "step-1" met error threshold of 1: error running step "step-1":
Argo CD Application "embervm-dev" in namespace "argocd" is not authorized
```

Kargo requires an Application to opt in via `kargo.akuity.io/authorized-stage` before a Stage may patch it. monolith's two Applications have carried it since that pipeline was built. embervm's were never given it, and I did not notice because the template and values are where I was looking: the annotation lives on the Application, which is a different file in a different project directory.

## Why nothing else complained

This is the part worth keeping. From every other vantage point the system was fine:

- `embervm` and `embervm-dev` were both **Synced and Healthy**
- the Kargo Project reported **Ready**, the Warehouse had Freight
- the chart pin simply did not move

An unauthorized Promotion is Kargo **declining**, not anything being broken, so the only place the failure appears is `kubectl get promotion -n kargo-embervm`. The `#4863` acceptance criteria said "a chart publish moves embervm-dev's LIVE targetRevision", and that check is exactly what caught this. A merge-and-assume would have left a pipeline that looks installed and promotes nothing, which is the same shape as the `autoPromotionEnabled` default the monolith template already warns about: "a fresh install looks fully wired and silently does nothing".

## The fix

`kargo.akuity.io/authorized-stage: kargo-embervm:dev` and `:prod` on the two Applications, with the comment explaining the guard and what its absence looks like.

Production carrying the annotation does **not** make production auto-promote: the prod Stage sets `autoPromotion: false`, so promotion there remains a deliberate click. The annotation only says the click is permitted to take effect.

## Live state

Both annotations were applied live to unwedge the stage before this PR was written, so `git` is catching up with the cluster rather than leading it. That matters because `canada` renders these Applications from git and would strip an annotation it does not know about on its next sync.

A one-shot Promotion does not retry after reaching a terminal Errored phase, so the stage also needed a fresh Promotion created against the same Freight. That is the documented manual promotion path.