### PR TITLE
fix(embervm): size the two timeout layers a promotion actually depends on

### DIFF
--- a/projects/embervm/chart/templates/brick-deployment.yaml
+++ b/projects/embervm/chart/templates/brick-deployment.yaml
@@ -65,6 +65,9 @@ metadata:
   labels:
     {{- include "embervm.brick.labels" (dict "ctx" $ctx "class" $class.name) | nindent 4 }}
 spec:
+  # Explicit, because the inherited 600s default is shorter than a healthy brick
+  # rebuild and would red a good promotion (#4868). See bricks.progressDeadlineSeconds.
+  progressDeadlineSeconds: {{ $ctx.Values.bricks.progressDeadlineSeconds }}
   # A brick's memory is a HARD reservation (request==limit), so two same-class
   # bricks never fit where one does on a capacity-tight node. The default
   # RollingUpdate surges (new pod before old), which needs 2x the class's memory
@@ -146,6 +149,9 @@ metadata:
   labels:
     {{- include "embervm.brickFloor.labels" (dict "ctx" $ctx "class" $class "node" $floor.node) | nindent 4 }}
 spec:
+  # Same reasoning as the class Deployment above: the 600s default is shorter
+  # than a healthy rootfs rebuild (#4868).
+  progressDeadlineSeconds: {{ $ctx.Values.bricks.progressDeadlineSeconds }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1104,6 +1104,25 @@ bricks:
   # the Workload CRs. Raise it only if something new needs to land between the CP
   # and the bricks; the relative order of the bricks themselves is positional.
   syncWaveBase: 2
+  # How long a brick Deployment may take to become available before Kubernetes
+  # marks it Progressing=False, which ArgoCD surfaces as Degraded.
+  #
+  # EXPLICIT BECAUSE THE INHERITED DEFAULT IS THE BINDING CONSTRAINT (#4868).
+  # Unset, this is 600s, and a brick rebuilds its guest rootfs on every image
+  # digest change: measured 160s to 240s per brick on the 2026-08-14 rolls, so a
+  # slower node, a larger base, or scratch pressure making mkfs.ext4 crawl puts
+  # one brick past 600s. That trips the whole Deployment Degraded, and Kargo's
+  # argocd-wait fails fast on a Degraded transition, so a HEALTHY rollout reds
+  # the promotion. A gate that reds on healthy rollouts teaches the operator to
+  # ignore it.
+  #
+  # 1200s is about 5x the measured worst case. It is a DETECTOR, not a budget:
+  # the promotion's own timeout (kargo values.promotion.pipelines[].waitTimeout)
+  # is the budget, and it is deliberately far longer. Sizing this one too high
+  # would leave a genuinely wedged brick undetected until that budget expires;
+  # sizing it too low is the false-red above. Derive it from a measurement, not
+  # from the budget.
+  progressDeadlineSeconds: 1200
   # Per-class DESIRED replica count the Embervm.BrickController reconciles the
   # brick Deployments to (and the value each renders at first create). A MAP keyed
   # by size-class label, not a per-class list field, so a deploy-values overlay can

--- a/projects/platform/kargo/templates/promotion.yaml
+++ b/projects/platform/kargo/templates/promotion.yaml
@@ -201,6 +201,27 @@ spec:
     spec:
       steps:
         - uses: argocd-update
+          {{- /*
+          THIS TIMEOUT IS THE ONE THAT ACTUALLY BINDS, and it was missing.
+
+          argocd-update does not merely apply and return. It waits for its own
+          ArgoCD SYNC OPERATION to complete, and for a fleet that rolls through
+          sync waves one Deployment at a time that operation IS the rollout. Its
+          unconfigured default is 5m0s.
+
+          So the first embervm production promotion failed on a completely
+          healthy deploy (#4894): the pin was applied, the fleet rolled normally
+          and went Synced/Healthy in about thirteen minutes, and the Promotion
+          errored at 15:13 with `step "step-1" timed out after 5m0s` while the
+          carefully measured 30m0s sat on argocd-wait below, never reached.
+
+          It never surfaced on monolith because its rollout is about ten
+          seconds, so 5m0s is generous there. A default is still a bound, and it
+          is the SHORTEST bound on the path that decides the outcome, not the
+          one that was tuned.
+          */}}
+          retry:
+            timeout: {{ $pipeline.waitTimeout | quote }}
           config:
             apps:
               - name: {{ $stage.application }}

--- a/projects/platform/kargo/templates/promotion.yaml
+++ b/projects/platform/kargo/templates/promotion.yaml
@@ -57,14 +57,12 @@ The schema notes auto-promotion is "commonly set to true for Stages that
 subscribe to Warehouses instead of other, upstream Stages", which is an
 argument for gating prod rather than a prohibition.
 
-WHETHER PROD AUTO-PROMOTES IS PER-STAGE DATA, not a property of this template,
-and the two pipelines deliberately differ. Each stage's rationale is written
-beside its own `autoPromotion` in values.yaml: monolith's prod is `true` (the
-pipeline was being proven end to end, and it is risk-equivalent to the CI
-write-back it replaced), embervm's prod is `false` (every roll spends
-unreclaimed brick scratch, so promotions are batched by hand until #4364
-re-arms retention). Read the value, not this comment, to know what a given
-environment does.
+WHETHER PROD AUTO-PROMOTES IS PER-STAGE DATA, not a property of this template.
+Both pipelines are `true` today, and embervm's was briefly `false` on a scratch
+argument that turned out to be wrong (a base rebuilds on a SIGNATURE change, not
+on every chart version, and batching only defers a digest change rather than
+avoiding it). The rationale lives beside each `autoPromotion` in values.yaml.
+Read the value, not this comment, to know what a given environment does.
 
 Flipping the value is both the hold lever and the manual promotion path.
 */}}

