### PR TITLE
perf(embervm): punch holes in memfiles to reclaim snapshot disk

### DIFF
--- a/projects/embervm/noded/fcvm/driver/BUILD
+++ b/projects/embervm/noded/fcvm/driver/BUILD
@@ -8,10 +8,10 @@ go_library(
         "launcher.go",
         "mountns_linux.go",
         "mountns_other.go",
+        "provisioner.go",
         "punchholes.go",
         "punchholes_linux.go",
         "punchholes_other.go",
-        "provisioner.go",
     ],
     importpath = "github.com/jomcgi/homelab/projects/embervm/noded/fcvm/driver",
     visibility = ["//projects/embervm/noded:__subpackages__"],
@@ -19,8 +19,15 @@ go_library(
         "//projects/embervm/noded/fcvm/fcclient",
         "//projects/embervm/noded/substrate",
         "@io_opentelemetry_go_otel//:otel",
-        "@org_golang_x_sys//unix",
-    ],
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_test(
@@ -29,12 +36,19 @@ go_test(
         "driver_test.go",
         "group_test.go",
         "gueststats_test.go",
-        "punchholes_linux_test.go",
         "provisioner_test.go",
+        "punchholes_linux_test.go",
     ],
     embed = [":driver"],
     deps = [
         "//projects/embervm/noded/substrate",
-        "@org_golang_x_sys//unix",
-    ],
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/projects/embervm/noded/fcvm/driver/BUILD
+++ b/projects/embervm/noded/fcvm/driver/BUILD
@@ -8,6 +8,9 @@ go_library(
         "launcher.go",
         "mountns_linux.go",
         "mountns_other.go",
+        "punchholes.go",
+        "punchholes_linux.go",
+        "punchholes_other.go",
         "provisioner.go",
     ],
     importpath = "github.com/jomcgi/homelab/projects/embervm/noded/fcvm/driver",
@@ -16,6 +19,7 @@ go_library(
         "//projects/embervm/noded/fcvm/fcclient",
         "//projects/embervm/noded/substrate",
         "@io_opentelemetry_go_otel//:otel",
+        "@org_golang_x_sys//unix",
     ],
 )
 
@@ -25,8 +29,12 @@ go_test(
         "driver_test.go",
         "group_test.go",
         "gueststats_test.go",
+        "punchholes_linux_test.go",
         "provisioner_test.go",
     ],
     embed = [":driver"],
-    deps = ["//projects/embervm/noded/substrate"],
+    deps = [
+        "//projects/embervm/noded/substrate",
+        "@org_golang_x_sys//unix",
+    ],
 )

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -1150,6 +1150,10 @@ func (d *Driver) Snapshot(ctx context.Context, h substrate.Handle) (substrate.Sn
 		_ = d.Release(ctx, h)
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: resume after snapshot: %w", err)
 	}
