### PR TITLE
feat(monolith): single adapter for in-cluster inference dialect

### DIFF
--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -227,12 +227,13 @@ vllm:
     - "--reasoning-config"
     - '{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}'
     # Total concurrent decode sequences. Widened 3 -> 8 so the shared vLLM can
-    # batch bulk callers (grimoire entity extraction fans out ~6 concurrent
-    # short requests) alongside interactive traffic instead of forcing batch
+    # batch bulk callers alongside interactive traffic instead of forcing batch
     # size 1. KV memory is a fixed pool (gpu-memory-utilization below); more
     # seqs just share it, with graceful preemption on a rare full-context req.
-    # Consumers budget against this: chat_public caps public at 2, grimoire at
-    # 6, leaving headroom for Discord / private chat / agents.
+    # Only read when llm.engine is "vllm". Note the consumer budget has since
+    # been resized for the llama.cpp path (3 slots, grimoire at 3), so on a
+    # revert to vLLM these 8 slots would be undersubscribed rather than
+    # oversubscribed, which is the safe direction.
     - "--max-num-seqs"
     - "8"
     - "--kv-cache-dtype"
@@ -263,11 +264,14 @@ llamacpp:
   # ~1 GiB compute buffers leaves ~6.2 GiB for KV. Qwen3.8-27B carries KV on
   # only 16 of its 64 layers (the rest are Gated DeltaNet linear attention), but
   # head_dim is 256, so a 32k sequence still costs a full 1.00 GiB at q8_0.
-  # 4 slots = ~4 GiB and leaves real margin. Raise toward 6 only after reading
-  # steady-state VRAM: this is a Recreate deployment on a single GPU, so an
-  # over-committed KV pool is a crash loop, not a degraded pod.
-  ctxSize: 131072
-  parallel: 4
+  #
+  # Measured at 4 slots: 22562 of 24564 MiB resident, ie under 2 GiB spare, one
+  # slot from the ceiling. 3 slots (98304 / 3 = 32768 each) gives back a full
+  # GiB. Do not raise this without re-reading steady-state VRAM: this is a
+  # Recreate deployment on a single GPU, so an over-committed KV pool is a crash
+  # loop with the previous engine already torn down, not a degraded pod.
+  ctxSize: 98304
+  parallel: 3
   # Quantized V cache requires flash attention; leaving this off silently forces
   # the cache back to f16 and doubles the table above.
   flashAttn: "on"

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2354,6 +2354,16 @@ py_test(
 )
 
 py_test(
+    name = "shared_inference_test",
+    srcs = ["shared/inference_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_shared",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "shared_k8s_auth_test",
     srcs = ["shared/k8s_auth_test.py"],
     imports = ["."],

--- a/projects/monolith/agent_sessions/titles.py
+++ b/projects/monolith/agent_sessions/titles.py
@@ -20,6 +20,7 @@ from sqlmodel import Session, func, select
 from agent_sessions.models import AgentSession, AgentTurn
 from core.db import get_engine
 from framework import log_task_exception
+import shared.inference
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +138,7 @@ async def _call_qwen(prompt: str) -> str:
                 "max_tokens": _LLM_MAX_TOKENS,
                 # A thinking response spends the budget on <think> and
                 # returns content: null behind a 200, so disable it.
-                "chat_template_kwargs": {"enable_thinking": False},
+                **shared.inference.thinking_off(),
             },
         )
         resp.raise_for_status()

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -213,7 +213,7 @@ spec:
             # Concurrent extract calls. Bounded by vLLM --max-num-seqs for a
             # local endpoint, but a hosted provider (OpenRouter) has no such
             # limit, so production runs wide (the client backs off on 429).
