### PR TITLE
fix(monolith): move the dev refresh out of container args and verify every phase

### DIFF
--- a/projects/monolith/chart/scripts/dev-refresh.sh
+++ b/projects/monolith/chart/scripts/dev-refresh.sh
@@ -1,0 +1,220 @@
+#!/bin/sh
+# Refresh the dev database from production.
+#
+# This lives in a file, mounted from a ConfigMap, rather than inline in the
+# CronWorkflow's container `args`. That is not tidiness, it is correctness.
+# kubelet runs its own `$(VAR)` expansion over `command`, `args` and `env`
+# values at container start, in which `$$` is the escape for a literal `$`. An
+# inline PL/pgSQL block therefore reached the shell as `DO $` and failed with a
+# syntax error, while the whole wipe was skipped:
+#
+#   ERROR:  syntax error at or near "$"
+#   LINE 1: DO $
+#
+# `helm template` plus `sh -n` could not catch that, because the rendered
+# manifest still contains `$$`; the mangling happens later, inside kubelet.
+# Mounted file contents are never expanded, so what is in git is byte for byte
+# what the shell executes, and static checks on this file are meaningful. It
+# also retires the rest of the class: any future `$(WORD)` in an inline script
+# where WORD matches a defined env var would be silently substituted.
+#
+# Every phase asserts what it did. Four consecutive nightly failures were each a
+# different cause with one shape in common: a step reported success without
+# having done anything. Exit codes lie here (psql exits 0 on failed statements
+# unless ON_ERROR_STOP is set) and so do rendered manifests, so the job trusts
+# neither and reads the database back instead.
+#
+# Deliberately no `set -x`: it would print PGPASSWORD into the Workflow logs.
+set -eu
+
+dump_file=/tmp/monolith.dump
+list_file=/tmp/monolith.list
+
+case "$DEV_PGHOST" in
+*monolith-dev*) ;;
+*)
+	echo "refusing non-dev restore target: $DEV_PGHOST" >&2
+	exit 1
+	;;
+esac
+
+# --no-psqlrc so no operator's ~/.psqlrc can alter behaviour, ON_ERROR_STOP so a
+# failed statement fails the script. Without it psql exits 0 having errored,
+# which is exactly how the wipe failed silently and the restore then ran against
+# a populated database and produced 664 "already exists" errors.
+dev_psql() {
+	psql --host "$DEV_PGHOST" --port 5432 --username app --dbname monolith \
+		--no-psqlrc --set ON_ERROR_STOP=1 "$@"
+}
+
+# The barrier: dev must hold no actionable queue state, or the chat leader
+# re-posts production's Discord and WhatsApp messages and DBOS resumes
+# production's in-flight agent runs.
+#
+# Two separate calls on purpose. A single --command 'A; B' without
+# ON_ERROR_STOP lets a failed A silently skip B.
+barrier() {
+	dev_psql --command 'DROP SCHEMA IF EXISTS dbos CASCADE;'
+	dev_psql --command 'TRUNCATE TABLE chat.discord_outbox, chat.whatsapp_outbox;'
+}
+
+# ---------------------------------------------------------------- dump
+export PGPASSWORD=$DUMP_PASSWORD
+# The PRIMARY, not the -ro replica. A standby cancels a query whose snapshot
+# blocks WAL replay, and the COPY of knowledge.chunks is long enough to hit that
+# every single night ("canceling statement due to conflict with recovery").
+pg_dump \
+	--host "$PROD_PGHOST" --port 5432 \
+	--username "$DUMP_ROLE" --dbname monolith \
+	--format custom --file "$dump_file"
+
+prod_chunks=$(psql --host "$PROD_PGHOST" --port 5432 \
+	--username "$DUMP_ROLE" --dbname monolith \
+	--no-psqlrc --set ON_ERROR_STOP=1 \
+	-tAc 'SELECT count(*) FROM knowledge.chunks')
+
+# ---------------------------------------------------------------- restore list
+# Never restore the dangerous data in the first place, so dev holds no
+# actionable queue state at ANY instant rather than only after the barrier runs.
+# activeDeadlineSeconds SIGKILLs the pod, and an untrapped fatal signal does not
+# run an EXIT trap, so a deadline-killed restore would otherwise leave
+# production's outbox rows live in dev with only MONOLITH_LEADER_SINGLETONS
+# standing between them and being posted a second time.
+#
+#   EXTENSION          app owns neither vector nor uuid-ossp, so DROP/COMMENT on
+#                      them fail the ownership check and pg_restore exits 1
+#   SCHEMA - public    public is app-owned here, so a CREATE SCHEMA public entry
+#                      would fail "already exists" once --clean is gone. Not
+#                      observed in this archive, kept because it is harmless and
+#                      the failure it prevents is another whole round
+#   dbos               DBOS recreates its own schema on launch
+#   TABLE DATA chat …  the outbox TABLES are still created, just left empty
+#
+# Verified before adopting this: no foreign key from outside dbos points into
+# dbos or into either outbox table, so excluding them cannot break the restore
+# of a referencing table.
+pg_restore --list "$dump_file" |
+	grep -Ev ' EXTENSION | SCHEMA - public | dbos | TABLE DATA chat (discord_outbox|whatsapp_outbox) ' \
+		>"$list_file"
+
+# An empty list is the dangerous outcome, not an error one. There is no pipefail
+# here, so a failed --list leaves grep succeeding on no input and --use-list
+# would then restore NOTHING while exiting 0: dev silently keeps yesterday's
+# data and every signal stays green.
+if [ ! -s "$list_file" ]; then
+	echo "refusing to restore: empty restore list from $dump_file" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------- wipe
+export PGPASSWORD=$DEV_PASSWORD
+trap barrier EXIT
+
+# The dev app holds locks on these tables. Without this the wipe blocks until
+# the hour deadline SIGKILLs the pod, which reads as a hang rather than a
+# conflict. usename filter because terminating another role's backend raises an
+# error without pg_signal_backend.
+dev_psql --command "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+	WHERE datname = current_database() AND pid <> pg_backend_pid() AND usename = 'app';"
+
+# \gexec rather than PL/pgSQL: no dollar quoting anywhere for anything to
+# mangle, one connection, and ON_ERROR_STOP applies to every generated
+# statement. lock_timeout so a re-grabbed lock is a loud failure in a minute
+# rather than an hour-long hang.
+#
+# public is excluded from the schema sweep and its objects dropped individually.
+# It is owned by app too, so a plain DROP OWNED BY app CASCADE would take the
+# schema with it and cascade into vector and uuid-ossp, which live there and are
+# owned by postgres. app cannot recreate either (vector is not a trusted
+# extension, and cnpg-cluster.yaml installs them only at cluster bootstrap), so
+# that would break the refresh permanently and need a cluster rebuild. The
+# deptype = 'e' exclusions are what keep both extensions alive.
+dev_psql <<'SQL'
+SET lock_timeout = '60s';
+
+SELECT format('DROP SCHEMA %I CASCADE', nspname)
+FROM pg_namespace
+WHERE nspname NOT LIKE 'pg\_%'
+  AND nspname NOT IN ('information_schema', 'public')
+\gexec
+
+SELECT format('DROP %s IF EXISTS public.%I CASCADE',
+       CASE c.relkind WHEN 'v' THEN 'VIEW' WHEN 'm' THEN 'MATERIALIZED VIEW'
+                      WHEN 'S' THEN 'SEQUENCE' ELSE 'TABLE' END, c.relname)
+FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relkind IN ('r','p','v','m','S')
+  AND NOT EXISTS (SELECT 1 FROM pg_depend d WHERE d.objid = c.oid AND d.deptype = 'e')
+\gexec
+
+SELECT format('DROP ROUTINE IF EXISTS %s CASCADE', p.oid::regprocedure)
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND NOT EXISTS (SELECT 1 FROM pg_depend d WHERE d.objid = p.oid AND d.deptype = 'e')
+\gexec
+SQL
+
+# ASSERT EMPTY. The load-bearing check: it makes an incomplete wipe loud, and
+# loud BEFORE the restore rather than as hundreds of "already exists" errors
+# after it. Round four failed precisely because nothing stood here.
+leftover=$(
+	dev_psql -tA <<'SQL'
+SELECT 'schema ' || nspname FROM pg_namespace
+WHERE nspname NOT LIKE 'pg\_%' AND nspname NOT IN ('information_schema', 'public')
+UNION ALL
+SELECT 'relation public.' || c.relname
+FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relkind IN ('r','p','v','m','S')
+  AND NOT EXISTS (SELECT 1 FROM pg_depend d WHERE d.objid = c.oid AND d.deptype = 'e')
+SQL
+)
+if [ -n "$leftover" ]; then
+	echo "wipe incomplete, refusing to restore onto a populated database:" >&2
+	echo "$leftover" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------- restore
+# With an asserted-empty target and no --clean, zero errors are expected, so a
+# non-zero exit is now trustworthy rather than routine noise.
+pg_restore \
+	--host "$DEV_PGHOST" --port 5432 \
+	--username app --dbname monolith \
+	--use-list "$list_file" \
+	--no-owner --no-acl "$dump_file"
+
+# ---------------------------------------------------------------- verify
+# Explicitly, in the main flow, not only from the trap. The trap fires at exit,
+# which is AFTER the verification below, so a trap-only barrier would be
+# verified before it had run. The trap stays as the backstop for an early exit
+# and simply repeats this idempotently.
+barrier
+
+dbos_present=$(dev_psql -tAc "SELECT count(*) FROM information_schema.schemata WHERE schema_name = 'dbos'")
+discord_rows=$(dev_psql -tAc 'SELECT count(*) FROM chat.discord_outbox')
+whatsapp_rows=$(dev_psql -tAc 'SELECT count(*) FROM chat.whatsapp_outbox')
+if [ "$dbos_present" != "0" ] || [ "$discord_rows" != "0" ] || [ "$whatsapp_rows" != "0" ]; then
+	echo "safety barrier did not hold: dbos=$dbos_present discord=$discord_rows whatsapp=$whatsapp_rows" >&2
+	exit 1
+fi
+
+# Compare the schemas the archive carries against the schemas dev now has,
+# rather than asserting a hardcoded count that would rot as prod grows. dbos is
+# absent from both sides, since it is filtered out of the list above.
+# Keyed on the "SCHEMA -" marker rather than a field offset from the end: the
+# owner is the last field today, so $(NF-1) would work, but it silently picks
+# the wrong token on any entry that omits it.
+grep ' SCHEMA - ' "$list_file" |
+	awk '{ for (i = 1; i <= NF; i++) if ($i == "SCHEMA" && $(i + 1) == "-") print $(i + 2) }' |
+	sort >/tmp/expected_schemas
+dev_psql -tAc "SELECT nspname FROM pg_namespace \
+	WHERE nspname NOT LIKE 'pg\_%' AND nspname NOT IN ('information_schema', 'public') \
+	ORDER BY nspname" >/tmp/actual_schemas
+diff -u /tmp/expected_schemas /tmp/actual_schemas
+
+dev_chunks=$(dev_psql -tAc 'SELECT count(*) FROM knowledge.chunks')
+if [ "$dev_chunks" -lt $((prod_chunks * 9 / 10)) ]; then
+	echo "restore looks short: dev knowledge.chunks=$dev_chunks vs prod=$prod_chunks" >&2
+	exit 1
+fi
+
+echo "refresh OK: chunks dev=$dev_chunks prod=$prod_chunks, schemas match archive, barrier verified"

