### PR TITLE
fix(embervm): make dev's postgres gate stick and arm dev base retention

### DIFF
--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -113,8 +113,17 @@ bazelQueryWorkload:
 claudeRuntimeWorkload:
   enabled: false
 
+# scratchPostgres carries BOTH of its dev settings here, deliberately. It also
+# needs an empty guest image (the base-builder block below empties one repository
+# per unused workload), but a second `scratchPostgres:` key at that level is a
+# duplicate YAML mapping key: the later block wins and this `enabled: false` is
+# dropped silently, exactly the hazard the `noded.enabled` note below describes.
+# That is what happened until now, and it was masked only because the chart
+# default for `enabled` is also false.
 scratchPostgres:
   enabled: false
+  guestImage:
+    repository: ""
 
 demoPostgres:
   enabled: false
@@ -148,16 +157,32 @@ resources:
   limits:
     memory: 512Mi
 
-# Base retention and GC: keep disabled in dev. The 1gi class is small and
-# the build cost is negligible.
+# Base retention: ARMED, matching production, so dev exercises the paths
+# production actually runs. The previous reasoning (the 1gi class is small and
+# the rebuild cost is negligible) argued that dev did not NEED retention, which
+# is true and beside the point: production arms all three of these gates, so
+# leaving them empty here meant every change to eviction logic reached
+# production having never run anywhere. #4907 changed which bases the sweep
+# collects and dev could not have caught a regression in it.
+#
+# All three are set because they are not redundant. sweepEnabled alone leaves
+# the sweep logging "DRY RUN, deletion disabled", since candidates come from the
+# disk-driven plan gated by diskDrivenEnabled; remoteSweepEnabled is the store
+# side. Dev writes to its own embervm-dev bucket and its own scratch root, and a
+# base is a reconstructible artifact, so a wrong delete here costs a rebuild.
+# Rollback for any of them is setting it back to "".
 baseRetention:
-  sweepEnabled: ""
-  diskDrivenEnabled: ""
-  remoteSweepEnabled: ""
+  sweepEnabled: "1"
+  diskDrivenEnabled: "1"
+  remoteSweepEnabled: "1"
 
 warmthRetention:
-  sweepEnabled: ""
+  sweepEnabled: "1"
 
+# S3-direct warmth GC stays disabled here, and not for symmetry: arming it also
+# needs warmthS3Gc.expectedNodes naming dev's fleet, because an empty fleet
+# contract makes every sweep abort on the freshness check, dry run included.
+# Arming the flag alone would render config that silently never acts.
 warmthS3Gc:
   enabled: ""
 
@@ -258,9 +283,9 @@ runtimeClaude:
   guestImage:
     repository: ""
 
-scratchPostgres:
-  guestImage:
-    repository: ""
+# scratchPostgres belongs in this list too, but its entry lives with its
+# `enabled: false` in the workload block above: one key, both settings. Do not
+# re-add a `scratchPostgres:` block here.
 
 bazelQuery:
   guestImage:


### PR DESCRIPTION
Two dev-only defects of the same kind: config that reads as set and reaches
nothing.

## The postgres gate was silently dropped

`scratchPostgres:` appeared twice as a top-level key in
`projects/embervm/dev/deploy/values.yaml`, once carrying `enabled: false` (line
116) and once carrying an empty guest image (line 261). YAML takes the later
block, so `enabled: false` was discarded.

It was masked, not harmless: the chart default for `enabled` is also `false`,
so dev landed on the intended value by coincidence rather than by the values
file saying so. Had that default ever flipped, dev would have armed a
scratch-postgres guest with nothing in its values file appearing to ask for it.

Merged into one key holding both settings, with a pointer left in the guest
image list so it is not re-split. The file already warned about this exact
hazard for `noded.enabled` twenty lines above the first block.

## Base retention never ran in dev

Production arms all three `baseRetention` gates plus `warmthRetention`. Dev had
all four empty. The stated reason was that the 1gi class is small and the
rebuild cost negligible, which argues dev does not NEED retention. That is
true and beside the point: it meant every change to eviction logic reached
production having run nowhere first. #4907 changed which bases the sweep
collects, and dev could not have caught a regression in it.

All three base gates are set because they are not redundant. `sweepEnabled`
alone leaves the sweep logging `DRY RUN, deletion disabled`, since candidates
come from the disk-driven plan that `diskDrivenEnabled` gates;
`remoteSweepEnabled` covers the store side. Setting one would have produced a
dev that looks armed and evicts nothing.

## What is deliberately NOT in this PR

`warmthS3Gc` stays disabled. Arming it needs `expectedNodes` naming dev's
fleet as well, because an empty fleet contract aborts every sweep including
the dry run. Flipping the flag alone would render config that provably never
acts, which is worse than off because it reads as covered.

## Verification

Rendered `projects/embervm/dev/deploy/values.yaml` through the chart:

- no duplicate top-level keys remain
- `scratchPostgres` resolves to `enabled: false` AND `guestImage.repository: ''`
- `EMBERVM_BASE_RETENTION_SWEEP`, `EMBERVM_BASE_RETENTION_DISK_DRIVEN`,
  `EMBERVM_BASE_REMOTE_RETENTION_SWEEP` and `EMBERVM_WARMTH_RETENTION_SWEEP`
  each render `"1"`
- `EMBERVM_WARMTH_S3_GC` is still absent

Production values and the chart are untouched, so production rendering cannot
change. Rollback for any gate is setting it back to `""`.

Follow-ups, not in this PR: the brick controller env block is nested inside
`{{- if .Values.servingEnvoy.enabled }}` (`deployment.yaml:263`), so dev's
declared `bricks.autoscale.mode: observe` renders nothing at all; and
`EMBERVM_NODED_REQUIRE_BLESSING` is now true in both environments, so its
false branch is dead and the gate can collapse.