### PR TITLE
feat(monolith): point every model in dev at the in-cluster Qwen

### DIFF
--- a/projects/monolith/dev/deploy/values.yaml
+++ b/projects/monolith/dev/deploy/values.yaml
@@ -11,7 +11,17 @@
 # production, at which point dev stops rehearsing what you are about to promote
 # and becomes its own configuration with its own bugs. The leaderSingletons
 # switch below already stops every side effect those features would produce,
-# while leaving their routes, models and migrations identical to prod.
+# while leaving their routes and migrations identical to prod.
+#
+# MODELS ARE THE ONE DELIBERATE EXCEPTION, and this paragraph used to promise
+# the opposite. Dev points every model at the in-cluster Qwen so that
+# exercising it costs nothing: the point of dev is running synthetics and
+# poking at behaviour without spending on a metered or subscription provider.
+# This is a values choice, not a guard. Nothing rejects a paid model here, so
+# a NEW model-consuming feature has to be pointed at the free lane in this
+# file too, or dev will quietly inherit production's provider. See issue #4859
+# for the console's offered list, which is still a bundle literal and so is
+# NOT covered by anything in this file.
 
 backend:
   # THE side-effect mute. One switch covers all five leader singletons (Discord
@@ -125,3 +135,58 @@ whatsapp:
 # own gate while leaving ARGO_JOBS populated, so dev runs them nowhere.
 jobs:
   image: ""
+
+# EVERY MODEL IN DEV POINTS AT THE IN-CLUSTER QWEN.
+#
+# Three separate settings reach a provider from this deployment, and each one
+# is metered or subscription-funded in production. Dev exists to be poked at
+# cheaply, so all three go to inference.inference.svc.cluster.local, which is
+# the homelab's own GPU and costs nothing per token.
+#
+# The list is not self-maintaining. A new model-consuming feature lands with
+# production's provider as its chart default and inherits it here unless
+# someone adds a line. That is the tradeoff of configuring rather than
+# enforcing (issue #4860 closed on exactly that reasoning): there is no
+# rejection, only these values.
+
+# Brief compiler (ADR 036). Production runs Nemotron primary with a DeepSeek
+# hop and only falls back to in-cluster Qwen as its LAST resort. Dev collapses
+# that to the last resort alone: no primary worth failing over FROM, so the
+# fallback list is empty rather than carrying a paid hop that would be reached
+# on the first timeout.
+#
+# apiKeySecretKey stays pointed at a real field on purpose. Blanking it is the
+# inverted-guard trap: a blank key is a fail-closed DENY in the egress catalog
+# while REMOVING an entry is an uncredentialed pass-through, and neither is
+# what "talk to the cluster's own GPU" means. The in-cluster endpoint ignores
+# the key it is handed.
+orchestrator:
+  model: "qwen3.6-27b"
+  baseUrl: "http://inference.inference.svc.cluster.local:8080/v1"
+  fallbacks: []
+
+# Grimoire extraction. Production calls DeepSeek directly (first-party, native
+# precision, prompt cache preserved), which is metered per token.
+#
+# Inert in dev today because jobs.image is blank above, so the extract
+# CronWorkflow never runs. Set anyway: "inert" is a property of a DIFFERENT
+# line in this file, and if that line ever changes this one should already be
+# right rather than discovered wrong by a bill.
+grimoire:
+  extractModel: "qwen3.6-27b"
+  extractBaseUrl: "http://inference.inference.svc.cluster.local:8080/v1/chat/completions"
+
+# Swarm run lane. luna is Codex-billed and opus is subscription-billed.
+#
+# Also inert today, for a different reason again: leaderSingletons above keeps
+# DBOS from launching, so every run endpoint 503s in dev and no implementer is
+# ever dispatched. Enabling dev's run lane is a separate design fork about the
+# nightly refresh importing production's queue tables, tracked separately.
+#
+# reviewerModel moves here too, which production must NEVER do: ADR 038
+# decision 5 floors review at Opus because a review is assessable only by
+# reading. Dev is not gating a real merge, so the floor buys nothing and a
+# subscription-billed reviewer on a throwaway run buys less.
+swarm:
+  implementerModel: "qwen"
+  reviewerModel: "qwen"


### PR DESCRIPTION
Dev exists to be poked at: synthetics, exploratory runs, checking a surface behaves before it reaches production. All three of its model-consuming settings inherited production's provider, so doing any of that spent real money.

| setting | production | dev |
|---|---|---|
| `orchestrator` | Nemotron primary, DeepSeek fallback | in-cluster Qwen, no fallbacks |
| `grimoire` | `api.deepseek.com` | in-cluster Qwen |
| `swarm` | `luna` implementer, `opus` reviewer | `qwen`, `qwen` |

## Choices worth flagging

**Fallbacks emptied, not trimmed.** The orchestrator's last resort in production is already the in-cluster Qwen. Once that IS the primary there is nothing worth failing over from, and a retained paid hop would be reached on the first timeout, which is the opposite of the intent.

**`apiKeySecretKey` deliberately still points at a real field.** Blanking it is the inverted-guard trap: a blank key is a fail-closed deny in the egress catalog while a *removed* entry is an uncredentialed pass-through. Neither is what "talk to the cluster's own GPU" means, and the in-cluster endpoint ignores the key it is handed.

**`reviewerModel` moves to qwen, which production must never do.** ADR 038 decision 5 floors review at Opus because a review is assessable only by reading. Dev gates no real merge, so the floor buys nothing there.

**Two of the three are inert today, for two different reasons, and are set anyway.** Grimoire extraction never runs because `jobs.image` is blank; the swarm run lane 503s because `leaderSingletons` keeps DBOS unlaunched. "Inert" is a property of a different line in each case, and if either changes this one should already be right rather than discovered wrong by a bill.

## The header rewrite

The overlay header promised models identical to production. That is now deliberately false, so it is rewritten, along with a note that this is **configuration and not a guard**: nothing rejects a paid model, so a new model-consuming feature inherits production's provider unless someone adds a line here. Issue #4860 was closed on exactly that reasoning.

## Verification

Rendered both stacks:

```
dev:   SWARM_IMPLEMENTER_MODEL=qwen  SWARM_REVIEWER_MODEL=qwen
       GRIMOIRE_EXTRACT_MODEL=qwen3.6-27b
       ORCHESTRATOR_MODEL=qwen3.6-27b   (ORCHESTRATOR_FALLBACKS not rendered)
prod:  SWARM_IMPLEMENTER_MODEL=luna  SWARM_REVIEWER_MODEL=opus
       GRIMOIRE_EXTRACT_MODEL=deepseek-v4-flash
       ORCHESTRATOR_MODEL=nvidia/nemotron-3-ultra-550b-a55b
```

Production is unchanged. The empty fallback list is handled on both sides: the template guards with `{{- if .Values.orchestrator.fallbacks }}` so nothing renders, and `orchestrator_client.py:103` reads `os.environ.get("ORCHESTRATOR_FALLBACKS", "")`, so absent means no chain rather than a parse error.

`ci test //projects/monolith/chart:chart_env_identity_test --nocache_test_results` → `Executed 1 out of 1 test: 1 test passes`. That test asserts dev claims nothing production owns, and a model divergence does not trip it.

## Not covered here

The console's offered model list is still a bundle literal shipped in the same image to both environments, so dev still *offers* paid models for sessions even though every server-side setting now points at Qwen. That is #4859.