+	// Punch after resume so the guest is paused for less time. The running guest
+	// does not read the finalized memfile, and this best-effort cleanup must not
+	// turn a successful snapshot into a failed operation.
+	bestEffortDigHoles(memPath, "snapshot")
 
 	ref := substrate.SnapshotRef{
 		ID:        newID("snap"),
@@ -1225,6 +1229,9 @@ func (d *Driver) SnapshotBase(ctx context.Context, h substrate.Handle, baseKey s
 		_ = d.Release(ctx, h)
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: resume after base snapshot: %w", err)
 	}
+	// Punch after resume so the guest is paused for less time. The base memfile
+	// is finalized here and is not read by the running guest afterward.
+	bestEffortDigHoles(memTmp, "base")
 	// Publish memfile before snapfile: a restore reads the snapfile to locate the
 	// memfile, so the memfile must already be in place when the snapfile appears.
 	if err := os.Rename(memTmp, memPath); err != nil {
@@ -1310,6 +1317,7 @@ func (d *Driver) SnapshotSession(ctx context.Context, h substrate.Handle, snapsh
 	if err := inst.client.CreateSnapshot(ctx, fcclient.SnapshotCreate{SnapshotPath: snapTmp, MemFilePath: memTmp}); err != nil {
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: create session snapshot: %w", err)
 	}
+	bestEffortDigHoles(memTmp, "session-bank")
 	// Publish memfile before snapfile: a restore reads the snapfile to locate the
 	// memfile, so the memfile must already be in place when the snapfile appears.
 	if err := os.Rename(memTmp, memPath); err != nil {
@@ -1409,6 +1417,7 @@ func (d *Driver) SnapshotServing(ctx context.Context, h substrate.Handle, snapsh
 	if err := inst.client.CreateSnapshot(ctx, fcclient.SnapshotCreate{SnapshotPath: snapTmp, MemFilePath: memTmp}); err != nil {
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: create serving snapshot: %w", err)
 	}
+	bestEffortDigHoles(memTmp, "serving-bank")
 	// Publish memfile before snapfile (a restore reads the snapfile to locate the
 	// memfile), then the IP sidecar. A rescan treats a bundle without a snapfile as
 	// half-written and skips it, so the snapfile is published LAST.
@@ -1590,6 +1599,7 @@ func (d *Driver) SnapshotStateful(ctx context.Context, h substrate.Handle, snaps
 	if err := inst.client.CreateSnapshot(ctx, fcclient.SnapshotCreate{SnapshotPath: snapTmp, MemFilePath: memTmp}); err != nil {
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: create stateful snapshot: %w", err)
 	}
+	bestEffortDigHoles(memTmp, "stateful-bank")
 	// Publish memfile before snapfile (a restore reads the snapfile to locate the
 	// memfile), then the generation sidecar, then the snapfile LAST so a rescan
 	// that finds a snapfile always finds a complete bundle (mirrors serving's
@@ -1671,6 +1681,7 @@ func (d *Driver) CheckpointStateful(ctx context.Context, h substrate.Handle, sna
 		_ = os.RemoveAll(tmpDir)
 		return "", fmt.Errorf("driver: create checkpoint snapshot: %w", err)
 	}
+	bestEffortDigHoles(memPath, "stateful-checkpoint")
 	d.mu.Lock()
 	d.checkpoints[token] = &statefulCheckpoint{handle: h, snapshotRef: snapshotRef, generation: generation, tmpDir: tmpDir, pinnedIP: pinnedIP}
 	d.mu.Unlock()
@@ -2082,6 +2093,7 @@ func (d *Driver) SnapshotGroupMember(ctx context.Context, h substrate.Handle, se
 	if err := inst.client.CreateSnapshot(ctx, fcclient.SnapshotCreate{SnapshotPath: snapTmp, MemFilePath: memTmp}); err != nil {
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: create group member snapshot: %w", err)
 	}
+	bestEffortDigHoles(memTmp, "group-member-bank")
 	// Publish memfile before snapfile (a restore reads the snapfile to locate the
 	// memfile), then the snapfile LAST so a rescan that finds a snapfile always
 	// finds a complete bundle (the same publish-last discipline every other class

--- a/projects/embervm/noded/fcvm/driver/punchholes.go
+++ b/projects/embervm/noded/fcvm/driver/punchholes.go
@@ -1,0 +1,12 @@
+package driver
+
+import "log/slog"
+
+func bestEffortDigHoles(path, kind string) {
+	freed, err := digHoles(path)
+	if err != nil {
+		slog.Default().Warn("driver: punch memfile holes failed", "kind", kind, "path", path, "error", err)
+		return
+	}
+	slog.Default().Info("driver: punched memfile holes", "kind", kind, "path", path, "bytes_freed", freed)
+}

--- a/projects/embervm/noded/fcvm/driver/punchholes_linux.go
+++ b/projects/embervm/noded/fcvm/driver/punchholes_linux.go
@@ -1,0 +1,86 @@
+//go:build linux
+
+package driver
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	holeBlockSize = int64(4096)
+	holeChunkSize = int64(1 << 20)
+)
+
+// digHoles deallocates all-zero regions of the file at path, leaving its
+// logical size and its contents-as-read unchanged. It returns the number of
+// bytes requested for deallocation.
+func digHoles(path string) (freed int64, err error) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if closeErr := f.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
+
+	st, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	var runStart, runLength int64
+	punchRun := func() error {
+		if runLength == 0 {
+			return nil
+		}
+		if err := unix.Fallocate(int(f.Fd()), unix.FALLOC_FL_PUNCH_HOLE|unix.FALLOC_FL_KEEP_SIZE, runStart, runLength); err != nil {
+			return err
+		}
+		freed += runLength
+		runStart, runLength = 0, 0
+		return nil
+	}
+
+	buf := make([]byte, holeChunkSize)
+	for offset := int64(0); offset+holeBlockSize <= st.Size(); {
+		readLength := holeChunkSize
+		if remaining := st.Size() - offset; remaining < readLength {
+			readLength = remaining
+		}
+		n, readErr := f.ReadAt(buf[:readLength], offset)
+		if readErr != nil && readErr != io.EOF {
+			return freed, readErr
+		}
+		for blockOffset := int64(0); blockOffset+holeBlockSize <= int64(n); blockOffset += holeBlockSize {
+			block := buf[blockOffset : blockOffset+holeBlockSize]
+			zero := true
+			for _, b := range block {
+				if b != 0 {
+					zero = false
+					break
+				}
+			}
+			if zero {
+				if runLength == 0 {
+					runStart = offset + blockOffset
+				}
+				runLength += holeBlockSize
+			} else if err := punchRun(); err != nil {
+				return freed, fmt.Errorf("punch zero run at offset %d: %w", runStart, err)
+			}
+		}
+		offset += int64(n)
+		if n == 0 {
+			break
+		}
+	}
+	if err := punchRun(); err != nil {
+		return freed, fmt.Errorf("punch zero run at offset %d: %w", runStart, err)
+	}
+	return freed, nil
+}

--- a/projects/embervm/noded/fcvm/driver/punchholes_linux_test.go
+++ b/projects/embervm/noded/fcvm/driver/punchholes_linux_test.go
@@ -1,0 +1,118 @@
+//go:build linux
+
+package driver
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestDigHolesPreservesMixedFile(t *testing.T) {
+	const block = 4096
+	data := make([]byte, 3*1024*1024+block/2)
+	copy(data[block/2:], bytes.Repeat([]byte{0x7f}, block+block/2))
+	copy(data[2*1024*1024+block/2:], bytes.Repeat([]byte{0x23}, 2*block+123))
+	path := filepath.Join(t.TempDir(), "memfile")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeSize := fileSize(t, path)
+	freed, err := digHoles(path)
+	if err != nil {
+		t.Fatalf("digHoles: %v", err)
+	}
+	if freed == 0 {
+		t.Fatal("digHoles freed zero bytes")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("file contents changed after punching holes")
+	}
+	if got := fileSize(t, path); got != beforeSize {
+		t.Fatalf("logical size changed: before %d, after %d", beforeSize, got)
+	}
+}
+
+func TestDigHolesDropsBlocks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "memfile")
+	data := make([]byte, 2*1024*1024)
+	data[0] = 1
+	data[len(data)-1] = 1
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before := fileBlocks(t, path)
+	if _, err := digHoles(path); err != nil {
+		t.Fatal(err)
+	}
+	if after := fileBlocks(t, path); after >= before {
+		t.Fatalf("allocated blocks did not decrease: before %d, after %d", before, after)
+	}
+}
+
+func TestDigHolesEdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "all zero", data: make([]byte, 2*4096)},
+		{name: "all non-zero", data: bytes.Repeat([]byte{1}, 2*4096)},
+		{name: "smaller than block", data: []byte{1, 2, 3}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "memfile")
+			if err := os.WriteFile(path, tt.data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			beforeSize := fileSize(t, path)
+			freed, err := digHoles(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.name == "all non-zero" && freed != 0 {
+				t.Fatalf("freed %d bytes from non-zero file", freed)
+			}
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(before, after) || fileSize(t, path) != beforeSize {
+				t.Fatal("edge-case file changed")
+			}
+		})
+	}
+}
+
+func fileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return st.Size()
+}
+
+func fileBlocks(t *testing.T, path string) int64 {
+	t.Helper()
+	var st unix.Stat_t
+	if err := unix.Stat(path, &st); err != nil {
+		t.Fatal(err)
+	}
+	return st.Blocks
+}

