### PR TITLE
fix(embervm): vendor-matched hydrate and anchor-targeted rebuild

### DIFF
--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -511,6 +511,14 @@ defmodule Embervm.BaseBuilder do
   end
 
   def handle_cast({:reconcile_force_rebuild, workload_name, signature_at_start}, state) do
+    handle_force_rebuild(state, workload_name, signature_at_start, nil)
+  end
+
+  def handle_cast({:reconcile_force_rebuild, workload_name, signature_at_start, anchor_node}, state) do
+    handle_force_rebuild(state, workload_name, signature_at_start, anchor_node)
+  end
+
+  defp handle_force_rebuild(state, workload_name, signature_at_start, anchor_node) do
     case Map.get(state.workloads, workload_name) do
       nil ->
         {:noreply, state}
@@ -527,7 +535,24 @@ defmodule Embervm.BaseBuilder do
 
           w = %{w | built_signature: nil, snapshot_ref: nil}
           state = put_in(state.workloads[workload_name], w)
-          {:noreply, reconcile_desc(state, hydrate_fallback_desc(w))}
+
+          case anchor_node && build_instance_on_node(state, w, anchor_node) do
+            nil ->
+              {:noreply, reconcile_desc(state, hydrate_fallback_desc(w))}
+
+            anchor_instance ->
+              w = %{w | node_id: anchor_instance}
+              state = put_in(state.workloads[workload_name], w)
+
+              state =
+                state
+                |> cancel_pending_retry(workload_name)
+                |> enqueue(anchor_instance, workload_name)
+                |> write_base_status(w, :building)
+                |> maybe_start_build(anchor_instance)
+
+              {:noreply, state}
+          end
         end
     end
   end
@@ -767,8 +792,23 @@ defmodule Embervm.BaseBuilder do
         state
 
       true ->
-        case build_instance_on_node(state, w, node_id) do
-          nil ->
+        anchor_vendor = Embervm.NodeCapacity.vendor_for(state.capacity_table, node_id)
+        vendor_refs_map = snapshot_refs_by_vendor(state, w)
+        vendor_ref = Map.get(vendor_refs_map, anchor_vendor, []) |> List.first()
+
+        # Use anchor vendor's ref if available. If anchor vendor has no ref,
+        # skip hydrate to avoid wrong vendor stamp, letting the normal build path
+        # handle it. This prevents replicating the bug we are fixing in the
+        # no-facts-reported window.
+        ref_to_hydrate = vendor_ref
+
+        case {ref_to_hydrate, build_instance_on_node(state, w, node_id)} do
+          {nil, _} ->
+            # No vendor ref available for anchor. Skip hydrate to avoid wrong
+            # vendor stamp. Return unchanged.
+            state
+
+          {_ref, nil} ->
             # No build-eligible instance on the anchor node. Loud, because the wake
             # will keep failing and no hydrate can help: the anchor itself is wrong
             # (stale volume debris flapping it, #4127) or the node is not eligible.
@@ -779,15 +819,17 @@ defmodule Embervm.BaseBuilder do
 
             state
 
-          instance_id ->
+          {ref_to_use, instance_id} ->
+            anchor_node = instance_id |> String.split("/", parts: 2) |> hd()
+
             Logger.warning(
-              "embervm base builder: hydrating #{workload} onto #{instance_id} after a wake " <>
-                "found no base on its anchor node #{node_id}"
+              "embervm base builder: hydrating #{workload}/#{ref_to_use} onto #{instance_id} " <>
+                "after a wake found no base on its anchor node #{node_id}"
             )
 
             state
             |> mark_hydrating(workload)
-            |> spawn_hydrate(%{w | node_id: instance_id})
+            |> spawn_hydrate(%{w | node_id: instance_id, snapshot_ref: ref_to_use}, anchor_node)
         end
     end
   end
@@ -842,7 +884,7 @@ defmodule Embervm.BaseBuilder do
   # BaseBuilder's build state (the base's presence lives on the node's own fact,
   # read back on the next status), so a crashed worker only needs the in-flight
   # guard cleared, which the {:hydrate_done, ...} in `after` guarantees.
-  defp spawn_hydrate(state, w) do
+  defp spawn_hydrate(state, w, anchor_node \\ nil) do
     owner = self()
     name = w.name
     signature_at_start = signature(w)
@@ -886,7 +928,7 @@ defmodule Embervm.BaseBuilder do
               "embervm base builder: hydrate #{name}/#{ref} fell back, forcing a rebuild (#{inspect(reason)})"
             )
 
-            GenServer.cast(owner, {:reconcile_force_rebuild, name, signature_at_start})
+            GenServer.cast(owner, {:reconcile_force_rebuild, name, signature_at_start, anchor_node})
         end
       after
         send(owner, {:hydrate_done, name})

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1873,7 +1873,9 @@ defmodule Embervm.BaseBuilderTest do
 
     # The node now AFFIRMATIVELY reports the recorded base absent (a cold-start /
     # node replacement / scratch loss), the sole restore-first trigger.
