### PR TITLE
fix(swarm): stop the classifier spending its whole budget thinking

### DIFF
--- a/projects/monolith/swarm/classifier.py
+++ b/projects/monolith/swarm/classifier.py
@@ -14,7 +14,20 @@ _CLASSIFICATION_PATTERN = re.compile(
     r"CLASSIFICATION:\s*(one_shot|planned)", re.IGNORECASE
 )
 _TAIL_LINES = 3
-_TIMEOUT_SECONDS = 5.0
+# The alias resolves to a REASONING model since the llama.cpp switch
+# (9697abc47). Reasoning tokens count against the generation budget even
+# though --reasoning-format deepseek routes them into `reasoning_content`,
+# so a budget sized for a one-line answer is spent thinking and `content`
+# comes back empty. That parses to None, which fails closed to one_shot, so
+# EVERY task became a session and no run could ever start.
+#
+# Two changes rather than one, deliberately. `enable_thinking: false` is the
+# real fix (a binary classification does not need deliberation, and skipping
+# it also makes the call fast), and the wider budget is the belt: if a future
+# model or template ignores the flag, the answer still fits instead of
+# silently reverting the entrypoint to sessions-only.
+_TIMEOUT_SECONDS = 20.0
+_MAX_TOKENS = 512
 _MODEL = "qwen3.6-27b"
 
 
@@ -62,7 +75,12 @@ async def classify_task_with_outcome(text: str) -> tuple[str, int, str, str | No
                         {"role": "user", "content": text},
                     ],
                     "temperature": 0,
-                    "max_tokens": 64,
+                    "max_tokens": _MAX_TOKENS,
+                    # Skip deliberation for a binary label. Qwen reads this
+                    # through the jinja chat template; a server that does not
+                    # understand it ignores it, which is why _MAX_TOKENS still
+                    # has to be large enough to hold reasoning plus answer.
+                    "chat_template_kwargs": {"enable_thinking": False},
                 },
             )
         response.raise_for_status()

--- a/projects/monolith/swarm/classifier_test.py
+++ b/projects/monolith/swarm/classifier_test.py
@@ -118,3 +118,40 @@ async def test_error_fails_closed(monkeypatch):
     assert classification == "one_shot"
     assert outcome == "error"
     assert refusal == "down"
+
+
+@pytest.mark.asyncio
+async def test_request_leaves_room_for_a_reasoning_model(monkeypatch):
+    """The request must not budget for a one-line answer alone.
+
+    The alias resolves to a reasoning model, whose reasoning tokens count
+    against max_tokens even when the server routes them into a separate
+    field. A 64 token budget was spent thinking, `content` came back empty,
+    and the classifier failed closed to one_shot for every task, so no run
+    could ever start. Assert both halves of the fix: thinking is disabled,
+    and the budget is large enough to survive a server that ignores that.
+    """
+    captured = {}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def post(self, *args, **kwargs):
+            captured["json"] = kwargs["json"]
+            return FakeResponse("CLASSIFICATION: planned")
+
+    monkeypatch.setattr("httpx.AsyncClient", FakeAsyncClient)
+    classification, _, outcome, _ = await classify_task_with_outcome("ship a feature")
+
+    assert classification == "planned"
+    assert outcome == "success"
+    assert captured["json"]["chat_template_kwargs"]["enable_thinking"] is False
+    assert captured["json"]["max_tokens"] >= 256
+    assert captured["timeout"] >= 10


### PR DESCRIPTION
**Every task submitted through the console became a session.** No run could start, which made the run tier unreachable from the entrypoint built to reach it.

## Cause

The classifier asks for a single line and budgeted 64 tokens for it:

```python
"temperature": 0,
"max_tokens": 64,
```

That was correct until `9697abc47`, merged today, switched the inference engine to llama.cpp serving **Qwen3.8-27B, a reasoning model**. `--reasoning-format deepseek` routes reasoning into `reasoning_content`, but those tokens still count against `max_tokens`. The budget was spent deliberating and `content` came back empty or truncated.

Empty content parses to `None`, and the classifier fails closed:

```python
if classification is None:
    return ("one_shot", ..., "unparseable", "unparseable response")
```

Fail-closed is the right design and it did exactly what it promised. It just made an entire tier silently unreachable while every layer reported success: the request 200s, the recording says `unparseable`, and the console shows a session.

Corroborating evidence from the llama.cpp logs: real generations on this server run 122 to 2033 tokens. A 64 token ceiling is far below what the model needs to reach an answer.

## Fix

Two changes, deliberately.

**`chat_template_kwargs: {"enable_thinking": false}`** is the real fix. A binary classification needs no deliberation, and skipping it also makes the call fast.

**A wider budget and timeout** are the belt. If a future model or chat template ignores that flag, the answer still fits instead of quietly reverting the entrypoint to sessions-only. This failure mode is invisible from every signal we have, so it earns a second line of defence.

## Verification

`ci test //projects/monolith:swarm_classifier_test --nocache_test_results` → `Executed 1 out of 1 test: 1 test passes`. Forced, not a cache replay.

The new test captures the outgoing request and asserts both halves, so a future edit that drops either one fails rather than silently restoring the bug.

## Two findings this exposed

**Nothing reads `swarm_conductor_call`.** It records `outcome` and `refusal_code` per classification, which is exactly the evidence for this bug, and no consumer surfaces it. The data was there the whole time and nothing showed it. Worth its own issue.

**A `planned` classification still needs repo and branch** (`router.py:281`), and the task box presents both as optional. Once this fix lands and runs actually classify, submitting a planning-shaped task on a scratch workspace will return a 400 after the fact. That is a separate defect and not fixed here, but it becomes reachable the moment this merges.

## Related

Second failure today from the same engine swap. #4884 is the other: the egress proxy forwards absolute-form request lines that llama.cpp rejects, breaking every qwen session.