--- a/projects/monolith/chart/templates/cnpg-dev-refresh-cronworkflow.yaml
+++ b/projects/monolith/chart/templates/cnpg-dev-refresh-cronworkflow.yaml
@@ -38,120 +38,26 @@ spec:
       secondsAfterFailure: 86400
     podGC:
       strategy: OnWorkflowSuccess
+    volumes:
+      - name: dev-refresh-script
+        configMap:
+          name: cnpg-dev-refresh-script
+          # sh reads the script as an argument, so read permission is all that
+          # is strictly required; the execute bit just keeps it runnable if the
+          # invocation ever changes. Written 0555 so YAML reads it as octal.
+          defaultMode: 0555
     templates:
       - name: refresh
         container:
           image: {{ .Values.postgres.devRefresh.refreshImage | quote }}
-          command: ["/bin/sh", "-ceu"]
-          args:
-            - |
-              dump_file=/tmp/monolith.dump
-              case "$DEV_PGHOST" in
-                *monolith-dev*) ;;
-                *) echo "refusing non-dev restore target: $DEV_PGHOST" >&2; exit 1 ;;
-              esac
-              export PGPASSWORD=$DUMP_PASSWORD
-              pg_dump \
-                --host "$PROD_PGHOST" --port 5432 \
-                --username "$DUMP_ROLE" --dbname monolith \
-                --format custom --file "$dump_file"
-              export PGPASSWORD=$DEV_PASSWORD
-              # SAFETY BARRIER, armed BEFORE the restore rather than sequenced
-              # after it. dev must hold no actionable queue state: the chat
-              # leader would post production's discord_outbox messages a second
-              # time, and DBOS would resume production's in-flight agent runs
-              # from dbos on launch.
-              #
-              # It runs on EXIT because the failure that matters is a restore
-              # that dies PARTWAY. Sequenced after pg_restore under `set -e` it
-              # is skipped exactly when it is most needed, which is what
-              # happened on 2026-08-15: the restore loaded production's rows,
-              # exited non-zero, and left dev holding 1302 discord_outbox rows,
-              # 125 whatsapp_outbox rows and the dbos schema. Only
-              # MONOLITH_LEADER_SINGLETONS=false stopped those being posted, so
-              # the barrier was not supplementing that env var as the old
-              # comment claimed, it was absent and the env var carried it alone.
-              #
-              # Schema-qualified because these tables live in `chat`, and
-              # neither the role nor the database sets a search_path, so the
-              # default is "$user", public and the unqualified names resolved
-              # to nothing. The barrier could never have run as written, even
-              # on a completely clean restore.
-              barrier() {
-                psql \
-                  --host "$DEV_PGHOST" --port 5432 \
-                  --username app --dbname monolith \
-                  --command 'DROP SCHEMA IF EXISTS dbos CASCADE; TRUNCATE TABLE chat.discord_outbox, chat.whatsapp_outbox;'
-              }
-              trap barrier EXIT
-
-              # WIPE FIRST, then restore into an empty database. --clean is not
-              # used at all, and that is the point: every failure this job has
-              # had after the dump was fixed came from --clean emitting a DROP
-              # that Postgres refuses, and each fix only revealed the next one.
-              #
-              #   must be owner of extension vector       (DROP EXTENSION)
-              #   cannot drop inherited constraint        (ships.positions_*)
-              #
-              # Both are harmless, and both make pg_restore exit 1 on "errors
-              # ignored on restore", which under `set -e` fails the job. Two
-              # instances of one class is enough: remove the class. With
-              # nothing to drop, no DROP is generated and no benign error can
-              # be mistaken for a real one.
-              #
-              # `app` owns all 27 schemas and all 140 tables (the restore runs
-              # --no-owner, so it owns whatever it creates), which is what makes
-              # a wholesale wipe possible.
-              #
-              # public is EXCLUDED and its tables dropped individually instead.
-              # It is owned by app too, so a plain `DROP OWNED BY app CASCADE`
-              # would take the schema with it and cascade into vector and
-              # uuid-ossp, which live there and are owned by postgres. app
-              # cannot recreate either (vector is not a trusted extension), so
-              # that would break the refresh permanently on the first run and
-              # need a cluster rebuild to recover.
-              psql \
-                --host "$DEV_PGHOST" --port 5432 \
-                --username app --dbname monolith <<'SQL'
-              DO $$
-              DECLARE obj text;
-              BEGIN
-                FOR obj IN
-                  SELECT nspname FROM pg_namespace
-                  WHERE nspname NOT LIKE 'pg\_%'
-                    AND nspname NOT IN ('information_schema', 'public')
-                LOOP
-                  EXECUTE format('DROP SCHEMA IF EXISTS %I CASCADE', obj);
-                END LOOP;
-                FOR obj IN SELECT tablename FROM pg_tables WHERE schemaname = 'public'
-                LOOP
-                  EXECUTE format('DROP TABLE IF EXISTS public.%I CASCADE', obj);
-                END LOOP;
-              END $$;
-              SQL
-
-              # The archive still carries COMMENT ON EXTENSION entries, which
-              # fail the same ownership check even with no --clean, so keep
-              # filtering EXTENSION out. Skipping CREATE EXTENSION too is safe
-              # because the extensions are not the restore's to provide:
-              # cnpg-cluster.yaml installs them as postgres in the cluster's
-              # post-init SQL, so a rebuilt dev cluster has vector and uuid-ossp
-              # before any refresh runs. That is the dependency this relies on.
-              pg_restore --list "$dump_file" | grep -v ' EXTENSION ' > /tmp/restore.list
-              # An empty list is the dangerous outcome, not an error one: there
-              # is no pipefail here, so a failed --list leaves grep succeeding
-              # on no input and --use-list would then restore NOTHING while
-              # exiting 0. Dev would silently keep yesterday's data and every
-              # signal would be green.
-              if [ ! -s /tmp/restore.list ]; then
-                echo "refusing to restore: empty restore list from $dump_file" >&2
-                exit 1
-              fi
-              pg_restore \
-                --host "$DEV_PGHOST" --port 5432 \
-                --username app --dbname monolith \
-                --use-list /tmp/restore.list \
-                --no-owner --no-acl "$dump_file"
+          # No args, and no -c. The script is a mounted file, so kubelet has
+          # nothing to expand: $(VAR) substitution and the $$ escape apply only
+          # to command, args and env values, never to file contents.
+          command: ["/bin/sh", "-eu", "/scripts/dev-refresh.sh"]
+          volumeMounts:
+            - name: dev-refresh-script
+              mountPath: /scripts
+              readOnly: true
           # Declared rather than omitted, because a container with no requests
           # is BestEffort and is the first thing evicted under pressure. This
           # cluster is not roomy: node-1 sits at 91% of requestable memory, so