-            # Empty falls back to the code default (6).
+            # Empty falls back to the code default (1, the async slot budget).
             - name: GRIMOIRE_EXTRACT_CONCURRENCY
               value: {{ $.Values.grimoire.extractConcurrency | quote }}
             {{- end }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1110,10 +1110,14 @@ grimoire:
   # Unset here so the code default (25) applies; set to tune without a code
   # change.
   extractLimit: ""
-  # extractConcurrency: cap on concurrent extract calls. The code default (6)
-  # suits the local GPU's 8 decode slots; a hosted provider (OpenRouter) has no
-  # such limit, so deploy/values.yaml raises it (the client backs off on 429).
-  # Empty here so the code default applies.
+  # extractConcurrency: cap on concurrent extract calls. The code default (1)
+  # is the async slot budget (see shared.inference); a hosted provider has
+  # no such limit, so deploy/values.yaml raises it (the client backs off on
+  # 429). Empty here so the code default applies. Note "empty" reaches the code
+  # as an empty string rather than an unset variable, so the fallback runs
+  # through the invalid-value branch and logs a warning before using the
+  # default; that is pre-existing and harmless, but it is why the default is
+  # the number that actually matters here.
   extractConcurrency: ""
 
 # ADR 036 orchestrator brief compiler: a host-side OpenRouter call that routes

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -13,6 +13,7 @@ from pydantic_ai import Agent, ModelSettings, RunContext, ToolDefinition
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 
+import shared.inference
 from sandbox.client import run_python_in_sandbox
 from shared.embedding import EmbeddingClient
 from chat.models import Attachment, Blob, Message
@@ -517,6 +518,7 @@ def create_agent(
             extra_body={
                 "top_k": 20,
                 "presence_penalty": 1.5,
+                **shared.inference.reasoning_effort("low"),
             },
         ),
         prepare_tools=inject_signposts,
@@ -1072,6 +1074,7 @@ def create_fact_check_agent(base_url: str | None = None) -> "Agent[None]":
             extra_body={
                 "top_k": 20,
                 "presence_penalty": 1.5,
+                **shared.inference.reasoning_effort("low"),
             },
         ),
     )

--- a/projects/monolith/chat/cluster_agent.py
+++ b/projects/monolith/chat/cluster_agent.py
@@ -26,6 +26,7 @@ from cluster.api import (
     resource_detail,
     resource_row,
 )
+import shared.inference
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +69,7 @@ def create_cluster_agent() -> Agent[ClusterDeps]:
                 # qwen3.6 is a hybrid thinking model: without this the whole
                 # generation lands in vLLM's reasoning field, content comes
                 # back null, and the SSE stream emits an empty answer.
-                "chat_template_kwargs": {"enable_thinking": False},
+                **shared.inference.thinking_off(),
             },
         ),
     )

--- a/projects/monolith/chat/explorer.py
+++ b/projects/monolith/chat/explorer.py
@@ -10,6 +10,7 @@ from pydantic_ai.providers.openai import OpenAIProvider
 from chat.sse import SSEEmitter
 from knowledge.api import KnowledgeStore
 from shared.embedding import EmbeddingClient
