### PR TITLE
feat(inference): serve Qwen3.8-27B on llama.cpp behind an engine switch

### DIFF
--- a/projects/inference/deploy/templates/_helpers.tpl
+++ b/projects/inference/deploy/templates/_helpers.tpl
@@ -69,6 +69,30 @@ Embedding llama-server CLI arguments.
 {{- end }}
 
 {{/*
+LLM llama-server CLI arguments (llm.engine "llamacpp").
+
+Mirrors inference.embeddingArgs but for the generative path: GPU offload, a
+multi-slot KV pool, and the jinja/reasoning flags that make tool calls and
+reasoning_content come back in the shape the monolith already parses. The model
+and mmproj paths are auto-discovered in the container, so they are not emitted
+here.
+*/}}
+{{- define "inference.llamaCppArgs" -}}
+--n-gpu-layers {{ .Values.llamacpp.nGpuLayers | quote }} \
+--ctx-size {{ .Values.llamacpp.ctxSize | quote }} \
+--parallel {{ .Values.llamacpp.parallel | quote }} \
+{{- if .Values.llamacpp.flashAttn }}
+--flash-attn {{ .Values.llamacpp.flashAttn | quote }} \
+{{- end }}
+--cache-type-k {{ .Values.llamacpp.cacheTypeK | quote }} \
+--cache-type-v {{ .Values.llamacpp.cacheTypeV | quote }} \
+--threads {{ .Values.llamacpp.threads | quote }} \
+--host {{ .Values.server.host | quote }} \
+--port {{ .Values.server.port | quote }}{{ range .Values.llamacpp.extraArgs }} \
+{{ . | quote }}{{ end }}
+{{- end }}
+
+{{/*
 vLLM CLI arguments.
 */}}
 {{- define "inference.vllmArgs" -}}

