### PR TITLE
fix(monolith): route /api/swarm to the backend instead of the SPA shell

### DIFF
--- a/projects/monolith/chart/templates/httproute-private.yaml
+++ b/projects/monolith/chart/templates/httproute-private.yaml
@@ -61,6 +61,34 @@ spec:
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.service.apiPort | int }}
+    # Swarm API: the agents console calls this DIRECTLY from the browser, not
+    # through a SvelteKit server route, so it needs a rule of its own for the
+    # same reason /api/grimoire above does.
+    #
+    # Without it every /api/swarm/* call falls through to the catch-all, lands
+    # on the SvelteKit port and comes back as the SPA shell. The browser then
+    # fails at JSON.parse with:
+    #
+    #   Unexpected token '<', "<!doctype "... is not valid JSON
+    #
+    # which reads like a frontend bug and is a routing gap. That broke the
+    # single task box (POST /api/swarm/classify-and-start), the session
+    # walkthrough (/api/swarm/walkthrough/...) and the compare proxy
+    # (/api/swarm/compare/...), all of which shipped green because nothing in
+    # CI exercises a browser-originated path against the real ingress.
+    #
+    # The timeout matches the other model-calling rules: classify-and-start
+    # runs the Qwen classifier inline before it returns.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/swarm
+      timeouts:
+        request: 600s
+        backendRequest: 600s
+      backendRefs:
+        - name: {{ include "monolith.fullname" . }}
+          port: {{ .Values.service.apiPort | int }}
     # Chat interface — SvelteKit SSR calls LLM backend, needs long timeout
     - matches:
         - path:


### PR DESCRIPTION
**Production is broken and this is the fix.** No task can be submitted from the agents console.

## The symptom

```
Unexpected token '<', "<!doctype "... is not valid JSON
```

## The cause

The agents console calls `/api/swarm/*` **directly from the browser**, not through a SvelteKit server route. The private HTTPRoute has explicit rules for `/api/knowledge`, `/api/demos`, `/api/scheduler` and `/api/grimoire`, and none for `/api/swarm`.

So every such call falls through to the catch-all, lands on the SvelteKit port, and comes back as the SPA shell. The browser then tries to `JSON.parse` an HTML document.

```
['/api/knowledge'] -> ['monolith:8000']
['/api/demos']     -> ['monolith:8000']
['/api/scheduler'] -> ['monolith:8000']
['/api/grimoire']  -> ['monolith:8000']
['/']              -> ['monolith:3000']     <- everything else, including /api/swarm
```

## What this broke

| endpoint | feature |
|---|---|
| `POST /api/swarm/classify-and-start` | the single task box, so nothing could be submitted at all |
| `GET /api/swarm/walkthrough/{s}/{t}` | the session walkthrough |
| `GET /api/swarm/compare/{s}/{t}` | the compare proxy |

All three shipped green.

## Why nothing caught it

**Nothing in CI exercises a browser-originated path against the real ingress.** The endpoint exists, its unit tests pass, the chart renders, the Application syncs, the pod is healthy, and the call still cannot reach the process. Every signal we have was accurate about its own layer and silent about the join.

I verified the walkthrough was live earlier today by exporting the running images and grepping for the route handler and the client markup. Both were genuinely there. That check proves the code shipped; it says nothing about whether the browser can reach it, which is the question that mattered.

The comment on `/api/grimoire` directly above this new rule already records the same failure mode: *"falls through to the catch-all below and lands on the SvelteKit port, which 404s it"*. The private tier has now hit it twice.

## Verification

Rendered the chart and confirmed the rule lands ahead of the catch-all and points at the API port:

```
['/api/grimoire'] -> ['monolith:8000']
['/api/swarm']    -> ['monolith:8000']
['/']             -> ['monolith:3000']
```

`ci test //projects/monolith/chart:chart_env_identity_test --nocache_test_results` → `Executed 1 out of 1 test: 1 test passes`.

Timeout matches the other model-calling rules, because `classify-and-start` runs the Qwen classifier inline before it returns.

**Not verified: that the task box works end to end.** That is only observable after this merges, the chart version is written back, and ArgoCD applies the new HTTPRoute. I will confirm by curling the route rather than by reading the manifest.

## Follow-up worth filing

A check that walks each browser-called path and asserts it reaches the API port rather than the SPA. It would have caught this, and it would have caught the grimoire instance too.