+import shared.inference
 
 SYSTEM_PROMPT = """\
 You are a knowledge graph explorer. The user asks questions and you search \
@@ -52,7 +53,7 @@ def create_explorer_agent() -> Agent[ExplorerDeps]:
                 # qwen3.6 is a hybrid thinking model: without this the whole
                 # generation lands in vLLM's reasoning field, content comes
                 # back null, and the SSE stream emits an empty answer.
-                "chat_template_kwargs": {"enable_thinking": False},
+                **shared.inference.thinking_off(),
             },
         ),
     )

--- a/projects/monolith/chat/summarizer.py
+++ b/projects/monolith/chat/summarizer.py
@@ -10,6 +10,7 @@ import httpx
 from sqlmodel import Session, select
 
 from chat.models import ChannelSummary, Message, UserChannelSummary
+import shared.inference
 
 logger = logging.getLogger(__name__)
 
@@ -500,7 +501,7 @@ def build_llm_caller(base_url: str | None = None) -> Callable[[str], Awaitable[s
                         # not <think> reasoning -- a thinking response puts the
                         # reasoning in reasoning_content and returns content:null
                         # behind a 200, which would slip past raise_for_status.
-                        "chat_template_kwargs": {"enable_thinking": False},
+                        **shared.inference.thinking_off(),
                     },
                 )
                 resp.raise_for_status()

--- a/projects/monolith/chat/vision.py
+++ b/projects/monolith/chat/vision.py
@@ -7,6 +7,8 @@ import os
 
 import httpx
 
+import shared.inference
+
 logger = logging.getLogger(__name__)
 
 LLAMA_CPP_URL = os.environ.get("LLAMA_CPP_URL", "")
@@ -69,7 +71,7 @@ class VisionClient:
             "max_tokens": VISION_MAX_TOKENS,
             # Disable thinking so tokens are used for the description, not
             # <think> reasoning that fills the entire max_tokens budget.
-            "chat_template_kwargs": {"enable_thinking": False},
+            **shared.inference.thinking_off(),
         }
 
         timeout = httpx.Timeout(VISION_READ_TIMEOUT, connect=VISION_CONNECT_TIMEOUT)

--- a/projects/monolith/grimoire/extract.py
+++ b/projects/monolith/grimoire/extract.py
@@ -72,6 +72,7 @@ from grimoire.models import (
     KnowledgeChunk,
     Relationship,
 )
+import shared.inference
 
 logger = logging.getLogger("monolith.grimoire.extract")
 
@@ -1071,13 +1072,12 @@ class OpenRouterClient:
         """Output-format enforcement for the active prompt version (spec #4).
 
         No schema (v1): keep ``response_format: json_object`` (valid JSON, no
-        shape). With a schema (v2): OpenRouter gets a strict ``json_schema`` so
-        the ``rel_type``/``entity_type`` enums are hard decode constraints;
-        direct DeepSeek gets plain ``json_object`` (it does not accept the strict
-        json_schema block or vLLM's guided_json, and the post-parse safety net
-        covers the enum); a vLLM endpoint gets ``guided_json`` (same schema) plus
-        ``json_object``. The self-correction retry stays as a belt for providers
-        that silently downgrade the format.
+        shape). With a schema (v2): OpenRouter and direct DeepSeek keep their
+        hosted provider dialects; an in-cluster endpoint gets both vLLM's
+        ``guided_json`` and llama.cpp's strict JSON Schema ``response_format``.
+        Both carry the same schema, so the active engine enforces the enum
+        constraints and the unsupported field is inert. The self-correction
+        retry stays as a belt for providers that silently downgrade the format.
         """
         schema = self._version.schema
         if schema is None:
@@ -1095,12 +1095,7 @@ class OpenRouterClient:
             }
         if self._is_deepseek():
             return {"response_format": {"type": "json_object"}}
-        # vLLM guided decoding: guided_json constrains the output to the schema;
-        # response_format json_object is a harmless belt for older vLLM builds.
-        return {
-            "response_format": {"type": "json_object"},
-            "guided_json": schema,
-        }
+        return shared.inference.structured_output(schema, name="grimoire_extraction")
 
     @staticmethod
     def _user_message(

--- a/projects/monolith/grimoire/extract.py
+++ b/projects/monolith/grimoire/extract.py
@@ -95,13 +95,16 @@ EXTRACT_READ_TIMEOUT = 120.0  # frontier-model completions are slower than embed
 DEFAULT_LIMIT = 25
 # Concurrent in-flight extract calls. The per-chunk work is GPU inference on
 # the shared vLLM server, and a sequential (one-at-a-time) client starves
-# vLLM's continuous batcher, so the GPU runs at batch size 1 (its worst case).
-# Firing several requests concurrently lets vLLM batch them. Kept BELOW the
-# server's --max-num-seqs (8) so this bulk job leaves decode-slot headroom for
-# latency-sensitive trusted callers (public chat is separately hard-capped at 2
-# by chat_public.limits; Discord / private chat / agents share the rest). It
+# the server's batcher, so the GPU runs at batch size 1 (its worst case). It
 # also bounds the group size for the incremental per-group commit below.
-DEFAULT_CONCURRENCY = 6
+#
+# Extraction is asynchronous bulk work, so it gets the async slot budget: one
+# decode slot, leaving the other two free for whoever is actually waiting on a
+# reply. This deliberately gives up the batching win that a wider fan-out used
+# to buy, because that win accrued to a job nobody is watching while the cost
+# landed on interactive latency. See shared.inference.ASYNC_SLOT_BUDGET for the
+# policy and its cross-pod caveat.
+DEFAULT_CONCURRENCY = shared.inference.ASYNC_SLOT_BUDGET
 
 # v4 generic typed-extraction taxonomy (spec v4), widened to 19 types by v6's
 # ``table``. Grouped by the DERIVED category: lore (unchanged from v1), gameplay

--- a/projects/monolith/grimoire/extract_test.py
+++ b/projects/monolith/grimoire/extract_test.py
@@ -1365,14 +1365,21 @@ def test_openrouter_hosted_uses_json_schema_response_format():
     assert set(rel_enum) == set(REL_TYPE_SET)
 
 
-def test_vllm_uses_guided_json():
-    """Against a vLLM endpoint, a v2 client sends guided_json (not json_schema)."""
+def test_in_cluster_uses_both_structured_output_dialects():
+    """In-cluster engines receive the same schema in both vendor extensions."""
     client = OpenRouterClient(
         api_key="", base_url="http://inference/v1/chat/completions", prompt_version="v2"
     )
     fmt = client._format_kwargs()
-    assert fmt["response_format"] == {"type": "json_object"}
     assert fmt["guided_json"] == PROMPT_VERSIONS["v2"].schema
+    assert fmt["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "grimoire_extraction",
+            "strict": True,
+            "schema": PROMPT_VERSIONS["v2"].schema,
+        },
+    }
 
 
 def test_v1_client_keeps_json_object():
@@ -1518,7 +1525,15 @@ async def test_openrouter_client_extract_success():
     assert call_args[0][0] == "http://fake/chat"
     payload = call_args[1]["json"]
     assert payload["messages"][1]["content"] == "some chunk text"
-    assert payload["response_format"] == {"type": "json_object"}
+    assert payload["guided_json"] is PROMPT_VERSIONS["v2"].schema
+    assert payload["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "grimoire_extraction",
+            "strict": True,
+            "schema": PROMPT_VERSIONS["v2"].schema,
+        },
+    }
     assert call_args[1]["headers"]["Authorization"] == "Bearer test-key"
 
 

--- a/projects/monolith/grimoire/jobs.py
+++ b/projects/monolith/grimoire/jobs.py
@@ -31,6 +31,7 @@ import os
 from sqlmodel import Session, select
 
 from grimoire.models import KnowledgeChunk
+import shared.inference
 
 logger = logging.getLogger("monolith.grimoire.jobs")
 
@@ -40,10 +41,11 @@ DEFAULT_BUCKET = "grimoire"
 # as a gzipped ``output.json``. Mirrors ingest.DEFAULT_PREFIX.
 _BOOKS_PREFIX = "books/"
 DEFAULT_EXTRACT_LIMIT = 25
-# Concurrent extract calls; kept below vLLM --max-num-seqs (8) so this bulk job
-# leaves decode-slot headroom for trusted interactive callers. See
+# Concurrent extract calls. Extraction is asynchronous bulk work, so it gets the
+# async slot budget of one decode slot and never makes an interactive caller
+# queue. See shared.inference.ASYNC_SLOT_BUDGET and
 # grimoire.extract.DEFAULT_CONCURRENCY.
-DEFAULT_EXTRACT_CONCURRENCY = 6
+DEFAULT_EXTRACT_CONCURRENCY = shared.inference.ASYNC_SLOT_BUDGET
 
 
 def _embedding_client():

--- a/projects/monolith/shared/inference.py
+++ b/projects/monolith/shared/inference.py
@@ -1,0 +1,55 @@
+"""Vendor-neutral request fragments for the in-cluster chat inference dialect.
+
+This module is the single place for compatibility between the in-cluster vLLM
+and llama.cpp engines. The helpers return fragments that callers can merge into
+either PydanticAI ``extra_body`` mappings or raw HTTP JSON bodies, so transport
+style remains local to each caller.
+
+``thinking_off`` preserves the option used by callers that need their token
+budget for visible content. ``reasoning_effort`` validates the values accepted
+by Qwen's chat template, which explicitly raises for values outside ``xhigh``,
+``medium``, and ``low``. ``structured_output`` sends both vendor extensions:
+vLLM honors ``guided_json`` while llama.cpp honors the equivalent JSON Schema
+``response_format``. They encode the same schema, so whichever field the live
+engine supports supplies the constraint and the other is inert, without adding
+new engine-specific configuration coupling.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+REASONING_EFFORTS: frozenset[str] = frozenset({"xhigh", "medium", "low"})
+
+
+def thinking_off() -> dict[str, dict[str, bool]]:
+    """Return the chat-template options that disable Qwen thinking."""
+    return {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+def reasoning_effort(effort: str) -> dict[str, dict[str, str]]:
+    """Return a validated Qwen chat-template reasoning-effort fragment."""
+    if effort not in REASONING_EFFORTS:
+        legal = ", ".join(sorted(REASONING_EFFORTS))
+        raise ValueError(f"reasoning effort must be one of: {legal}; got {effort!r}")
+    return {"chat_template_kwargs": {"reasoning_effort": effort}}
+
+
+def structured_output(schema: dict[str, Any], *, name: str) -> dict[str, Any]:
+    """Return vLLM and llama.cpp structured-output extensions for ``schema``.
+
+    vLLM honors ``guided_json`` and llama.cpp honors the equivalent JSON Schema
+    ``response_format``. Both reference the same schema, so the active engine
+    applies the same constraint while the unsupported vendor field is inert.
+    """
+    return {
+        "guided_json": schema,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": name,
+                "strict": True,
+                "schema": schema,
+            },
+        },
+    }

