### PR TITLE
fix(embervm): let retention collect orphans when the current base is unexported

### DIFF
--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -1350,8 +1350,7 @@ defmodule Embervm.BaseBuilder do
   # scratch and survives a noded pod restart, but the build-time placement instance_id
   # churns with the pod. Without this remap `find_capacity_fact`/`node_addr` miss after
   # any pod restart (the churned pod_uid no longer matches w.node_id), which silently
-  # parks the durability export AND the local retention drain: the current base is
-  # never seen as exportable, so the sweep skips every workload as unexported.
+  # parks the durability export and local retention drain until the node reports again.
   defp current_instance_on_node(state, stale_id, workload) do
     target = node_name(stale_id)
 
@@ -2101,13 +2100,13 @@ defmodule Embervm.BaseBuilder do
   # gated action. The plan is returned for tests/visibility; the action is the
   # spawned evictions (gate on) or the dry-run log (gate off).
   #
-  # For each node with a current, exported local base, candidates are local bases
+  # For each node with a reported current local base, candidates are local bases
   # minus the node's current ref and still-refcounted superseded refs. Base ownership
   # is a NODE property because bases live on shared hostPath scratch, so each node is
   # considered once even when several bricks report the same local inventory. BUILDING
-  # local bases are never candidates, and an unexported current base only blocks
-  # eviction on that same node. noded's in-use/current/BUILDING guard is the final
-  # backstop beneath this.
+  # local bases are never candidates. The per-base desired, refcount, BUILDING,
+  # and age filters make each candidate non-current and unreferenced by
+  # construction. This avoids the old durability guard deadlocking against #4893.
   defp retention_sweep_plan(state) do
     state = %{state | retention_sweep_evictions: 0}
     {plan, state} = Enum.reduce(state.workloads, {[], state}, fn {name, w}, {plan, acc} ->
@@ -2121,11 +2120,6 @@ defmodule Embervm.BaseBuilder do
           {:skip, node_id, accounting} ->
             entry = %{workload: name, evict_refs: [], evict_bytes: 0, candidates: [],
               skipped_unexported: false, node_id: node_id, retention_accounting: accounting}
-            {[entry | p], a}
-
-          {:skip_unexported, node_id, accounting} ->
-            entry = %{workload: name, evict_refs: [], evict_bytes: 0, skipped_unexported: true,
-              node_id: node_id, retention_accounting: accounting}
             {[entry | p], a}
 
           {:evict, node_id, refs, bytes, manifest, accounting} ->
@@ -2154,7 +2148,6 @@ defmodule Embervm.BaseBuilder do
 
   # Decide one retention outcome per node from the representative reported facts:
   #   :skip                          - no local base or nothing to evict
-  #   {:skip_unexported, node_id}    - this node's current base is not exported
   #   {:evict, node_id, refs, bytes} - this node's local bases to evict + bytes
   defp workload_retention(state, w) do
     for fact <- representative_facts_by_node(state, w.name),
@@ -2171,11 +2164,6 @@ defmodule Embervm.BaseBuilder do
         not is_binary(node_ref) or node_ref == "" ->
           local_bases = Enum.filter(Map.get(fact, :local_bases, []), &(&1.workload == w.name))
           {:skip, fact[:instance_id], retention_accounting(local_bases, [], w.base_refs, [])}
-
-        get_in(fact, [:workloads, w.name, :exported]) != true ->
-          {:skip_unexported, fact[:instance_id], retention_accounting(
-            Enum.filter(Map.get(fact, :local_bases, []), &(&1.workload == w.name)),
-            desired_refs_for_node(node_ref, w), w.base_refs, [])}
 
         true ->
           desired = desired_refs_for_node(node_ref, w)

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1050,7 +1050,7 @@ defmodule Embervm.BaseBuilderTest do
     refute log =~ "DELETING"
   end
 
-  test "retention sweep skips a workload whose current base is not yet exported (durability floor)" do
+  test "retention sweep reclaims an orphan when the current base is not exported" do
     agent = start_recorder()
     test_pid = self()
     table = new_cap_table()
@@ -1074,8 +1074,8 @@ defmodule Embervm.BaseBuilderTest do
 
     build_current(builder, agent, "w__current")
 
-    # Current base is present but NOT yet exported: the whole workload is skipped,
-    # so the local cache is never emptied before the S3 durability floor lands.
+    # The current base is present but NOT yet exported. That must not prevent
+    # reclaiming an aged, superseded base that nothing references.
     put_local_bases_fact(table, "w", "w__current", false, [
       ready_base("w__current", "w", 512),
       ready_base("w__orphan1", "w", 2_048)
@@ -1084,9 +1084,45 @@ defmodule Embervm.BaseBuilderTest do
     plan = BaseBuilder.retention_sweep_now(builder)
 
     entry = Enum.find(plan, &(&1.workload == "w"))
-    assert entry.skipped_unexported == true
-    assert entry.evict_refs == []
-    refute_receive {:evicted, "w", "w__orphan1"}, 200
+    assert entry.skipped_unexported == false
+    assert entry.evict_refs == ["w__orphan1"]
+    assert_receive {:evicted, "w", "w__orphan1"}, 1_000
+  end
+
+  test "retention filters protect every non-current base safety rail when current is unexported" do
+    agent = start_recorder()
+    table = new_cap_table()
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: fn :fake_channel, _req -> {:ok, resp("w__current")} end,
+        retention_sweep_enabled: true,
+        retention_disk_driven_enabled: true
+      )
+
+    build_current(builder, agent, "w__current")
+
+    :sys.replace_state(builder, fn state ->
+      w = state.workloads["w"]
+      w = %{w | base_refs: %{"w__refcounted" => %{primed: 1, sessions: 0, evicted: true}}}
+      %{state | workloads: %{"w" => w}}
+    end)
+
+    young = Map.put(ready_base("w__young", "w", 4), :created_at_unix_ms, System.system_time(:millisecond) - 100_000)
+    building = Map.put(ready_base("w__building", "w", 8), :base_state, :BASE_BUILD_STATE_BUILDING)
+
+    put_local_bases_fact(table, "w", "w__current", false, [
+      ready_base("w__current", "w", 512),
+      ready_base("w__refcounted", "w", 1),
+      building,
+      young,
+      ready_base("w__orphan", "w", 2_048)
+    ])
+
+    [entry] = Enum.filter(BaseBuilder.retention_sweep_now(builder), &(&1.workload == "w"))
+    assert entry.evict_refs == ["w__orphan"]
   end
 
   test "retention sweep and export per node when fleet has mixed vendors" do
@@ -1149,9 +1185,9 @@ defmodule Embervm.BaseBuilderTest do
     assert intel.evict_bytes == 2_048
 
     amd = Enum.find(plan, &(&1.node_id == "node-4/amd"))
-    assert amd.skipped_unexported == true
-    assert amd.evict_refs == []
-    refute_receive {:evicted, "w", "w__old_amd"}, 200
+    assert amd.skipped_unexported == false
+    assert amd.evict_refs == ["w__old_amd"]
+    assert amd.evict_bytes == 4_096
   end
 
   test "retention and export run once for two bricks sharing a node's base inventory" do
@@ -1201,9 +1237,8 @@ defmodule Embervm.BaseBuilderTest do
     assert_receive {:exported, "w__current"}, 1_000
     refute_receive {:exported, "w__current"}, 100
 
-    # Export coalescing needs the unexported facts above. Retention, however, is
-    # gated on durability, so update both node-mate facts before asserting that the
-    # shared inventory is planned and evicted once.
+    # Export coalescing needs the unexported facts above. Retention should plan the
+    # shared inventory once per node regardless of export state.
     put_node_local_bases_fact(table, "node-4", "large", "w", "w__current", true, local_bases)
     put_node_local_bases_fact(table, "node-4", "small", "w", "w__current", true, local_bases)
 


### PR DESCRIPTION
Closes #4364.

## The defect

The base retention sweep has reported `0 candidates, 0 bytes evicted` on every cycle for weeks, while orphaned bases accumulated on disk. It is armed, it runs, it sees the garbage, and it collects nothing.

The new per-node accounting from the 0.13.7 work makes it arithmetically visible. One sweep:

```
node-1  seen_on_disk=1  desired=1  too_young=0  refcount_protected=0  candidates=0   consistent
node-2  seen_on_disk=3  desired=3  too_young=0  refcount_protected=0  candidates=0   consistent
node-4  seen_on_disk=6  desired=6  too_young=0  refcount_protected=0  candidates=0   consistent
node-3  seen_on_disk=3  desired=2  too_young=0  refcount_protected=0  candidates=0   CONTRADICTION
```

node-3 sees three bases and wants two. The surplus is excluded by neither the age rail nor a refcount, and is still not selected. Every stated reason to spare a base reads zero and it is spared anyway.

## Cause

The node-level `:skip_unexported` arm hardcoded the candidate list to empty:

```elixir
get_in(fact, [:workloads, w.name, :exported]) != true ->
  {:skip_unexported, fact[:instance_id], retention_accounting(local_bases, desired, w.base_refs, [])}
```

So one workload's current base being unexported spared **every** local base on that node.

That guard was deliberate (dc934d507: "durability-before-eviction"). The problem is it never releases: `export_reconcile/1` only inspects the anchor node rather than whichever node holds the base (#4893), so the current base frequently never gets exported at all. On node-3 both `demo-postgres` bases are unexported, including `ba4ef0bad08b` which the #4865 recovery had just built.

Guard plus export bug equals a leak that grows without bound.

## Why removed rather than narrowed

A candidate already passes four per-base filters:

```elixir
b.base_state != :BASE_BUILD_STATE_BUILDING,
b.ref not in desired,                        # never the CURRENT base
not base_protected?(w.base_refs, b.ref),     # no session or primed VM rides it
base_age_seconds(b) >= @retention_min_age_seconds
```

So a candidate is a superseded artifact that nothing references. **Deleting it cannot reduce the durability of the current base, because they are different files.** The guard was protecting a roll-back-to-a-superseded-base scenario that is not a supported operation, and charging a permanent leak for it.

This conflation is the same one tracked in #4893: "the current base is not in the store" was being used to answer "may I delete a different, unreferenced, superseded file from local disk". Two unrelated facts, one field. That is now its third confirmed instance, after the builder looping on an unfetchable base and `export_reconcile` checking the anchor instead of the holder.

## The safety argument now rests entirely on the per-base filters

So each one gets a test asserting it still spares its case **while the current base is unexported**: the current ref, a refcounted ref, a BUILDING base, and a too-young base. None of the filters were touched.

## Verification

Red first, against unmodified `base_builder.ex`:

```
1) test retention sweep and export per node when fleet has mixed vendors
2) test retention sweep reclaims an orphan when the current base is not exported
3) test retention filters protect every non-current base safety rail when current is unexported
1303 tests, 3 failures, 6 skipped
```

Exactly the two tests that encoded the removed guard, plus the new safety-rail test, and nothing else. Green with the fix: `1303 tests, 0 failures, 6 skipped`. Both runs executed on this branch.

Two existing tests are inverted rather than weakened. `"retention sweep skips a workload whose current base is not yet exported (durability floor)"` asserted the behaviour this PR deliberately removes, so it had to change; leaving it green would have meant the guard was still there.

## Expected effect after deploy

node-3's `demo-postgres__8dde24352f92` becomes a candidate and is evicted, and the masters' scratch should fall for the first time since the sweep was armed on 2026-08-05. Worth watching the first armed sweep after rollout and reading `bytes evicted` rather than assuming.