### PR TITLE
docs(inference): align qwen references on Qwen3.8-27B and llama.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See [docs/security.md](docs/security.md) for the defense-in-depth model, [projec
 | Secrets        | 1Password Operator, OnePasswordItem CRDs, nothing in Git                                   |
 | Storage        | Longhorn for persistent volumes, SeaweedFS for S3-compatible object storage                |
 | Messaging      | NATS JetStream: pub/sub backbone for AIS data, trip points, agent jobs                     |
-| GPU            | NVIDIA GPU Operator: Qwen3.6-35B-A3B MoE via vLLM; voyage-4-nano embeddings via llama.cpp  |
+| GPU            | NVIDIA GPU Operator: Qwen3.8-27B via llama.cpp; voyage-4-nano embeddings via llama.cpp     |
 | Images         | apko + rules_apko: no Dockerfiles, dual-arch (x86_64 + aarch64), non-root                  |
 | CI             | BuildBuddy Workflows: remote build execution, `bazel test //...`, image push               |
 | GitOps         | ArgoCD with colocated `deploy/` dirs; `kubectl` is read-only                               |
@@ -57,7 +57,7 @@ projects/             # All services, operators, websites, colocated with deploy
 ├── monolith/         #   Knowledge graph, Discord bot, task management, public apps, frontend
 ├── monolith-public/  #   Read-only public replica of the monolith
 ├── mcp/              #   Context Forge gateway + MCP servers
-├── inference/        #   On-cluster vLLM (Qwen3.6) + llama.cpp embeddings
+├── inference/        #   On-cluster llama.cpp (Qwen3.8-27B) + llama.cpp embeddings
 ├── operators/        #   Custom Kubernetes operators
 ├── sextant/          #   State-machine code generator for operators
 ├── embervm/          #   Firecracker microVM orchestrator (Elixir control plane + Go node daemon)

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -23,12 +23,12 @@ from chat.web_search import search_web
 LLAMA_CPP_URL = os.environ.get("LLAMA_CPP_URL", "")
 
 # The served inference model's knowledge cutoff. Qwen did not publish a cutoff
-# for Qwen3.6-35B-A3B (released 2026-04-16), so we anchor to the release month
-# as a conservative bound: the true cutoff is at or before it, so telling the
-# model its knowledge ends here never overstates what it knows, and correctly
-# frames anything more recent as beyond its training. Update when the served
-# model changes.
-MODEL_KNOWLEDGE_CUTOFF = "April 2026"
+# for Qwen3.8-27B (released August 2026) either, so we keep anchoring to the
+# release month as a conservative bound: the true cutoff is at or before it, so
+# telling the model its knowledge ends here never overstates what it knows, and
+# correctly frames anything more recent as beyond its training. Update when the
+# served model changes.
+MODEL_KNOWLEDGE_CUTOFF = "August 2026"
 
 logger = logging.getLogger(__name__)
 

--- a/projects/monolith/chat/cluster_agent.py
+++ b/projects/monolith/chat/cluster_agent.py
@@ -66,8 +66,8 @@ def create_cluster_agent() -> Agent[ClusterDeps]:
             extra_body={
                 "top_k": 20,
                 "presence_penalty": 1.5,
-                # qwen3.6 is a hybrid thinking model: without this the whole
-                # generation lands in vLLM's reasoning field, content comes
+                # The served Qwen is a hybrid thinking model: without this the
+                # whole generation lands in the reasoning field, content comes
                 # back null, and the SSE stream emits an empty answer.
                 **shared.inference.thinking_off(),
             },

--- a/projects/monolith/chat/explorer.py
+++ b/projects/monolith/chat/explorer.py
@@ -50,8 +50,8 @@ def create_explorer_agent() -> Agent[ExplorerDeps]:
             extra_body={
                 "top_k": 20,
                 "presence_penalty": 1.5,
-                # qwen3.6 is a hybrid thinking model: without this the whole
-                # generation lands in vLLM's reasoning field, content comes
+                # The served Qwen is a hybrid thinking model: without this the
+                # whole generation lands in the reasoning field, content comes
                 # back null, and the SSE stream emits an empty answer.
                 **shared.inference.thinking_off(),
             },

--- a/projects/monolith/chat_public/router.py
+++ b/projects/monolith/chat_public/router.py
@@ -51,8 +51,8 @@ router = APIRouter(prefix="/internal/chat", tags=["chat_public"])
 # The default is intentionally a constrained, clearly-scoped persona so a
 # jailbreak yields only off-brand text and nothing privileged.
 _DEFAULT_SYSTEM_PROMPT = (
-    "You are Qwen 3.6, an open model running on Joe McGinley's self-hosted "
-    "Kubernetes homelab cluster, served with vLLM and no external API. You are "
+    "You are Qwen 3.8, an open model running on Joe McGinley's self-hosted "
+    "Kubernetes homelab cluster, served with llama.cpp and no external API. You are "
     "the assistant behind Joe's public knowledge graph: the notes and context "
     "you are given are his own public notes and thoughts. "
     "Answer the user's question directly and substantively, explaining the topic "

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
@@ -153,7 +153,7 @@
   // the page. No new backend endpoint, and the browser never calls the backend
   // directly. When stats are unavailable the GPU items just drop out.
   const MODEL_NAME = "QWEN3.6-27B"; // CHAT_PUBLIC_MODEL = qwen3.6-27b
-  const BOT_LABEL = "QWEN3.6 / LOCAL"; // model family + "runs on my cluster"
+  const BOT_LABEL = "QWEN3.8 / LOCAL"; // model family + "runs on my cluster"
   const CONTEXT_WINDOW = 32768; // CHAT_PUBLIC_MODEL_WINDOW_TOKENS
   // Public note count for the KG readout + empty-state copy. The chat view does
   // NOT load the graph payload on initial render (that lazy fetch only happens

--- a/projects/monolith/frontend/src/routes/public/app/notes/s/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/s/[id]/+page.svelte
@@ -14,7 +14,7 @@
 
   let { data } = $props();
 
-  const BOT_LABEL = "QWEN3.6 / LOCAL";
+  const BOT_LABEL = "QWEN3.8 / LOCAL";
 
   function renderReply(text) {
     // Empty title map: [[wikilinks]] render as inert text (no graph nav here).

--- a/projects/monolith/frontend/src/routes/public/engineering/diagrams/AgentPlatform.svelte
+++ b/projects/monolith/frontend/src/routes/public/engineering/diagrams/AgentPlatform.svelte
@@ -23,7 +23,7 @@
   <DBox role="store" sub="placeholder to real key">TLS egress proxy</DBox>
   <DArrow />
   <DGroup label="Models" stack>
-    <DBox role="output" sub="vLLM on 4090">Qwen3.6 MoE</DBox>
+    <DBox role="output" sub="llama.cpp on 4090">Qwen3.8 27B</DBox>
     <DBox role="external" sub="over swapped egress">Frontier API</DBox>
   </DGroup>
 </Diagram>

--- a/projects/monolith/frontend/src/routes/public/engineering/engineering-data.js
+++ b/projects/monolith/frontend/src/routes/public/engineering/engineering-data.js
@@ -76,7 +76,7 @@ export const projects = [
       },
       {
         k: "Local inference",
-        v: "vLLM serves a Qwen3.6 MoE (35B-A3B, int4) on a single RTX 4090 for routine work; frontier models are reached over the swapped egress only where the task warrants it.",
+        v: "llama.cpp serves Qwen3.8-27B (dense, 4-bit GGUF) on a single RTX 4090 for routine work; frontier models are reached over the swapped egress only where the task warrants it.",
       },
     ],
     links: [


### PR DESCRIPTION
The cutover swapped both the model (Qwen3.6-35B-A3B MoE → Qwen3.8-27B dense) and the engine (vLLM → llama.cpp), but the places describing the stack still named the old ones.

## Two of these are not cosmetic

**The public chatbot's self-description.** `chat_public/router.py`'s default system prompt said:

> "You are Qwen 3.6, an open model running on Joe McGinley's self-hosted Kubernetes homelab cluster, served with vLLM and no external API."

Wrong model and wrong engine, told to every visitor on jomcgi.dev since the cutover.

**`MODEL_KNOWLEDGE_CUTOFF`.** Anchored to Qwen3.6-35B-A3B's April 2026 release, with a comment saying "Update when the served model changes." Qwen publish no explicit cutoff for Qwen3.8-27B either, so the same anchor-to-release-month convention gives **August 2026** (from the model card citation: `month = {August}, year = {2026}`). The temporal-grounding test asserts on the constant rather than the literal, so it follows automatically.

## Copy

`README.md` (stack table + tree comment), `BOT_LABEL` on both public notes pages, the `AgentPlatform` diagram box (`vLLM on 4090 / Qwen3.6 MoE` → `llama.cpp on 4090 / Qwen3.8 27B`), and the engineering page prose. Two code comments naming a version are now version-neutral, since the hybrid-thinking behaviour they describe holds for both models.

## Deliberately unchanged

| What | Why |
|---|---|
| alias `qwen3.6-27b` | API identity 10+ call sites hardcode and `/v1/models` serves; renaming is a coordinated change, not a docs sweep |
| ADRs | they record what was decided when; reading one as current state is what they are explicitly not for |
| `leaderboard.json`, `reports/leaderboard.md` | recorded measurements, rewriting falsifies what was measured |
| vLLM block in `inference/deploy/values.yaml` | it is the revert target and is accurate as written |
| `hf2oci` Qwen2.5 examples | generic CLI samples, not deployment claims |

## One left for a decision

`model-bench/models.yaml` still lists `qwen/qwen3.6-27b` as active. It resolves through the alias, so a new bench run would file **Qwen3.8** results under a 3.6 label. `qwen/qwen3.6-35b-a3b` points at a model no longer served at all. Renaming either breaks the join with existing leaderboard rows and rewrites what past measurements referred to, so this is a data-integrity call rather than a docs one and is left out.

## Verification

`ci test`: `Executed 236 out of 716 tests: 716 tests pass`.

Note `ci` (full) currently fails at the regen stage on this repo for unrelated reasons: gazelle rewrites 38 Go BUILD files to `go_default_library` naming and `//bazel/semgrep/defs/gazelle:gazelle_test` then fails analysis. That churn was discarded; this PR carries only the 9 intended files. It is the defect flagged in #4882's description, now confirmed to break the build rather than merely suspected.