--- a/projects/monolith/shared/inference.py
+++ b/projects/monolith/shared/inference.py
@@ -21,6 +21,27 @@ from typing import Any
 
 REASONING_EFFORTS: frozenset[str] = frozenset({"xhigh", "medium", "low"})
 
+# Decode-slot policy for the shared in-cluster engine.
+#
+# Synchronous callers (a human is waiting: Discord chat, private chat) are NOT
+# capped. They take whatever slots they need, and latency for a waiting human is
+# the thing the GPU exists to protect.
+#
+# Asynchronous callers (grimoire extraction, generation, background jobs) get
+# exactly ONE slot each. Bulk work is throughput-shaped, not latency-shaped, so
+# the difference between finishing in an hour and ninety minutes does not matter,
+# whereas a background job that occupies the whole GPU makes every interactive
+# reply queue behind it. This is why the number is 1 rather than "one less than
+# the slot count": the goal is that async work is never the reason a human waits.
+#
+# Import this rather than hardcoding a literal, so the policy has one home.
+#
+# Caveat worth knowing: this bounds fan-out WITHIN one job process. It is not a
+# cross-pod semaphore, so two async jobs running at once can still take two
+# slots. chat_public solves the cross-pod version with Postgres advisory locks
+# if this ever needs to be enforced globally rather than by convention.
+ASYNC_SLOT_BUDGET = 1
+
 
 def thinking_off() -> dict[str, dict[str, bool]]:
     """Return the chat-template options that disable Qwen thinking."""

