### PR TITLE
fix(embervm): let the warmth reaper reclaim pre-sidecar stateful orphans

### DIFF
--- a/projects/embervm/control/lib/embervm/warmth_reaper.ex
+++ b/projects/embervm/control/lib/embervm/warmth_reaper.ex
@@ -72,7 +72,7 @@ defmodule Embervm.WarmthReaper do
   use GenServer
   require Logger
 
-  alias Embervm.{GroupState, GroupStore, NodeCapacity, StatefulState, StatefulStore, WakeInstance}
+  alias Embervm.{GroupState, GroupStore, NodeCapacity, S3Client, StatefulState, StatefulStore, WakeInstance}
 
   alias Embervm.Node.V1.{
     ArtifactRef,
@@ -122,6 +122,8 @@ defmodule Embervm.WarmthReaper do
     channel_fun = Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1)
     evict_snapshot_fun = Keyword.get(opts, :evict_snapshot_fun, &default_evict_snapshot/2)
     evict_artifact_fun = Keyword.get(opts, :evict_artifact_fun, &default_evict_artifact/2)
+    remote_stateful_index_fun =
+      Keyword.get(opts, :remote_stateful_index_fun, &default_remote_stateful_index/0)
 
     # 0 disables the timer entirely (the unit-test default, so a test drives
     # :sweep_now explicitly and asserts deterministically); production uses the
@@ -141,6 +143,7 @@ defmodule Embervm.WarmthReaper do
       channel_fun: channel_fun,
       evict_snapshot_fun: evict_snapshot_fun,
       evict_artifact_fun: evict_artifact_fun,
+      remote_stateful_index_fun: remote_stateful_index_fun,
       sweep_interval_ms: sweep_interval_ms,
       sweep_enabled: sweep_enabled
     }
@@ -254,15 +257,16 @@ defmodule Embervm.WarmthReaper do
 
   defp apply_plan(state, plan) do
     {stateful, group} = Enum.split_with(plan, &(&1.kind == :stateful))
+    stateful_index = remote_stateful_index(state, stateful)
 
-    log_and_evict(state, :stateful, stateful)
-    log_and_evict(state, :group, group)
+    log_and_evict(state, :stateful, stateful, stateful_index)
+    log_and_evict(state, :group, group, nil)
     :ok
   end
 
-  defp log_and_evict(_state, _kind, []), do: :ok
+  defp log_and_evict(_state, _kind, [], _index), do: :ok
 
-  defp log_and_evict(state, kind, entries) do
+  defp log_and_evict(state, kind, entries, index) do
     count = length(entries)
     bytes = entries |> Enum.map(& &1.evict_bytes) |> Enum.sum()
 
@@ -271,11 +275,13 @@ defmodule Embervm.WarmthReaper do
         "embervm warmth reaper: warmth-retention sweep evicting #{count} orphaned #{kind} warmth artifact(s) (~#{bytes} bytes)"
       )
 
-      Enum.each(entries, &evict_entry(state, &1))
+      Enum.each(entries, &evict_entry(state, &1, index))
     else
       Logger.info(
         "embervm warmth reaper: warmth-retention sweep (DRY RUN, gate off) WOULD evict #{count} orphaned #{kind} warmth artifact(s) (~#{bytes} bytes)"
       )
+
+      Enum.each(entries, &log_dry_run_entry(&1, index))
     end
 
     :ok
@@ -303,24 +309,38 @@ defmodule Embervm.WarmthReaper do
   # uses); the single remote EvictArtifact{remote: true, kind: GROUP_SET, workload:
   # group_instance_id, ref: set_id} that drops the whole set prefix at once fires
   # ONLY when EVERY member's local eviction succeeded.
