### PR TITLE
feat(agents): hide the site nav on private routes and let dev cut the model list

### DIFF
--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -577,6 +577,8 @@ spec:
           env:
             - name: API_BASE
               value: "http://localhost:8000"
+            - name: AGENTS_LOCAL_MODELS_ONLY
+              value: {{ .Values.agents.localModelsOnly | quote }}
             - name: OTEL_COLLECTOR_HTTP_URL
               value: {{ .Values.frontend.otelCollectorUrl | quote }}
             {{- if .Values.imgproxySigning.enabled }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -45,6 +45,12 @@ progress:
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
     pullPolicy: IfNotPresent
 
+# Restrict the agents console model picker to the in-cluster model when true.
+# Production keeps the full model list; dev overrides this to avoid offering
+# providers that are not intended for dev use.
+agents:
+  localModelsOnly: false
+
 # Off-pod batch-job execution via Argo CronWorkflows.
 #
 # Each cronWorkflows entry renders (chart/templates/cronworkflows.yaml) as a

--- a/projects/monolith/dev/deploy/values.yaml
+++ b/projects/monolith/dev/deploy/values.yaml
@@ -20,8 +20,7 @@
 # This is a values choice, not a guard. Nothing rejects a paid model here, so
 # a NEW model-consuming feature has to be pointed at the free lane in this
 # file too, or dev will quietly inherit production's provider. See issue #4859
-# for the console's offered list, which is still a bundle literal and so is
-# NOT covered by anything in this file.
+# for the fuller console configuration change this defers.
 
 backend:
   # THE side-effect mute. One switch covers all five leader singletons (Discord
@@ -161,6 +160,9 @@ tokenBroker:
 # own gate while leaving ARGO_JOBS populated, so dev runs them nowhere.
 jobs:
   image: ""
+
+agents:
+  localModelsOnly: true
 
 # EVERY MODEL IN DEV POINTS AT THE IN-CLUSTER QWEN.
 #

--- a/projects/monolith/frontend/src/routes/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/+layout.svelte
@@ -42,6 +42,7 @@
   // to /ember.
   let hideNav = $derived(
     isPrivate ||
+      /^\/private(?:\/|$)/.test($page.url.pathname) ||
       /^\/(public\/|private\/)?app\//.test($page.url.pathname) ||
       /^\/(public\/|private\/)?docs(\/|$)/.test($page.url.pathname) ||
       /^\/(public\/|private\/)?artifact(\/|$)/.test($page.url.pathname) ||

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -33,6 +33,7 @@
   let { data } = $props();
 
   const MODELS = ["opus", "fable", "sonnet", "luna", "terra", "sol", "qwen"];
+  const DEV_MODELS = ["qwen"];
   // Sidebar RECENT is a 24-hour navigation convenience. MasterView's activity
   // summary intentionally uses a separate seven-day window.
   const RECENT_HISTORY_MS = 24 * 60 * 60 * 1000;
@@ -67,6 +68,7 @@
     }
   }
   let sessions = $state(data.sessions ?? []);
+  let availableModels = $state(MODELS);
   let runs = $state([]);
   let showTerminalHistory = $state(false);
   let terminalRuns = $state([]);
@@ -440,6 +442,10 @@
       if (!response.ok) throw new Error("Unable to refresh sessions");
       const body = await response.json();
       sessions = Array.isArray(body) ? body : (body.sessions ?? []);
