### PR TITLE
feat(swarm): ask for repo and branch when a task classifies as planned

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -87,9 +87,12 @@
   let composerModelOverride = $state(null);
   let sending = $state(false);
   let creating = $state(false);
+  let needsInputState = $state(false);
+  let pendingTaskId = $state(null);
   let showNewPanel = $state(false);
   let newButtonEl = $state(null);
   let newPromptEl = $state(null);
+  let repoControlEl = $state(null);
   let titleEl = $state(null);
   let focusSessionId = null;
   let previousSessionId = null;
@@ -690,10 +693,14 @@
 
   function closeNewPanel() {
     showNewPanel = false;
+    needsInputState = false;
+    pendingTaskId = null;
     tick().then(() => newButtonEl?.focus({ preventScroll: true }));
   }
 
   function openNewPanel() {
+    needsInputState = false;
+    pendingTaskId = null;
     showNewPanel = true;
   }
 
@@ -790,6 +797,7 @@
     try {
       const requestBody = {
         task: newSession.prompt.trim(),
+        ...(pendingTaskId ? { task_id: pendingTaskId } : {}),
         model: newSession.model,
         repo: newSession.repo || null,
         branch: newSession.branch || null,
@@ -802,9 +810,19 @@
       const body = await response.json();
       if (!response.ok)
         throw new Error(body.detail || P.labels.taskCreateFailed);
+      if (body.kind === "needs_input" && body.needs_input) {
+        needsInputState = true;
+        pendingTaskId = body.task_id;
+        creating = false;
+        await tick();
+        repoControlEl?.focus({ preventScroll: true });
+        return;
+      }
       closeNewPanel();
       newSession = { prompt: "", model: "", repo: "", branch: "" };
       branches = [];
+      needsInputState = false;
+      pendingTaskId = null;
       if (body.kind === "run" && body.workflow_id) selectRun(body.workflow_id);
       else if (body.session_id) selectSession(body.session_id);
       // Released only after navigation, not before it. Clearing this on the
@@ -1517,6 +1535,9 @@
         </div>
         <label
           >{P.labels.repoWord}<select
+            bind:this={repoControlEl}
+            class:needs-input={needsInputState}
+            aria-invalid={needsInputState}
             class="mono"
             bind:value={newSession.repo}
             disabled={repoLoading}
@@ -1537,6 +1558,11 @@
             {/if}
           </select></label
         >
+        {#if needsInputState}
+          <div class="needs-input-message" role="status">
+            {P.labels.plannedNeedsRepoBranch}
+          </div>
+        {/if}
         <label>
           branch<select
             class="mono"
@@ -2413,6 +2439,14 @@
     text-transform: none;
     letter-spacing: normal;
     font-size: var(--size-body);
+  }
+  .new-panel select.needs-input {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+  .needs-input-message {
+    color: var(--accent);
+    font-size: var(--size-meta);
   }
   .new-actions {
     justify-content: flex-end;

--- a/projects/monolith/frontend/src/routes/private/agents/lexicon.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/lexicon.test.js
@@ -63,4 +63,14 @@ describe("run lexicon", () => {
   test("no lexicon value contains an em-dash", () => {
     expect(EVERY_VALUE.filter((value) => value.includes("—"))).toEqual([]);
   });
+
+  test("planned task input question preserves the task and focuses the repo", () => {
+    const page = surface("+page.svelte");
+    expect(page).toContain("let needsInputState = $state(false)");
+    expect(page).toContain("pendingTaskId ? { task_id: pendingTaskId } : {}");
+    expect(page).toContain('body.kind === "needs_input"');
+    expect(page).toContain("repoControlEl?.focus");
+    expect(page).toContain("P.labels.plannedNeedsRepoBranch");
+    expect(page).toContain("class:needs-input={needsInputState}");
+  });
 });

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -151,6 +151,8 @@ export const RUN_LEXICON = {
     launcherPromptPlaceholder: "what should the agent do?",
     submitTask: "submit task",
     taskCreateFailed: "Task was not created",
+    plannedNeedsRepoBranch:
+      "This planned task needs a repository and branch before it can start.",
     classify: "classify",
     recentHeading: "recent",
     noRecentActivity: "no activity in the last 7 days",

--- a/projects/monolith/swarm/router.py
+++ b/projects/monolith/swarm/router.py
@@ -46,6 +46,7 @@ class RunRequest(BaseModel):
 
 class ClassifyAndStartRequest(BaseModel):
     task: str
+    task_id: str | None = None
     repo: str | None = None
     branch: str | None = None
     model: str
@@ -54,9 +55,11 @@ class ClassifyAndStartRequest(BaseModel):
 
 class ClassifyAndStartResponse(BaseModel):
     task_id: str
+    classification: str
     session_id: int | None = None
     workflow_id: str | None = None
     kind: str
+    needs_input: dict[str, bool] | None = None
 
 
 class PromoteSessionRequest(BaseModel):
@@ -246,6 +249,24 @@ def _set_task_link_sync(task_id: str, **links) -> None:
         update_task_links(task_id, session=db, **links)
 
 
+def _update_task_inputs_sync(
+    task_id: str, repo: str | None, branch: str | None
+) -> None:
+    """Fill in the repository inputs on a task being resubmitted."""
+    from core.db import get_engine
+    from sqlmodel import Session
+    from swarm.models import SwarmTask
+
+    with Session(get_engine()) as db:
+        row = db.get(SwarmTask, task_id)
+        if row is None:
+            raise ValueError(f"Unknown swarm task {task_id}")
+        row.repo = repo
+        row.base_branch = branch
+        db.add(row)
+        db.commit()
+
+
 @router.post("/classify-and-start", response_model=ClassifyAndStartResponse)
 async def classify_and_start(request: Request, body: ClassifyAndStartRequest):
     task = body.task.strip()
@@ -257,31 +278,47 @@ async def classify_and_start(request: Request, body: ClassifyAndStartRequest):
 
     from swarm import classifier, models
 
-    task_id = models.mint_task_id()
-    await asyncio.to_thread(
-        _create_task_sync, task_id, task, body.repo, body.branch, body.budget_usd
-    )
+    is_resubmission = body.task_id is not None
+    task_id = body.task_id or models.mint_task_id()
+    if is_resubmission:
+        try:
+            await asyncio.to_thread(
+                _update_task_inputs_sync, task_id, body.repo, body.branch
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+    else:
+        await asyncio.to_thread(
+            _create_task_sync, task_id, task, body.repo, body.branch, body.budget_usd
+        )
     (
         classification,
         latency_ms,
         outcome,
         refusal_code,
     ) = await classifier.classify_task_with_outcome(task)
-    await asyncio.to_thread(
-        _record_classification_sync,
-        task_id,
-        task,
-        classification,
-        latency_ms,
-        outcome,
-        refusal_code,
-        body.budget_usd,
-    )
+    if not is_resubmission:
+        await asyncio.to_thread(
+            _record_classification_sync,
+            task_id,
+            task,
+            classification,
+            latency_ms,
+            outcome,
+            refusal_code,
+            body.budget_usd,
+        )
 
     if classification == "planned":
         if not body.repo or not body.branch:
-            raise HTTPException(
-                status_code=400, detail="planned tasks require repo and branch"
+            return ClassifyAndStartResponse(
+                task_id=task_id,
+                classification=classification,
+                kind="needs_input",
+                needs_input={
+                    "repo": not bool(body.repo),
+                    "branch": not bool(body.branch),
+                },
             )
         try:
             result = start_run(
@@ -303,7 +340,10 @@ async def classify_and_start(request: Request, body: ClassifyAndStartRequest):
             _set_task_link_sync, task_id, workflow_id=result["workflow_id"]
         )
         return ClassifyAndStartResponse(
-            task_id=task_id, workflow_id=result["workflow_id"], kind="run"
+            task_id=task_id,
+            classification=classification,
+            workflow_id=result["workflow_id"],
+            kind="run",
         )
 
     from agent_sessions.router import StartRequest, start_session
@@ -330,7 +370,10 @@ async def classify_and_start(request: Request, body: ClassifyAndStartRequest):
         _set_task_link_sync, task_id, session_id=result["session_id"]
     )
     return ClassifyAndStartResponse(
-        task_id=task_id, session_id=result["session_id"], kind="session"
+        task_id=task_id,
+        classification=classification,
+        session_id=result["session_id"],
+        kind="session",
     )
 
 

--- a/projects/monolith/swarm/router.py
+++ b/projects/monolith/swarm/router.py
@@ -252,7 +252,15 @@ def _set_task_link_sync(task_id: str, **links) -> None:
 def _update_task_inputs_sync(
     task_id: str, repo: str | None, branch: str | None
 ) -> None:
-    """Fill in the repository inputs on a task being resubmitted."""
+    """Fill in the repository inputs on a task being resubmitted.
+
+    `task_id` arrives from the client, so this narrows what a resubmission
+    may touch rather than trusting the id. Only a task that is still
+    awaiting its inputs qualifies: one with no repo recorded and nothing
+    started against it. That keeps the field editable for exactly the
+    round trip it exists for, and makes a stale or wrong id a 400 instead
+    of a silent write to somebody else's row.
+    """
     from core.db import get_engine
     from sqlmodel import Session
     from swarm.models import SwarmTask
@@ -261,6 +269,8 @@ def _update_task_inputs_sync(
         row = db.get(SwarmTask, task_id)
         if row is None:
             raise ValueError(f"Unknown swarm task {task_id}")
+        if row.repo or row.workflow_id or row.session_id:
+            raise ValueError(f"Swarm task {task_id} is not awaiting inputs")
         row.repo = repo
         row.base_branch = branch
         db.add(row)

--- a/projects/monolith/swarm/router_test.py
+++ b/projects/monolith/swarm/router_test.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -493,3 +494,59 @@ def test_list_runs_clamps_limit_query_parameter(monkeypatch):
     assert client().get("/api/swarm/runs?active=false&limit=100").status_code == 200
     assert client().get("/api/swarm/runs?active=false&limit=0").status_code == 200
     assert captured == [50, 1]
+
+
+def test_update_task_inputs_refuses_a_task_not_awaiting_inputs(monkeypatch):
+    """`task_id` comes from the client, so the row it names has to be checked.
+
+    A resubmission may only fill in a task still waiting for its inputs.
+    Anything already carrying a repo, a workflow or a session is somebody
+    else's started work, and naming its id must fail rather than silently
+    rewrite it.
+    """
+
+    class Row:
+        def __init__(self, **kwargs):
+            self.repo = kwargs.get("repo")
+            self.base_branch = None
+            self.workflow_id = kwargs.get("workflow_id")
+            self.session_id = kwargs.get("session_id")
+
+    class FakeSession:
+        def __init__(self, row):
+            self._row = row
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def get(self, _model, _task_id):
+            return self._row
+
+        def add(self, _row):
+            return None
+
+        def commit(self):
+            return None
+
+    def run_with(row):
+        monkeypatch.setattr(
+            "sqlmodel.Session", lambda *args, **kwargs: FakeSession(row)
+        )
+        swarm_router._update_task_inputs_sync("task-1", "jomcgi/homelab", "main")
+
+    for started in (
+        Row(repo="jomcgi/homelab"),
+        Row(workflow_id="wf-1"),
+        Row(session_id=7),
+    ):
+        with pytest.raises(ValueError, match="not awaiting inputs"):
+            run_with(started)
+
+    # The awaiting case still writes.
+    awaiting = Row()
+    run_with(awaiting)
+    assert awaiting.repo == "jomcgi/homelab"
+    assert awaiting.base_branch == "main"

--- a/projects/monolith/swarm/router_test.py
+++ b/projects/monolith/swarm/router_test.py
@@ -161,6 +161,118 @@ def test_planned_run_rejects_unknown_model(monkeypatch):
     assert "Unknown model" in response.json()["detail"]
 
 
+def test_planned_without_repo_returns_needs_input(monkeypatch):
+    monkeypatch.setenv("SWARM_ENABLED", "true")
+    recorded = []
+
+    async def classify(_task):
+        return "planned", 1, "success", None
+
+    monkeypatch.setattr("swarm.classifier.classify_task_with_outcome", classify)
+    monkeypatch.setattr("swarm.models.mint_task_id", lambda: "task-1")
+    monkeypatch.setattr(swarm_router, "_create_task_sync", lambda *args: None)
+    monkeypatch.setattr(
+        swarm_router, "_record_classification_sync", lambda *args: recorded.append(args)
+    )
+    monkeypatch.setattr(
+        swarm_router,
+        "start_run",
+        lambda _request: (_ for _ in ()).throw(AssertionError("run must not start")),
+    )
+
+    response = client().post(
+        "/api/swarm/classify-and-start",
+        json={"task": "fix", "model": "terra"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "task_id": "task-1",
+        "classification": "planned",
+        "session_id": None,
+        "workflow_id": None,
+        "kind": "needs_input",
+        "needs_input": {"repo": True, "branch": True},
+    }
+    assert recorded
+
+
+def test_planned_resubmission_reuses_task_id(monkeypatch):
+    monkeypatch.setenv("SWARM_ENABLED", "true")
+    started = []
+    updated = []
+
+    async def classify(_task):
+        return "planned", 1, "success", None
+
+    monkeypatch.setattr("swarm.classifier.classify_task_with_outcome", classify)
+    monkeypatch.setattr("swarm.models.mint_task_id", lambda: "task-1")
+    monkeypatch.setattr(swarm_router, "_create_task_sync", lambda *args: None)
+    monkeypatch.setattr(
+        swarm_router,
+        "_update_task_inputs_sync",
+        lambda *args: updated.append(args),
+    )
+    monkeypatch.setattr(swarm_router, "_record_classification_sync", lambda *args: None)
+    monkeypatch.setattr(
+        swarm_router,
+        "start_run",
+        lambda request: started.append(request) or {"workflow_id": "wf-1"},
+    )
+    monkeypatch.setattr(
+        swarm_router, "_set_task_link_sync", lambda *args, **kwargs: None
+    )
+
+    first = client().post(
+        "/api/swarm/classify-and-start",
+        json={"task": "fix", "model": "terra"},
+    )
+    second = client().post(
+        "/api/swarm/classify-and-start",
+        json={
+            "task": "fix",
+            "task_id": first.json()["task_id"],
+            "repo": "jomcgi/homelab",
+            "branch": "main",
+            "model": "terra",
+        },
+    )
+
+    assert first.json()["task_id"] == "task-1"
+    assert second.status_code == 200
+    assert second.json()["task_id"] == "task-1"
+    assert second.json()["kind"] == "run"
+    assert len(updated) == 1
+    assert len(started) == 1
+
+
+def test_one_shot_without_repo_starts_session(monkeypatch):
+    monkeypatch.setenv("SWARM_ENABLED", "true")
+
+    async def classify(_task):
+        return "one_shot", 1, "success", None
+
+    async def start_session(_request, _body):
+        return {"session_id": 42}
+
+    monkeypatch.setattr("swarm.classifier.classify_task_with_outcome", classify)
+    monkeypatch.setattr(swarm_router, "_create_task_sync", lambda *args: None)
+    monkeypatch.setattr(swarm_router, "_record_classification_sync", lambda *args: None)
+    monkeypatch.setattr("agent_sessions.router.start_session", start_session)
+    monkeypatch.setattr(
+        swarm_router, "_set_task_link_sync", lambda *args, **kwargs: None
+    )
+
+    response = client().post(
+        "/api/swarm/classify-and-start",
+        json={"task": "explain", "model": "terra"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["kind"] == "session"
+    assert response.json()["session_id"] == 42
+
+
 def test_promote_session_carries_model(monkeypatch):
     captured = []
     row = type(


### PR DESCRIPTION
The task box presents repo and branch as optional (the default is "none (scratch workspace)"). Sessions genuinely do not need them. **Runs do**, and `classify_and_start` enforced that with a raise:

```python
if classification == "planned":
    if not body.repo or not body.branch:
        raise HTTPException(status_code=400, detail="planned tasks require repo and branch")
```

So the classifier could route a submission somewhere its inputs could not go, and you found out as a 400 after submitting, with nothing beforehand marking the choice as load-bearing.

This was latent until today: #4887 had every task classifying as `one_shot`, so the branch was unreachable. Fixing that makes this the next visible failure.

## Behaviour

On `planned` with a missing repo or branch, the endpoint now returns `kind: "needs_input"` carrying the classification, which inputs are missing, and the already-minted `task_id`. The console keeps the typed prompt, says why in one line, and completes the same submission once a repo is chosen. One task, not two.

Two alternatives were considered and rejected:

- **Silently falling back to a session** downgrades work you asked to be planned without telling you.
- **Requiring repo and branch on every submission** breaks the cheap "just ask it something" case that scratch workspace exists for.

Asking matches the direction already set for this surface: the entrypoint stays conversational and may ask fast initial follow-up questions. No run/session toggle is reintroduced; this is a question about inputs, not a mode switch.

## Review fix included

`task_id` arrives from the client on the resubmission path, and `_update_task_inputs_sync` looked the row up and wrote to it with no check beyond existence. Naming any task id would rewrite that task's repo and branch, including one already started.

Narrowed to the case the field exists for: no repo recorded, no workflow, no session. A stale or wrong id is a 400 instead of a silent write to another row. Column names verified against `SwarmTask` rather than assumed.

## Verification

`ci test //projects/monolith:swarm_router_test //projects/monolith/frontend:build //projects/monolith/frontend:test --nocache_test_results` → `Executed 2 out of 2 tests: 2 tests pass`. Forced, not a cache replay.

`frontend:build` is included deliberately: the vitest target does not compile the app, so a Svelte template error passes `:test` and fails only `:build`. That bit me earlier today on #4879.

Coverage: planned with repo still starts a run; planned without repo returns needs-input and starts nothing; `one_shot` without a repo still starts a session; resubmission reuses the `task_id`; and the guard refuses a task carrying a repo, a workflow or a session while still writing the awaiting case.

## Known behaviour worth a second opinion

A resubmission re-runs the classifier rather than trusting the recorded classification. Temperature is 0 so it should be stable, but a flip to `one_shot` would start a session right after you supplied a repo to get a run. Reusing the recorded value would be cheaper and deterministic. Left as is because it is a behaviour change beyond this fix, and worth deciding rather than assuming.