### PR TITLE
fix(argocd): put the CRD normalizer under cm: where the chart reads it

### DIFF
--- a/projects/platform/argocd/values.yaml
+++ b/projects/platform/argocd/values.yaml
@@ -60,21 +60,30 @@ argo-cd:
           #
           # Fleet-wide was never safe, only quiet. Keep replica ignores scoped
           # to the specific Application whose controller owns the field.
-    # The same {} != absent asymmetry as the Deployment annotations above, but
-    # arriving from the opposite direction. The upstream Kyverno chart renders
-    # `annotations: {}` and `labels: {}` on its CRDs; the apiserver drops an
-    # empty map on write, so live has no key at all while the predicted state
-    # keeps {}. Eleven policies.kyverno.io CRDs sat OutOfSync on nothing else.
-    #
-    # Unlike a field-level ignore this cannot mask real drift: the map is
-    # deleted only when it is already empty, so any actual label or annotation
-    # keeps it and the normal diff applies. Nothing upstream to fix here, which
-    # is why this is a normalizer rather than a chart change like the rest of
-    # this PR. Kyverno already syncs with RespectIgnoreDifferences=true.
-    resource.customizations.ignoreDifferences.apiextensions.k8s.io_CustomResourceDefinition: |
-      jqPathExpressions:
-        - '.metadata.annotations | select(. != null and length == 0)'
-        - '.metadata.labels | select(. != null and length == 0)'
+      # The same {} != absent asymmetry as the Deployment annotations above, but
+      # arriving from the opposite direction. The upstream Kyverno chart renders
+      # `annotations: {}` and `labels: {}` on its CRDs; the apiserver drops an
+      # empty map on write, so live has no key at all while the predicted state
+      # keeps {}. Eleven policies.kyverno.io CRDs sat OutOfSync on nothing else.
+      #
+      # Unlike a field-level ignore this cannot mask real drift: the map is
+      # deleted only when it is already empty, so any actual label or annotation
+      # keeps it and the normal diff applies. Nothing upstream to fix here, which
+      # is why this is a normalizer rather than a chart change like the rest of
+      # this PR. Kyverno already syncs with RespectIgnoreDifferences=true.
+      #
+      # Indentation is load-bearing: this key must sit under `cm:`, alongside
+      # the apps_Deployment entry above. Landed one level out (a sibling of
+      # `cm:`) it becomes configs.resource.customizations..., which the
+      # argo-cd chart reads nothing from. That renders no ConfigMap entry at
+      # all, and it is silent the whole way: valid YAML, green lint, green
+      # tests, green PR checks, and the Application still reports Synced
+      # because the manifest it applied genuinely matches git. Verify a change
+      # here by rendering the ConfigMap, not by the app going Synced.
+      resource.customizations.ignoreDifferences.apiextensions.k8s.io_CustomResourceDefinition: |
+        jqPathExpressions:
+          - '.metadata.annotations | select(. != null and length == 0)'
+          - '.metadata.labels | select(. != null and length == 0)'
     rbac:
       policy.csv: |
         p, mcp-agent, applications, *, */*, allow


### PR DESCRIPTION
Follow-up to #4908. Four of the five apps converged; `kyverno` did not, because the normalizer I added landed at the wrong nesting level.

It sat as a sibling of `cm:` instead of a child, so it rendered as `configs.resource.customizations...`, a key the argo-cd chart reads nothing from. No ConfigMap entry was produced at all.

## Why nothing caught it

This is worth recording because every signal was green:

- valid YAML
- `ci lint` green, `ci test` green (716 pass)
- all three PR checks green
- the `argocd` Application reported **Synced**, and correctly so, because the manifest it applied genuinely did match git

The only observable was the absent key in the live ConfigMap. `kubectl get cm argocd-cm -n argocd` is the check that would have caught it, and "the app is Synced" is specifically not.

## Verification

Rendered the ConfigMap this time rather than trusting sync status:

```
RENDERED KEY: resource.customizations.ignoreDifferences.apiextensions.k8s.io_CustomResourceDefinition
```

And checked the jq expressions against the real `managed-resources` states pulled from the cluster:

| Input | Expected | Result |
|---|---|---|
| predicted (chart renders `{}`) | match, so the empty map is deleted | matches |
| live (key absent) | no match, no-op | no match |
| map with a real annotation | no match, drift still visible | no match |

That last row is the safety property: the map is deleted only when already empty, so this cannot mask real annotation or label drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CVxWW96h5c9Ybhu4bxBzr