+      availableModels =
+        !Array.isArray(body) && body.localModelsOnly === true
+          ? DEV_MODELS
+          : MODELS;
       await loadRuns();
       errorMessage = null;
       if (
@@ -1686,7 +1692,7 @@
       aria-pressed={!current}
       onclick={() => choose("")}>{P.labels.defaultWord}</button
     >
-    {#each MODELS as model}
+    {#each availableModels as model}
       <button
         type="button"
         class="chip"
@@ -1705,10 +1711,11 @@
       onchange={(event) => choose(event.currentTarget.value)}
     >
       <option value="">{P.labels.defaultWord}</option>
-      {#if current && !MODELS.includes(current)}
+      {#if current && !availableModels.includes(current)}
         <option value={current}>{current}</option>
       {/if}
-      {#each MODELS as model}<option value={model}>{model}</option>{/each}
+      {#each availableModels as model}<option value={model}>{model}</option
+        >{/each}
     </select>
   </label>
 {/snippet}

--- a/projects/monolith/frontend/src/routes/private/agents/data/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/data/+server.js
@@ -1,14 +1,22 @@
 const API_BASE = process.env.API_BASE;
+const LOCAL_MODELS_ONLY = process.env.AGENTS_LOCAL_MODELS_ONLY === "true";
 
 export async function GET() {
   try {
     const res = await fetch(`${API_BASE}/api/agents/sessions`, {
       signal: AbortSignal.timeout(10000),
     });
-    return new Response(res.body, {
-      status: res.status,
-      headers: { "Content-Type": "application/json" },
-    });
+    const body = await res.json();
+    return new Response(
+      JSON.stringify({
+        sessions: Array.isArray(body) ? body : (body.sessions ?? []),
+        localModelsOnly: LOCAL_MODELS_ONLY,
+      }),
+      {
+        status: res.status,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   } catch {
     return new Response(JSON.stringify({ error: "sessions unavailable" }), {
       status: 502,


### PR DESCRIPTION
Two symptoms on `dev.jomcgi.dev/private/agents`, one shape: **a rule keyed on a production hostname that dev does not match.**

## The nav

`+layout.svelte` suppressed the public site nav when the HOSTNAME started with `private.`, or when the PATH matched one of several patterns. Production's private tier is `private.jomcgi.dev` so the hostname arm covered it. **Dev serves both surfaces on the single host `dev.jomcgi.dev`**, and `/private/agents` matched none of the path patterns, so the public nav rendered on top of a full-page tool that brings its own chrome.

Fixed on the path, not with a second hostname special case:

```js
/^\/private(?:\/|$)/.test($page.url.pathname) ||
```

A route under `/private/` is the private tier whatever host serves it, and the existing `/app/`, `/docs`, `/artifact`, `/demos`, `/ember` patterns already show path is the right axis. Adding another hostname check is what created this bug.

**This closes the same latent problem for every private route at once** — chat, demos, notes, perf and review all live under `src/routes/private/` and would each have shown the nav in dev.

## The model list

The picker was a hardcoded literal in the bundle, and the same image ships to both environments, so there was no per-environment path to a different list. #4872 pointed every server-side model setting in dev at the in-cluster Qwen while the console still offered `opus`.

`agents.localModelsOnly` **defaults to false**, so production keeps the full list and nothing changes there; the dev overlay opts out. Rendered both stacks to confirm:

```
prod: AGENTS_LOCAL_MODELS_ONLY="false"
dev:  AGENTS_LOCAL_MODELS_ONLY="true"
```

The value reaches the frontend container as env and is read **server-side**, never sniffed from the client hostname, which is exactly the mistake the nav half of this PR is correcting.

**Degrades toward the full list.** An unreadable or absent flag offers everything. Dev showing too many models is a nuisance; production showing too few would break real work.

The local list is `["qwen"]` alone, because `qwen` is the only name mapping to the `pi` family (the in-cluster GPU). Every other name is metered or subscription-billed.

## Deliberately not #4859

No catalogue, no allowlist, no validation, no rejection. This is configuration and there is no adversary; the point is only that dev stops offering models it cannot cheaply run. #4859 remains open for the fuller server-served version.

## Verification

`ci test //projects/monolith/frontend:build //projects/monolith/frontend:test //projects/monolith/chart:chart_env_identity_test --nocache_test_results` → `Executed 2 out of 2 tests: 2 tests pass`, with zero build errors.

`frontend:build` is included deliberately: the vitest target does not compile the app, so a Svelte template error passes `:test` and fails only `:build`.

## Note on the data route

`/agents/data` changes from a body passthrough to `{sessions, localModelsOnly}`. The client already tolerated both shapes (`Array.isArray(body) ? body : (body.sessions ?? [])` predates this change), so no consumer breaks.

## Sibling fix

#4896 fixed the third dev symptom, "unable to load session": `monolith-dev` was calling production's EmberVM and getting a 403 from the ingress allowlist. Same class again, a production URL inherited by dev.