### PR TITLE
feat(agents): follow the private tier's time-of-day palette in the console

### DIFF
--- a/projects/monolith/frontend/src/app.html
+++ b/projects/monolith/frontend/src/app.html
@@ -18,6 +18,28 @@
         // localStorage blocked or quota exceeded; continue with expanded
       }
     </script>
+    <script>
+      /* Set the initial period attribute before first paint.
+         This runs inline and blocking to avoid a white flash when switching
+         to night mode. The period module (src/lib/private/period.js) is the
+         source of truth; this duplication must remain inline because app.html
+         has no module graph. The agents console updates this attribute after
+         hydration in response to clock ticks every 60s. */
+      try {
+        const hour = new Date().getHours();
+        const period =
+          hour >= 5 && hour < 11
+            ? "dawn"
+            : hour >= 11 && hour < 17
+              ? "day"
+              : hour >= 17 && hour < 22
+                ? "dusk"
+                : "night";
+        document.documentElement.setAttribute("data-agents-period", period);
+      } catch (e) {
+        // Gracefully degrade if Date is not available
+      }
+    </script>
     <!-- Declared in the static shell (not just the layout) so it is present at
          initial parse: the /app/* pages are ssr=false, so a layout-injected
          icon arrives after hydration and the browser has already 404'd on the

--- a/projects/monolith/frontend/src/lib/private/period.js
+++ b/projects/monolith/frontend/src/lib/private/period.js
@@ -1,0 +1,18 @@
+/**
+ * Period computation for the private tier's time-of-day palette.
+ * Period boundaries must remain in sync with the agents console and the
+ * landing page's `+page.svelte`. The landing page's `greeting` message uses
+ * different boundaries and is a separate concern.
+ */
+
+/**
+ * Compute the current period from an hour value.
+ * @param {number} hour - Hour value from 0-23
+ * @returns {"dawn" | "day" | "dusk" | "night"} The period for the hour
+ */
+export function periodForHour(hour) {
+  if (hour >= 5 && hour < 11) return "dawn";
+  if (hour >= 11 && hour < 17) return "day";
+  if (hour >= 17 && hour < 22) return "dusk";
+  return "night";
+}

--- a/projects/monolith/frontend/src/lib/private/period.test.js
+++ b/projects/monolith/frontend/src/lib/private/period.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { periodForHour } from "./period.js";
+
+describe("periodForHour", () => {
+  it("returns 'night' for hour 0", () => {
+    expect(periodForHour(0)).toBe("night");
+  });
+
+  it("returns 'night' for hour 4", () => {
+    expect(periodForHour(4)).toBe("night");
+  });
+
+  it("returns 'dawn' for hour 5", () => {
+    expect(periodForHour(5)).toBe("dawn");
+  });
+
+  it("returns 'dawn' for hour 10", () => {
+    expect(periodForHour(10)).toBe("dawn");
+  });
+
+  it("returns 'day' for hour 11", () => {
+    expect(periodForHour(11)).toBe("day");
+  });
+
+  it("returns 'day' for hour 16", () => {
+    expect(periodForHour(16)).toBe("day");
+  });
+
+  it("returns 'dusk' for hour 17", () => {
+    expect(periodForHour(17)).toBe("dusk");
+  });
+
+  it("returns 'dusk' for hour 21", () => {
+    expect(periodForHour(21)).toBe("dusk");
+  });
+
+  it("returns 'night' for hour 22", () => {
+    expect(periodForHour(22)).toBe("night");
+  });
+
+  it("returns 'night' for hour 23", () => {
+    expect(periodForHour(23)).toBe("night");
+  });
+});

--- a/projects/monolith/frontend/src/routes/private/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/+page.svelte
@@ -3,6 +3,7 @@
   import { launcher } from "$lib/private/launcher.js";
   import ClusterChatPanel from "$lib/private/components/ClusterChatPanel.svelte";
   import "$lib/private/dashboard-theme.css";
+  import { periodForHour } from "$lib/private/period.js";
 
   let { data } = $props();
 
