### PR TITLE
fix(egress-proxy): normalize absolute-form request lines to origin-form

### DIFF
--- a/projects/firecracker/substrate/egress-proxy/cmd/main.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/main.go
@@ -56,7 +56,9 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -290,11 +292,161 @@ func (p *proxy) handle(client net.Conn) {
 	defer up.Close()
 
 	// Pump both directions. br carries the peeked-but-unconsumed client bytes, so
-	// the upstream sees the exact original stream. Either close unblocks the other.
+	// the upstream sees the exact original stream, apart from absolute-form HTTP
+	// request lines. The wrapper re-enters request-line detection after each
+	// request body, so keep-alive connections are normalized request by request.
 	done := make(chan struct{}, 2)
-	go func() { _, _ = io.Copy(up, br); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(up, newOriginFormReader(br)); done <- struct{}{} }()
 	go func() { _, _ = io.Copy(client, up); done <- struct{}{} }()
 	<-done
+}
+
+// originFormReader is deliberately only a request-line filter, not a reverse
+// proxy. It consumes headers solely to find the next request boundary and
+// copies every header and body byte unchanged. If the stream does not begin
+// with an HTTP request line, it fails open and becomes a byte-for-byte reader,
+// which keeps git and other non-HTTP protocols on the blind tunnel.
+type originFormReader struct {
+	src         *bufio.Reader
+	pending     []byte
+	state       originFormReaderState
+	contentLeft int64
+	rewriteHost string
+	headerBuf   []byte
+	hasHost     bool
+}
+
+type originFormReaderState uint8
+
+const (
+	originFormRequestLine originFormReaderState = iota
+	originFormHeaders
+	originFormBody
+	originFormPassthrough
+)
+
+func newOriginFormReader(src *bufio.Reader) io.Reader {
+	return &originFormReader{src: src, state: originFormRequestLine}
+}
+
+func (r *originFormReader) Read(p []byte) (int, error) {
+	for len(r.pending) == 0 {
+		switch r.state {
+		case originFormRequestLine:
+			line, err := r.src.ReadString('\n')
+			if err != nil {
+				r.state = originFormPassthrough
+				r.pending = []byte(line)
+				if len(line) == 0 {
+					return 0, err
+				}
+				break
+			}
+			rewritten, host, absolute, ok := classifyRequestLine(line)
+			if !ok {
+				r.state = originFormPassthrough
+				r.pending = []byte(line)
+				break
+			}
+			r.pending = []byte(line)
+			if absolute {
+				r.pending = []byte(rewritten)
+			}
+			r.rewriteHost = host
+			r.headerBuf = r.headerBuf[:0]
+			r.hasHost = false
+			r.state = originFormHeaders
+		case originFormHeaders:
+			line, err := r.src.ReadString('\n')
+			if len(line) == 0 && err != nil {
+				r.state = originFormPassthrough
+				return 0, err
+			}
+			if strings.EqualFold(strings.TrimSpace(strings.SplitN(line, ":", 2)[0]), "host") {
+				r.hasHost = true
+			}
+			r.headerBuf = append(r.headerBuf, line...)
+			if line == "\r\n" || line == "\n" {
+				if r.rewriteHost != "" && !r.hasHost {
+					r.headerBuf = append([]byte("Host: "+r.rewriteHost+"\r\n"), r.headerBuf...)
+				}
+				r.contentLeft = contentLength(r.headerBuf)
+				r.pending = append(r.pending, r.headerBuf...)
+				r.headerBuf = r.headerBuf[:0]
+				if r.contentLeft > 0 {
+					r.state = originFormBody
+				} else {
+					r.state = originFormRequestLine
+				}
+			}
+			if err != nil {
+				if len(r.headerBuf) > 0 {
+					r.pending = append(r.pending, r.headerBuf...)
+					r.headerBuf = r.headerBuf[:0]
+				}
+				r.state = originFormPassthrough
+			}
+		case originFormBody:
+			if r.contentLeft == 0 {
+				r.state = originFormRequestLine
+				continue
+			}
+			n := len(p)
+			if int64(n) > r.contentLeft {
+				n = int(r.contentLeft)
+			}
+			buf := make([]byte, n)
+			read, err := io.ReadFull(r.src, buf)
+			r.pending = append(r.pending, buf[:read]...)
+			r.contentLeft -= int64(read)
+			if err != nil {
+				r.state = originFormPassthrough
+			}
+		case originFormPassthrough:
+			n, err := r.src.Read(p)
+			return n, err
+		}
+	}
+
+	n := copy(p, r.pending)
+	r.pending = r.pending[n:]
+	return n, nil
+}
+
+func classifyRequestLine(line string) (string, string, bool, bool) {
+	parts := strings.Fields(strings.TrimRight(line, "\r\n"))
+	if len(parts) != 3 || !strings.HasPrefix(parts[2], "HTTP/") {
+		return "", "", false, false
+	}
+	if strings.HasPrefix(parts[1], "/") {
+		return line, "", false, true
+	}
+	u, err := url.ParseRequestURI(parts[1])
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return "", "", false, false
+	}
+	origin := u.RequestURI()
+	if origin == "" {
+		origin = "/"
+	}
+	ending := "\n"
+	if strings.HasSuffix(line, "\r\n") {
+		ending = "\r\n"
+	}
+	return parts[0] + " " + origin + " " + parts[2] + ending, u.Host, true, true
+}
+
+func contentLength(headers []byte) int64 {
+	for _, line := range strings.Split(string(headers), "\n") {
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) == 2 && strings.EqualFold(strings.TrimSpace(parts[0]), "content-length") {
+			n, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+			if err == nil && n >= 0 {
+				return n
+			}
+		}
+	}
+	return 0
 }
 
 // allowed reports whether dest is permitted by allowlist (used for the internal