--- a/projects/platform/kargo/values.yaml
+++ b/projects/platform/kargo/values.yaml
@@ -242,29 +242,38 @@ promotion:
           # the settling window has to outlast the rollout it is settling after,
           # or it expires while bricks are still coming up and proves nothing.
           requiredSoakTime: 5m0s
-          # FALSE, unlike monolith's prod, and unlike dev above. Promotion to
-          # embervm production is a deliberate click in the UI.
+          # TRUE, matching monolith. This was false for one day and the
+          # reasoning behind that was wrong, so it is written down rather than
+          # quietly flipped.
           #
-          # Every embervm prod roll rebuilds each brick's guest rootfs and
-          # spends about 2.8 GiB of each master's 35 GiB scratch cap, which
-          # nothing reclaims while base retention is disarmed (#4364): roughly
-          # five rolls of runway. Batching is the point. A manual promotion
-          # takes the LATEST soaked Freight, so N merged chart versions cost
-          # ONE spend, which is strictly better than the CI write-back this
-          # replaces. `true` would only match it.
+          # The argument was: an embervm prod roll rebuilds each brick's guest
+          # rootfs and spends ~2.8 GiB of each master's 35 GiB cap, reclaimed by
+          # nothing, so batching N merges into one manual promotion conserves a
+          # scarce resource.
           #
-          # Scratch exhaustion does not present as a disk error. It presents as
-          # `no_capacity` on session create, or bricks wedged in
-          # PodInitializing on build-semgrep-rootfs, or Firecracker reporting a
-          # backing file as missing when mkfs could not write it. embervm is
-          # the isolation plane agent sessions run on, so that failure class
-          # should not be reachable by an unattended merge.
+          # Both halves are wrong. A base is rebuilt when its SIGNATURE changes,
+          # not on every chart version: production went 0.12.9 -> 0.13.7, eight
+          # versions, and the base refs on every node were unchanged apart from
+          # the demo-postgres rebuild that the #4865 incident forced. node-2's
+          # scratch went DOWN across that roll. A publish that does not move a
+          # guest image digest costs approximately nothing.
           #
-          # This does not cost pipeline confidence: dev auto-promotes on every
-          # publish, so the embervm pipeline is exercised end to end
-          # continuously. Flip to true in the same change that re-arms base
-          # retention (#4364).
-          autoPromotion: false
+          # And batching does not avoid the cost of a digest change, it only
+          # defers it: that change deploys eventually and costs the same then.
+          # Batching only wins when several digest-changing rolls collapse into
+          # one, which the history says is rare.
+          #
+          # What is actually accumulating is orphaned bases the retention sweep
+          # cannot see (#4364): node-3 held demo-postgres__8dde24352f92 and
+          # demo-postgres__ba4ef0bad08b at once, the stale one belonging to
+          # neither vendor list, while the sweep reported `0 candidates`. Rate
+          # limiting deploys to compensate for a collector that does not collect
+          # costs release velocity and leaves the leak growing at the same rate.
+          #
+          # So: fix the collector, do not throttle the pipeline. If scratch ever
+          # becomes the binding constraint again, the lever is #4364, not this
+          # flag.
+          autoPromotion: true
 
 # Private-tier ingress: https://private.jomcgi.dev/app/kargo
 #


