### PR TITLE
fix(monolith): dump dev refresh from the primary and let its pods reap

### DIFF
--- a/projects/monolith/chart/templates/cnpg-dev-refresh-cronworkflow.yaml
+++ b/projects/monolith/chart/templates/cnpg-dev-refresh-cronworkflow.yaml
@@ -22,6 +22,22 @@ spec:
     # nightly refresh and dev quietly goes stale. An hour is far above the
     # observed shape of the work (the database is under 2 GB).
     activeDeadlineSeconds: 3600
+    # Without these this workflow reaped NOTHING, ever. Unlike the CronWorkflows
+    # in cronworkflows.yaml it declared neither, so every failed run left its
+    # Workflow and its pod behind permanently: a run from 2026-08-12 was still
+    # sitting in the namespace on 2026-08-15, alongside one per night since.
+    # failedJobsHistoryLimit above does not cover this; it caps the CronWorkflow's
+    # own child history, not the pods, and it is not what was leaking.
+    #
+    # Same values as cronworkflows.yaml so the two agree: a failure stays
+    # readable for a day, which is what made the recovery-conflict cause above
+    # recoverable at all, and a success is cleaned up promptly.
+    ttlStrategy:
+      secondsAfterCompletion: 3600
+      secondsAfterSuccess: 3600
+      secondsAfterFailure: 86400
+    podGC:
+      strategy: OnWorkflowSuccess
     templates:
       - name: refresh
         container:
@@ -75,8 +91,30 @@ spec:
               memory: 512Mi
               ephemeral-storage: 4Gi
           env:
+            # The PRIMARY, not monolith-pg-ro, and the -ro replica is what this
+            # used to read. A standby cancels a query whose snapshot blocks WAL
+            # replay, and pg_dump's COPY of knowledge.chunks is long enough to
+            # hit that every single night:
+            #
+            #   pg_dump: error: Dumping the contents of table "chunks" failed
+            #   ERROR: canceling statement due to conflict with recovery
+            #   DETAIL: User query might have needed to see row versions that
+            #           must be removed.
+            #
+            # It failed on the same table every run from at least 2026-08-12,
+            # so it is deterministic rather than flaky, and it is silent: a
+            # failed CronWorkflow pages nobody, so dev just served stale data.
+            #
+            # Dumping from the primary removes the failure mode outright rather
+            # than tuning around it, because recovery conflicts only exist on a
+            # standby. hot_standby_feedback and max_standby_streaming_delay
+            # would each keep the read on the replica at the cost of bloat or
+            # lag on the primary, and the delay knob is a guess that the
+            # growing chunks table would eventually outrun again. The dump is
+            # one short nightly read of a sub-2 GB database, so the read load
+            # the replica was there to deflect does not justify either.
             - name: PROD_PGHOST
-              value: monolith-pg-ro.monolith.svc.cluster.local
+              value: monolith-pg-rw.monolith.svc.cluster.local
             # monolith-dev-pg-rw: the dev Application runs this chart under
             # releaseName `monolith-dev`, which it must, because the chart also
             # renders cluster-scoped RBAC that two Applications cannot both own.


### PR DESCRIPTION
Found while reaping the failed workflow pods. Two defects in `cnpg-dev-refresh`, one of which has been quietly breaking dev for days.

## The nightly failure

Every run since at least **2026-08-12** has failed at the same point:

```
pg_dump: error: Dumping the contents of table "chunks" failed
ERROR:  canceling statement due to conflict with recovery
DETAIL:  User query might have needed to see row versions that must be removed.
```

Textbook hot standby query conflict. The dump read `monolith-pg-ro`; a standby cancels a query whose snapshot prevents WAL replay from reclaiming row versions, and `pg_dump`'s `COPY` of `knowledge.chunks` (embeddings, so it is the big one) runs long enough to hit it. Same table every night, so deterministic, not flaky.

**The dev database has been serving stale data for at least three days and nothing said so**, because a failed CronWorkflow is wired to no alert.

### Why the primary rather than tuning the replica

| Option | Effect |
|---|---|
| **Dump from `-rw`** | Recovery conflicts only exist on a standby, so the failure mode is gone, not deferred |
| `hot_standby_feedback = on` | Keeps the read on the replica; primary defers vacuum for the dump's duration, so bloat |
| `max_standby_streaming_delay` | A guessed number; the growing `chunks` table outruns it again later |

One short nightly read of a sub-2 GB database does not need the load deflection the replica was there to provide.

Only the dump **source** moves. The restore target is unchanged, so the `case "$DEV_PGHOST" in *monolith-dev*` guard still protects exactly what it did before.

## The pods that never reaped

This workflow declared **neither `ttlStrategy` nor `podGC`**, unlike the CronWorkflows in `cronworkflows.yaml`. So every failed run left its Workflow and pod behind permanently:

```
2026-08-12T05:13:17Z  ttlFail=NONE  podGC=NONE  cnpg-dev-refresh-manual-grq2p
2026-08-13T04:00:00Z  ttlFail=NONE  podGC=NONE  cnpg-dev-refresh-1786593600
2026-08-14T04:00:00Z  ttlFail=NONE  podGC=NONE  cnpg-dev-refresh-1786680000
2026-08-15T04:00:00Z  ttlFail=NONE  podGC=NONE  cnpg-dev-refresh-1786766400
```

`failedJobsHistoryLimit: 5` does not cover this: it caps the CronWorkflow's own child history, not the pods, and it is not what was leaking. Adopting the same values as `cronworkflows.yaml` keeps a failure readable for 24h, which is what made the recovery-conflict diagnosis above possible at all.

## Verification

- Rendered the CronWorkflow and confirmed `PROD_PGHOST=monolith-pg-rw...`, `ttlStrategy` and `podGC` all present, and `DEV_PGHOST` unchanged.
- `monolith-pg-rw` confirmed as the live primary service.
- `ci test`: `Executed 2 out of 716 tests: 716 tests pass`.

The real proof is tonight's 04:00 run succeeding; I have not claimed that here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CVxWW96h5c9Ybhu4bxBzr