-  # Empty-binding SKIP (#38 fix C): a bundle boot-scanned from disk before the
-  # binding sidecar shipped (or after a crash between snapfile-publish and
-  # sidecar-write) seeds with workload/group_instance_id = "" or nil. Its LOCAL
-  # evict would succeed and DRAIN the on-disk copy, but the REMOTE (S3) evict needs
-  # the workload to compose the prefix and fails InvalidArgument, so the set/bundle
-  # would be locally gone yet its S3 copy stranded FOREVER with no handle to find it
-  # again (Fable F2, worse than nothing). So we run NEITHER copy's evict and log ONE
-  # info line. Reclaiming these pre-sidecar orphans is a separate decision (task
-  # #39); until then they are safely left whole.
-  defp evict_entry(_state, %{kind: :stateful, id: ref, workload: workload}) when workload in [nil, ""] do
+  # GROUP_SET is not searchable by the same ref in this reaper. Its remote layout
+  # is keyed by group_instance_id, so the conservative empty-binding skip remains.
+
+  defp evict_entry(state, %{kind: :stateful, id: ref, workload: workload} = entry, {:ok, index})
+       when workload in [nil, ""] do
+    case Map.get(index, ref) do
+      %{vendor: vendor, workload: recovered_workload} ->
+        Logger.info(
+          "embervm warmth reaper: recovered binding for orphaned stateful bundle #{inspect(ref)} from remote index (vendor #{inspect(vendor)}, workload #{inspect(recovered_workload)})"
+        )
+
+        evict_stateful(state, %{entry | workload: recovered_workload}, vendor)
+
+      nil ->
+        Logger.info(
+          "embervm warmth reaper: evicting local-only orphaned stateful bundle #{inspect(ref)} (not found in remote index; no remote copy can be stranded)"
+        )
+
+        evict_stateful(state, entry, nil, false)
+    end
+  end
+
+  defp evict_entry(_state, %{kind: :stateful, id: ref, workload: workload}, {:error, reason})
+       when workload in [nil, ""] do
     Logger.info(
-      "embervm warmth reaper: SKIP orphaned stateful bundle #{inspect(ref)} (no workload binding on disk; cannot evict remote copy safely, leaving whole)"
+      "embervm warmth reaper: SKIP orphaned stateful bundle #{inspect(ref)} (remote index lookup failed: #{inspect(reason)}; leaving whole)"
     )
 
     :ok
   end
 
-  defp evict_entry(_state, %{kind: :group, id: set_id, workload: gid}) when gid in [nil, ""] do
+  defp evict_entry(_state, %{kind: :group, id: set_id, workload: gid}, _index) when gid in [nil, ""] do
     Logger.info(
       "embervm warmth reaper: SKIP orphaned group set #{inspect(set_id)} (no group_instance_id binding on disk; cannot evict remote copy safely, leaving whole)"
     )
@@ -328,18 +348,20 @@ defmodule Embervm.WarmthReaper do
     :ok
   end
 
-  defp evict_entry(state, %{kind: :stateful, id: ref, workload: workload, node_id: node_id}) do
+  defp evict_entry(state, %{kind: :stateful} = entry, _index), do: evict_stateful(state, entry)
+
+  defp evict_stateful(state, %{id: ref, workload: workload, node_id: node_id}, vendor \\ nil, remote \\ true) do
     dial_key = WakeInstance.dial_for_bundle(state.capacity_table, node_id, ref)
     artifact = %ArtifactRef{kind: :ARTIFACT_KIND_STATEFUL, workload: workload, ref: ref}
 
     local = {:artifact, %EvictArtifactRequest{artifact: artifact, remote: false, trace: %Trace{workload: workload}}}
-    remote = {:artifact, %EvictArtifactRequest{artifact: artifact, remote: true, trace: %Trace{workload: workload}}}
+    remote_request = %EvictArtifactRequest{artifact: artifact, remote: true, vendor: vendor || "", trace: %Trace{workload: workload}}
 
     spawn(fn ->
       with {:ok, channel} <- safe_channel(state, dial_key) do
         # Remote (S3) evict fires ONLY if the local disk evict succeeded: never
         # delete the recovery copy of a bundle the node refused/failed to remove.
-        run_evict(state, channel, [local], remote)
+        run_evict(state, channel, [local], if(remote, do: {:artifact, remote_request}, else: nil))
         release_channel(state, channel)
       end
     end)
@@ -347,7 +369,7 @@ defmodule Embervm.WarmthReaper do
     :ok
   end
 
-  defp evict_entry(state, %{kind: :group, id: set_id, workload: group_instance_id, node_id: node_id, member_refs: member_refs}) do
+  defp evict_entry(state, %{kind: :group, id: set_id, workload: group_instance_id, node_id: node_id, member_refs: member_refs}, _index) do
     dial_key = WakeInstance.dial_for_group(state.capacity_table, node_id, group_instance_id)
 
     remote =
