### PR TITLE
feat(agents): rework the run view to be outcome-first

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/RunView.svelte
@@ -47,6 +47,16 @@
   // Ids are plumbing: needed for copy and correlation, never for scanning.
   const shortId = (id) => String(id || "").slice(-12);
   const path = (i, suffix) => `run.nodes[${i}]${suffix}`;
+  const deviationsForNode = (nodeKey) =>
+    (run?.deviations ?? []).filter(
+      (deviation) => deviation.node_key === nodeKey,
+    );
+  const fallbackDeviations = $derived(
+    (run?.deviations ?? []).filter(
+      (deviation) =>
+        !run?.nodes?.some((node) => node.key === deviation.node_key),
+    ),
+  );
   let copied = $state(false);
 
   function copyWorkflowId() {
@@ -191,6 +201,24 @@
           >{P.labels.openBranch}</a
         >{/if}
     </div>
+    {#if run.disposition}<div
+        class="disposition"
+        class:human-attention={run.nodes.some(
+          (node) => node.blocked_on?.kind === "human",
+        )}
+      >
+        <div class="disposition-state">
+          {P.dispositionStates[run.disposition.state] ?? run.disposition.state}
+        </div>
+        <div class="disposition-reason">
+          <span class="disposition-label">{P.labels.reason}</span>
+          {run.disposition.reason}
+        </div>
+        {#if run.disposition.next}<div class="disposition-next">
+            <span class="disposition-label">{P.labels.next}</span>
+            {run.disposition.next}
+          </div>{/if}
+      </div>{/if}
     <div class="staged">
       {#each computeRanks(run.nodes) as group, rank}
         {#if rank}<div class="connector"></div>{/if}
@@ -202,18 +230,10 @@
           </div>{:else}{@render nodeCard(group[0], false)}{/if}
       {/each}
     </div>
-    {#if run.disposition}<div class="disposition" data-register="fact">
-        <div class="disposition-state">
-          {P.dispositionStates[run.disposition.state] ?? run.disposition.state}
-        </div>
-        <div>{run.disposition.reason}</div>
-        {#if run.disposition.next}<div class="disposition-next">
-            {run.disposition.next}
-          </div>{/if}
-      </div>{/if}
-    {#if run.deviations?.length}<div class="deviations" data-register="fact">
+    {#if fallbackDeviations.length}<div class="deviations" data-register="fact">
         <div class="stage-head">{P.labels.deviations}</div>
-        {#each run.deviations as deviation}<div class="deviation-text">
+        <!-- Keep unmatched deviations visible because system facts must not be dropped silently. -->
+        {#each fallbackDeviations as deviation}<div class="deviation-text">
             <span class="dev-chip"
               >{P.deviationCodes[deviation.code] ?? deviation.code}</span
             >
@@ -246,7 +266,7 @@
   {@const i = run.nodes.indexOf(node)}
   {@const iconClass = nodeStateClass(node)}
   <div
-    class={`${lane ? "lane-card" : "node-card"} ${node.state === "escalated" || node.blocked_on?.kind === "human" ? "trouble" : ""}`}
+    class={`${lane ? "lane-card" : "node-card"} ${node.blocked_on?.kind === "human" ? "trouble" : ""}`}
   >
     <div class={`card-head ${node.state === "running" ? "is-running" : ""}`}>
       <StateIcon icon={nodeIconKey(node)} class={iconClass} />
@@ -409,5 +429,18 @@
         ><button class="btn-quiet" type="button">{P.labels.deny}</button>
       </div>{/if}
     {#if node.note}<div class="node-note">{node.note}</div>{/if}
+    {#if deviationsForNode(node.key).length}<div
+        class="node-deviations"
+        data-register="fact"
+      >
+        {#each deviationsForNode(node.key) as deviation}<div
+            class="fact-deviation"
+          >
+            <span class="dev-chip"
+              >{P.deviationCodes[deviation.code] ?? deviation.code}</span
+            >
+            <span>{deviation.text}</span>
+          </div>{/each}
+      </div>{/if}
   </div>
 {/snippet}

--- a/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-fixtures.js
@@ -146,6 +146,11 @@ const homeAttentionRun = run("home-attention", "escalated", {
 
 const running = run("running", "running", {
   plan: { ...plan, budget_usd: 0.15 },
+  disposition: {
+    state: "running",
+    reason: "the implementer is still working",
+    next: "wait for the current attempt",
+  },
   deviations: [
     {
       code: "retry_taken",
@@ -158,6 +163,12 @@ const running = run("running", "running", {
       node_key: "run",
       evidence: "cost_usd: $0.20; pinned budget_usd: $0.15",
       text: "run spent $0.20 against a pinned $0.15 budget.",
+    },
+    {
+      code: "model_mismatch",
+      node_key: "review",
+      evidence: "expected reviewer model: opus; observed model: luna",
+      text: "review used a different model than the recorded plan.",
     },
   ],
   nodes: [
@@ -571,6 +582,71 @@ const wide = run("wide", "running", {
   ],
 });
 
+const humanBlocked = run("human-blocked", "escalated", {
+  dbos_status: "SUCCESS",
+  disposition: {
+    state: "escalated",
+    reason: "the run is waiting for a human decision",
+    next: "approve or deny the pending gate",
+  },
+  nodes: [
+    node("implement", "implement", "done"),
+    node("push_gate", "push gate", "escalated", {
+      blocked_on: {
+        kind: "human",
+        note: "the branch is ready for your decision",
+      },
+    }),
+    node("review", "review", "future"),
+  ],
+});
+
+const failedNoHuman = run("failed-no-human", "failed", {
+  dbos_status: "ERROR",
+  disposition: {
+    state: "failed",
+    reason: "the implementer failed before producing a reviewable branch",
+    next: "inspect the failed attempt and retry if needed",
+  },
+  nodes: [
+    node("implement", "implement", "failed", {
+      attempts: [attempt(1, "failed")],
+    }),
+    node("push_gate", "push gate", "cancelled"),
+    node("review", "review", "future"),
+  ],
+});
+
+const multiNodeDeviations = run("multi-node-deviations", "approved", {
+  dbos_status: "SUCCESS",
+  disposition: {
+    state: "approved",
+    reason: "the reviewer approved the changes",
+    next: null,
+  },
+  deviations: [
+    {
+      code: "retry_taken",
+      node_key: "implement",
+      evidence: "attempts: 2",
+      text: "implement needed a retry before completing.",
+    },
+    {
+      code: "model_mismatch",
+      node_key: "review",
+      evidence: "expected reviewer model: opus; observed model: luna",
+      text: "review used a different model than the recorded plan.",
+    },
+  ],
+  nodes: [
+    node("implement", "implement", "done", {
+      attempts: [attempt(1, "done")],
+    }),
+    node("push_gate", "push gate", "passed"),
+    node("review", "review", "done"),
+  ],
+});
+
 // --- Session walkthrough fixtures (ADR 056) -------------------------------
 // One fixture per degradation-ladder rung, plus the cross-check and scale
 // cases. Payload shapes mirror GET /api/swarm/walkthrough/{session}/{turn}
@@ -723,6 +799,9 @@ export const RUN_FIXTURES = {
     },
   ]),
   wide: entry(wide),
+  "human-blocked": entry(humanBlocked),
+  "failed-no-human": entry(failedNoHuman),
+  "multi-node-deviations": entry(multiNodeDeviations),
   "home-with-activity": homeEntry(
     "home-with-activity",
     [homeActivityRun],

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -97,6 +97,8 @@ export const RUN_LEXICON = {
     creating: "creating…",
     startingRun: "starting…",
     deviations: "deviations",
+    reason: "reason:",
+    next: "next:",
     noSpendYet: "nothing spent yet",
     workflowWord: "workflow",
     copyId: "copy id",
@@ -213,6 +215,7 @@ export const RUN_LEXICON = {
     cancelled: "cancelled",
     review_cycles_exhausted: "review cycles exhausted, awaiting decision",
     gated: "waiting at a gate",
+    failed: "failed",
   },
   verdictCodes: {
     approve: "approved",

--- a/projects/monolith/frontend/src/routes/private/agents/run-view.css
+++ b/projects/monolith/frontend/src/routes/private/agents/run-view.css
@@ -221,21 +221,35 @@
 }
 .disposition {
   margin-top: 14px;
-  border-top: 1px solid var(--line);
-  padding-top: 10px;
-}
-.disposition {
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--line-strong);
+  border-radius: var(--radius-md);
+  padding: 12px;
   color: var(--text-soft);
-  font-size: var(--size-detail);
+  font-size: var(--size-body);
+}
+.disposition.human-attention {
+  border-color: var(--attn);
+  background: var(--attn-soft);
 }
 .disposition-state {
   color: var(--text);
-  font: var(--size-meta) var(--font-mono);
+  font-size: var(--size-title);
+  font-weight: 650;
+  line-height: 1.3;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
-.disposition-next {
+.disposition-label {
   color: var(--muted);
+  font: var(--size-meta) var(--font-mono);
+  text-transform: uppercase;
+}
+.disposition-reason {
+  margin-top: 4px;
+}
+.disposition-next {
+  color: var(--text-soft);
   margin-top: 4px;
 }
 .verdict-text {
@@ -248,6 +262,19 @@
   margin-top: 16px;
   border-top: 1px solid var(--line);
   padding-top: 8px;
+}
+.node-deviations {
+  margin-top: 8px;
+  border-left: 2px solid var(--line-strong);
+  padding-left: 12px;
+}
+.fact-deviation {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-top: 4px;
+  color: var(--text-soft);
+  font-size: var(--size-detail);
 }
 .deviation-text {
   display: flex;
@@ -307,7 +334,7 @@
 }
 .card-head .card-label {
   font-weight: 550;
-  font-size: var(--size-detail);
+  font-size: var(--size-meta);
 }
 .is-running .card-label {
   font-weight: 700;


### PR DESCRIPTION
Closes #4806, but note that four of that issue's five defects were already fixed by #4808 (the narrative rail removal). What remained was the three below.

## 1. The outcome was at the bottom

`run.disposition` carries the state word, the reason, and `next`: what happened and whether it needs a human. It rendered *below* the entire node rail, so a reader scrolled the mechanism to reach the answer.

It now sits above the rail as an outcome band.

## 2. Deviations were detached from the nodes that produced them

`swarm/deviations.py:6` returns `{"code", "node_key", "evidence", "text"}`. **Every deviation already carried its node key**, and the client rendered a flat list at the bottom, discarding the association the server had handed it.

Each deviation now folds into its node card, matched on `node_key`. Deviations whose `node_key` matches no rendered node keep the standalone section rather than vanishing, with a comment saying why: a system-computed fact must not be dropped silently.

**System-computed deviations and per-attempt rationale deviations stay visually distinct.** They look mergeable and are not: `run.deviations` is fact (the system observed a retry, a model mismatch), `attempt.rationale.deviations` is the agent's own words, testimony. Two registers, expressed as treatment, never as a printed label.

## 3. Weight

Hierarchy through the existing type scale only: `--size-title` for the outcome, `--size-body` for its reason, `--size-meta` for the mechanism, `--size-detail` for detail. No new sizes.

Colour discipline tightened rather than extended. Amber (`--attn`) now applies **only** when a node is genuinely blocked on a human. The `trouble` class previously fired on `escalated || blocked_on.kind === "human"`, which spent the reserved colour on runs nobody needed to look at. Escalated nodes keep their own state icon and colour through `nodeStateClass`, so no signal is lost.

## Verification

`ci test //projects/monolith/frontend:test --nocache_test_results` → `Executed 1 out of 1 test: 1 test passes`. Forced, not a cache replay.

Checked every CSS custom property this adds against `agents-theme.css` rather than assuming: `--size-title`, `--size-body`, `--size-meta`, `--size-detail`, `--attn`, `--attn-soft`, `--line-strong`, `--radius-md` all exist. An undefined token would have failed silently as an inherited size.

Three new fixtures, reachable without a live run:

| fixture | state |
|---|---|
| `?fixture=human-blocked` | escalated, needs a human decision (the only amber case) |
| `?fixture=failed-no-human` | failed with nothing to decide |
| `?fixture=multi-node-deviations` | approved, deviations on more than one node |

## Not in scope

No narrative rail, no event stream, no register chip. #4808 removed those deliberately and this does not reintroduce them.