--- a/projects/inference/deploy/templates/deployment-llamacpp.yaml
+++ b/projects/inference/deploy/templates/deployment-llamacpp.yaml
@@ -1,4 +1,9 @@
-{{- if eq .Values.llm.engine "vllm" }}
+{{- if eq .Values.llm.engine "llamacpp" }}
+{{/*
+The generative LLM served by llama.cpp. Carries the same name, component label,
+and port as the vLLM deployment, so the Service, its selector, and every caller
+URL are identical across an engine flip -- only one of the two ever renders.
+*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,25 +44,36 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: llama-server
-          image: "{{ .Values.image.vllm.repository }}:{{ .Values.image.vllm.tag }}"
-          imagePullPolicy: {{ .Values.image.vllm.pullPolicy }}
+          image: "{{ .Values.image.llamacpp.repository }}:{{ .Values.image.llamacpp.tag }}"
+          imagePullPolicy: {{ .Values.image.llamacpp.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
-              # Auto-discover model: HuggingFace format (config.json) or GGUF.
-              MODEL=$(find {{ .Values.modelVolume.mountPath }} -maxdepth 2 -name 'config.json' -type f -exec dirname {} \; | head -1)
+              MODEL=$(find {{ .Values.llamacpp.modelVolume.mountPath }} -maxdepth 2 -name '*.gguf' ! -name 'mmproj*' -type f | sort | head -1)
               if [ -z "$MODEL" ]; then
-                MODEL=$(find {{ .Values.modelVolume.mountPath }} -maxdepth 2 -name '*.gguf' ! -name 'mmproj*' -type f | sort | head -1)
-              fi
-              if [ -z "$MODEL" ]; then
-                echo "ERROR: no model found under {{ .Values.modelVolume.mountPath }}" >&2
+                echo "ERROR: no .gguf file found under {{ .Values.llamacpp.modelVolume.mountPath }}" >&2
                 exit 1
               fi
               echo "Auto-discovered model: $MODEL"
-              exec vllm serve "$MODEL" \
-                {{ include "inference.vllmArgs" . | indent 16 | trim }}
+              set -- --model "$MODEL"
+              {{- if .Values.llamacpp.mmproj }}
+              # Prefer the F16 projector by exact name: a glob like 'mmproj*F16*'
+              # also matches mmproj-BF16.gguf, and sorts it first.
+              MMPROJ=$(find {{ .Values.llamacpp.modelVolume.mountPath }} -maxdepth 2 -name 'mmproj-F16.gguf' -type f | head -1)
+              if [ -z "$MMPROJ" ]; then
+                MMPROJ=$(find {{ .Values.llamacpp.modelVolume.mountPath }} -maxdepth 2 -name 'mmproj*.gguf' -type f | sort | head -1)
+              fi
+              if [ -z "$MMPROJ" ]; then
+                echo "ERROR: mmproj requested but no mmproj*.gguf found under {{ .Values.llamacpp.modelVolume.mountPath }}" >&2
+                exit 1
+              fi
+              echo "Auto-discovered mmproj: $MMPROJ"
+              set -- "$@" --mmproj "$MMPROJ"
+              {{- end }}
+              exec /app/llama-server "$@" \
+                {{ include "inference.llamaCppArgs" . | indent 16 | trim }}
           ports:
             - name: http
               containerPort: {{ .Values.server.port }}
@@ -77,35 +93,20 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            {{- if .Values.modelVolume.enabled }}
+            {{- if .Values.llamacpp.modelVolume.enabled }}
             - name: model
-              mountPath: {{ .Values.modelVolume.mountPath }}
+              mountPath: {{ .Values.llamacpp.modelVolume.mountPath }}
               readOnly: true
             {{- end }}
-            {{- if .Values.server.chatTemplate }}
-            - name: chat-template
-              mountPath: /etc/chat-template
-              readOnly: true
-            {{- end }}
-            - name: vllm-cache
-              mountPath: /root/.cache
             - name: dshm
               mountPath: /dev/shm
       volumes:
-        {{- if .Values.modelVolume.enabled }}
+        {{- if .Values.llamacpp.modelVolume.enabled }}
         - name: model
           image:
-            reference: {{ .Values.modelVolume.reference }}
+            reference: {{ .Values.llamacpp.modelVolume.reference }}
             pullPolicy: IfNotPresent
         {{- end }}
-        {{- if .Values.server.chatTemplate }}
-        - name: chat-template
-          configMap:
-            name: {{ include "inference.fullname" . }}-chat-template
-        {{- end }}
-        - name: vllm-cache
-          persistentVolumeClaim:
-            claimName: {{ include "inference.fullname" . }}-vllm-cache
         - name: dshm
           emptyDir:
             medium: Memory

--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -1,10 +1,29 @@
 fullnameOverride: "inference"
 
-# LLM is served by vLLM (single backend — no swappable hosting tech).
+# Which engine serves the LLM. Exactly one runs: node-4 has a single RTX 4090
+# and both deployments request it, so the unselected one is not rendered at all
+# (not scaled to zero) to keep the GPU request honest.
+#
+# "llamacpp" is a deliberate, temporary state. Qwen3.8-27B is a dense 27B whose
+# only Ada-executable quantization today is GGUF: the FP8 build is 28.75 GiB and
+# the NVFP4 build quantizes activations to 4 bits, which needs Blackwell tensor
+# cores that sm_89 does not have. Revert to "vllm" (a one-line change, both
+# blocks below are kept intact) once a weight-only int4 with 16-bit activations
+# ships, in the mould of the Intel AutoRound quant this cluster ran before.
+llm:
+  engine: llamacpp
+
 image:
   vllm:
     repository: vllm/vllm-openai
     tag: "v0.19.1"
+    pullPolicy: IfNotPresent
+  # Same repository the embeddings deployment runs, pinned independently: that
+  # one is serving live retrieval traffic on a build known good for it, and
+  # Qwen3.8 support only exists in much newer builds.
+  llamacpp:
+    repository: ghcr.io/ggml-org/llama.cpp
+    tag: "server-cuda-b10423@sha256:a475c08c7c472425e3ebf7f6be9c6cb3a17e82ec28070ddeb22fffe3ca754a94"
     pullPolicy: IfNotPresent
 
 imagePullSecret:
@@ -218,6 +237,64 @@ vllm:
     - "8"
     - "--kv-cache-dtype"
     - "fp8"
+
+# llama.cpp LLM settings. Only read when llm.engine is "llamacpp".
+llamacpp:
+  modelVolume:
+    enabled: true
+    # Qwen3.8-27B, unsloth GGUF Q4_K_M plus both mmproj variants, pushed with
+    # `hf2oci copy unsloth/Qwen3.8-27B-GGUF -r ghcr.io/jomcgi/models
+    #  --file Qwen3.8-27B-Q4_K_M --include-mmproj`. As with the vLLM model this
+    # is the resolved ghcr ref, not the hf.co form, so the oci-model-cache
+    # webhook does not gate the pod: the image must exist in ghcr before ArgoCD
+    # syncs or the pod ImagePullBackOffs. Pushed and verified 2026-08-14 at
+    # sha256:5756850ee602b50c2e697d5dcf44c075b4be08caee3ba526cbf73a11dcd45b3b.
+    reference: "ghcr.io/jomcgi/models/qwen/qwen3.8-27b:unsloth-gguf-q4-k-m-mmproj"
+    mountPath: "/model-image"
+  # 99 = offload every layer. Unlike the embeddings deployment (which is
+  # deliberately n-gpu-layers 0 and holds its weights in host RAM), the whole
+  # model is meant to be resident in VRAM here.
+  nGpuLayers: 99
+  # ctxSize is the TOTAL KV pool, divided across `parallel` slots -- it is NOT
+  # per-sequence like vLLM's --max-model-len. 131072 / 4 = 32768 per slot, which
+  # preserves the 32k window every monolith callsite is written against.
+  #
+  # VRAM budget on the 24564 MiB card: 15.92 GiB weights + 0.86 GiB mmproj +
+  # ~1 GiB compute buffers leaves ~6.2 GiB for KV. Qwen3.8-27B carries KV on
+  # only 16 of its 64 layers (the rest are Gated DeltaNet linear attention), but
+  # head_dim is 256, so a 32k sequence still costs a full 1.00 GiB at q8_0.
+  # 4 slots = ~4 GiB and leaves real margin. Raise toward 6 only after reading
+  # steady-state VRAM: this is a Recreate deployment on a single GPU, so an
+  # over-committed KV pool is a crash loop, not a degraded pod.
+  ctxSize: 131072
+  parallel: 4
+  # Quantized V cache requires flash attention; leaving this off silently forces
+  # the cache back to f16 and doubles the table above.
+  flashAttn: "on"
+  cacheTypeK: "q8_0"
+  cacheTypeV: "q8_0"
+  threads: 4
+  # Vision projector. chat/vision.py is a live callsite that sends image_url and
+  # hard-fails without this. Auto-discovered from the model image (both BF16 and
+  # F16 ship in it); F16 is preferred, hence the ordering in the template.
+  mmproj: true
+  extraArgs:
+    # Keeps the served model name stable so the 10+ callsites that hardcode the
+    # alias, and the model-bench leaderboard, do not have to change.
+    - "--alias"
+    - "qwen3.6-27b"
+    # --jinja uses the chat template embedded in the GGUF (Qwen3.8's own) and is
+    # what makes tool calls parse into OpenAI-shaped tool_calls. Note the
+    # server.chatTemplate configmap is NOT mounted here on purpose: it holds the
+    # Qwen3.6 template, hand-injected because AutoRound stripped it, and feeding
+    # it to Qwen3.8 would silently produce the wrong prompt format.
+    - "--jinja"
+    # Emits reasoning into the `reasoning_content` field, which is what
+    # summarizer.py and the chat agents already read from vLLM's qwen3
+    # reasoning-parser output.
+    - "--reasoning-format"
+    - "deepseek"
+    - "--metrics"
 
 runtimeClassName: nvidia
 


### PR DESCRIPTION
Flips the in-cluster LLM from Qwen3.6-35B-A3B on vLLM to **Qwen3.8-27B on llama.cpp**, behind a new `llm.engine` values switch so the move is reversible in one line.

## Why llama.cpp, and why this is temporary

Not a preference. It is the only format that runs this model on node-4's RTX 4090 (24564 MiB, Ada sm_89). Measured from the HF API:

| Build | Weights | Fits? |
|---|---:|---|
| `Qwen/Qwen3.8-27B` BF16 | 51.75 GiB | no |
| `Qwen/Qwen3.8-27B-FP8` | 28.75 GiB | no |
| `huginnfork/...-NVFP4A16` | 28.84 GiB | no |
| `unsloth/...-NVFP4` | 21.81 GiB | fits on paper, but see below |
| **unsloth GGUF Q4_K_M + mmproj** | **16.79 GiB** | **yes** |

The NVFP4 build is `format: mixed-precision`, and its `group_1` quantizes **activations** to 4 bits. FP4 tensor cores arrived with Blackwell; node-4 is Ada sm_89. The A16 variant that would run on Ada is larger than FP8.

Revert to `llm.engine: vllm` once a weight-only int4 with 16-bit activations ships, in the mould of the Intel AutoRound quant this cluster ran before. Both blocks are kept intact for exactly that.

## Shape

- Both deployments carry the same name, `app.kubernetes.io/component: inference`, and port, so `Service/inference` and every caller URL are untouched. `--alias qwen3.6-27b` keeps the model string the 10+ hardcoded callsites use.
- Only one renders. Node-4 has one GPU and both request it, so the unselected engine is not rendered rather than scaled to zero.
- The Qwen3.6 chat template configmap is **not** mounted on the llama.cpp path. `--jinja` uses the template embedded in the GGUF; feeding Qwen3.6's hand-injected template to Qwen3.8 would silently produce the wrong prompt format.
- llama.cpp image is pinned independently of the embeddings deployment, which stays on `b8643` while serving live retrieval traffic.

## VRAM budget

23.99 GiB card, minus 15.92 weights, minus 0.86 mmproj, minus ~1 compute buffers, leaves ~6.2 GiB for KV. Qwen3.8-27B carries KV on only 16 of 64 layers (the rest are Gated DeltaNet linear attention) but `head_dim` is 256, so a 32k sequence still costs a full 1.00 GiB at `q8_0`.

`--ctx-size 131072 --parallel 4` gives 4 slots x 32k, preserving the 32k window every callsite is written against, at ~4 GiB with real margin. Raise toward 6 only after reading steady-state VRAM: this is a `Recreate` deployment on a single GPU, so an over-committed KV pool is a crash loop, not a degraded pod.

## Verification

- `helm template` renders exactly one `Deployment/inference` on each engine setting, and the `vllm` path still produces the old image and model reference.
- Model image pushed and confirmed resolvable in ghcr before merge: `ghcr.io/jomcgi/models/qwen/qwen3.8-27b:unsloth-gguf-q4-k-m-mmproj@sha256:5756850ee602b50c2e697d5dcf44c075b4be08caee3ba526cbf73a11dcd45b3b`. The values use the resolved ref, not the `hf.co/...` form, so the oci-model-cache webhook does not gate the pod.
- `ci` green: `Executed 2 out of 715 tests: 715 tests pass`.

## Known follow-ups, deliberately not in this PR

1. **`reasoning_effort` defaults to `xhigh`.** Qwen3.8's template still honours `enable_thinking`, so the five thinking-off callsites are unaffected. But `chat/agent.py` runs with thinking on and sets no effort, so it inherits `xhigh`. On a dense 27B that is a latency regression, not a breakage.
2. **grimoire `guided_json`.** `grimoire/extract.py` sends vLLM's `guided_json` for in-cluster endpoints. llama.cpp ignores it and falls through to the `json_object` belt, dropping the `rel_type`/`entity_type` enum decode constraint. Silent quality loss, not an error. Not extracting right now, so it follows.

Both land through a shared `shared/inference.py` adapter so future compatibility differences have one home.