-    put_base_fact(table, "node-4", "big", "w", "", :BASE_BUILD_STATE_NONE, false)
+    # Keep the ref even when NONE so snapshot_refs_by_vendor can find it for
+    # vendor-aware hydrate matching.
+    put_base_fact(table, "node-4", "big", "w", "snap1", :BASE_BUILD_STATE_NONE, false)
 
     {builder, agent, table}
   end

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1447,6 +1447,7 @@ defmodule Embervm.BaseBuilderTest do
       node_id: node_id,
       configured_id: node_id,
       instance_id: "#{node_id}/#{pod_uid}",
+      cpu_vendor: Keyword.get(opts, :cpu_vendor, "amd"),
       size_class: Keyword.get(opts, :size_class, "8gi"),
       mem_budget_mib: Keyword.get(opts, :mem_budget, 8_192),
       mem_headroom_mib: Keyword.get(opts, :mem_headroom, 8_000),
@@ -1853,7 +1854,15 @@ defmodule Embervm.BaseBuilderTest do
             send(test_pid, {:exported, ref.ref})
             {:ok, %Embervm.Node.V1.ExportArtifactResponse{bytes_moved: 0, skipped: true, generation: 0}}
           end
-        ] ++ Keyword.take(opts, [:restore_fun, :op_log, :op_log_mod, :hydrate_poll_interval_ms, :hydrate_poll_max])
+        ] ++
+          Keyword.take(opts, [
+            :connect_fun,
+            :restore_fun,
+            :op_log,
+            :op_log_mod,
+            :hydrate_poll_interval_ms,
+            :hydrate_poll_max
+          ])
       )
 
     put_brick(table, "node-4", "big", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
@@ -2655,6 +2664,31 @@ defmodule Embervm.BaseBuilderTest do
     :ok = BaseBuilder.note_base_missing(builder, "w", "node-9")
 
     assert_receive {:restore_called, "snap1"}, 1_000
+  end
+
+  test "note_base_missing hydrates the anchor vendor ref, not the builder vendor ref" do
+    test_pid = self()
+
+    restore_fun = fn :fake_channel, %Embervm.Node.V1.RestoreArtifactRequest{artifact: ref} ->
+      send(test_pid, {:restore_called, ref.ref})
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+    end
+
+    {builder, _agent, table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 5,
+        hydrate_poll_max: 50
+      )
+
+    put_brick(table, "node-1", "intel", cpu_vendor: "intel", mem_budget: 16_384, mem_headroom: 16_000)
+    put_vendor_fact(table, "node-1", "intel", "w", "snap-intel", "intel")
+    :ok = BaseBuilder.add_node(builder, "node-1/intel", "a1")
+
+    :ok = BaseBuilder.note_base_missing(builder, "w", "node-1")
+
+    assert_receive {:restore_called, "snap-intel"}, 1_000
+    refute_receive {:restore_called, "snap1"}, 100
   end
 
   test "note_base_missing spawns ONE hydrate for a repeating wake failure" do

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -2653,6 +2653,13 @@ defmodule Embervm.BaseBuilderTest do
       )
 
     # A SECOND node exists and advertises NOTHING: no base fact for "w" at all. That
+    # is the #4127 shape. But another node in the fleet (node-1) still reports the
+    # snap1 base as READY, so snapshot_refs_by_vendor can find it and the anchor can
+    # hydrate from that fleet-wide ref even though it has no fact of its own.
+    put_brick(table, "node-1", "a1", size_class: "8gi", mem_budget: 8_192, mem_headroom: 8_000)
+    put_base_fact(table, "node-1", "a1", "w", "snap1", :BASE_BUILD_STATE_READY, true)
+
+    # The anchor node-9 has no base fact at all (node has not reported yet).
     # is the #4127 shape, and node_reports_base_absent?/3 is false for it (a MISSING
     # fact is deliberately not "absent"), so the periodic reconcile can never hydrate
     # it. A wake failure is stronger evidence: the daemon was asked and said no.
