### PR TITLE
fix(bazel): stop ci regen rewriting the tree into something that will not build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9,6 +9,27 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 npm_link_all_packages(name = "node_modules")
 
 # gazelle:prefix github.com/jomcgi/homelab
+# How gazelle labels deps that live in EXTERNAL Go repos. Under bzlmod the
+# go_deps extension generates targets with the "import" convention (the target
+# is named for the Go package, so the label is @repo//pkg/authn, and
+# @repo//pkg/v1:pkg where the package name differs from the directory). Gazelle
+# still defaults this to the legacy "go_default_library", so without this
+# directive every `ci regen` rewrites all external Go deps to
+# @repo//pkg/authn:go_default_library. Those targets do not exist, and the tree
+# then fails ANALYSIS rather than anything obvious: `//bazel/semgrep/defs/gazelle
+# :gazelle_test` aborts the build before a single test runs. The repo's own Go
+# targets already match the default, so only the external convention is set.
+# gazelle:go_naming_convention_external import
+# bazel_gazelle is brought in under the repo name `gazelle`, and its targets use
+# the import convention. Gazelle's resolver does not know either fact about
+# itself, so without these it rewrites this repo's two gazelle plugins to
+# @bazel_gazelle//config:go_default_library and friends, which do not exist.
+# gazelle:resolve go github.com/bazelbuild/bazel-gazelle/config @gazelle//config
+# gazelle:resolve go github.com/bazelbuild/bazel-gazelle/label @gazelle//label
+# gazelle:resolve go github.com/bazelbuild/bazel-gazelle/language @gazelle//language
+# gazelle:resolve go github.com/bazelbuild/bazel-gazelle/repo @gazelle//repo
+# gazelle:resolve go github.com/bazelbuild/bazel-gazelle/resolve @gazelle//resolve
+# gazelle:resolve go github.com/bazelbuild/bazel-gazelle/rule @gazelle//rule
 # gazelle:exclude .claude
 # Explicit-only agent procedures + helper scripts (not py packages; imports are
 # runtime/monolith paths Gazelle cannot resolve). Same class as .claude/skills.

--- a/projects/design-system/BUILD
+++ b/projects/design-system/BUILD
@@ -1,3 +1,8 @@
+# Hand-maintained: the js extension wants to add an npm_package target here,
+# but consumers depend on the npm_link_all_packages link
+# (:node_modules/@homelab/design-system), not on a package target, so the
+# generated one is dead weight and shows up as permanent `ci regen` drift.
+# gazelle:ignore
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 


### PR DESCRIPTION
`ci regen` rewrote **38 BUILD files on every run**, into a tree that fails analysis:

```
ERROR: Analysis of target '//bazel/semgrep/defs/gazelle:gazelle_test' failed; build aborted
ERROR: Couldn't start the build. Unable to run tests
```

So anyone running full `ci` had to notice the churn and discard it by hand. That fixes one PR and leaves the cause. This drops the churn to **zero**.

Follows #4882, which fixed the *load-time* failure (`ts_project` targets with no `tsconfig.json`). This is the *analysis-time* one underneath it.

## Three separate causes

**1. External Go naming convention (34 files).** Under bzlmod the `go_deps` extension generates external targets with the `import` convention, so the label is `@repo//pkg/authn`, and `@repo//pkg/v1:pkg` where the Go package name differs from the directory. Gazelle still defaults `go_naming_convention_external` to legacy `go_default_library` and the directive was never set:

```diff
-        "@com_github_google_go_containerregistry//pkg/authn",
+        "@com_github_google_go_containerregistry//pkg/authn:go_default_library",
```

The repo's own Go targets already match gazelle's default, so only the external convention needed setting.

**2. Gazelle's own plugins (2 files).** `bazel_gazelle` is brought in under the repo name `gazelle`, and its targets use the import convention. Gazelle's resolver knows neither fact about itself:

```diff
-        "@gazelle//config",
+        "@bazel_gazelle//config:go_default_library",
```

Six `# gazelle:resolve go` directives teach it the real labels, which keeps generation working rather than switching those packages off.

**3. design-system (1 file).** The js extension wanted to add an `npm_package` target. Consumers depend on the `npm_link_all_packages` link (`:node_modules/@homelab/design-system`); nothing references a package target, so the generated one was dead weight. Marked hand-maintained.

## Verification

| Step | Result |
|---|---|
| `ci regen`, then `git status` | clean apart from the 2 intentional edits |
| full `ci` (regen + lint + test) | `Executed 0 out of 716 tests: 716 tests pass` |
| `git status` after full `ci` | still clean, no drift left behind |

Churn by stage: 38 files → 3 after fix 1 → 0 after fixes 2 and 3.

## Suggested follow-up

This class stays invisible by construction: PR CI tests the **committed** tree and never compares it against what the generator would produce, so the only signal is a human running `ci` locally and reading past the exit code (and per #4118 the exit code can be 0 on a run that never started). A guard that runs `ci regen` and fails on a non-empty diff would turn this into a named red check. Not included here to keep the fix reviewable.