### PR TITLE
fix(embervm): wait for the initial NodeStatus before advancing the test clock

### DIFF
--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -605,6 +605,24 @@ defmodule Embervm.NodeRegistryTest do
     )
   end
 
+  # Wait until the watcher's INITIAL NodeStatus has been absorbed, not merely until
+  # register/2 has created the instance.
+  #
+  # blocking_watch/0 emits that status from the watcher process, so it is concurrent
+  # with the test. Waiting on the instance key only proves register/2 landed: the
+  # emit can still be in flight. If it arrives after a clock advance it restamps
+  # last_status_at at the ADVANCED time and sets health back to :healthy
+  # (handle_status/2), and two-signal expiry needs :down, so the instance survives an
+  # advance that should have aged it out. That is the intermittent
+  # node_registry_test failure in #4078.
+  #
+  # A newly registered instance is :starting with last_status_at nil, and only the
+  # first NodeStatus makes it :healthy, so health is a precise barrier for "the emit
+  # landed" rather than a proxy for it.
+  defp await_initial_status(reg, instance_id) do
+    eventually(fn -> match?(%{health: :healthy}, NodeRegistry.status(reg)[instance_id]) end, 200)
+  end
+
   test "register/2 upserts an instance keyed by (node, pod_uid) and dials it" do
     {reg, table} = start_registry(register_seams([]))
 
@@ -750,7 +768,7 @@ defmodule Embervm.NodeRegistryTest do
       )
 
     :ok = NodeRegistry.register(reg, %{"node" => "node-4", "pod_uid" => "uid-1", "address" => "10.0.0.1:9090"})
-    eventually(fn -> Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1") end, 200)
+    await_initial_status(reg, "node-4/uid-1")
 
     # Drive both expiry signals: registration lapses (advance past expire_after) AND
     # the stream goes dead (advance past down_after with no fresh status).
@@ -816,9 +834,9 @@ defmodule Embervm.NodeRegistryTest do
       )
 
     :ok = NodeRegistry.register(reg, %{"node" => node, "pod_uid" => "uid-A", "address" => a_addr})
-    eventually(fn -> Map.has_key?(NodeRegistry.status(reg), a_id) end, 200)
+    await_initial_status(reg, a_id)
     :ok = NodeRegistry.register(reg, %{"node" => node, "pod_uid" => "uid-B", "address" => b_addr})
-    eventually(fn -> Map.has_key?(NodeRegistry.status(reg), b_id) end, 200)
+    await_initial_status(reg, b_id)
 
     # Sanity: before expiry, both instance_id keys resolve to their own address, and
     # the bare node name resolves to nothing (no alias post-B0c).
@@ -874,7 +892,7 @@ defmodule Embervm.NodeRegistryTest do
       )
 
     :ok = NodeRegistry.register(reg, %{"node" => "node-4", "pod_uid" => "uid-1", "address" => "10.0.0.1:9090"})
-    eventually(fn -> Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1") end, 200)
+    await_initial_status(reg, "node-4/uid-1")
 
     # Registration lapses but the stream is still HEALTHY (the blocking watch keeps
     # emitting on connect; here no fresh status arrives, but we only advance a bit):


### PR DESCRIPTION
Refs #4078. Fixes **one instance** of the flaky-suite class, not the class.

Replaces #4875, which got stuck with `mergeable: UNKNOWN` and a PR head desynced from its branch. Identical content.

## Diagnosis

Not an expiry bug. `blocking_watch/0` emits the initial `NodeStatus` from the **watcher process**:

```elixir
fn _ch, node_id, emit ->
  emit.(node_status(node_id: node_id))    # concurrent with the test
  receive do: (:never -> {:ok, :closed})
end
```

The tests waited on `Map.has_key?`, which only proves `register/2` landed while that emit is still in flight. When it arrived after `advance.(100_000)` it restamped `last_status_at` at the **advanced** time and set health back to `:healthy`. Two-signal expiry needs both halves:

```elixir
if lapsed? and rt.health == :down do
```

so the instance survived an advance that should have aged it out, and the `refute` failed while printing a map showing `health: :healthy` and `updated_at` at the advanced clock. No other sequence produces that map.

## The behaviour it tripped over is correct

A node that has just reported in is alive, and that semantic is **already pinned by the test fifty lines below**, which injects a status after an advance and asserts the instance survives. Same mechanism: deliberate there, accidental in the flaky ones. Nothing in `node_registry.ex` changes here.

## Fix

`await_initial_status/2`, waiting on `health == :healthy`. That is a precise barrier rather than a proxy: a newly registered instance is `:starting` with `last_status_at: nil` (`new_runtime/1`), and only the first `NodeStatus` makes it `:healthy`.

Applied at **four** sites, not just the one that failed. The two registrations in the sibling-instance test carry the identical latent race, so fixing only today's failure would have left it to resurface under a different test name.

## Evidence, stated honestly

`1301 tests, 0 failures` via `ci test //bazel/erlang:mix_test_smoke`.

A green run is **weak** evidence for a race that already passed most of the time. What the diagnosis actually rests on is the printed status map and the existing test that pins the same mechanism deliberately. There is no local Elixir toolchain, so remote is the only way to run this suite.

## Scope

#4078 stays open. It lists other failures (`Placement.RetryTest`, `DrainCoordinatorTest`) with the same general shape, lifecycle and timing races, but different mechanisms. Each will need its own barrier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CVxWW96h5c9Ybhu4bxBzr