### PR TITLE
fix(embervm): converge to BuildBase when a recorded base is unobtainable

### DIFF
--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -511,6 +511,16 @@ defmodule Embervm.BaseBuilder do
   end
 
   def handle_cast({:reconcile_force_rebuild, workload_name, signature_at_start}, state) do
+    handle_cast(
+      {:reconcile_force_rebuild, workload_name, signature_at_start, :not_present_in_store},
+      state
+    )
+  end
+
+  def handle_cast(
+        {:reconcile_force_rebuild, workload_name, signature_at_start, failure_reason},
+        state
+      ) do
     case Map.get(state.workloads, workload_name) do
       nil ->
         {:noreply, state}
@@ -525,9 +535,18 @@ defmodule Embervm.BaseBuilder do
             "embervm base builder: forcing rebuild for #{workload_name}, cleared snapshot ref #{inspect(cleared_ref)}"
           )
 
-          w = %{w | built_signature: nil, snapshot_ref: nil}
+          # Remember only a ref confirmed absent from the store. A queued
+          # reconcile can otherwise preserve it through merge_desc/3 and select
+          # hydrate again before the rebuild gets a chance to start.
+          w = %{
+            w
+            | built_signature: nil,
+              snapshot_ref: nil,
+              unobtainable_snapshot_ref:
+                if(failure_reason == :not_present_in_store, do: cleared_ref, else: nil)
+          }
           state = put_in(state.workloads[workload_name], w)
-          {:noreply, reconcile_desc(state, hydrate_fallback_desc(w))}
+          {:noreply, reconcile_desc(state, hydrate_fallback_desc(w, clear_snapshot_ref: true))}
         end
     end
   end
@@ -809,6 +828,7 @@ defmodule Embervm.BaseBuilder do
 
   defp should_hydrate?(state, w, node_id) do
     is_binary(w.snapshot_ref) and w.built_signature == signature(w) and
+      Map.get(w, :unobtainable_snapshot_ref) != w.snapshot_ref and
       node_reports_base_absent?(state, node_id, w.name) and
       not already_targeting?(state, node_id, w.name, signature(w)) and
       not MapSet.member?(state.hydrating, w.name)
@@ -886,7 +906,15 @@ defmodule Embervm.BaseBuilder do
               "embervm base builder: hydrate #{name}/#{ref} fell back, forcing a rebuild (#{inspect(reason)})"
             )
 
-            GenServer.cast(owner, {:reconcile_force_rebuild, name, signature_at_start})
+            # In particular, :not_present_in_store is terminal for this recorded
+            # ref on this anchor, so the next reconcile must build.
+
+            GenServer.cast(owner, {
+              :reconcile_force_rebuild,
+              name,
+              signature_at_start,
+              reason
+            })
         end
       after
         send(owner, {:hydrate_done, name})
@@ -1021,7 +1049,7 @@ defmodule Embervm.BaseBuilder do
   # The desc a hydrate fallback re-drives: reconstruct the minimal build descriptor
   # from the workload's own recorded fields, so the reconcile rebuilds the SAME
   # base the hydrate failed to restore. class/zip are optional map keys.
-  defp hydrate_fallback_desc(w) do
+  defp hydrate_fallback_desc(w, opts \\ []) do
     %{
       name: w.name,
       namespace: w.namespace,
@@ -1033,7 +1061,8 @@ defmodule Embervm.BaseBuilder do
       ready_path: w.ready_path,
       vcpus: w.vcpus,
       mem_mib: w.mem_mib,
-      init_env: w.init_env
+      init_env: w.init_env,
+      clear_snapshot_ref: Keyword.get(opts, :clear_snapshot_ref, false)
     }
   end
 
@@ -1364,6 +1393,7 @@ defmodule Embervm.BaseBuilder do
       init_env: desc.init_env || %{},
       built_signature: nil,
       snapshot_ref: nil,
+      unobtainable_snapshot_ref: nil,
       snapshot_digest: nil,
       superseded_refs: [],
       # R2 refcounting: per-superseded-ref refcount tracking, keyed by snapshot
@@ -1385,7 +1415,7 @@ defmodule Embervm.BaseBuilder do
   end
 
   defp merge_desc(prev, desc, node_id) do
