### PR TITLE
feat(agents): qwen session synthetic and keep invoke failure bodies

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -6250,6 +6250,15 @@ py_test(
     srcs = ["ember_public/synthetic_probe_test.py"],
     imports = ["."],
     deps = [
+        # probe_qwen imports agent_sessions.api lazily, inside the function, so
+        # the public binary never pulls it in at module load (main_public_imports
+        # _test stays green and the public-tier boundary is unaffected). The
+        # probe endpoint is served by the PRIVATE monolith, which is where the
+        # trigger POSTs, so the lazy import resolves at runtime. The test still
+        # needs the real module on the path because it monkeypatches
+        # agent_sessions.api.run_synthetic_session, and monkeypatch imports the
+        # target module to resolve the attribute.
+        ":pkg_agent_sessions",
         ":pkg_ember_public",
         "@pip//httpx",
         "@pip//pytest",

--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -13,9 +13,13 @@ from agent_sessions.codex_login import codex_login_gate, watch_for_login
 from agent_sessions.mcp import (
     _append_rationale_trailer,
     _clear_ember_bindings_for,
+    _delete_pending_message_sync,
     _load_session_row,
+    _mark_turn_error_sync,
+    _persist_ember_session,
     _persist_pending_message,
     _persist_session,
+    _persist_turn_from_pending_sync,
     _schedule_next_message,
     _set_session_status,
     _transport,
@@ -25,6 +29,75 @@ from core.db import get_engine
 from goosecracker.api import REPO_CATALOG
 
 logger = logging.getLogger(__name__)
+
+
+async def run_synthetic_session(prompt: str, model: str = "qwen"):
+    """Run and persist one short synthetic session through the normal path.
+
+    This is intentionally a direct, awaited form of the session worker for
+    probes. It still uses the shared transport and turn persistence, but gives
+    the caller the completed turn instead of requiring a background task and a
+    database poll. The session is always destroyed before returning.
+    """
+    from agent_sessions.mcp import _turn_status
+
+    model_family(model)
+    row = await asyncio.to_thread(
+        _persist_session,
+        str(uuid4()),
+        "<guest>",
+        "main",
+        model,
+        None,
+    )
+    assert row.id is not None
+    turn_seq = await asyncio.to_thread(_persist_pending_message, row.id, prompt, model)
+    ember = None
+
+    async def persist_callback(created_ember, _cli_session_id):
+        nonlocal ember
+        # Capture the created session before the persistence hop so a failed
+        # invoke or callback still reaches the cleanup block below.
+        ember = created_ember
+        await asyncio.to_thread(_persist_ember_session, row.id, created_ember)
+
+    try:
+        turn, _returned_ember = await _transport.deliver(
+            None,
+            None,
+            prompt,
+            model,
+            on_create=persist_callback,
+        )
+        ember = _returned_ember
+        status = _turn_status(turn)
+        await asyncio.to_thread(
+            _persist_turn_from_pending_sync,
+            row.id,
+            turn_seq,
+            prompt,
+            turn,
+            turn.result.strip()[:200],
+            status,
+            turn.session_id,
+            model,
+        )
+        await asyncio.to_thread(_delete_pending_message_sync, row.id, turn_seq)
+        return turn
+    except Exception as exc:
+        # Transport errors already contain _status_error_detail when the
+        # control plane supplied a response body. Persist that same detail on
+        # the failed turn, not only in the transport log.
+        await asyncio.to_thread(_mark_turn_error_sync, row.id, turn_seq, str(exc))
+        raise
+    finally:
+        if ember is not None:
+            try:
+                await _transport.destroy_session(ember.session_id)
+            except EmberSessionGone:
+                pass
+            finally:
+                await asyncio.to_thread(_clear_ember_bindings_for, ember.session_id)
 
 
 def start_session_for_swarm(

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -519,10 +519,17 @@ class EmberVmShimTransport:
                 )
                 raise EmberVMTimeout(str(exc)) from exc
             except httpx.HTTPStatusError as exc:
+                # _status_error_detail, not str(exc): the guest reports WHY in
+                # the response body, and this log is what a human reads first.
+                # #4884 was a bare "422 Unprocessable Content" here for every
+                # qwen session, while the body said "File Not Found" (llama.cpp
+                # rejecting the absolute-form request line the egress proxy
+                # forwarded). The body reached the raised error downstream but
+                # never the log, so the one layer that saw the cause dropped it.
                 logger.warning(
                     "embervm invoke failed for session %s: %s",
                     current.session_id,
-                    exc,
+                    _status_error_detail(exc),
                 )
                 raise
             except httpx.TransportError as exc:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -42,22 +42,33 @@ def ember_synthetic_trigger() -> None:
     """Trigger the synthetic probes in the monolith API pod.
 
     Deliberately lightweight: it POSTs the running API pod's internal endpoint,
-    which fires all four probes IN THAT process (where the EmberVM credentials,
+    which fires the demo probes IN THAT process (where the EmberVM credentials,
     DEMO_POSTGRES_DSN, and a DB session already live). The
     probes run in the API pod, not this ephemeral job pod, so the job needs
     only HTTP access, not tokens or DB.
     """
+    _post_synthetic("/internal/ember/synthetic-probe", "ember-synthetic-trigger")
+
+
+@app.command("ember-qwen-synthetic-trigger")
+def ember_qwen_synthetic_trigger() -> None:
+    """Trigger the qwen session synthetic in the monolith API pod."""
+    _post_synthetic(
+        "/internal/ember/qwen-session-probe", "ember-qwen-synthetic-trigger"
+    )
+
+
+def _post_synthetic(path: str, name: str) -> None:
     import httpx
 
     configure_logging()
     url = os.environ.get("MONOLITH_INTERNAL_URL", "")
     if not url:
         raise RuntimeError("MONOLITH_INTERNAL_URL is not set")
-    logger.info("ember-synthetic-trigger: POST %s/internal/ember/synthetic-probe", url)
-    resp = httpx.post(f"{url}/internal/ember/synthetic-probe", timeout=180)
+    logger.info("%s: POST %s%s", name, url, path)
+    resp = httpx.post(f"{url}{path}", timeout=180)
     resp.raise_for_status()
-    body = resp.json()
-    logger.info("ember-synthetic-trigger: %s", body)
+    logger.info("%s: %s", name, resp.json())
 
 
 @app.callback()

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -748,7 +748,7 @@ jobs:
       concurrencyPolicy: Forbid
       # The trigger allows 180s for a demo-postgres cold boot, plus margin.
       activeDeadlineSeconds: 300
-      # ARMED 2026-07-27 after a live API-pod run returned all four green:
+      # ARMED 2026-07-27 after a live API-pod run returned all four probes green:
       #   bazel    ok  "warm, 501ms"       (was 403: wrong ServiceAccount)
       #   semgrep  ok  "5 finding(s)"      (was missing EmberVM credentials)
       #   pages    ok  "all pages, 311ms"
@@ -766,6 +766,29 @@ jobs:
       env:
         # The in-cluster API service the trigger POSTs; injected here (not baked
         # in code) so a release rename cannot silently break the DNS name.
+        MONOLITH_INTERNAL_URL: "http://monolith.monolith.svc.cluster.local:8000"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
+
+    # The qwen session synthetic is deliberately separate from the original
+    # demo probes so its hourly cadence does not turn a local-model VM test
+    # into a five-minute workload. It is suspended until Joe watches a live
+    # run return a completed turn with a non-empty result and confirms that
+    # the session is destroyed afterward. Landing a prober you have not
+    # watched succeed is how #4074 paged on its own gaps.
+    - name: ember-qwen-session-synthetic
+      args: ["ember-qwen-synthetic-trigger"]
+      schedule: "0 * * * *"
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 300
+      # Joe arms this after watching the first green live run. That run must
+      # show a completed, non-empty qwen turn and a destroyed EmberVM session.
+      suspend: true
+      env:
         MONOLITH_INTERNAL_URL: "http://monolith.monolith.svc.cluster.local:8000"
       resources:
         requests:

--- a/projects/monolith/ember_public/synthetic_probe.py
+++ b/projects/monolith/ember_public/synthetic_probe.py
@@ -274,6 +274,37 @@ async def probe_postgres() -> dict:
     return await _retry_probe(_probe_postgres_once)
 
 
+async def probe_qwen() -> dict:
+    """Exercise a real pi-family session through the EmberVM egress path."""
+    started = perf_counter()
+    try:
+        from agent_sessions.api import run_synthetic_session
+
+        turn = await run_synthetic_session(
+            "Reply with exactly: qwen synthetic ok",
+            model="qwen",
+        )
+        if turn.terminal_reason not in {"completed", "stop"}:
+            return {
+                "ok": False,
+                "detail": f"turn reason {turn.terminal_reason!r}",
+                "latency_ms": (perf_counter() - started) * 1000,
+            }
+        if not turn.result.strip():
+            return {
+                "ok": False,
+                "detail": "completed turn had an empty result",
+                "latency_ms": (perf_counter() - started) * 1000,
+            }
+        return {
+            "ok": True,
+            "detail": f"completed, destroyed, {(perf_counter() - started) * 1000:.0f}ms",
+            "latency_ms": (perf_counter() - started) * 1000,
+        }
+    except Exception as exc:  # noqa: BLE001 - probes report failures in-band
+        return _failure(exc)
+
+
 def _record_sync(demo: str, result: dict) -> None:
     now = datetime.now(timezone.utc)
     with Session(get_engine()) as session:  # jobs use the private app-role DATABASE_URL

--- a/projects/monolith/ember_public/synthetic_probe_test.py
+++ b/projects/monolith/ember_public/synthetic_probe_test.py
@@ -159,6 +159,35 @@ async def test_postgres_aggregate_roundtrip_success(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_qwen_requires_completed_nonempty_turn(monkeypatch):
+    class Turn:
+        terminal_reason = "stop"
+        result = " qwen synthetic ok "
+
+    async def run_session(*_, **__):
+        return Turn()
+
+    monkeypatch.setattr("agent_sessions.api.run_synthetic_session", run_session)
+    result = await probe.probe_qwen()
+    assert result["ok"] is True
+    assert result["detail"].startswith("completed,")
+
+
+@pytest.mark.asyncio
+async def test_qwen_failure_is_latched_in_band(monkeypatch):
+    async def run_session(*_, **__):
+        raise RuntimeError("llama.cpp rejected absolute-form target")
+
+    monkeypatch.setattr("agent_sessions.api.run_synthetic_session", run_session)
+    result = await probe.probe_qwen()
+    assert result == {
+        "ok": False,
+        "detail": "llama.cpp rejected absolute-form target",
+        "latency_ms": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_page_5xx_retried_once_then_failed(monkeypatch):
     class Response:
         status_code = 503

--- a/projects/monolith/ember_public/synthetic_router.py
+++ b/projects/monolith/ember_public/synthetic_router.py
@@ -43,7 +43,7 @@ _probe_in_flight = False
 
 @internal_router.post("/synthetic-probe")
 async def synthetic_probe_endpoint() -> dict:
-    """Run all four ember probes concurrently and record their latch rows."""
+    """Run all four demo probes concurrently and record their latch rows."""
     global _probe_in_flight
 
     if _probe_in_flight:
@@ -75,5 +75,27 @@ async def synthetic_probe_endpoint() -> dict:
             *(synthetic_probe.record(demo, result) for demo, result in results.items())
         )
         return results
+    finally:
+        _probe_in_flight = False
+
+
+@internal_router.post("/qwen-session-probe")
+async def qwen_session_probe_endpoint() -> dict:
+    """Run and latch only the qwen session synthetic."""
+    global _probe_in_flight
+
+    if _probe_in_flight:
+        logger.info("synthetic probe already in flight, skipping this trigger")
+        return {"skipped": True, "detail": "already running"}
+
+    _probe_in_flight = True
+    try:
+        from ember_public import synthetic_probe
+
+        result = await synthetic_probe.probe_qwen()
+        if not result["ok"]:
+            logger.warning("ember synthetic qwen failed: %s", result["detail"])
+        await synthetic_probe.record("qwen", result)
+        return {"qwen": result}
     finally:
         _probe_in_flight = False

--- a/projects/monolith/ember_public/synthetic_router_test.py
+++ b/projects/monolith/ember_public/synthetic_router_test.py
@@ -94,6 +94,25 @@ def test_in_flight_flag_is_cleared_after_a_run(app, recorded):
     assert set(client.post("/internal/ember/synthetic-probe").json()) == set(DEMOS)
 
 
+def test_qwen_probe_endpoint_runs_and_records(app, monkeypatch):
+    recorded = {}
+
+    async def probe_qwen():
+        return {"ok": True, "detail": "completed, destroyed", "latency_ms": 1}
+
+    async def record(demo, result):
+        recorded[demo] = result
+
+    monkeypatch.setattr("ember_public.synthetic_probe.probe_qwen", probe_qwen)
+    monkeypatch.setattr("ember_public.synthetic_probe.record", record)
+
+    response = TestClient(app).post("/internal/ember/qwen-session-probe")
+
+    assert response.status_code == 200
+    assert response.json()["qwen"]["ok"] is True
+    assert recorded["qwen"]["detail"] == "completed, destroyed"
+
+
 def test_record_failure_propagates(app, monkeypatch):
     """A failed write must surface, so the job fails rather than going blind."""
     for demo in DEMOS:


### PR DESCRIPTION
Closes #4885.

## Why

Nothing exercised a pi-family (qwen) session invoke end to end against a real EmberVM, so the lane could break invisibly. It did: the inference swap to llama.cpp broke **every qwen session in prod and dev the same day** (#4884), and a human found it by running one by hand, reproducing on the first try.

The failing hop was proxy-to-backend HTTP semantics (the egress proxy forwards absolute-form request targets; llama.cpp rejects them, vLLM tolerated them), so no unit test could have caught it:

| Existing coverage | Why it missed |
|---|---|
| guest shim pi adapter tests | unit-level with fake processes, never cross the egress proxy |
| `pi_context_window_sync_test` | static config assertion, not an invoke |
| `*/5` ember synthetics | probe demo endpoints and health; **stayed green throughout the outage** |

There is no EmberVM fleet in CI, which is the argument for a synthetic rather than a bazel test.

## The probe

`run_synthetic_session` starts a real qwen session (trivial prompt, no repo checkout), waits for the turn, asserts `completed`/`stop` with a non-empty result, and **always destroys the session in a `finally` block**.

It captures the created session in the `on_create` callback rather than from the return value, so a **failed** invoke still reaches cleanup. An hourly probe that leaked a VM slot on the exact failure it exists to detect would be worse than no probe.

**Hourly, not `*/5`.** A session VM is far heavier than the HTTP page fetches the existing probes do.

**Ships `suspend: true`.** The `ember-synthetic` entry records why: *"Landing a prober you have not watched succeed is how #4074 paged on its own gaps."* The values comment states what a first green run must show before arming.

## Keeping the failure body

The invoke error path logged `str(exc)` rather than `_status_error_detail(exc)`. That helper already existed in the same file, added for #4252 for exactly this reason, and was wired at six other call sites. The invoke path was the one that did not use it.

So the body survived into the raised error downstream but was destroyed in the log, which is what a human reads first. #4884 therefore presented as a bare `422 Unprocessable Content` while the body said `File Not Found`. Failed turn records carry the same detail.

## Public-tier note

`probe_qwen` imports `agent_sessions.api` **lazily, inside the function**, so the public binary never pulls it in at module load and the boundary is unaffected (`main_public_imports_test` green). The probe endpoint is served by the **private** monolith, which is where the trigger POSTs, so the lazy import resolves at runtime. The test target still needs the real module on the path because `monkeypatch` imports the target module to resolve the attribute. Do not hoist that import: it would pass every local test and fail only inside the public image, which is item 3 of the public-tier checklist.

## Review notes

Two defects were fixed during review of the generated implementation, both worth knowing about:

1. **The new CronWorkflow entry was spliced between the existing `ember-synthetic` entry's `requests:` and its `limits:`**, so YAML re-parented the block and the live `ember-synthetic` probe silently lost its memory limit. Caught by parsing the values file, not by reading the diff. Same shape as #4830.
2. The probe test target was missing its `agent_sessions` dep, so both new tests failed with `ModuleNotFoundError`.

`ci test`: `Executed 1 out of 716 tests: 716 tests pass`.