### PR TITLE
fix(chat_public): cap public inference at one decode slot, drop an inert key

### DIFF
--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -98,13 +98,13 @@ chatPublic:
   maxSessionTokens: 32000
   # Session / cookie TTL in seconds (the SSR cookie maxAge mirrors this).
   sessionTtlSeconds: 1800
-  # CLUSTER-WIDE ceiling: max in-flight public inference calls at once across ALL
-  # replicas (ADR 005 layer 2+3). Enforced via Postgres advisory locks, not a
-  # per-pod counter, so it holds as the backend scales out. vLLM max_num_seqs=8,
-  # public is capped here at 2, leaving the rest for trusted callers (grimoire
-  # extraction, Discord, private chat, agents). Mirrored as
-  # CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT on web.env below.
-  globalMaxConcurrent: 2
+  # NOTE: the public concurrency ceiling is NOT set here. It lives solely as
+  # CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT on web.env below, because values.yaml
+  # cannot reference its own keys and web.env is a literal list. A
+  # `globalMaxConcurrent` key used to sit here describing itself as "mirrored"
+  # to that env, but nothing rendered it: it was referenced by no template in
+  # the repo, so editing it changed nothing while reading exactly like the live
+  # knob. Removed rather than wired, so there is one place to change.
   # Turnstile siteverify HTTP timeout (seconds): keep short so a slow/unreachable
   # Cloudflare fails closed quickly. Mirrored as TURNSTILE_TIMEOUT_SECONDS below.
   turnstileTimeoutSeconds: 5
@@ -294,10 +294,20 @@ web:
       value: "1800"
     # CLUSTER-WIDE cap on concurrent public inference calls (not per-pod): the
     # limiter is enforced via Postgres advisory locks, so this is the aggregate
-    # ceiling across ALL replicas. vLLM max_num_seqs=8; public is capped at 2,
-    # leaving the rest for trusted callers (grimoire, Discord, private, agents).
+    # ceiling across ALL replicas (ADR 005 layer 2+3). This is the ONLY place the
+    # ceiling is set.
+    #
+    # Resized 2 -> 1 with the engine change. The old value was sized against
+    # vLLM's 8 decode slots, where 2 was a small slice. The in-cluster engine is
+    # now llama.cpp with 3 slots (Qwen3.8-27B is a dense 27B and each 32k slot
+    # costs a full GiB of VRAM), so 2 would hand untrusted public traffic two
+    # thirds of the GPU and leave one slot for Discord, private chat and agents
+    # combined. This is an abuse boundary rather than a latency knob, so it does
+    # not follow the "sync callers are uncapped" policy that trusted interactive
+    # callers get: the point is that anonymous traffic cannot crowd out the
+    # people the GPU is for. Keep it proportional if slot count changes again.
     - name: CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT
-      value: "2"
+      value: "1"
     # Shared vLLM endpoint for public-chat inference (ADR 005 layer 6 / Phase 3).
     # In-cluster service URL literal (NOT a secret); mirrors chatPublic.inferenceUrl
     # above (Helm values cannot self-reference). The backend refuses to call

--- a/projects/monolith/chat_public/limits.py
+++ b/projects/monolith/chat_public/limits.py
@@ -60,10 +60,20 @@ SESSION_TTL_SECONDS = int(os.environ.get("CHAT_PUBLIC_SESSION_TTL_SECONDS", "180
 # the single-process fallback for the SQLite dev/test path.
 #
 # SIZING RULE (reserved-headroom): public aggregate in-flight inference is capped
-# at GLOBAL_MAX_CONCURRENT across ALL pods, and the remaining vLLM decode slots
-# are left for trusted callers (grimoire extraction, Discord, private chat,
-# agents). Today max_num_seqs=8 and public is capped at 2.
-GLOBAL_MAX_CONCURRENT = int(os.environ.get("CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT", "2"))
+# at GLOBAL_MAX_CONCURRENT across ALL pods, and the remaining decode slots are
+# left for trusted callers (Discord, private chat, agents, grimoire extraction).
+# The in-cluster engine is llama.cpp with 3 slots, so public is capped at 1.
+#
+# Keep this proportional if the slot count changes. It is an abuse boundary, not
+# a latency knob, so it deliberately does NOT follow the "synchronous callers are
+# uncapped" policy that trusted interactive traffic gets: public chat is
+# synchronous too, and the point is precisely that anonymous traffic cannot crowd
+# out the people the GPU exists for.
+#
+# Production always sets the env explicitly (monolith-public chart, web.env), so
+# this default governs dev and test only. It is kept in step with the chart so
+# the two cannot tell different stories about what the ceiling is.
+GLOBAL_MAX_CONCURRENT = int(os.environ.get("CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT", "1"))
 
 # Advisory-lock namespace (classid) for the GPU limiter. A stable app-specific
 # magic so these locks never collide with any other advisory lock; the objid is


### PR DESCRIPTION
Follow-up to the llama.cpp cutover (#4876) and the slot policy in #4880.

## The resize

`CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT` was sized against vLLM's 8 decode slots, where 2 was a small slice. The in-cluster engine is now llama.cpp with **3** slots (Qwen3.8-27B is a dense 27B, and each 32k slot costs a full GiB of VRAM on a card already at 22562/24564 MiB). At 2, untrusted public traffic gets two thirds of the GPU and Discord, private chat and agents share the remaining one.

Resized to **1**, restoring the proportion the reserved-headroom control (ADR 005 layer 2+3, enforced via Postgres advisory locks so it holds across HPA replicas) was designed to give.

**This deliberately does not follow "sync callers are uncapped."** Public chat is synchronous too. The distinction that matters here is trusted vs untrusted, not sync vs async: this is an abuse boundary, and the point is that anonymous traffic cannot crowd out the people the GPU exists for. That reasoning is now in the code so the next person resizing does not "fix" the inconsistency.

## The inert key

`chatPublic.globalMaxConcurrent: 2` sat directly above the real knob, describing itself as:

> Mirrored as `CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT` on web.env below.

It was referenced by **no template anywhere in the repo**. `git grep globalMaxConcurrent` returns exactly one line: its own definition. Editing it would have changed nothing while reading exactly like the live setting, which is the failure mode this repo keeps hitting.

`values.yaml` cannot reference its own keys, so it is removed rather than wired, leaving the env literal as the single place the ceiling is set.

`limits.py`'s code default and `SIZING RULE` comment move in step (the comment still said "Today max_num_seqs=8 and public is capped at 2"). Production always sets the env, so the default governs dev and test only, but leaving the two telling different stories is how this drifts.

## Public-tier checklist

Worked through `docs/runbooks/public-tier-checklist.md`:

- **public_reader grants** — N/A, no new table or read path.
- **No `/api` on the public origin** — N/A, no new fetch.
- **gazelle-exclude vs the public binary** — N/A, no new import.
- **is_global / visibility filtering** — N/A, no query change.
- **Rollout** — touches `monolith-public` (the env) and `monolith` (`chat_public/limits.py`). No chart version bumps in the PR, per ADR platform/009; the post-merge write-back owns those.
- **Post-deploy verification** — will `curl` `https://jomcgi.dev` live after the rollout rather than treating merge as done.

## Verification

`ci test`: `Executed 72 out of 715 tests: 715 tests pass`. `helm template` renders `CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT: "1"`.