--- a/projects/firecracker/substrate/egress-proxy/cmd/main_test.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/main_test.go
@@ -1,9 +1,88 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"io"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestOriginFormReader(t *testing.T) {
+	absolute := "POST http://inference.inference.svc.cluster.local:8080/v1/chat/completions HTTP/1.1\r\n" +
+		"Host: inference.inference.svc.cluster.local:8080\r\nContent-Length: 0\r\n\r\n"
+	origin := "POST /v1/chat/completions HTTP/1.1\r\nHost: inference.inference.svc.cluster.local:8080\r\nContent-Length: 0\r\n\r\n"
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "absolute form preserves host",
+			in:   absolute,
+			want: origin,
+		},
+		{
+			name: "origin form passes through",
+			in:   origin,
+			want: origin,
+		},
+		{
+			name: "keep alive rewrites every request",
+			in:   absolute + absolute,
+			want: origin + origin,
+		},
+		{
+			name: "non HTTP bytes pass through",
+			in:   "git-upload-pack\x00\x01\xffbinary",
+			want: "git-upload-pack\x00\x01\xffbinary",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got bytes.Buffer
+			if _, err := io.Copy(&got, newOriginFormReader(bufio.NewReader(strings.NewReader(tt.in)))); err != nil {
+				t.Fatal(err)
+			}
+			if got.String() != tt.want {
+				t.Errorf("rewritten stream = %q, want %q", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestOriginFormReaderHandlesSplitRequestLine(t *testing.T) {
+	line := "POST http://inference.inference.svc.cluster.local:8080/v1/chat/completions HTTP/1.1\r\n"
+	in := strings.NewReader(line[:17])
+	reader := &chunkedReader{first: in, second: strings.NewReader(line[17:] + "Host: inference.inference.svc.cluster.local:8080\r\n\r\n")}
+	var got bytes.Buffer
+	if _, err := io.Copy(&got, newOriginFormReader(bufio.NewReader(reader))); err != nil {
+		t.Fatal(err)
+	}
+	want := "POST /v1/chat/completions HTTP/1.1\r\nHost: inference.inference.svc.cluster.local:8080\r\n\r\n"
+	if got.String() != want {
+		t.Errorf("rewritten split stream = %q, want %q", got.String(), want)
+	}
+}
+
+type chunkedReader struct {
+	first, second io.Reader
+}
+
+func (r *chunkedReader) Read(p []byte) (int, error) {
+	if r.first != nil {
+		n, err := r.first.Read(p)
+		if err == io.EOF {
+			r.first = nil
+		}
+		if n > 0 {
+			return n, nil
+		}
+	}
+	return r.second.Read(p)
+}
 
 func TestAllowed(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Closes #4884. Every qwen (pi family) agent session fails at invoke, in console, MCP and Discord alike, because all three funnel into the same `agent_sessions.transport`.

## Cause

Pi reaches its provider through `HTTP_PROXY`, so it emits **absolute-form** request lines per RFC 7230:

```
POST http://inference.inference.svc.cluster.local:8080/v1/chat/completions HTTP/1.1
```

The non-credentialed lane of this proxy is a verbatim byte tunnel (`io.Copy` both ways), so that line reached the backend unrewritten. Only the credentialed claude lane parses and re-issues.

vLLM accepted absolute-form. `9697abc47`, merged today, switched `llm.engine` to llama.cpp to serve Qwen3.8-27B, and **cpp-httplib 404s an absolute-form target**. The failure is a 236 byte `404 File Not Found` with `Connection: close`, killing the turn in under a second before any model phase.

Nothing was wrong on either side. Pi emits absolute-form correctly, llama.cpp rejects it correctly, and the proxy forwarded faithfully. The defect is that **a forwarding proxy is supposed to normalize** (RFC 7230 section 5.3.1) and this one never had to, because vLLM happened to be lenient.

## Approach

An `originFormReader` wrapping the upstream copy: a request-line filter, not a reverse proxy. The lane stays a tunnel.

| concern | handling |
|---|---|
| **Keep-alive** | Tracks `Content-Length` to find the body end, then returns to the request-line state, so every request on the connection is normalized, not just the first |
| **Non-HTTP** | Anything that does not classify as an HTTP request line switches to `originFormPassthrough` permanently. Git and friends stay on the blind tunnel |
| **Host header** | Authority from the absolute-form target is injected only when no `Host` header is present |
| **Split reads** | Request lines arriving across TCP reads are handled, with a dedicated test |
| **Errors** | Fall through to passthrough, never mangle |
| **Nagle** | `SetNoDelay` at main.go:283 untouched, still load-bearing for git clone latency |

## Verification

`ci test //projects/firecracker/substrate/egress-proxy/... --nocache_test_results` → `Executed 1 out of 1 test: 1 test passes`. Forced, not a cache replay.

**Not verified: that a qwen session now completes.** That is only observable after this deploys. I will confirm by starting one and reading its status, the same way #4884 was reproduced, rather than by inspecting the diff.

## Known limitation worth stating

A request using `Transfer-Encoding: chunked` has no `Content-Length`, so the reader cannot find the body end and degrades to passthrough for the rest of that connection. It never corrupts the stream, it just stops normalizing. Pi's calls send JSON with a `Content-Length`, so this does not affect the failing lane, but it is a real edge and better named than discovered.

## Related

Second failure today from the same engine swap. #4887 is the other: the classifier budgeted 64 tokens for its answer, which a reasoning model spends thinking, so every task fell back to a session and no run could start.