### PR TITLE
fix(embervm): stream store compression so it never writes into the artifact dir

### DIFF
--- a/projects/embervm/noded/store/store.go
+++ b/projects/embervm/noded/store/store.go
@@ -120,19 +120,46 @@ type Store struct {
 // empty, which every caller reads as "the store is disabled" (export is skipped,
 // restore-on-miss is impossible, and the continuity verbs refuse). The endpoint
 // is normalised to have no trailing slash so key joins are unambiguous. The
-// optional compress argument enables zstd for newly exported objects; omitting
-// it preserves the legacy writer behavior.
-func New(endpoint, bucket string, compress ...bool) *Store {
+// compress enables zstd for newly exported objects.
+func New(endpoint, bucket string, compress bool) *Store {
 	if endpoint == "" {
 		return nil
 	}
-	compressEnabled := len(compress) > 0 && compress[0]
 	return &Store{
 		endpoint: strings.TrimRight(endpoint, "/"),
 		bucket:   bucket,
 		client:   &http.Client{},
-		compress: compressEnabled,
+		compress: compress,
 	}
+}
+
+// countingReader counts the bytes actually read out of a request body, so an
+// export can report compressed bytes moved without knowing the encoded size in
+// advance.
+//
+// Close is NOT optional and must not be dropped. net/http wraps a plain
+// io.Reader body in io.NopCloser, so a counting reader that only implements
+// Read would swallow the underlying Close. On the compressed path the body is
+// an *io.PipeReader, and the transport closing it is the ONLY thing that
+// unblocks the encoder goroutine when a request is aborted mid-body (a failed
+// PUT, a cancelled context). Without this method that goroutine blocks forever
+// on pw.Write, leaking itself and its encoder buffers on every failed export.
+type countingReader struct {
+	io.Reader
+	n int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	r.n += int64(n)
+	return n, err
+}
+
+func (r *countingReader) Close() error {
+	if c, ok := r.Reader.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
 }
 
 // url composes the object URL for a key under the bucket. The key is used
@@ -309,7 +336,7 @@ func (s *Store) Export(ctx context.Context, prefix, localDir string, files []str
 		if oerr != nil {
 			return bytesMoved, false, fmt.Errorf("store: open artifact file %q: %w", name, oerr)
 		}
-		putPath := path
+		var body io.Reader = f
 		putSize := fm.Size
 		if s.compress {
 			// This is a two-phase rollout. A daemon that does not understand the
@@ -320,21 +347,27 @@ func (s *Store) Export(ctx context.Context, prefix, localDir string, files []str
 			// rollout, causing a self-inflicted outage. This follows the existing
 			// ship-inert, arm-later pattern used by WarmthReaper's
 			// EMBERVM_WARMTH_RETENTION_SWEEP gate.
-			f, putPath, putSize, oerr = compressFile(localDir, name, f)
-			if oerr != nil {
-				return bytesMoved, false, oerr
+			pr, pw := io.Pipe()
+			enc, eerr := zstd.NewWriter(pw, zstd.WithEncoderConcurrency(1), zstd.WithEncoderLevel(zstd.SpeedFastest))
+			if eerr != nil {
+				_ = f.Close()
+				return bytesMoved, false, fmt.Errorf("store: create zstd writer for %q: %w", name, eerr)
 			}
+			go func() {
+				_, cerr := io.Copy(enc, f)
+				pw.CloseWithError(errors.Join(cerr, enc.Close()))
+			}()
+			body = pr
+			putSize = -1
 			meta.Files[name] = FileMeta{Size: fm.Size, Sha256: fm.Sha256, Compression: "zstd"}
 		}
-		perr := s.Put(ctx, prefix+"/"+name, f, putSize)
+		cr := &countingReader{Reader: body}
+		perr := s.Put(ctx, prefix+"/"+name, cr, putSize)
 		_ = f.Close()
-		if s.compress {
-			_ = os.Remove(putPath)
-		}
 		if perr != nil {
 			return bytesMoved, false, perr
 		}
-		bytesMoved += putSize
+		bytesMoved += cr.n
 	}
 
 	// meta.json LAST: only now is the artifact visible as complete.
@@ -398,7 +431,7 @@ func (s *Store) restoreFile(ctx context.Context, key, dst string, want FileMeta)
 	var decoded io.Reader = body
 	var decoder *zstd.Decoder
 	if want.Compression == "zstd" {
-		decoder, err = zstd.NewReader(body)
+		decoder, err = zstd.NewReader(body, zstd.WithDecoderConcurrency(1))
 		if err != nil {
 			_ = f.Close()
 			_ = os.Remove(tmp)
@@ -431,54 +464,6 @@ func (s *Store) restoreFile(ctx context.Context, key, dst string, want FileMeta)
 		return 0, fmt.Errorf("store: publish restored file %q: %w", dst, err)
 	}
 	return n, nil
-}
-
-func compressFile(localDir, name string, src *os.File) (*os.File, string, int64, error) {
-	tmp, err := os.CreateTemp(localDir, "."+filepath.Base(name)+".zstd-*")
-	if err != nil {
-		_ = src.Close()
-		return nil, "", 0, fmt.Errorf("store: create compression temp for %q: %w", name, err)
-	}
-	tmpPath := tmp.Name()
-	cleanup := func() {
-		_ = tmp.Close()
-		_ = src.Close()
-		_ = os.Remove(tmpPath)
-	}
-	zw, err := zstd.NewWriter(tmp)
-	if err != nil {
-		cleanup()
-		return nil, "", 0, fmt.Errorf("store: create zstd writer for %q: %w", name, err)
-	}
-	if _, err := io.Copy(zw, src); err != nil {
-		_ = zw.Close()
-		cleanup()
-		return nil, "", 0, fmt.Errorf("store: compress artifact file %q: %w", name, err)
-	}
-	if err := zw.Close(); err != nil {
-		cleanup()
-		return nil, "", 0, fmt.Errorf("store: finish compression for %q: %w", name, err)
-	}
-	if err := src.Close(); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpPath)
-		return nil, "", 0, fmt.Errorf("store: close artifact file %q: %w", name, err)
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return nil, "", 0, fmt.Errorf("store: close compression temp for %q: %w", name, err)
-	}
-	info, err := os.Stat(tmpPath)
-	if err != nil {
-		_ = os.Remove(tmpPath)
-		return nil, "", 0, fmt.Errorf("store: stat compression temp for %q: %w", name, err)
-	}
-	f, err := os.Open(tmpPath)
-	if err != nil {
-		_ = os.Remove(tmpPath)
-		return nil, "", 0, fmt.Errorf("store: open compression temp for %q: %w", name, err)
-	}
-	return f, tmpPath, info.Size(), nil
 }
 
 // DeleteArtifact removes an artifact from the store. It deletes meta.json FIRST

--- a/projects/embervm/noded/store/store_test.go
+++ b/projects/embervm/noded/store/store_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"io"
@@ -26,7 +27,8 @@ type fakeObjectStore struct {
 	objects map[string][]byte
 	// putOrder records the path of every PUT in order, so a test can assert
 	// meta.json is written LAST.
-	putOrder []string
+	putOrder     []string
+	failFilePuts bool
 }
 
 func newFakeObjectStore() *fakeObjectStore {
@@ -38,6 +40,10 @@ func (f *fakeObjectStore) handler() http.Handler {
 		key := r.URL.Path
 		switch r.Method {
 		case http.MethodPut:
+			if f.failFilePuts && !strings.HasSuffix(key, "/"+metaObject) {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 			body, _ := io.ReadAll(r.Body)
 			f.mu.Lock()
 			f.objects[key] = body
@@ -330,11 +336,11 @@ func TestCompressedExportRoundTrip(t *testing.T) {
 }
 
 func TestCompressedIncompressibleRoundTrip(t *testing.T) {
-	s, _ := newTestStoreWithCompression(t, true)
+	s, fake := newTestStoreWithCompression(t, true)
 	ctx := context.Background()
 	plaintext := make([]byte, 256<<10)
-	for i := range plaintext {
-		plaintext[i] = byte(i*31 + 7)
+	if _, err := rand.Read(plaintext); err != nil {
+		t.Fatal(err)
 	}
 	srcDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(srcDir, "random"), plaintext, 0o600); err != nil {
@@ -342,6 +348,9 @@ func TestCompressedIncompressibleRoundTrip(t *testing.T) {
 	}
 	if _, _, err := s.Export(ctx, "base/random", srcDir, []string{"random"}, 1, 1, "", ""); err != nil {
 		t.Fatalf("Export: %v", err)
+	}
+	if stored := fake.object("/embervm/base/random/random"); len(stored) <= len(plaintext) {
+		t.Fatalf("incompressible stored object size = %d, want greater than plaintext %d", len(stored), len(plaintext))
 	}
 	dstDir := t.TempDir()
 	if _, _, err := s.Restore(ctx, "base/random", dstDir); err != nil {
@@ -354,6 +363,81 @@ func TestCompressedIncompressibleRoundTrip(t *testing.T) {
 	if !bytes.Equal(got, plaintext) {
 		t.Fatal("incompressible compressed restore changed the plaintext")
 	}
+}
+
+func dirEntryNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestCompressedExportLeavesArtifactDirUntouched(t *testing.T) {
+	s, _ := newTestStoreWithCompression(t, true)
+	ctx := context.Background()
+	srcDir, names := writeLocalArtifact(t, map[string]string{
+		"memfile":  "mem-content",
+		"snapfile": "snap-content",
+	})
+	if err := os.WriteFile(filepath.Join(srcDir, ".artifact-marker"), []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wantEntries := dirEntryNames(t, srcDir)
+
+	if _, _, err := s.Export(ctx, "base/clean", srcDir, names, 1, 1, "", ""); err != nil {
+		t.Fatalf("first Export: %v", err)
+	}
+	if got := dirEntryNames(t, srcDir); !slicesEqual(got, wantEntries) {
+		t.Fatalf("artifact directory after first Export = %v, want %v", got, wantEntries)
+	}
+	if _, skipped, err := s.Export(ctx, "base/clean", srcDir, names, 1, 2, "", ""); err != nil || !skipped {
+		t.Fatalf("second Export = (skipped=%v, %v), want (true, nil)", skipped, err)
+	}
+	if got := dirEntryNames(t, srcDir); !slicesEqual(got, wantEntries) {
+		t.Fatalf("artifact directory after second Export = %v, want %v", got, wantEntries)
+	}
+}
+
+func TestCompressedExportPutFailureLeavesDirClean(t *testing.T) {
+	s, fake := newTestStoreWithCompression(t, true)
+	fake.failFilePuts = true
+	ctx := context.Background()
+	srcDir, names := writeLocalArtifact(t, map[string]string{
+		"memfile":  "mem-content",
+		"snapfile": "snap-content",
+	})
+	if err := os.WriteFile(filepath.Join(srcDir, ".artifact-marker"), []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wantEntries := dirEntryNames(t, srcDir)
+	if _, _, err := s.Export(ctx, "base/failure", srcDir, names, 1, 1, "", ""); err == nil {
+		t.Fatal("Export succeeded, want file PUT failure")
+	}
+	if fake.has("/embervm/base/failure/meta.json") {
+		t.Fatal("meta.json was PUT after file PUT failure")
+	}
+	if got := dirEntryNames(t, srcDir); !slicesEqual(got, wantEntries) {
+		t.Fatalf("artifact directory after failed Export = %v, want %v", got, wantEntries)
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestLegacyObjectRestoresWithCompressionEnabled(t *testing.T) {


### PR DESCRIPTION
Follow-up to #4906, which merged before its review returned. The review found one blocker, latent because the writer ships off (`noded.store.compress` defaults false). This fixes it before anyone arms the writer.

## The defect

`compressFile` staged each compressed file with `os.CreateTemp(localDir, "."+base+".zstd-*")`, writing **into the artifact directory**. `enumerateArtifactFiles` (`noded/server/store.go:379`) decides what a file IS and skips only a `.tmp` suffix, `meta.json`, and the retirement intent file. The temp matches none of them.

| # | Consequence |
|---|---|
| 1 | A crash, OOM, eviction, or reboot during a multi-minute base export leaves the temp with no sweeper. The next export hashes it into `meta.Files`, uploads it, and writes it into `meta.json`, after which it is a **permanent member of the artifact**, restored onto every fresh node, inflating exactly the bytes compression exists to cut. |
| 2 | **No crash needed.** The async export queue dedupes by prefix, but the synchronous `ExportArtifact` path (every non-BASE kind) never consults that set. A sync export can enumerate the async worker's temp mid-write, so `fileMeta` hashes a moving file and the recorded sha256 mismatches the uploaded bytes, making the artifact copy **unrestorable** until content changes. |
| 3 | A crash between the file PUT and the meta PUT orphans an S3 object under a unique key that no later export overwrites and no GC ever names. |
| 4 | The `ErrStaleGeneration` fence does not help: a poisoned meta carries an equal generation and passes cleanly. |

## The fix

Stream the zstd encode through an `io.Pipe` straight into the PUT. No temp file exists to leak, enumerate, or sweep. `Put` already supports this: its contract documents that a negative size lets net/http chunk the body.

**Why streaming rather than a skip pattern in `enumerateArtifactFiles`.** The invariant then holds by construction instead of by two packages continuing to agree. The producer lives in the store package and the filter in the server package, and that drift is what created the defect. Renaming the temp to `*.tmp` was rejected separately: `isCompleteBase` returns false on any `.tmp` file in a base dir, so it would report a base incomplete with `sizeBytes: 0` for the whole export window and could trigger a spurious rebuild.

An audit read `noded/server/store.go` and `noded/store/store.go` end to end and confirmed `enumerateArtifactFiles` is the **only** file-level artifact enumerator in noded, so no other package needs changing. Every other walker was checked against the pattern: `isCompleteBase` ignores it, the `Reconcile*`/`Scan*` walkers skip non-dir entries and stat fixed names, rootfs GC requires a `rootfs-` prefix, the retirement sweep matches only `.retirement-intent`, and volume `Scan` keys on `vol.img`.

## `countingReader` implements `Close` deliberately

net/http wraps a plain `io.Reader` body in `io.NopCloser`, so a counting reader that only implemented `Read` would **swallow the underlying Close**. On the compressed path the body is an `*io.PipeReader`, and the transport closing it is the only thing that unblocks the encoder goroutine when a request is aborted mid-body. Without that method the goroutine blocks forever on `pw.Write`, leaking itself and its encoder buffers on every failed export. `TestCompressedExportPutFailureLeavesDirClean` exercises that exact path and passes either way, since Go tests do not observe goroutine leaks, so the reasoning is recorded on the type.

## Other changes

- Encoder and decoder concurrency pinned to 1. The default fills a pool of `GOMAXPROCS` encoders, each holding a 1 MiB long table plus a 256 KiB short table, while exactly one is ever used: roughly 20 MiB of dead allocation per export against a 512 MiB daemon reserve.
- Level `SpeedFastest`. With a 92% zero profile the ratio difference is negligible and the CPU on multi-GB memfiles is not.
- `New(endpoint, bucket, compress)` drops its variadic, so a future forgotten wiring is a compile error rather than a silent `compress=false`.

## Tests

- **`TestCompressedExportLeavesArtifactDirUntouched`** is the regression guard: the artifact directory listing, **including dotfiles**, is identical before and after an export, and again after the already-durable skip path. The leaked temp was a dotfile, so a test ignoring dotfiles would not have caught it.
- **`TestCompressedExportPutFailureLeavesDirClean`** covers the pipe error path: Export errors, no `meta.json` is PUT, listing unchanged.
- **`TestCompressedIncompressibleRoundTrip`** used a payload with period 256 that compressed roughly 194:1 and never exercised the case its name claims. It now uses `crypto/rand` and asserts the stored object exceeds the plaintext size.
- The other compressed tests (round trip, legacy empty-marker, truncated object) pass unchanged, which is the point: streaming must not alter observable behaviour.

Verified with the focused target under `--nocache_test_results --test_output=all --test_arg=-test.v`, so the tests provably executed:

```
Executed 1 out of 1 test: 1 test passes.
21 test functions passing, 0 failing
```

## Known unknown

SeaweedFS accepting a Content-Length-less PUT is not provable in CI (httptest accepts chunked trivially). It resolves at arming time. The failure mode is loud and safe: the export errors, the artifact stays local-durable, and the pre-agreed fallback is staging in a scratch dir outside every artifact root.

## Note on CI

Full `ci` currently fails on `main` for an unrelated reason: MODULE.bazel pins `gazelle` at `0.47.0` while `go.mod` requires `bazel-gazelle` `0.52.2`, so `@bazel_gazelle` cannot resolve. That is a separate one-line fix and is deliberately not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTQ29PfFZShnxQUBAsW977