### PR DESCRIPTION
Closes #4894 and #4868. One PR because one chart bump means one promotion closes both layers, and because fixing either alone makes things worse.

## What happened

The first embervm production promotion (chart 0.12.9 -> 0.13.7, the one that ended the six-hour #4865 outage) **errored on a completely healthy deploy**:

```
15:08:06  promotion created
15:13:11  step "step-1" timed out after 5m0s     <- Promotion Errored
15:21:20  rollout completes, /health 200          (~13 min, entirely normal)
```

The deploy was fine. `argocd-update` applied the pin, the fleet rolled, `/health` recovered. Only the Promotion record failed, which means Kargo never marks the freight verified for production and the next promotion has to be driven by hand.

## Layer 1: the timeout that actually binds was never set (#4894)

```yaml
step-1  uses: argocd-update   (no retry)                <- defaulted to 5m0s
step-2  uses: argocd-wait     retry: {timeout: 30m0s}   <- the value I measured
```

`argocd-update` does not merely apply and return. It waits for its own ArgoCD **sync operation**, and for a fleet that rolls through sync waves one Deployment at a time that operation IS the rollout. So the measured 30m0s from #4863 sat one step below the thing that decided the outcome.

It never surfaced on monolith because its rollout is about ten seconds, so 5m0s is generous there. **A default is still a bound, and the shortest bound on the path decides, not the one that was tuned.**

Both steps now take the pipeline's value:

```
kargo-monolith/dev   [(argocd-update, 10m0s), (argocd-wait, 10m0s)]
kargo-monolith/prod  [(argocd-update, 10m0s), (argocd-wait, 10m0s)]
kargo-embervm/dev    [(argocd-update, 30m0s), (argocd-wait, 30m0s)]
kargo-embervm/prod   [(argocd-update, 30m0s), (argocd-wait, 30m0s)]
```

monolith is unchanged in effect: an implicit 5m0s becomes an explicit 10m0s, which for a ten-second rollout is the same behaviour and one fewer unchosen number.

## Layer 2: the detector was mis-sized too (#4868)

Brick Deployments inherited `progressDeadlineSeconds: 600`, while a brick rebuilds its guest rootfs in a **measured 160s to 240s**. A slower node, a larger base, or scratch pressure making `mkfs.ext4` crawl puts one brick past 600s, which trips the Deployment Degraded, which `argocd-wait` fails fast on: a healthy rollout reds the promotion.

Now explicit at `1200`, about 5x the measured worst case, on all 9 brick Deployments (5 classes, 4 floors).

## Why they must land together

Raising the promotion timeout alone trades a **false red** for a **slow red**. Today a wedged embervm promotion fails in five minutes, wrongly but fast. At 30m it fails in thirty, and the only quick signal is gone unless the detector works.

The two have different jobs, and conflating them is what produced this bug:

| | role | value |
| --- | --- | --- |
| `progressDeadlineSeconds` | **detector**: trips Degraded on a genuinely stuck brick | 1200s |
| step timeouts | **budget**: headroom for a healthy roll, backstop for a workload that never reaches a terminal state | 10m / 30m |

The budget should never be what catches failures. That is only true once the detector is sized from a measurement, which is why the values comment says so explicitly rather than leaving the next reader to infer it.

## Verification

`Executed 92 out of 716 tests: 716 tests pass.`

Rendered both charts and asserted the actual output, since the whole defect was a value that looked set and was not:

- every waiting step in every pipeline carries its pipeline's timeout (table above)
- all 9 brick Deployments render `progressDeadlineSeconds: 1200`
- monolith's rendered Stages are unchanged apart from the now-explicit step-1 timeout

## Landing this

It has to travel through the bug it fixes: the promotion that deploys this will itself hit the 5m0s default, so it needs driving by hand one last time. After that, embervm promotions should complete rather than error.