--- a/projects/monolith/chart/templates/dev-refresh-configmap.yaml
+++ b/projects/monolith/chart/templates/dev-refresh-configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgres.devRefresh.enabled }}
+# The dev refresh script, shipped as a file rather than inline in the
+# CronWorkflow's container args. kubelet expands $(VAR) over command, args and
+# env values at container start, treating $$ as an escape for a literal $, which
+# silently mangled an inline PL/pgSQL block into invalid SQL. Mounted file
+# contents are never expanded, so the bytes in git are the bytes the shell runs.
+# Same .Files.Get idiom as migrations-configmap.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cnpg-dev-refresh-script
+  namespace: {{ .Values.jobs.workflowNamespace }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cron-job
+data:
+  dev-refresh.sh: |
+    {{- .Files.Get "scripts/dev-refresh.sh" | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
Round four of this job failed because the wipe never ran:

```
ERROR:  syntax error at or near "$"
LINE 1: DO $
```

kubelet expands `$(VAR)` over `command`, `args` and `env` values at container start, and `$$` is its escape for a literal `$`. The inline PL/pgSQL block was mangled before the shell ever saw it. Then, because `psql` exits 0 even when its statements fail, the script carried on into the restore against a still-populated database: 664 "already exists" errors.

**`helm template` plus `sh -n` could not catch this.** The rendered manifest still contains `$$`; the mangling happens later, inside kubelet. Fable confirmed the diagnosis independently by porting kubelet's expansion algorithm and running it over the rendered manifest.

## Why restructure rather than patch again

| Round | Cause | Fix |
|---|---|---|
| 1 | dump from a hot standby, cancelled by WAL replay | dump from the primary |
| 2 | `DROP EXTENSION` ownership; barrier both mis-sequenced and unqualified | filter list, arm EXIT trap, qualify |
| 3 | `DROP CONSTRAINT` on inherited partition keys | drop `--clean`, wipe first |
| 4 | `$$` mangled by kubelet; wipe failed silently | this PR |

Four causes, one shape: **a step reports success without having done anything.** Patching instance five was the wrong move. Two changes make the class impossible.

### Transport

The script moves to `chart/scripts/dev-refresh.sh`, mounted from a ConfigMap via the same `.Files.Get` idiom as `migrations-configmap.yaml`. kubelet never expands file contents, so the bytes in git are the bytes the shell runs, and static checks on the file are meaningful. This retires the whole class, not the instance: any future `$(WORD)` in an inline script where WORD matches a defined env var would be substituted silently.

### Verification

Every phase asserts what it did, because neither exit codes nor rendered manifests can be trusted here:

- `ON_ERROR_STOP=1` and `--no-psqlrc` on every `psql` call
- wipe via `\gexec`: no dollar quoting to mangle, one connection, ON_ERROR_STOP covers every generated statement
- **ASSERT EMPTY before restoring.** An incomplete wipe is now loud, and loud *before* the restore. Nothing stood here in round four
- schemas restored are `diff`ed against the schemas the archive carries, which self-calibrates as prod grows rather than rotting like a hardcoded count
- chunk count compared against prod, read back from dev

### Safety

The barrier no longer depends on running at all: `dbos` and the two outbox tables' **data** are excluded from the restore list (the tables are still created, empty), so dev holds no actionable queue state at any instant.

This closes a hole nobody had hit yet: `activeDeadlineSeconds` SIGKILLs the pod, and **a fatal signal does not run an EXIT trap**, so the trap alone never guaranteed the barrier. Confirmed first that no foreign key from outside `dbos` points into `dbos` or either outbox, so the exclusion cannot break a referencing table.

The barrier is also now called explicitly in the main flow and then verified, with the trap kept as an idempotent backstop. A trap-only barrier would have run *after* the verification, not before it.

Plus: terminate dev app backends and `SET lock_timeout = '60s'` so the wipe cannot block on their locks until the hour deadline, which would read as a hang rather than a conflict.

## Verification done

- `sh -n` on the real artifact, re-run after `shfmt` reformatted it
- ConfigMap data key extracted from `helm template` and diffed against the git file: **byte-identical**, proving the Helm transport
- kubelet expansion emulator over the rendered CronWorkflow: **changes nothing**
- `defaultMode` renders as decimal 365, i.e. `0555` octal, not 555
- the exclusion grep and the schema-name parser exercised against realistic `pg_restore --list` input: `SCHEMA - public` excluded while `chat_public` survives, only the outbox data dropped
- the ASSERT EMPTY query run against currently-populated dev: returns 33 objects, so it would correctly refuse
- `ci test`: `Executed 2 out of 717 tests: 717 tests pass`

## Predicted round five, pre-empted

Fable predicted a `SCHEMA - public` TOC entry failing "already exists" once `--clean` is gone, `public` being app-owned here. Not present in this archive (checked round four's log), filtered anyway: harmless if absent, and the failure it prevents is another whole round.

## Still unproven

A green run. That is the only thing that closes this, and I will trigger one after rollout rather than claiming it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CVxWW96h5c9Ybhu4bxBzr