### PR TITLE
fix(agents): keep the composer above the iOS software keyboard

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -24,6 +24,7 @@
   import { firstLine, fmtCost, joinMeta } from "./run-format.js";
   import { partitionRuns, recentRuns, runActivityAt } from "./run-history.js";
   import { crumbTrail, sessionLineage } from "./lineage.js";
+  import { setupVisualViewport } from "./visual-viewport.js";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
   import PaneHeader from "./PaneHeader.svelte";
   import SessionWalkthrough from "./SessionWalkthrough.svelte";
@@ -120,6 +121,7 @@
   let renderedPending = $state({});
   let vms = $state({});
   let turnsEl = $state(null);
+  let consoleEl = $state(null);
 
   const selectedSession = $derived(
     sessions.find((session) => String(session.id) === String(selectedId)) ??
@@ -366,11 +368,16 @@
     return index === 0 ? "starting" : "waiting";
   }
 
+  function nearBottom() {
+    if (!turnsEl) return false;
+    return (
+      turnsEl.scrollHeight - turnsEl.scrollTop - turnsEl.clientHeight < 200
+    );
+  }
+
   function autoScroll(force = false) {
     if (!turnsEl) return;
-    const nearBottom =
-      turnsEl.scrollHeight - turnsEl.scrollTop - turnsEl.clientHeight < 200;
-    if (force || nearBottom) turnsEl.scrollTop = turnsEl.scrollHeight;
+    if (force || nearBottom()) turnsEl.scrollTop = turnsEl.scrollHeight;
   }
 
   function syncPendingPartials(entries) {
@@ -877,6 +884,17 @@
 
   onMount(() => {
     loadRuns();
+    const teardownViewport = setupVisualViewport(
+      window,
+      consoleEl,
+      {
+        measure: nearBottom,
+        apply: (wasNearBottom) => {
+          if (wasNearBottom) autoScroll(true);
+        },
+      },
+      MOBILE_MEDIA_QUERY,
+    );
     const handleKeydown = (event) => {
       if (event.key === "Escape" && !event.isComposing && showNewPanel) {
         event.preventDefault();
@@ -885,6 +903,7 @@
     };
     window.addEventListener("keydown", handleKeydown);
     return () => {
+      teardownViewport();
       window.removeEventListener("keydown", handleKeydown);
     };
   });
@@ -1053,6 +1072,7 @@
 <svelte:head><title>{P.labels.pageTitle}</title></svelte:head>
 
 <main
+  bind:this={consoleEl}
   class:sidebar-collapsed={sidebarCollapsed}
   class:mobile-transcript={mobileTranscript}
   class="console"
@@ -1730,7 +1750,7 @@
 
   .console {
     color-scheme: light;
-    height: 100dvh;
+    height: var(--console-h, 100dvh);
     display: grid;
     grid-template-columns: 300px minmax(0, 1fr);
     background: var(--page-bg);

--- a/projects/monolith/frontend/src/routes/private/agents/visual-viewport.js
+++ b/projects/monolith/frontend/src/routes/private/agents/visual-viewport.js
@@ -1,0 +1,63 @@
+export function setupVisualViewport(
+  window,
+  element,
+  { measure, apply },
+  mobileMediaQuery = "(max-width: 760px)",
+) {
+  const viewport = window.visualViewport;
+  if (!viewport) return () => {};
+
+  const mediaQuery = window.matchMedia(mobileMediaQuery);
+  let viewportSubscribed = false;
+
+  function handleViewportResize() {
+    const measured = measure();
+    element.style.setProperty("--console-h", `${viewport.height}px`);
+    if (viewport.offsetTop !== 0) window.scrollTo(0, 0);
+    apply(measured);
+  }
+
+  function handleViewportScroll() {
+    const measured = measure();
+    element.style.setProperty("--console-h", `${viewport.height}px`);
+    apply(measured);
+  }
+
+  function subscribeViewport() {
+    if (viewportSubscribed) return;
+
+    const heightChanged = element.clientHeight !== viewport.height;
+    const measured = heightChanged ? measure() : undefined;
+    element.style.setProperty("--console-h", `${viewport.height}px`);
+    if (heightChanged) apply(measured);
+    viewport.addEventListener("resize", handleViewportResize);
+    viewport.addEventListener("scroll", handleViewportScroll);
+    viewportSubscribed = true;
+  }
+
+  function unsubscribeViewport() {
+    if (!viewportSubscribed) return;
+
+    viewport.removeEventListener("resize", handleViewportResize);
+    viewport.removeEventListener("scroll", handleViewportScroll);
+    viewportSubscribed = false;
+  }
+
+  function handleMediaChange(event) {
+    if (event.matches) {
+      subscribeViewport();
+      return;
+    }
+
+    unsubscribeViewport();
+    element.style.removeProperty("--console-h");
+  }
+
+  mediaQuery.addEventListener("change", handleMediaChange);
+  if (mediaQuery.matches) subscribeViewport();
+
+  return () => {
+    unsubscribeViewport();
+    mediaQuery.removeEventListener("change", handleMediaChange);
+  };
+}

--- a/projects/monolith/frontend/src/routes/private/agents/visual-viewport.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/visual-viewport.test.js
@@ -1,0 +1,245 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { setupVisualViewport } from "./visual-viewport.js";
+
+function createEventSource(properties = {}) {
+  const listeners = new Map();
+
+  return {
+    ...properties,
+    addEventListener: vi.fn((type, listener) => {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type).add(listener);
+    }),
+    removeEventListener: vi.fn((type, listener) => {
+      listeners.get(type)?.delete(listener);
+    }),
+    dispatch(type, event = {}) {
+      for (const listener of listeners.get(type) ?? []) listener(event);
+    },
+    listenerCount(type) {
+      return listeners.get(type)?.size ?? 0;
+    },
+  };
+}
+
+function createFixture({
+  matches = true,
+  height = 720,
+  clientHeight = 800,
+} = {}) {
+  const values = new Map();
+  const style = {
+    setProperty: vi.fn((name, value) => values.set(name, value)),
+    removeProperty: vi.fn((name) => values.delete(name)),
+    getPropertyValue: vi.fn((name) => values.get(name) ?? ""),
+  };
+  const element = { clientHeight, style };
+  const visualViewport = createEventSource({ height, offsetTop: 0 });
+  const mediaQuery = createEventSource({ matches });
+  const window = {
+    visualViewport,
+    matchMedia: vi.fn(() => mediaQuery),
+    scrollTo: vi.fn(),
+  };
+  const measure = vi.fn();
+  const apply = vi.fn();
+
+  return {
+    apply,
+    element,
+    measure,
+    mediaQuery,
+    style,
+    values,
+    visualViewport,
+    window,
+  };
+}
+
+describe("setupVisualViewport", () => {
+  test("writes the viewport height on subscribe and resize", () => {
+    const fixture = createFixture();
+
+    setupVisualViewport(fixture.window, fixture.element, {
+      measure: fixture.measure,
+      apply: fixture.apply,
+    });
+
+    expect(fixture.values.get("--console-h")).toBe("720px");
+
+    fixture.visualViewport.height = 414;
+    fixture.visualViewport.dispatch("resize");
+
+    expect(fixture.values.get("--console-h")).toBe("414px");
+    expect(fixture.style.setProperty).toHaveBeenCalledTimes(2);
+  });
+
+  test("is a no-op when visualViewport is absent", () => {
+    const matchMedia = vi.fn();
+    const element = {
+      style: {
+        setProperty: vi.fn(),
+        removeProperty: vi.fn(),
+      },
+    };
+
+    const teardown = setupVisualViewport({ matchMedia }, element, {
+      measure: vi.fn(),
+      apply: vi.fn(),
+    });
+
+    expect(() => teardown()).not.toThrow();
+    expect(matchMedia).not.toHaveBeenCalled();
+    expect(element.style.setProperty).not.toHaveBeenCalled();
+    expect(element.style.removeProperty).not.toHaveBeenCalled();
+  });
+
+  test("does not write or subscribe to viewport events when media does not match", () => {
+    const fixture = createFixture({ matches: false });
+
+    setupVisualViewport(fixture.window, fixture.element, {
+      measure: fixture.measure,
+      apply: fixture.apply,
+    });
+
+    expect(fixture.style.setProperty).not.toHaveBeenCalled();
+    expect(fixture.visualViewport.addEventListener).not.toHaveBeenCalled();
+    expect(fixture.mediaQuery.listenerCount("change")).toBe(1);
+  });
+
+  test("starts and stops viewport handling as the media query changes", () => {
+    const fixture = createFixture({ matches: false });
+
+    setupVisualViewport(fixture.window, fixture.element, {
+      measure: fixture.measure,
+      apply: fixture.apply,
+    });
+
+    fixture.mediaQuery.matches = true;
+    fixture.mediaQuery.dispatch("change", { matches: true });
+
+    expect(fixture.values.get("--console-h")).toBe("720px");
+    expect(fixture.visualViewport.listenerCount("resize")).toBe(1);
+    expect(fixture.visualViewport.listenerCount("scroll")).toBe(1);
+
+    fixture.mediaQuery.matches = false;
+    fixture.mediaQuery.dispatch("change", { matches: false });
+
+    expect(fixture.values.has("--console-h")).toBe(false);
+    expect(fixture.style.removeProperty).toHaveBeenCalledWith("--console-h");
+    expect(fixture.visualViewport.listenerCount("resize")).toBe(0);
+    expect(fixture.visualViewport.listenerCount("scroll")).toBe(0);
+  });
+
+  test("teardown removes every listener it added", () => {
+    const fixture = createFixture();
+    const teardown = setupVisualViewport(fixture.window, fixture.element, {
+      measure: fixture.measure,
+      apply: fixture.apply,
+    });
+
+    teardown();
+
+    expect(fixture.visualViewport.listenerCount("resize")).toBe(0);
+    expect(fixture.visualViewport.listenerCount("scroll")).toBe(0);
+    expect(fixture.mediaQuery.listenerCount("change")).toBe(0);
+    expect(fixture.visualViewport.removeEventListener).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function),
+    );
+    expect(fixture.visualViewport.removeEventListener).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+    );
+    expect(fixture.mediaQuery.removeEventListener).toHaveBeenCalledWith(
+      "change",
+      expect.any(Function),
+    );
+  });
+
+  test("scrolls the layout viewport to the top on resize if offset is non-zero", () => {
+    const fixture = createFixture();
+
+    setupVisualViewport(fixture.window, fixture.element, {
+      measure: fixture.measure,
+      apply: fixture.apply,
+    });
+    expect(fixture.window.scrollTo).not.toHaveBeenCalled();
+
+    fixture.visualViewport.offsetTop = 32;
+    fixture.visualViewport.dispatch("resize");
+    expect(fixture.window.scrollTo).toHaveBeenCalledOnce();
+    expect(fixture.window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  test("does not scroll the layout viewport on scroll events", () => {
+    const fixture = createFixture();
+
+    setupVisualViewport(fixture.window, fixture.element, {
+      measure: fixture.measure,
+      apply: fixture.apply,
+    });
+    expect(fixture.window.scrollTo).not.toHaveBeenCalled();
+
+    fixture.visualViewport.offsetTop = 32;
+    fixture.visualViewport.dispatch("scroll");
+    expect(fixture.window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  test("measures before writing height and applies the captured value after", () => {
+    const fixture = createFixture();
+    const order = [];
+    fixture.style.setProperty.mockImplementation((name, value) => {
+      fixture.values.set(name, value);
+      order.push(`write ${value}`);
+    });
+    const measure = vi.fn(() => {
+      order.push("measure");
+      return true;
+    });
+    const apply = vi.fn((measured) => order.push(`apply ${measured}`));
+
+    setupVisualViewport(fixture.window, fixture.element, { measure, apply });
+
+    expect(order).toEqual(["measure", "write 720px", "apply true"]);
+
+    order.length = 0;
+    fixture.visualViewport.height = 390;
+    fixture.visualViewport.dispatch("resize");
+    expect(order).toEqual(["measure", "write 390px", "apply true"]);
+    expect(apply).toHaveBeenLastCalledWith(true);
+  });
+
+  test("does not re-pin on mount when the fallback already has the viewport height", () => {
+    const fixture = createFixture({ height: 720, clientHeight: 720 });
+
+    setupVisualViewport(fixture.window, fixture.element, {
+      measure: fixture.measure,
+      apply: fixture.apply,
+    });
+
+    expect(fixture.values.get("--console-h")).toBe("720px");
+    expect(fixture.measure).not.toHaveBeenCalled();
+    expect(fixture.apply).not.toHaveBeenCalled();
+
+    fixture.visualViewport.dispatch("resize");
+    expect(fixture.measure).toHaveBeenCalledOnce();
+    expect(fixture.apply).toHaveBeenCalledOnce();
+  });
+
+  test("uses the supplied mobile media query", () => {
+    const fixture = createFixture();
+
+    setupVisualViewport(
+      fixture.window,
+      fixture.element,
+      { measure: fixture.measure, apply: fixture.apply },
+      "(max-width: 640px)",
+    );
+
+    expect(fixture.window.matchMedia).toHaveBeenCalledWith(
+      "(max-width: 640px)",
+    );
+  });
+});


### PR DESCRIPTION
Closes #4613.

On iOS Safari, focusing the `/agents` composer raised the software keyboard over it, so you typed into an input you could not see.

## Why the cheap fix does not apply

The issue floated adjusting the scroll container's padding as the less invasive option. That cannot work here. The composer is not `position: fixed`: it is the last normal-flow child of `.transcript`, a flex column inside `.console { height: 100dvh }`. Padding on `.turns` moves content *inside* the scroll box, and the composer sits *below* that box. What the keyboard covers is the container's own bottom edge.

So `100dvh` is the bug. `dvh` resolves against the layout viewport, which iOS does not shrink when the keyboard opens, so the whole flex column keeps extending under it.

## What this does

`.console` height becomes `var(--console-h, 100dvh)`, and a new `visual-viewport.js` writes `--console-h` from `visualViewport.height`. The `100dvh` fallback stays, so SSR, no-JS, and browsers without `visualViewport` render exactly as before.

**Scroll anchor.** Shrinking a scroll container preserves `scrollTop`, not the bottom anchor, so a height change alone would leave the transcript parked one keyboard-height above the newest turn. Concretely: at the bottom the near-bottom distance is 0; the keyboard takes 336px of `clientHeight` without moving `scrollTop` or `scrollHeight`, so the distance measures 336 and fails the 200px threshold. The measurement therefore straddles the write: `measure()` runs before, `apply()` re-pins after. The near-bottom test is split out of `autoScroll` so the 200px threshold is still defined exactly once.

**Desktop and Android.** Gated on the existing `MOBILE_MEDIA_QUERY` constant rather than applied everywhere, because desktop pinch-zoom also shrinks `visualViewport.height` and binding the app height to it there would shrink the console for a zoomed desktop user. The gate re-evaluates on `MediaQueryList` `change`, and removes `--console-h` when it stops matching so the `100dvh` fallback resumes.

**Zoom.** `scrollTo(0, 0)` on a non-zero `offsetTop` runs on `resize` only, never on `scroll`. A non-zero `offsetTop` is also what panning a pinch-zoomed page looks like, and resetting there would fight the user on every pan frame. Page zoom is an accessibility affordance (WCAG 1.4.4).

## Verification

- `ci lint` clean.
- `//projects/monolith/frontend:test` with `--nocache_test_results`: `Executed 1 out of 1 test: 1 test passes`, including `visual-viewport.test.js (10 tests)`.
- `//projects/monolith/frontend:build_test` with `--nocache_test_results`: `Executed 1 out of 1 test: 1 test passes`. The vitest target does not compile the app, so this is the check that catches a Svelte template error.

## Not verified

The iOS behaviour itself has not been observed on hardware. The fix is derived from `visualViewport` semantics and covered by unit tests, but neither CI nor a headless browser exercises a real software keyboard. Worth an eyeball on a phone once it deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)