### PR TITLE
fix(monolith): point dev at the dev EmberVM, not production's

### DIFF
--- a/projects/monolith/dev/deploy/values.yaml
+++ b/projects/monolith/dev/deploy/values.yaml
@@ -113,6 +113,32 @@ postgres:
 whatsapp:
   enabled: false
 
+# EmberVM: dev talks to the DEV control plane, not production's.
+#
+# These inherited production's URLs, so monolith-dev was calling
+# embervm-embervm.embervm on every agent page load and getting:
+#
+#   403 Forbidden /v1/workloads/claude-runtime/sessions
+#   {"error":"service account not permitted","retryable":false}
+#
+# which surfaced in the console as "unable to load session". The 403 is the
+# ingress allowlist working exactly as intended (#4628: a NEW caller is a
+# silent deny), so the defect was the URL, not the guard. Dev was asking
+# production's fleet for production's sessions and being told no.
+#
+# Same rule as whatsapp above and for the same reason: dev must not claim
+# production's identity or reach into production's state. An agent session is
+# both, since it is a real VM holding a real workload slot against
+# session.maxSessions.
+#
+# embervm-dev has been its own deployment since #4856 with the same service
+# shape, so this is a hostname swap and nothing more.
+semgrep:
+  embervmUrl: "http://embervm-dev-embervm.embervm-dev.svc.cluster.local:8080"
+
+tokenBroker:
+  url: "http://embervm-dev-embervm-tokenbroker.embervm-dev.svc.cluster.local:8080"
+
 # NO Argo CronWorkflows in dev, and this is the third identity collision this
 # overlay has had to close.
 #


### PR DESCRIPTION
The agents console in dev shows "unable to load session". The backend log says why:

```
403 Forbidden http://embervm-embervm.embervm.svc.cluster.local:8080/v1/workloads/claude-runtime/sessions
{"error":"service account not permitted","retryable":false}
```

`monolith-dev` inherited production's EmberVM URLs, so it was calling **production's** control plane and asking for **production's** sessions.

**The 403 is the guard working, not the bug.** The ingress allowlist denies an unknown caller (#4628), which is exactly what should happen when dev reaches for prod's fleet. The defect is the URL.

## The rule this restores

Same rule as the `whatsapp: enabled: false` block directly above it: dev must not claim production's identity or reach into production's state. An agent session is both, since it is a real VM holding a real workload slot against `session.maxSessions`.

`embervm-dev` has been its own deployment since #4856 with the same service shape (`embervm-dev-embervm`, `embervm-dev-embervm-tokenbroker`, both on 8080), so this is a hostname swap and nothing more.

## Verification

Rendered both stacks:

```
dev:   EMBERVM_URL=http://embervm-dev-embervm.embervm-dev.svc.cluster.local:8080
       EMBER_TOKENBROKER_URL=http://embervm-dev-embervm-tokenbroker.embervm-dev.svc.cluster.local:8080
prod:  EMBERVM_URL=http://embervm-embervm.embervm.svc.cluster.local:8080
       EMBER_TOKENBROKER_URL=http://embervm-embervm-tokenbroker.embervm.svc.cluster.local:8080
```

Production unchanged. `ci test //projects/monolith/chart:chart_env_identity_test --nocache_test_results` → `Executed 1 out of 1 test: 1 test passes`.

## Two sibling defects, same shape, not fixed here

Both are rules keyed on a production-shaped hostname that dev does not match:

- **The public site nav renders over the console in dev.** `+layout.svelte:9` suppresses it with `$page.url.hostname.startsWith("private.")`, and dev is `dev.jomcgi.dev`.
- **Dev offers every model.** `+page.svelte:35` is a hardcoded literal in the bundle, and the same image ships to both environments. #4859.

Filing those separately.