@@ -2707,6 +2714,11 @@ defmodule Embervm.BaseBuilderTest do
       )
 
     put_brick(table, "node-9", "b1", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+    # Fleet-wide fact: node-1 still reports the base as READY so snapshot_refs_by_vendor
+    # can find it even though the anchor (node-9) has no base fact.
+    put_brick(table, "node-1", "a1", size_class: "8gi", mem_budget: 8_192, mem_headroom: 8_000)
+    put_base_fact(table, "node-1", "a1", "w", "snap1", :BASE_BUILD_STATE_READY, true)
+
     # Registered too: eligible_build_instances/2 iterates state.node_ids, so a
     # capacity fact alone is not enough to make it a build candidate.
     :ok = BaseBuilder.add_node(builder, "node-9/b1", "a9")

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1873,9 +1873,7 @@ defmodule Embervm.BaseBuilderTest do
 
     # The node now AFFIRMATIVELY reports the recorded base absent (a cold-start /
     # node replacement / scratch loss), the sole restore-first trigger.
-    # Keep the ref even when NONE so snapshot_refs_by_vendor can find it for
-    # vendor-aware hydrate matching.
-    put_base_fact(table, "node-4", "big", "w", "snap1", :BASE_BUILD_STATE_NONE, false)
+    put_base_fact(table, "node-4", "big", "w", "", :BASE_BUILD_STATE_NONE, false)
 
     {builder, agent, table}
   end


### PR DESCRIPTION
Refs #4865. Carries fixes 1 and 2 of the four in that issue's diagnosis. **Fixes 3 and 4 are NOT included**, see below.

## The bug

Base keys hash the CPU vendor, `sha256(image_ref, revision, vendor)[:12]`. Nodes 1-3 are Intel, node-4 is AMD. The live CR shows both:

```
snapshotRefs: {"amd":["demo-postgres__ec8abc5c1149"],"intel":["demo-postgres__943a4c135461"]}
snapshotRef:  demo-postgres__ec8abc5c1149          <- AMD, because the build is pinned to node-4
```

`hydrate_for_anchor` restored `w.snapshot_ref`, the single builder-advanced ref, onto whichever node anchored the volume. `RestoreVendor.stamp` then correctly stamped the ANCHOR's vendor, so noded was asked for `bases/intel/.../demo-postgres__ec8abc5c1149`: a store coordinate that cannot exist, because that key is AMD's. The `:not_present_in_store` fallback forced a rebuild, global placement re-pinned it to node-4, `BuildBase` returned `AlreadyBuilt` in milliseconds, and the ref was silently restored. That is the 15 second loop, running since the fleet roll at 14:35 UTC.

A valid current Intel base existed on node-1 and node-2 throughout. Nothing ever moved it to the anchor.

## What this changes

**1. `hydrate_for_anchor` picks the anchor's vendor's ref.** Resolves the anchor vendor with `NodeCapacity.vendor_for` and selects the same-vendor ref from `snapshot_refs_by_vendor`, which already computes the map. With no same-vendor ref anywhere it skips the hydrate and lets the normal build path run, rather than requesting a coordinate that cannot exist.

**2. Anchor-miss rebuild targets the anchor**, via `build_instance_on_node(anchor)` rather than global placement, so an `AlreadyBuilt` on a non-anchor node cannot satisfy an anchor miss. This is what makes the loop terminate.

## Two review findings fixed in the branch

**A vacuous test was deleted.** An earlier commit added `test "export reconcile exports a current base for each vendor"` asserting `{:exported, "w__intel"}`, while `export_reconcile` was untouched by any hunk. It could not have been testing what it named. A test asserting a fix we did not ship is worse than no test, because the next reader sees green and moves on.

**A fixture change was reverted.** A commit changed `put_base_fact(..., "", :BASE_BUILD_STATE_NONE, ...)` to `"snap1"` so the vendor lookup would find a ref, justified as matching real-world behaviour. It does not. Checked in noded: `server.go:2248` gives a workload with no base entry `BaseState: NONE` and **no ref**, which is cold start, node replacement and scratch loss, the exact scenario that test's own comment names. `server.go:2687` sends NONE **with** a ref, but only for an entry whose rootfs is missing, a different case.

The correct fix, now in the branch, is to add **fleet-wide** base facts: the anchor has no fact of its own while another node reports the base READY, so `snapshot_refs_by_vendor` finds it. That is the production shape, and it is why the live incident had both vendor refs populated while node-3 had nothing.

Also removed: a dead `base_present_but_unexported?/4` the compiler was flagging, a duplicated comment line, and a fallback that hydrated `w.snapshot_ref` of unknown vendor when the vendor map was empty (the original bug in a narrower window).

## Not in this PR

- **Fix 3, per-vendor export.** The PR-1 export reconcile still exports only `w.snapshot_ref` from `w.node_id`, so the non-builder vendor's base is never in S3. After a fleet roll a node of that vendor cannot hydrate from the store and must rebuild locally. Slower, not a loop, so it does not block a promotion.
- **Fix 4, backoff.** The wake-hydrate-rebuild cycle still runs every 15 seconds. Hygiene, and less pressing once the loop terminates.

Both remain open on #4865.

## Verification

`ci test //bazel/erlang:mix_test_smoke --nocache_test_results --test_output=all` → **`1302 tests, 0 failures, 6 skipped`**, with bazel reporting `1 remote` rather than an action cache hit, so a real run. The count is one lower than before because the vacuous test was deleted.

That target is a genrule, so bazel always prints `Executed 0 out of N` and `--nocache_test_results` no-ops on it. Judge it by the Elixir line and the remote-vs-cache-hit, which is what I did.

**Not verified: that demo-postgres recovers.** That is observable only after this deploys, which needs a Kargo promotion of the embervm chart. Joe is landing this first deliberately, so the promotion does not roll the fleet through a broken base-recovery path.