### PR TITLE
fix(bazel): exclude the frontend subtree from gazelle so //... evaluates

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -30,6 +30,15 @@
 # gazelle:exclude grimoire
 # gazelle:exclude grimoire_chat
 # gazelle:exclude faas
+# The frontend is pnpm/rules_js with hand-written BUILD files, so gazelle must
+# not walk it. frontend/BUILD already carries a `# gazelle:ignore`, but that
+# directive applies ONLY to the directory it appears in and does NOT recurse:
+# gazelle still descended into src/routes/ and generated ts_project targets for
+# SvelteKit route directories, which have no tsconfig.json. Those targets fail
+# at load time ("No tsconfig.json file found"), which poisons `//...` evaluation
+# and makes `ci` unable to start any build at all. Excluding from here is what
+# every other subdirectory above does, and unlike `ignore` it covers the subtree.
+# gazelle:exclude frontend
 # Hand-written bdd_test targets (need the real-Postgres harness), so keep gazelle
 # from generating conflicting py_tests for them.
 # gazelle:exclude public_reader_grants_test.py


### PR DESCRIPTION
`ci regen` currently produces a tree that cannot build. Gazelle generates `ts_project` targets for SvelteKit route directories under `projects/monolith/frontend/src/routes/`, which have no `tsconfig.json`:

```
ERROR: No tsconfig.json file found in projects/monolith/frontend/src/routes/.
ERROR: package contains errors: projects/monolith/frontend/src/routes
ERROR: Skipping '//...': error loading package ...
ERROR: Couldn't start the build. Unable to run tests
```

So `ci` exits before running a single test. Combined with #4118 that can present as **exit code 0 with no `Executed N out of M` line at all**, which reads as success.

## Cause

A directive-scope trap. `frontend/BUILD` opens with `# gazelle:ignore`, which looks like it covers the frontend. It does not: that directive applies **only to the directory it appears in and does not recurse**. Gazelle skipped generating into `frontend/` itself while walking straight past it into `src/routes/`.

`# gazelle:exclude` **is** inherited by subdirectories, and `projects/monolith/BUILD` already excludes all 32 other subdirectories that way. `frontend` was the only one missing.

## Verification

- Re-ran `ci regen`: no BUILD files generated anywhere under `frontend/`.
- `ci test`: `Executed 0 out of 715 tests: 715 tests pass` (cache-hit; the point is that it reaches the tests at all instead of failing to start).

## What this does NOT fix

`ci regen` output still is not committable in general. Gazelle also wants to rewrite 38 Go BUILD files into the legacy `go_default_library` naming convention this repo does not use:

```diff
-        "@com_github_google_go_containerregistry//pkg/authn",
+        "@com_github_google_go_containerregistry//pkg/authn:go_default_library",
```

That is a separate defect (likely a missing `# gazelle:go_naming_convention` directive) and wants its own change. This PR carries only the one-line exclude.