@@ -373,6 +395,60 @@ defmodule Embervm.WarmthReaper do
     :ok
   end
 
+  defp remote_stateful_index(_state, []), do: {:ok, %{}}
+
+  defp remote_stateful_index(state, entries) do
+    if Enum.any?(entries, &(&1.workload in [nil, ""])) do
+      state.remote_stateful_index_fun.()
+    else
+      {:ok, %{}}
+    end
+  rescue
+    e -> {:error, {:lookup_raised, e}}
+  catch
+    kind, reason -> {:error, {:lookup_thrown, {kind, reason}}}
+  end
+
+  defp log_dry_run_entry(%{kind: :stateful, id: ref, workload: workload}, {:ok, index})
+       when workload in [nil, ""] do
+    action = if Map.has_key?(index, ref), do: "local and remote", else: "local-only"
+    Logger.info("embervm warmth reaper: DRY RUN WOULD evict #{action} for empty-binding stateful bundle #{inspect(ref)}")
+  end
+
+  defp log_dry_run_entry(%{kind: :stateful, id: ref, workload: workload}, {:error, reason})
+       when workload in [nil, ""] do
+    Logger.info("embervm warmth reaper: DRY RUN WOULD skip empty-binding stateful bundle #{inspect(ref)} because remote index lookup failed: #{inspect(reason)}")
+  end
+
+  defp log_dry_run_entry(_entry, _index), do: :ok
+
+  defp default_remote_stateful_index do
+    endpoint = System.get_env("EMBERVM_STORE_ENDPOINT", "") |> String.trim()
+    bucket = System.get_env("EMBERVM_STORE_BUCKET", "embervm")
+
+    case S3Client.new(endpoint, bucket) do
+      nil -> {:error, :store_disabled}
+      client ->
+        with {:ok, entries} <- S3Client.list_all(client, "stateful/") do
+          Enum.reduce_while(entries, {:ok, %{}}, fn %{key: key}, {:ok, index} ->
+            case String.split(key, "/") do
+              ["stateful", vendor, workload, ref, file]
+              when vendor != "" and workload != "" and ref != "" and file != "" ->
+                binding = %{vendor: vendor, workload: workload}
+
+                case Map.get(index, ref) do
+                  nil -> {:cont, {:ok, Map.put(index, ref, binding)}}
+                  ^binding -> {:cont, {:ok, index}}
+                  _ -> {:halt, {:error, {:conflicting_bindings, ref}}}
+                end
+
+              _ -> {:cont, {:ok, index}}
+            end
+          end)
+        end
+    end
+  end
+
   # Fire an entry's LOCAL evictions then, ONLY if every local succeeded, the single
   # REMOTE (S3) evict, on an already-dialled channel (#38). Locals are best-effort
   # among themselves (each is independent and idempotent, so one failure is logged
@@ -394,12 +470,14 @@ defmodule Embervm.WarmthReaper do
         end
       end)
 
-    if all_local_ok do
+    if all_local_ok and not is_nil(remote) do
       run_one(state, channel, remote)
     else
-      Logger.info(
-        "embervm warmth reaper: skipping remote evict #{inspect(remote_req(remote))} (a local eviction was refused or failed; recovery copy kept)"
-      )
+      if not is_nil(remote) do
+        Logger.info(
+          "embervm warmth reaper: skipping remote evict #{inspect(remote_req(remote))} (a local eviction was refused or failed; recovery copy kept)"
+        )
+      end
     end
 
     :ok

--- a/projects/embervm/control/test/embervm/warmth_reaper_test.exs
+++ b/projects/embervm/control/test/embervm/warmth_reaper_test.exs
@@ -85,6 +85,7 @@ defmodule Embervm.WarmthReaperTest do
   defp recording_evict_funs(test_pid) do
     artifact_fun = fn _channel, req ->
       send(test_pid, {:evict_artifact, req.artifact.kind, req.artifact.ref, req.remote})