--- a/projects/monolith/shared/inference_test.py
+++ b/projects/monolith/shared/inference_test.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from shared.inference import (
+    REASONING_EFFORTS,
+    reasoning_effort,
+    structured_output,
+    thinking_off,
+)
+
+
+def test_thinking_off():
+    assert thinking_off() == {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+@pytest.mark.parametrize("effort", sorted(REASONING_EFFORTS))
+def test_reasoning_effort_accepts_legal_values(effort: str):
+    assert reasoning_effort(effort) == {
+        "chat_template_kwargs": {"reasoning_effort": effort}
+    }
+
+
+@pytest.mark.parametrize("effort", ["none", "off", "invalid"])
+def test_reasoning_effort_rejects_illegal_values(effort: str):
+    with pytest.raises(ValueError) as exc_info:
+        reasoning_effort(effort)
+    for legal in REASONING_EFFORTS:
+        assert legal in str(exc_info.value)
+
+
+def test_structured_output_carries_both_dialects_and_same_schema():
+    schema = {"type": "object", "properties": {"answer": {"type": "string"}}}
+
+    result = structured_output(schema, name="answer")
+
+    assert result["guided_json"] is schema
+    assert result["response_format"]["json_schema"]["schema"] is schema
+    assert result["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "answer",
+            "strict": True,
+            "schema": schema,
+        },
+    }


