### PR TITLE
fix(monolith): make the dev refresh safety barrier actually run, and actually resolve

### DIFF
--- a/projects/monolith/chart/templates/cnpg-dev-refresh-cronworkflow.yaml
+++ b/projects/monolith/chart/templates/cnpg-dev-refresh-cronworkflow.yaml
@@ -56,19 +56,68 @@ spec:
                 --username "$DUMP_ROLE" --dbname monolith \
                 --format custom --file "$dump_file"
               export PGPASSWORD=$DEV_PASSWORD
+              # SAFETY BARRIER, armed BEFORE the restore rather than sequenced
+              # after it. dev must hold no actionable queue state: the chat
+              # leader would post production's discord_outbox messages a second
+              # time, and DBOS would resume production's in-flight agent runs
+              # from dbos on launch.
+              #
+              # It runs on EXIT because the failure that matters is a restore
+              # that dies PARTWAY. Sequenced after pg_restore under `set -e` it
+              # is skipped exactly when it is most needed, which is what
+              # happened on 2026-08-15: the restore loaded production's rows,
+              # exited non-zero, and left dev holding 1302 discord_outbox rows,
+              # 125 whatsapp_outbox rows and the dbos schema. Only
+              # MONOLITH_LEADER_SINGLETONS=false stopped those being posted, so
+              # the barrier was not supplementing that env var as the old
+              # comment claimed, it was absent and the env var carried it alone.
+              #
+              # Schema-qualified because these tables live in `chat`, and
+              # neither the role nor the database sets a search_path, so the
+              # default is "$user", public and the unqualified names resolved
+              # to nothing. The barrier could never have run as written, even
+              # on a completely clean restore.
+              barrier() {
+                psql \
+                  --host "$DEV_PGHOST" --port 5432 \
+                  --username app --dbname monolith \
+                  --command 'DROP SCHEMA IF EXISTS dbos CASCADE; TRUNCATE TABLE chat.discord_outbox, chat.whatsapp_outbox;'
+              }
+              trap barrier EXIT
+
+              # pg_restore --clean emits DROP/COMMENT for every object in the
+              # archive, extensions included, and `app` does not own `vector` or
+              # `uuid-ossp` so those four statements always fail. They are
+              # harmless (the extensions already exist in dev and are not being
+              # replaced) but pg_restore still exits 1 on "errors ignored on
+              # restore", which under `set -e` aborted the whole job.
+              #
+              # Drop the EXTENSION entries from the restore list rather than
+              # tolerating the exit code: filtering is deterministic, whereas
+              # matching on the error text would silently start passing real
+              # failures if a message ever changed. A genuine restore error
+              # still fails the job.
+              #
+              # Safe to skip CREATE EXTENSION as well as DROP because the
+              # extensions are not the restore's to provide: cnpg-cluster.yaml
+              # installs them as postgres in the cluster's post-init SQL, so a
+              # rebuilt dev cluster already has vector and uuid-ossp before any
+              # refresh runs. That is the dependency this filter relies on.
+              pg_restore --list "$dump_file" | grep -v ' EXTENSION ' > /tmp/restore.list
+              # An empty list is the dangerous outcome, not an error one: there
+              # is no pipefail here, so a failed --list leaves grep succeeding
+              # on no input and --use-list would then restore NOTHING while
+              # exiting 0. Dev would silently keep yesterday's data and every
+              # signal would be green.
+              if [ ! -s /tmp/restore.list ]; then
+                echo "refusing to restore: empty restore list from $dump_file" >&2
+                exit 1
+              fi
               pg_restore \
                 --host "$DEV_PGHOST" --port 5432 \
                 --username app --dbname monolith \
+                --use-list /tmp/restore.list \
                 --clean --if-exists --no-owner --no-acl "$dump_file"
-              # SAFETY BARRIER: dev must hold no actionable queue state. The
-              # chat leader would post production's discord_outbox messages a
-              # second time, and DBOS would resume production's in-flight agent
-              # runs from dbos on launch. This barrier supplements
-              # MONOLITH_LEADER_SINGLETONS=false rather than relying on one env var.
-              psql \
-                --host "$DEV_PGHOST" --port 5432 \
-                --username app --dbname monolith \
-                --command 'DROP SCHEMA IF EXISTS dbos CASCADE; TRUNCATE TABLE discord_outbox, whatsapp_outbox;'
           # Declared rather than omitted, because a container with no requests
           # is BestEffort and is the first thing evicted under pressure. This
           # cluster is not roomy: node-1 sits at 91% of requestable memory, so


### PR DESCRIPTION
Follow-up to #4910, found by triggering the refresh by hand instead of waiting for 04:00.

## #4910 works

The dump completed from the primary with no recovery conflict, and the data landed: dev and prod both at **24,535** `knowledge.chunks`. That fix is confirmed.

It then failed at two later steps the dump failure had been masking all along.

## 1. pg_restore exits 1 on extension ownership

```
pg_restore: error: could not execute query: ERROR:  must be owner of extension vector
Command was: DROP EXTENSION IF EXISTS vector;
pg_restore: warning: errors ignored on restore: 4
```

`--clean` emits DROP/COMMENT for every archive object including extensions, and `app` owns neither. Harmless statements, but `pg_restore` still exits 1, and under `set -e` that killed the job.

Fixed by filtering `EXTENSION` entries out of the restore list rather than tolerating the exit code. Filtering is deterministic; matching on error text would quietly start passing real failures if a message changed. Skipping CREATE is equally safe because `cnpg-cluster.yaml` installs both extensions as `postgres` in the cluster's post-init SQL, so dev has them before any refresh runs.

## 2. The safety barrier could never have run

This is the one that matters. Two independent reasons, either alone sufficient:

- **Sequenced after `pg_restore` under `set -e`**, so it was skipped exactly when a partial restore made it necessary.
- **`TRUNCATE TABLE discord_outbox, whatsapp_outbox` was unqualified**, but both tables live in schema `chat`. Neither the role nor the database sets a `search_path`, so the default is `"$user", public` and the names resolved to nothing. Verified directly:

```sql
set search_path to "$user", public;
select 'discord_outbox'::regclass;   -- ERROR: relation does not exist
```

The old comment said this barrier "supplements `MONOLITH_LEADER_SINGLETONS=false` rather than relying on one env var". In reality the barrier was inert and **the env var has been carrying it alone**.

### What the manual run actually left behind

| | After restore | After manual cleanup |
|---|---|---|
| `chat.discord_outbox` | 1302 | 0 |
| `chat.whatsapp_outbox` | 125 | 0 |
| `dbos` schema | present (11 tables) | dropped |

Nothing was posted: `posted_since_restore=0`, and `max(posted_at)` predates the restore. `MONOLITH_LEADER_SINGLETONS=false` held. Dev has been returned to the intended post-refresh state by hand.

Now armed as an **EXIT trap**, schema-qualified, so a restore that dies partway still cannot leave dev holding actionable queue state.

## 3. Empty-list guard

There is no `pipefail` here, so a failed `--list` would leave `grep` succeeding on no input and `--use-list` would restore **nothing while exiting 0** — dev silently keeping yesterday's data with every signal green. Guarded explicitly.

## Verification

- Rendered the CronWorkflow, extracted the generated script, `sh -n` clean.
- Confirmed dev's `vector` and `uuid-ossp` are owned by `postgres` and provisioned by `cnpg-cluster.yaml`, not by the restore.
- `ci test`: `Executed 77 out of 716 tests: 716 tests pass`.

I have not claimed this run is green end to end. I intend to trigger it once more after rollout, which is the only thing that proves all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CVxWW96h5c9Ybhu4bxBzr