+      send(test_pid, {:evict_artifact_req, req})
       {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
     end
 
@@ -198,6 +199,105 @@ defmodule Embervm.WarmthReaperTest do
       assert [%{kind: :stateful, id: "ghost", evict_bytes: 1_024}] = plan
       assert_receive {:evict_artifact, :ARTIFACT_KIND_STATEFUL, "ghost", false}, 1_000
       assert_receive {:evict_artifact, :ARTIFACT_KIND_STATEFUL, "ghost", true}, 1_000
+    end
+  end
+
+  describe "empty-binding stateful orphan lookup" do
+    defp empty_binding_reaper(table, artifact_fun, snapshot_fun, index_fun, enabled \\ true) do
+      stateful = start_store([stateful_instance(:destroyed, "orphan-nobind")])
+      group = start_store([])
+
+      start_reaper(
+        capacity_table: table,
+        stateful_store: stateful,
+        group_store: group,
+        evict_artifact_fun: artifact_fun,
+        evict_snapshot_fun: snapshot_fun,
+        channel_fun: fake_channel_fun(),
+        remote_stateful_index_fun: index_fun,
+        sweep_enabled: enabled
+      )
+    end
+
+    test "remote hit recovers vendor and workload, then evicts local before remote" do
+      test_pid = self()
+      table = new_cap_table()
+      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
+      put_warmth_fact(table, "node-4", [stateful_bundle("orphan-nobind", "", 4_096)], [])
+
+      reaper =
+        empty_binding_reaper(table, artifact_fun, snapshot_fun, fn ->
+          {:ok, %{"orphan-nobind" => %{vendor: "amd", workload: "demo-postgres"}}}
+        end)
+
+      WarmthReaper.sweep_now(reaper)
+      assert_receive {:evict_artifact_req, %{remote: false}}, 1_000
+      assert_receive {:evict_artifact_req, %{remote: true, vendor: "amd", artifact: %{workload: "demo-postgres"}}}, 1_000
+    end
+
+    test "remote miss evicts local only" do
+      test_pid = self()
+      table = new_cap_table()
+      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
+      put_warmth_fact(table, "node-4", [stateful_bundle("orphan-nobind", nil, 4_096)], [])
+
+      reaper = empty_binding_reaper(table, artifact_fun, snapshot_fun, fn -> {:ok, %{}} end)
+      WarmthReaper.sweep_now(reaper)
+
+      assert_receive {:evict_artifact, :ARTIFACT_KIND_STATEFUL, "orphan-nobind", false}, 1_000
+      refute_receive {:evict_artifact, :ARTIFACT_KIND_STATEFUL, "orphan-nobind", true}, 300
+    end
+
+    test "remote index failure preserves both copies" do
+      test_pid = self()
+      table = new_cap_table()
+      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
+      put_warmth_fact(table, "node-4", [stateful_bundle("orphan-nobind", "", 4_096)], [])
+
+      reaper = empty_binding_reaper(table, artifact_fun, snapshot_fun, fn -> {:error, :timeout} end)
+      WarmthReaper.sweep_now(reaper)
+
+      refute_receive {:evict_artifact, :ARTIFACT_KIND_STATEFUL, "orphan-nobind", _}, 300
+    end
+
+    test "gate off evicts nothing after a remote hit" do
+      test_pid = self()
+      table = new_cap_table()
+      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
+      put_warmth_fact(table, "node-4", [stateful_bundle("orphan-nobind", "", 4_096)], [])
+
+      reaper =
+        empty_binding_reaper(table, artifact_fun, snapshot_fun, fn ->
+          {:ok, %{"orphan-nobind" => %{vendor: "amd", workload: "demo-postgres"}}}
+        end, false)
+
+      WarmthReaper.sweep_now(reaper)
+      refute_receive {:evict_artifact, _, _, _}, 300
+      refute_receive {:evict_snapshot, _}, 100
+    end
+
+    test "fetches the remote index once for several empty-binding bundles" do
+      test_pid = self()
+      table = new_cap_table()
+      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
+      put_warmth_fact(table, "node-4", [stateful_bundle("orphan-a", "", 1), stateful_bundle("orphan-b", "", 2)], [])
+      stateful = start_store([stateful_instance(:destroyed, "orphan-a"), stateful_instance(:destroyed, "orphan-b")])
+
+      reaper =
+        start_reaper(
+          capacity_table: table,
+          stateful_store: stateful,
+          group_store: start_store([]),
+          evict_artifact_fun: artifact_fun,
+          evict_snapshot_fun: snapshot_fun,
+          channel_fun: fake_channel_fun(),
+          remote_stateful_index_fun: fn -> send(test_pid, :remote_index_lookup); {:ok, %{}} end,
+          sweep_enabled: true
+        )
+
+      WarmthReaper.sweep_now(reaper)
+      assert_receive :remote_index_lookup, 1_000
+      refute_receive :remote_index_lookup, 300
     end
   end
 
@@ -421,12 +521,11 @@ defmodule Embervm.WarmthReaperTest do
     end
   end
 
-  # #38 fix C: an orphan boot-scanned before the binding sidecar shipped has an
-  # empty workload/group_instance_id. Its local evict would drain the disk copy
-  # while its remote evict fails InvalidArgument, stranding the S3 copy forever. So
-  # such an entry is SKIPPED entirely: NEITHER local nor remote runs.
-  describe "empty-binding orphans are skipped entirely (#38 fix C)" do
-    test "a stateful orphan with no workload binding runs no local and no remote evict" do
+  # #38 fix C remains fail-safe when the remote index is unavailable. The group
+  # layout is not searchable by set id in the same way, so its empty binding still
+  # skips both copies.
+  describe "empty-binding lookup failures and groups remain fail-safe (#38 fix C)" do
+    test "a stateful orphan with no workload binding and no remote store runs no evict" do
       test_pid = self()
       table = new_cap_table()
       {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)


### PR DESCRIPTION
The WarmthReaper skipped every stateful bundle whose on-disk workload binding was empty:

```elixir
defp evict_entry(_state, %{kind: :stateful, id: ref, workload: workload}) when workload in [nil, ""] do
  # ...the bundle would be locally gone yet its S3 copy stranded FOREVER with no
  # handle to find it again (Fable F2, worse than nothing)... Reclaiming these
  # pre-sidecar orphans is a separate decision (task #39).
```

The reasoning is sound. The **premise was never tested**: it assumed a remote copy *might* exist and never looked.

## Measured in production today

| | |
|---|---|
| orphaned bundles on one brick | **149**, totalling **69.9 GiB** |
| share of that brick's snapshots dir | **48%** |
| created | Jul 17-22, never reclaimed |
| stateful bundles in S3, total | **7**, all with proper bindings |
| **overlap with the 149** | **ZERO** |

So the skip protected nothing while costing 70 GiB indefinitely, and it could never resolve itself, because nothing else was going to supply the missing binding.

## The store has what the bundle lost

A bundle with an empty binding cannot **compose** a remote prefix, but it can still be **searched for by ref**, and a hit at `stateful/<vendor>/<workload>/<ref>` yields exactly the vendor and workload the local copy lost.

Three branches:

| case | action |
|---|---|
| **found remotely** | recover the binding, evict **both** copies, remote only after local succeeds. Repairs the binding rather than working around it. |
| **not found** | local copy is the only copy: evict local only. Nothing can be stranded. |
| **lookup failed** | keep the previous skip exactly. An unavailable store must never read as "no remote copy exists". |

## Safety properties

- **Fail-safe preserved.** A store error, timeout, or unset endpoint takes the skip branch, never the delete branch.
- **One listing per sweep**, and only when some entry actually has an empty binding, so 149 orphans do not become 149 listings.
- **A raising or throwing store** becomes the lookup-failed branch rather than crashing the GenServer.
- **The destructive gate is unchanged.** With `EMBERVM_WARMTH_RETENTION_SWEEP` off, the sweep still deletes nothing and logs what it would do in each branch.
- **Group sets keep the conservative skip.** Their remote layout is keyed by `group_instance_id` rather than the set ref, so the same search does not apply. Deliberately untouched.

## Verification

`ci test` green. Note the counter reads `Executed 0 out of 716 tests` because the Elixir suite runs as the `//bazel/erlang:mix_test_smoke` **genrule** (a build action) rather than a bazel test target: the log confirms `From Executing genrule //bazel/erlang:mix_test_smoke` with the build completing successfully, and a failure there fails the build.

The 70 GiB on the affected brick was reclaimed by hand before this PR (verified: all workloads still `READY`, `demo-postgres` healthy, zero control-plane errors). This change is what stops it recurring.