-    %{
+    merged = %{
       prev
       | namespace: desc.namespace,
         generation: desc.generation,
@@ -1399,6 +1429,16 @@ defmodule Embervm.BaseBuilder do
         mem_mib: desc.mem_mib,
         init_env: desc.init_env || %{}
     }
+
+    # Normal spec reconciles intentionally preserve the recorded base while a
+    # replacement builds. A hydrate fallback is different: its failed ref is
+    # known to be unobtainable, so the fallback descriptor explicitly clears the
+    # ledger and must not let `%{prev | ...}` reinstate it.
+    if Map.get(desc, :clear_snapshot_ref, false) do
+      %{merged | built_signature: nil, snapshot_ref: nil, snapshot_digest: nil}
+    else
+      merged
+    end
   end
 
   # The base signature: the spec fields that actually shape the base. A rebuild
@@ -1723,6 +1763,7 @@ defmodule Embervm.BaseBuilder do
       w
       | built_signature: built_sig,
         snapshot_ref: resp.snapshot_ref,
+        unobtainable_snapshot_ref: nil,
         snapshot_digest: resp.image_digest,
         superseded_refs: superseded,
         base_refs: base_refs,

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1951,6 +1951,161 @@ defmodule Embervm.BaseBuilderTest do
     assert Agent.get(calls, & &1) == 2
   end
 
+  test "a transient hydrate fallback does not latch the recorded ref" do
+    test_pid = self()
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+    {:ok, restore_calls} = Agent.start_link(fn -> 0 end)
+
+    restore_fun = fn :fake_channel, _req ->
+      call = Agent.get_and_update(restore_calls, fn n -> {n + 1, n + 1} end)
+      send(test_pid, :transient_restore_called)
+
+      case call do
+        1 -> {:error, %GRPC.RPCError{status: 14, message: "temporarily unavailable"}}
+        2 -> {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+      end
+    end
+
+    build_fun = fn :fake_channel, _req ->
+      call = Agent.get_and_update(calls, fn n -> {n + 1, n + 1} end)
+
+      case call do
+        1 -> {:ok, resp("snap1")}
+        2 ->
+          send(test_pid, {:transient_rebuild_started, self()})
+
+          receive do
+            :release_transient_rebuild -> {:ok, resp("snap2")}
+          end
+      end
+    end
+
+    {builder, _agent, table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_receive :transient_restore_called, 1_000
+    assert_receive {:transient_rebuild_started, rebuild_worker}, 1_000
+
+    assert get_in(:sys.get_state(builder), [:workloads, "w", :unobtainable_snapshot_ref]) == nil
+
+    send(rebuild_worker, :release_transient_rebuild)
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap2" end)
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_receive :transient_restore_called, 1_000
+    put_base_fact(table, "node-4", "big", "w", "snap2", :BASE_BUILD_STATE_READY, true)
+  end
+
+  test "a successful rebuild clears the unobtainable ref latch" do
+    test_pid = self()
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    restore_fun = fn :fake_channel, _req ->
+      send(test_pid, :restore_called_after_rebuild)
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+    end
+
+    build_fun = fn :fake_channel, _req ->
+      call = Agent.get_and_update(calls, fn n -> {n + 1, n + 1} end)
+
+      case call do
+        1 -> {:ok, resp("snap1")}
+        2 ->
+          send(test_pid, {:same_ref_rebuild_started, self()})
+
+          receive do
+            :release_same_ref_rebuild -> {:ok, resp("snap1")}
+          end
+      end
+    end
+
+    {builder, _agent, table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        build_fun: build_fun
+      )
+
+    d = desc(%{mem_mib: 4_000})
+    signature_at_start = {d.image_ref, nil, d.vcpus, d.mem_mib, d.guest_port, d.ready_path, d.init_env}
+    GenServer.cast(builder, {:reconcile_force_rebuild, "w", signature_at_start})
+    assert_receive {:same_ref_rebuild_started, rebuild_worker}, 1_000
+    send(rebuild_worker, :release_same_ref_rebuild)
+
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap1" end)
+    assert get_in(:sys.get_state(builder), [:workloads, "w", :unobtainable_snapshot_ref]) == nil
+
+    put_base_fact(table, "node-4", "big", "w", "", :BASE_BUILD_STATE_NONE, false)
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_receive :restore_called_after_rebuild, 1_000
+  end
+
+  test "an unobtainable recorded ref converges to BuildBase across repeated reconciles" do
+    {:ok, hydrates} = Agent.start_link(fn -> [] end)
+    {:ok, builds} = Agent.start_link(fn -> 0 end)
+
+    restore_fun = fn :fake_channel, %Embervm.Node.V1.RestoreArtifactRequest{artifact: ref} ->
+      Agent.update(hydrates, &[ref.ref | &1])
+      {:error, %GRPC.RPCError{status: 9, message: "not present in store"}}
+    end
+
+    {builder, _agent, _table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        build_fun: fn :fake_channel, _req ->
+          Agent.update(builds, &(&1 + 1))
+          {:ok, resp("snap1")}
+        end
+      )
+
+    # Keep the node's affirmative NONE fact in place. This is the live outage
+    # shape: every reconcile sees the recorded ref as absent on its anchor.
+    for _ <- 1..3 do
+      :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+      assert_eventually(fn -> Agent.get(builds, & &1) >= 2 end)
+    end
+
+    assert Agent.get(builds, & &1) == 2
+    assert Agent.get(hydrates, & &1) == ["snap1", "snap1"]
+  end
+
+  test "a healthy recorded base survives a spec edit" do
+    agent = start_recorder()
+    test_pid = self()
+    {:ok, build_calls} = Agent.start_link(fn -> 0 end)
+
+    builder =
+      start_builder(
+        status_writer: recording_status_writer(agent),
+        build_fun: fn :fake_channel, _req ->
+          call = Agent.get_and_update(build_calls, fn n -> {n + 1, n + 1} end)
+
+          case call do
+            2 ->
+              send(test_pid, {:spec_edit_rebuild_started, self()})
+
+              receive do
+                :release_spec_edit -> {:ok, resp("snap2")}
+              end
+
+            1 ->
+              {:ok, resp("snap1")}
+          end
+        end
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap1" end)
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2, ready_path: "/new-ready"}))
+    assert_receive {:spec_edit_rebuild_started, rebuild_worker}, 1_000
+    assert BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap1"
+    send(rebuild_worker, :release_spec_edit)
+  end
+
   test "hydrate fallback with a changed signature uses plain reconcile semantics" do
     test_pid = self()
     {:ok, calls} = Agent.start_link(fn -> 0 end)


### PR DESCRIPTION
Refs #4865. This is the half that ends the outage.

## The defect

`jomcgi.dev/health` has returned 503 since 14:57 UTC. Every 15 seconds, for six hours:

```
wake failed reason=:no_eligible_instance workload=demo-postgres
base builder: hydrating demo-postgres onto node-3/535f32b4... after a wake found no base on its anchor node
base builder: hydrate demo-postgres/demo-postgres__ec8abc5c1149 fell back, forcing a rebuild (:not_present_in_store)
base builder: forcing rebuild for demo-postgres, cleared snapshot ref "demo-postgres__ec8abc5c1149"
```

**BuildBase attempts in six hours: zero.** The builder logs the intent thousands of times and never performs it. The ref it keeps requesting exists on no node (checked across all six bricks) and is not in the store, so it is looping on an artifact obtainable by no means, while never taking the one action that could produce it.

## Why the clear did not stick

The fallback clears `built_signature` and `snapshot_ref` and re-drives `reconcile_desc/2`. But:

```elixir
defp merge_desc(prev, desc, node_id) do
  %{prev | namespace: ..., generation: ..., ...}   # never writes snapshot_ref
end
```

`merge_desc/3` preserves the recorded base by construction, deliberately, so a rebuild-in-progress keeps serving the old base across spec edits. A queued reconcile therefore reinstated the ref the fallback had just cleared, and `should_hydrate?/3` gates on exactly that ref, so hydrate was re-selected forever.

## The fix

The fallback marks the ref unobtainable and passes an explicit clear through the descriptor which `merge_desc` honours, so the next reconcile builds. The preservation property it exists for is unchanged and covered by its own test.

Two scoping decisions, both learned at review:

- **Only `:not_present_in_store` latches.** Latching on every hydrate failure means one store blip permanently disables restore-first for that ref, silently discarding hydrate-on-miss (PR-2) and rebuilding from scratch forever after.
- **A successful build releases the latch**, so it cannot become a permanent false statement about a ref that now exists.

## Verification

The regression test was run **red first** against unmodified `base_builder.ex`:

```
1) test an unobtainable recorded ref converges to BuildBase across repeated reconciles
1305 tests, 1 failure, 6 skipped
```

and green with the fix:

```
1305 tests, 0 failures, 6 skipped
```

Both latch tests were likewise run red before green. This matters more than usual here: the defect is a loop that emits success-shaped log lines while doing nothing, so a test passing in both states would prove nothing. Every run above was executed on this branch rather than taken on report.

## Scope, and what this does NOT fix

Three defects were found on this outage. This PR is one of them.

1. **This PR:** the builder never converges. Restores service.
2. **Vendor-blind `snapshot_ref`:** the scalar collapses a per-vendor `snapshotRefs` map and selected the AMD ref for an Intel anchor. Real, tracked separately, branch exists.
3. **`export_reconcile/1` only inspects the anchor node.** The current base sat on node-4 with no `meta.json`, never exported, so hydrate to node-3 could never succeed. Real, separate.

A follow-up worth folding into 3: the latch's release condition should arguably be a successful **export**, not a successful build. A build proves the base exists locally; hydrate needs it in the store. Local existence and store availability are conflated at several layers here, which is the through-line of this whole incident.

## Deployment

embervm production promotion is a manual click (#4863), so this reaches production when someone promotes, not on merge. Worth batching with #4868 so one promotion carries both.