--- a/projects/embervm/noded/fcvm/driver/punchholes_other.go
+++ b/projects/embervm/noded/fcvm/driver/punchholes_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package driver
+
+// digHoles is unavailable off Linux. The caller treats hole punching as
+// best-effort, so retaining fully allocated files is safe.
+func digHoles(string) (int64, error) { return 0, nil }


### PR DESCRIPTION
Firecracker writes a guest's whole RAM image on snapshot, **fully allocated**. A 4096 memMib workload produces a 4294967296-byte memfile whose `du` reports 4.0G no matter how little the guest touched.

Measured on a live brick, that is nearly all of the snapshot storage:

```
167 memfiles totalling 143.6 GiB
whole snapshots dir:      145.0 G      (~99% is memfiles)
```

Sampled zero fractions, 4 KiB blocks:

| base | memMib | zero | absolute touched |
|---|---:|---:|---:|
| claude-runtime | 4096 | **92%** | ~330 MB |
| sandbox | 512 | **49%** | ~260 MB |

Guests touch a roughly **constant absolute amount** (~250-350 MB) whatever their ceiling, so the zero fraction is `1 - touched/memMib`. Declared `memMib` is billed as disk immediately and in full, which is the opposite of the usual intuition that over-provisioned memory is free until used.

## Why this is safe