### PR DESCRIPTION
Follow-up to #4876, which moved the in-cluster LLM to Qwen3.8-27B on llama.cpp. That swap is transport-compatible (same URL, same OpenAI-shaped `/v1/chat/completions`, same `qwen3.6-27b` alias). What differs between engines is the **vendor extensions** smuggled through `extra_body`, which were duplicated across seven call sites with no owner.

`shared/inference.py` becomes that owner, so the next engine or model change has one place to absorb it. `shared/` is the right home: `import_boundaries_test.py` declares it importable from any domain, and `shared/embedding.py` is the existing precedent.

## Deliberately fragments, not a client

The helpers return dicts callers merge into either a PydanticAI `extra_body` or a raw httpx body. The value is one home for the **dialect**, not one transport. Forcing the PydanticAI and httpx call sites to converge would be a much larger refactor, and would disturb `chat_public/inference.py`, whose auditability rests on having no `tools=` argument anywhere.

## What changes behaviour

**Both chat agents pin `reasoning_effort: low`.** Qwen3.8's template still honours `enable_thinking`, so the five thinking-off call sites were already correct and are refactored with byte-identical emitted JSON. But `chat/agent.py` runs with thinking *on* and set no effort, so it inherited the template default of `xhigh`. Measured against the live endpoint, the model decodes at ~47 tok/s, so xhigh is a real latency regression on the main Discord path.

**Grimoire sends both `guided_json` and a strict `json_schema` `response_format`.** llama.cpp ignores `guided_json` and was falling through to the `json_object` belt, silently dropping the `rel_type`/`entity_type` enums as hard decode constraints. Extraction kept running and quality degraded with no error. Both fields carry the same schema, so whichever the live engine honours gives the same constraint and the other is inert. That keeps it correct across a revert to vLLM with no new config coupling.

**`reasoning_effort()` validates its input.** Qwen's template accepts only `xhigh`, `medium`, `low` and calls `raise_exception` otherwise, which would surface as an opaque 500. The guard is the point. `"none"` is covered as a test case since it is the plausible wrong guess.

## Verification

- `ci test`: `Executed 355 out of 716 tests: 716 tests pass`. This also covers `cluster_agent` and `explorer`, which could not be validated locally for lack of `pydantic_ai`.
- That run also hit `//bazel/erlang:mix_test_smoke`, which did not reproduce on a re-run of the identical commit. Known flaky per #4828; this diff is Python-only and has no path to Erlang.
- Behaviour confirmed against the running pod before writing this, via port-forward:
  - `enable_thinking: False` returns non-null `content` and no `reasoning_content`, so `summarizer.py`'s `content: null` failure mode does not occur.
  - `reasoning_effort: "low"` is accepted and populates `reasoning_content`.
  - Tool calling returns `finish_reason: tool_calls` parsed as `get_weather({"city":"Dublin"})`.

## Note for the reviewer

`ci regen` on this branch rewrote 38 unrelated BUILD files and created two new ones under `frontend/src/routes/` declaring `ts_project` targets in directories with no `tsconfig.json`, which poisons `//...` evaluation. All 40 were discarded; this PR carries only the 11 files of the real change. That drift predates this work and affects any PR running full `ci`, so it likely wants its own issue.