@@ -151,15 +152,7 @@
   // The palette drifts with the clock: soft gold at dawn, airy by day,
   // rose at dusk, calm ink after dark. Same data, different light.
   let hour = $derived(now.getHours());
-  let period = $derived(
-    hour >= 5 && hour < 11
-      ? "dawn"
-      : hour >= 11 && hour < 17
-        ? "day"
-        : hour >= 17 && hour < 22
-          ? "dusk"
-          : "night",
-  );
+  let period = $derived(periodForHour(hour));
   let greeting = $derived(
     hour >= 5 && hour < 12
       ? "Good morning"

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -111,7 +111,7 @@
     }
   });
 
-  $effect.pre(() => {
+  onMount(() => {
     // Update the clock every 60 seconds to match the landing page's refresh rate.
     const id = setInterval(() => (now = new Date()), 60_000);
     return () => clearInterval(id);
@@ -1769,7 +1769,6 @@
   }
 
   .console {
-    color-scheme: light;
     height: var(--console-h, 100dvh);
     display: grid;
     grid-template-columns: 300px minmax(0, 1fr);
@@ -1780,9 +1779,6 @@
     line-height: 1.45;
   }
 
-  html[data-agents-period="night"] .console {
-    color-scheme: dark;
-  }
   .console * {
     font-family: var(--font-ui);
   }

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -28,6 +28,7 @@
   import { RUN_LEXICON as P } from "./run-lexicon.js";
   import PaneHeader from "./PaneHeader.svelte";
   import SessionWalkthrough from "./SessionWalkthrough.svelte";
+  import { periodForHour } from "$lib/private/period.js";
 
   const MOBILE_MEDIA_QUERY = "(max-width: 760px)";
 
@@ -97,6 +98,25 @@
   let newPromptEl = $state(null);
   let repoControlEl = $state(null);
   let titleEl = $state(null);
+  // ── Period (time-of-day palette) ────────────
+  let now = $state(new Date());
+  let period = $derived(periodForHour(now.getHours()));
+
+  $effect(() => {
+    // Update the period attribute on document.documentElement to enable CSS
+    // selectors that key off data-agents-period. This matches the initial
+    // value set by the blocking inline script in app.html.
+    if (typeof document !== "undefined") {
+      document.documentElement.setAttribute("data-agents-period", period);
+    }
+  });
+
+  $effect.pre(() => {
+    // Update the clock every 60 seconds to match the landing page's refresh rate.
+    const id = setInterval(() => (now = new Date()), 60_000);
+    return () => clearInterval(id);
+  });
+
   let focusSessionId = null;
   let previousSessionId = null;
   let showAllHistory = $state(false);
@@ -1758,6 +1778,10 @@
     font-family: var(--font-ui);
     font-size: var(--size-body);
     line-height: 1.45;
+  }
+
+  html[data-agents-period="night"] .console {
+    color-scheme: dark;
   }
   .console * {
     font-family: var(--font-ui);

--- a/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
+++ b/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
@@ -9,10 +9,14 @@
  * for state (running / attention / error). The previous grey-on-beige
  * scheme was rejected for readability; secondary text stays secondary
  * through size, never through washout (see .impeccable.md).
+ *
+ * The night period inverts the palette: dark paper background, light text,
+ * and adjusted state token lightness to maintain WCAG AA contrast.
  */
 .console {
-  /* Neutral surface, line, and text tokens: vary per period via
-     .shell.dawn/.shell.dusk/.shell.night overrides. */
+  /* Neutral surface, line, and text tokens for day period (default).
+     Dawn and dusk override only --page-bg for a subtle warm shift.
+     Night period overrides these with dark-mode equivalents below. */
   --page-bg: #eef0f2;
   --panel-bg: #ffffff;
   --text: #14171a;
@@ -33,7 +37,8 @@
   /* 3.66:1 on white background, 3.20:1 on --page-bg. */
   --dot-idle: #7e878e;
 
-  /* State tokens: period-invariant, never overridden. */
+  /* State tokens: hue preserved across periods, lightness adjusted per
+     background. Day period values below. Night period overrides for each. */
   --ok: #0a7c3c;
   --ok-soft: #dcf2e5;
   /* Diff panes (walkthrough): added/removed lines are fact register, so
@@ -64,4 +69,61 @@
   --size-detail: 13px;
   --size-title: clamp(15px, 2.6cqi + 8px, 19px);
   --scrim-bg: rgba(20, 23, 26, 0.45);
+}
+
+/* Night period: dark mode palette. */
+html[data-agents-period="night"] .console {
+  /* Neutral tokens anchored to dashboard-theme.css night values. */
+  --page-bg: #14151b;
+  --panel-bg: #1c1e26;
+  --text: #e8e5dc;
+  /* Adjusted from dashboard --ink-3 (#6f6d65, ~3.4:1) to clear 4.5:1
+     against --panel-bg for body text. */
+  --text-soft: #a5a297;
+  --muted: #7e7c74;
+  /* Derived from dashboard --line at rgba(232, 227, 210, 0.12). */
+  --line: rgba(232, 227, 210, 0.15);
+  /* Lightened to clear 3:1 against --panel-bg for input and control borders. */
+  --line-strong: #5a5854;
+  --hover: #242629;
+  /* Inverted pair: light surface with dark text for primary affordances. */
+  --ink: #e8e5dc;
+  --ink-text: #1c1e26;
+  --code-bg: #242629;
+  /* Raised from day value to register clearly on dark page. */
+  --dot-idle: #5a5854;
+
+  /* State tokens: hue from dashboard night palette, adjusted for
+     panel-bg contrast. */
+  /* 4.52:1 against --panel-bg. */
+  --ok: #6fbf8d;
+  /* color-mix tints: 30% lightens the base to stay readable on dark panel. */
+  --ok-soft: color-mix(in srgb, var(--ok) 30%, var(--panel-bg));
+  --diff-add-bg: color-mix(in srgb, var(--ok) 20%, var(--panel-bg));
+  --diff-add-mark: var(--ok);
+  /* 4.51:1 against --panel-bg. */
+  --attn: #d0a050;
+  /* 4.56:1 on --attn-soft. */
+  --attn-text: #f0e4c0;
+  --attn-soft: color-mix(in srgb, var(--attn) 30%, var(--panel-bg));
+  /* 4.53:1 against --panel-bg. */
+  --info: #7eb3f0;
+  --info-soft: color-mix(in srgb, var(--info) 30%, var(--panel-bg));
+  /* 4.52:1 against --panel-bg. */
+  --err: #d9776a;
+  --err-bg: color-mix(in srgb, var(--err) 20%, var(--panel-bg));
+  --err-line: color-mix(in srgb, var(--err) 30%, var(--panel-bg));
+  --diff-del-bg: color-mix(in srgb, var(--err) 20%, var(--panel-bg));
+  --diff-del-mark: var(--err);
+  /* Raised alpha from day value (0.45) for better modal separation on dark bg. */
+  --scrim-bg: rgba(20, 23, 26, 0.65);
+}
+
+/* Dawn and dusk: warm shift on --page-bg only. */
+.shell.dawn .console {
+  --page-bg: #f9f6f3;
+}
+
+.shell.dusk .console {
+  --page-bg: #f8f3f0;
 }

--- a/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
+++ b/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
@@ -83,15 +83,15 @@ html[data-agents-period="night"] .console {
   --muted: #7e7c74;
   /* Derived from dashboard --line at rgba(232, 227, 210, 0.12). */
   --line: rgba(232, 227, 210, 0.15);
-  /* Lightened to clear 3:1 against --panel-bg for input and control borders. */
-  --line-strong: #5a5854;
+  /* 3.76:1 against --panel-bg for input and control borders. */
+  --line-strong: #7a7870;
   --hover: #242629;
   /* Inverted pair: light surface with dark text for primary affordances. */
   --ink: #e8e5dc;
   --ink-text: #1c1e26;
   --code-bg: #242629;
-  /* Raised from day value to register clearly on dark page. */
-  --dot-idle: #5a5854;
+  /* 4.12:1 against --page-bg, 3.76:1 against --panel-bg. */
+  --dot-idle: #7a7870;
 
   /* State tokens: hue from dashboard night palette, adjusted for
      panel-bg contrast. */

--- a/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
+++ b/projects/monolith/frontend/src/routes/private/agents/agents-theme.css
@@ -15,8 +15,9 @@
  */
 .console {
   /* Neutral surface, line, and text tokens for day period (default).
-     Dawn and dusk override only --page-bg for a subtle warm shift.
+     color-scheme: light allows native controls to render appropriately.
      Night period overrides these with dark-mode equivalents below. */
+  color-scheme: light;
   --page-bg: #eef0f2;
   --panel-bg: #ffffff;
   --text: #14171a;
@@ -73,6 +74,7 @@
 
 /* Night period: dark mode palette. */
 html[data-agents-period="night"] .console {
+  color-scheme: dark;
   /* Neutral tokens anchored to dashboard-theme.css night values. */
   --page-bg: #14151b;
   --panel-bg: #1c1e26;
@@ -80,7 +82,8 @@ html[data-agents-period="night"] .console {
   /* Adjusted from dashboard --ink-3 (#6f6d65, ~3.4:1) to clear 4.5:1
      against --panel-bg for body text. */
   --text-soft: #a5a297;
-  --muted: #7e7c74;
+  /* 5.75:1 against --panel-bg, 6.30:1 against --page-bg. */
+  --muted: #9a9890;
   /* Derived from dashboard --line at rgba(232, 227, 210, 0.12). */
   --line: rgba(232, 227, 210, 0.15);
   /* 3.76:1 against --panel-bg for input and control borders. */
@@ -95,21 +98,21 @@ html[data-agents-period="night"] .console {
 
   /* State tokens: hue from dashboard night palette, adjusted for
      panel-bg contrast. */
-  /* 4.52:1 against --panel-bg. */
+  /* 7.53:1 against --panel-bg. */
   --ok: #6fbf8d;
   /* color-mix tints: 30% lightens the base to stay readable on dark panel. */
   --ok-soft: color-mix(in srgb, var(--ok) 30%, var(--panel-bg));
   --diff-add-bg: color-mix(in srgb, var(--ok) 20%, var(--panel-bg));
   --diff-add-mark: var(--ok);
-  /* 4.51:1 against --panel-bg. */
+  /* 6.99:1 against --panel-bg. */
   --attn: #d0a050;
-  /* 4.56:1 on --attn-soft. */
+  /* 7.34:1 on --attn-soft. */
   --attn-text: #f0e4c0;
   --attn-soft: color-mix(in srgb, var(--attn) 30%, var(--panel-bg));
-  /* 4.53:1 against --panel-bg. */
+  /* 7.60:1 against --panel-bg. */
   --info: #7eb3f0;
   --info-soft: color-mix(in srgb, var(--info) 30%, var(--panel-bg));
-  /* 4.52:1 against --panel-bg. */
+  /* 5.38:1 against --panel-bg. */
   --err: #d9776a;
   --err-bg: color-mix(in srgb, var(--err) 20%, var(--panel-bg));
   --err-line: color-mix(in srgb, var(--err) 30%, var(--panel-bg));
@@ -119,11 +122,12 @@ html[data-agents-period="night"] .console {
   --scrim-bg: rgba(20, 23, 26, 0.65);
 }
 
-/* Dawn and dusk: warm shift on --page-bg only. */
-.shell.dawn .console {
+/* Dawn period: warm shift on --page-bg only. */
+html[data-agents-period="dawn"] .console {
   --page-bg: #f9f6f3;
 }
 
-.shell.dusk .console {
+/* Dusk period: warm shift on --page-bg only. */
+html[data-agents-period="dusk"] .console {
   --page-bg: #f8f3f0;
 }


### PR DESCRIPTION
Closes #4683.

At night the private landing page is dark and clicking through to `/agents` threw a white page at you. The console now carries the same clock-driven palette as the rest of the tier.

## Corrections to the issue body

Three things in the issue were wrong, and are worth recording since its "What is not true" section was itself partly wrong:

- `color-scheme: light` **did** exist, at `+page.svelte:1732`, in the component style block rather than `agents-theme.css`. The critique the issue rebuts named the wrong file but was right about the fact.
- `agents-theme.css:14` already claimed the neutral tokens "vary per period via `.shell.dawn`/`.shell.dusk`/`.shell.night` overrides". No such overrides existed and `.console` carried no period class.
- `lib/styles/shared/tokens.css:49` defines `body.dark`, applied by nothing anywhere in `src/`. `.impeccable.md:155-157` describes the private tier as having "a real `body.dark` theme" on the strength of it. It is dead CSS, so there was no existing dark-mode convention to join.

## Approach

Option 1 from the issue, scoped so the hazard it names is designed out rather than accepted.

**Hue is period-invariant.** Green stays green, amber amber, red red. Only lightness moves, and only as far as WCAG AA requires. The issue rightly flags "a state chip learned as one shade is another an hour later" as a real hazard on a monitoring surface; holding hue fixed means the channel carrying the meaning never moves.

**Only night goes dark.** `day` is unchanged and is the default. `dawn` and `dusk` shift the `--page-bg` surround only, so panels stay white and the console's stated "white working surfaces" direction is preserved. That confines the state-token work to one period.

**Soft fills derive from the surface** via `color-mix(in srgb, var(--ok) N%, var(--panel-bg))` rather than four hand-tuned sets, so they track the panel automatically. Body text on them lands between 7.06:1 and 9.78:1.

**The inverted pair.** `--ink` / `--ink-text` paint a near-black chip with white text for `.chip.on` and `.send-button`. At night `--ink` (#1c2024) would have sat on `--panel-bg` (#1c1e26) and dissolved into it, so the pair inverts rather than darkens: 13.20:1.

## Mechanism: an `<html>` attribute, not a class

`data-agents-period` is stamped by a blocking inline script in `app.html`, following the existing `data-agents-rail` precedent, and kept current after hydration by a 60s clock.

A Svelte class would only apply at hydration, so a night visitor would get a white flash first, which is the exact jolt this issue exists to remove. SSR cannot fix it either: the server clock is UTC while the period is a property of the viewer's local time.

Period boundaries are extracted from `routes/private/+page.svelte` into `lib/private/period.js` so the console and the landing page cannot drift. The landing page's `greeting` uses different boundaries and is deliberately left alone.

## Contrast

Every value computed with the standard WCAG formula, measured against `--panel-bg` (#1c1e26) unless noted:

| Token | Ratio |
|---|---|
| `--text` #e8e5dc | 13.20:1 |
| `--text-soft` #a5a297 | 6.50:1 |
| `--muted` #9a9890 | 5.75:1 (6.30:1 on `--page-bg`) |
| `--line-strong` #7a7870 | 3.76:1 (UI boundary, 3:1 floor) |
| `--dot-idle` #7a7870 | 4.12:1 on `--page-bg` |
| `--ok` #6fbf8d | 7.53:1 |
| `--attn` #d0a050 | 6.99:1 |
| `--attn-text` #f0e4c0 | 7.34:1 on `--attn-soft` |
| `--info` #7eb3f0 | 7.60:1 |
| `--err` #d9776a | 5.38:1 |

## Verification

- `ci lint` clean.
- `//projects/monolith/frontend:test` and `:build_test` with `--nocache_test_results`: `Executed 2 out of 2 tests: 2 tests pass`, including `period.test.js (10 tests)`.
- `color-scheme` lives in `agents-theme.css` rather than the component. An unscoped `html[data-*]` selector inside a Svelte `<style>` block is deleted at compile time with a `css_unused_selector` warning that `build_test` does not surface, so the rule would have shipped as a no-op behind green CI. Moving it to the plain stylesheet removes the whole class of bug; the 15 remaining `html[...]` rules in the component are all `:global()`-wrapped.

## Not verified

The rendered result has not been looked at on a real screen in any period. Contrast is computed, not observed, and "clears AA" is not the same as "reads well at 2am".

🤖 Generated with [Claude Code](https://claude.com/claude-code)