`digHoles` uses `FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE`, so the **logical size and contents-as-read are unchanged** and only block allocation drops. `KEEP_SIZE` is load-bearing: without it the file is truncated and the snapshot destroyed.

Restore needs no change. The driver restores via `MemBackend{BackendType: "File"}`, which the fcclient documents as "mmaps the image and faults pages lazily", so holes read back as zeros and untouched pages were never faulted anyway. The mapping cannot be writing back, because many microVMs already restore **concurrently from one shared base memfile** (see `RootfsReadOnly` and `CanonicalVsockDir` at `driver.go:45-60`).

A new VM therefore still maps its full `memMib`. Same RAM, less disk.

## Wiring

Every point a memfile is finalized: snapshot, base build, session / serving / stateful / group-member banks, and the stateful checkpoint. All call sites go through a wrapper that **returns nothing**, so a punch failure structurally cannot fail a bank, fail a base build, or strand a paused VM. Bytes freed are logged at info so the win is observable in prod.

Punching happens after `Resume` rather than before: the guest is paused for less time, and a finalized memfile is not read by the running guest either way.

## Verification

Run with the focused target under `--nocache_test_results --test_output=all`, so the tests **provably executed** rather than being inferred from an aggregate count:

```
Executed 1 out of 1 test: 1 test passes
```

Tests assert the property that matters most, that a mixed file's bytes are **identical** after punching, plus unchanged logical size and strictly decreasing `st_blocks`, with all-zero / all-non-zero / sub-block edge cases. Full suite: `Executed 1 out of 716 tests: 716 tests pass`.

## Scope

This does **not** help the S3 path. `store.Put` takes the file's logical size and `io.Copy` reads holes back as zeros, so an upload still ships the full byte count. Compressing that path is separate follow-up work, and it also fixes hydration bandwidth which punching cannot.

Savings degrade over a session's life, since Linux does not zero freed pages, so touched-then-freed memory stays non-zero. Base bundles are the best case (pristine boot, built once) and are also the largest measured cost.

## Related

While measuring this I found **149 stateful bundles totalling 69.9 G (48% of the snapshots dir), all created Jul 17-22 and never reaped**, against a 7-day `bankedTtlSeconds`. That is a separate GC issue, not addressed here, and is likely a larger and cheaper win than this PR.