### PR TITLE
feat(agents): surface stream connection state in the VM chips

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -25,6 +25,7 @@
   import { partitionRuns, recentRuns, runActivityAt } from "./run-history.js";
   import { crumbTrail, sessionLineage } from "./lineage.js";
   import { setupVisualViewport } from "./visual-viewport.js";
+  import { formatAge, nextStatus } from "./vm-stream-status.js";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
   import PaneHeader from "./PaneHeader.svelte";
   import SessionWalkthrough from "./SessionWalkthrough.svelte";
@@ -140,6 +141,13 @@
   let requestSequence = 0;
   let renderedPending = $state({});
   let vms = $state({});
+  let vmStreamStatus = $state({
+    mode: "stalled",
+    lastUpdateAt: null,
+    error: null,
+  });
+  let vmStreamNow = $state(Date.now());
+  let vmFallbackArmed = false;
   let turnsEl = $state(null);
   let consoleEl = $state(null);
 
@@ -625,6 +633,11 @@
     });
   }
 
+  function updateVmStreamStatus(event) {
+    vmStreamStatus = nextStatus($state.snapshot(vmStreamStatus), event);
+    return vmStreamStatus;
+  }
+
   function selectRun(runOrId) {
     const id = typeof runOrId === "object" ? runOrId?.workflow_id : runOrId;
     if (id == null) return;
@@ -638,11 +651,30 @@
   async function loadVms() {
     try {
       const response = await fetch("/agents/vms");
-      if (!response.ok) return;
-      const body = await response.json();
-      vms = body.vms ?? {};
-    } catch {
+      const body = await response.json().catch(() => null);
+      if (!vmFallbackArmed) return;
+      if (!response.ok) {
+        updateVmStreamStatus({
+          type: "poll-fail",
+          error: body?.error ?? "Unable to load VM state",
+        });
+        return;
+      }
+      if (body == null) throw new Error("Invalid VM state response");
+      const status = updateVmStreamStatus({
+        type: "poll-ok",
+        at: Date.now(),
+        error: body?.error ?? null,
+      });
+      if (status.mode === "polling") vms = body?.vms ?? {};
+    } catch (error) {
       // VM state is advisory; keep the last known map on transient failures.
+      if (!vmFallbackArmed) return;
+      updateVmStreamStatus({
+        type: "poll-fail",
+        error:
+          error instanceof Error ? error.message : "Unable to load VM state",
+      });
     }
   }
 
@@ -1035,6 +1067,17 @@
     }
   });
 
+  // The clock only refreshes the displayed age. It never changes connection
+  // mode, which is driven exclusively by stream and fallback events.
+  $effect(() => {
+    if (vmStreamStatus.mode === "streaming") return;
+    vmStreamNow = Date.now();
+    const interval = setInterval(() => {
+      vmStreamNow = Date.now();
+    }, 30_000);
+    return () => clearInterval(interval);
+  });
+
   // Subscribe to the shared VM state stream. A slow poll is only a fallback
   // after the stream has failed repeatedly.
   $effect(() => {
@@ -1051,22 +1094,52 @@
 
     const startFallback = () => {
       if (fallbackInterval) return;
+      vmFallbackArmed = true;
       fallbackInterval = setInterval(loadVms, 2000);
+      updateVmStreamStatus({ type: "fallback-armed" });
       loadVms();
+    };
+
+    const stopFallback = () => {
+      vmFallbackArmed = false;
+      clearInterval(fallbackInterval);
+      fallbackInterval = undefined;
+    };
+
+    source.onopen = () => {
+      failures = 0;
+      stopFallback();
+      updateVmStreamStatus({ type: "open" });
     };
 
     source.onmessage = (event) => {
       failures = 0;
-      clearInterval(fallbackInterval);
-      fallbackInterval = undefined;
+      stopFallback();
       try {
-        vms = JSON.parse(event.data).vms ?? {};
-      } catch {
-        // Ignore malformed advisory state and retain the last snapshot.
+        const body = JSON.parse(event.data);
+        const status = updateVmStreamStatus({
+          type: "frame",
+          at: Date.now(),
+          error: body?.error ?? null,
+        });
+        if (status.mode === "streaming") vms = body?.vms ?? {};
+      } catch (error) {
+        // Retain the last snapshot and expose that the advisory frame failed.
+        updateVmStreamStatus({
+          type: "frame",
+          at: Date.now(),
+          error:
+            error instanceof Error
+              ? `Invalid VM stream payload: ${error.message}`
+              : "Invalid VM stream payload",
+        });
       }
     };
     source.onerror = () => {
       failures += 1;
+      if (source.readyState !== EventSource.OPEN) {
+        updateVmStreamStatus({ type: "closed" });
+      }
       // A fatal error (non-200, or a content type that is not
       // text/event-stream, which is what an expired Cloudflare Access
       // session returns) closes the source permanently and fires exactly
@@ -1078,6 +1151,7 @@
     };
 
     return () => {
+      vmFallbackArmed = false;
       source.close();
       clearInterval(fallbackInterval);
     };
@@ -1265,6 +1339,22 @@
                 : "no live microVM; the next prompt boots fresh"}
               >vm {vmState(selectedSession, vms)}</span
             >
+            <span
+              class={`vm-stream-state ${vmStreamStatus.mode}`}
+              title={vmStreamStatus.error
+                ? `VM state updates stalled: ${vmStreamStatus.error}`
+                : `VM state updates: ${vmStreamStatus.mode}`}
+            >
+              <span class="vm-stream-dot" aria-hidden="true"></span>
+              <span>{vmStreamStatus.mode}</span>
+              {#if vmStreamStatus.mode !== "streaming" && vmStreamStatus.lastUpdateAt != null}
+                <span class="vm-stream-age"
+                  >updated {formatAge(
+                    vmStreamNow - vmStreamStatus.lastUpdateAt,
+                  )}</span
+                >
+              {/if}
+            </span>
             {#if statusClass(selectedSession) !== "completed"}
               <span class={`session-state ${statusClass(selectedSession)}`}
                 >{statusLabel(selectedSession)}</span
@@ -2186,6 +2276,36 @@
   .vm-chip.vm-asleep {
     color: var(--info);
     background: var(--info-soft);
+  }
+  .vm-stream-state {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: var(--size-meta);
+    white-space: nowrap;
+  }
+  .vm-stream-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: var(--radius-circle);
+    background: var(--dot-idle);
+  }
+  .vm-stream-state.polling {
+    color: var(--text-soft);
+  }
+  .vm-stream-state.polling .vm-stream-dot {
+    background: var(--attn);
+  }
+  .vm-stream-state.stalled {
+    color: var(--err);
+  }
+  .vm-stream-state.stalled .vm-stream-dot {
+    background: var(--err);
+  }
+  .vm-stream-age {
+    color: inherit;
   }
   .session-state.warn {
     color: var(--attn-text);

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -142,7 +142,7 @@
   let renderedPending = $state({});
   let vms = $state({});
   let vmStreamStatus = $state({
-    mode: "stalled",
+    mode: "connecting",
     lastUpdateAt: null,
     error: null,
   });
@@ -661,12 +661,13 @@
         return;
       }
       if (body == null) throw new Error("Invalid VM state response");
-      const status = updateVmStreamStatus({
+      updateVmStreamStatus({
         type: "poll-ok",
         at: Date.now(),
         error: body?.error ?? null,
       });
-      if (status.mode === "polling") vms = body?.vms ?? {};
+      // Apply every backend map regardless of indicator mode; see router.py:246-254.
+      vms = body?.vms ?? {};
     } catch (error) {
       // VM state is advisory; keep the last known map on transient failures.
       if (!vmFallbackArmed) return;
@@ -1070,7 +1071,8 @@
   // The clock only refreshes the displayed age. It never changes connection
   // mode, which is driven exclusively by stream and fallback events.
   $effect(() => {
-    if (vmStreamStatus.mode === "streaming") return;
+    if (vmStreamStatus.mode !== "polling" && vmStreamStatus.mode !== "stalled")
+      return;
     vmStreamNow = Date.now();
     const interval = setInterval(() => {
       vmStreamNow = Date.now();
@@ -1117,12 +1119,13 @@
       stopFallback();
       try {
         const body = JSON.parse(event.data);
-        const status = updateVmStreamStatus({
+        updateVmStreamStatus({
           type: "frame",
           at: Date.now(),
           error: body?.error ?? null,
         });
-        if (status.mode === "streaming") vms = body?.vms ?? {};
+        // Apply every backend map regardless of indicator mode; see router.py:246-254.
+        vms = body?.vms ?? {};
       } catch (error) {
         // Retain the last snapshot and expose that the advisory frame failed.
         updateVmStreamStatus({
@@ -1341,19 +1344,39 @@
             >
             <span
               class={`vm-stream-state ${vmStreamStatus.mode}`}
-              title={vmStreamStatus.error
-                ? `VM state updates stalled: ${vmStreamStatus.error}`
-                : `VM state updates: ${vmStreamStatus.mode}`}
+              title={vmStreamStatus.mode === "connecting"
+                ? "VM state stream connecting"
+                : vmStreamStatus.mode === "streaming"
+                  ? "VM state stream connected"
+                  : vmStreamStatus.mode === "polling"
+                    ? `VM state fallback polling${vmStreamStatus.lastUpdateAt != null ? `, updated ${formatAge(vmStreamNow - vmStreamStatus.lastUpdateAt)}` : ""}`
+                    : `VM state updates stalled${vmStreamStatus.error ? `: ${vmStreamStatus.error}` : ""}`}
             >
               <span class="vm-stream-dot" aria-hidden="true"></span>
-              <span>{vmStreamStatus.mode}</span>
-              {#if vmStreamStatus.mode !== "streaming" && vmStreamStatus.lastUpdateAt != null}
-                <span class="vm-stream-age"
+              {#if vmStreamStatus.mode === "polling" || vmStreamStatus.mode === "stalled"}
+                <span aria-hidden="true">{vmStreamStatus.mode}</span>
+              {/if}
+              {#if (vmStreamStatus.mode === "polling" || vmStreamStatus.mode === "stalled") && vmStreamStatus.lastUpdateAt != null}
+                <span class="vm-stream-age" aria-hidden="true"
                   >updated {formatAge(
                     vmStreamNow - vmStreamStatus.lastUpdateAt,
                   )}</span
                 >
               {/if}
+              <span class="sr-only">
+                {#if vmStreamStatus.mode === "connecting"}
+                  VM state connecting...
+                {:else if vmStreamStatus.mode === "streaming"}
+                  VM state stream connected
+                {:else if vmStreamStatus.mode === "polling"}
+                  VM state fallback polling{#if vmStreamStatus.lastUpdateAt != null},
+                    updated {formatAge(
+                      vmStreamNow - vmStreamStatus.lastUpdateAt,
+                    )}{/if}
+                {:else}
+                  VM state updates stalled{#if vmStreamStatus.error}: {vmStreamStatus.error}{/if}
+                {/if}
+              </span>
             </span>
             {#if statusClass(selectedSession) !== "completed"}
               <span class={`session-state ${statusClass(selectedSession)}`}

--- a/projects/monolith/frontend/src/routes/private/agents/vm-stream-status.js
+++ b/projects/monolith/frontend/src/routes/private/agents/vm-stream-status.js
@@ -2,10 +2,25 @@ const hasError = (event) => event.error != null && event.error !== "";
 
 export function nextStatus(prev, event) {
   const current = {
-    mode: prev?.mode ?? "stalled",
+    mode: prev?.mode ?? "connecting",
     lastUpdateAt: prev?.lastUpdateAt ?? null,
     error: prev?.error ?? null,
   };
+
+  if (current.mode === "connecting") {
+    switch (event?.type) {
+      case "fallback-armed":
+        return { ...current, mode: "polling" };
+      case "open":
+      case "frame":
+      case "poll-ok":
+      case "poll-fail":
+      case "closed":
+        break;
+      default:
+        return current;
+    }
+  }
 
   switch (event?.type) {
     case "open":

--- a/projects/monolith/frontend/src/routes/private/agents/vm-stream-status.js
+++ b/projects/monolith/frontend/src/routes/private/agents/vm-stream-status.js
@@ -1,0 +1,54 @@
+const hasError = (event) => event.error != null && event.error !== "";
+
+export function nextStatus(prev, event) {
+  const current = {
+    mode: prev?.mode ?? "stalled",
+    lastUpdateAt: prev?.lastUpdateAt ?? null,
+    error: prev?.error ?? null,
+  };
+
+  switch (event?.type) {
+    case "open":
+      return { ...current, mode: "streaming", error: null };
+    case "frame":
+      if (hasError(event)) {
+        return { ...current, mode: "stalled", error: event.error };
+      }
+      return {
+        mode: "streaming",
+        lastUpdateAt: event.at,
+        error: null,
+      };
+    case "poll-ok":
+      if (hasError(event)) {
+        return { ...current, mode: "stalled", error: event.error };
+      }
+      return {
+        mode: "polling",
+        lastUpdateAt: event.at,
+        error: null,
+      };
+    case "poll-fail":
+      return {
+        ...current,
+        mode: "stalled",
+        error: hasError(event) ? event.error : current.error,
+      };
+    case "closed":
+      return current.mode === "polling"
+        ? current
+        : { ...current, mode: "stalled" };
+    case "fallback-armed":
+      return { ...current, mode: current.error ? "stalled" : "polling" };
+    default:
+      return current;
+  }
+}
+
+export function formatAge(milliseconds) {
+  const elapsed = Math.max(0, Number(milliseconds) || 0);
+  if (elapsed < 60_000) return "just now";
+  if (elapsed < 3_600_000) return `${Math.floor(elapsed / 60_000)}m ago`;
+  if (elapsed < 86_400_000) return `${Math.floor(elapsed / 3_600_000)}h ago`;
+  return `${Math.floor(elapsed / 86_400_000)}d ago`;
+}

--- a/projects/monolith/frontend/src/routes/private/agents/vm-stream-status.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/vm-stream-status.test.js
@@ -1,0 +1,130 @@
+import { describe, expect, test, vi } from "vitest";
+import { formatAge, nextStatus } from "./vm-stream-status.js";
+
+const initial = () => ({ mode: "stalled", lastUpdateAt: null, error: null });
+
+describe("VM stream status", () => {
+  test("moves from open to a successful streaming frame", () => {
+    const opened = nextStatus(initial(), { type: "open" });
+    const framed = nextStatus(opened, { type: "frame", at: 1_000 });
+
+    expect(opened.mode).toBe("streaming");
+    expect(framed).toEqual({
+      mode: "streaming",
+      lastUpdateAt: 1_000,
+      error: null,
+    });
+  });
+
+  test("treats an error payload as stalled even though a frame arrived", () => {
+    const status = nextStatus(
+      { mode: "streaming", lastUpdateAt: 1_000, error: null },
+      { type: "frame", at: 2_000, error: "control plane unreachable" },
+    );
+
+    expect(status).toEqual({
+      mode: "stalled",
+      lastUpdateAt: 1_000,
+      error: "control plane unreachable",
+    });
+  });
+
+  test("moves to polling when the fallback is armed", () => {
+    expect(nextStatus(initial(), { type: "fallback-armed" }).mode).toBe(
+      "polling",
+    );
+  });
+
+  test("stalls after the stream closes and a fallback poll fails", () => {
+    const closed = nextStatus(
+      { mode: "streaming", lastUpdateAt: 1_000, error: null },
+      { type: "closed" },
+    );
+    const failed = nextStatus(closed, {
+      type: "poll-fail",
+      error: "request failed",
+    });
+
+    expect(closed.mode).toBe("stalled");
+    expect(failed.mode).toBe("stalled");
+  });
+
+  test("recovers from a failed poll", () => {
+    const failed = nextStatus(initial(), {
+      type: "poll-fail",
+      error: "request failed",
+    });
+    const recovered = nextStatus(failed, { type: "poll-ok", at: 2_000 });
+
+    expect(recovered).toEqual({
+      mode: "polling",
+      lastUpdateAt: 2_000,
+      error: null,
+    });
+  });
+
+  test("treats an error in a successful poll response as stalled", () => {
+    const status = nextStatus(initial(), {
+      type: "poll-ok",
+      at: 2_000,
+      error: "control plane unreachable",
+    });
+
+    expect(status).toEqual({
+      mode: "stalled",
+      lastUpdateAt: null,
+      error: "control plane unreachable",
+    });
+  });
+
+  test("advances the update time only for successful frames and polls", () => {
+    const framed = nextStatus(initial(), { type: "frame", at: 1_000 });
+    const errorFrame = nextStatus(framed, {
+      type: "frame",
+      at: 2_000,
+      error: "control plane unreachable",
+    });
+    const failedPoll = nextStatus(errorFrame, {
+      type: "poll-fail",
+      at: 3_000,
+      error: "request failed",
+    });
+    const successfulPoll = nextStatus(failedPoll, {
+      type: "poll-ok",
+      at: 4_000,
+    });
+
+    expect(errorFrame.lastUpdateAt).toBe(1_000);
+    expect(failedPoll.lastUpdateAt).toBe(1_000);
+    expect(successfulPoll.lastUpdateAt).toBe(4_000);
+  });
+
+  test("stays streaming through a long idle period with no frames", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-14T00:00:00Z"));
+      const status = nextStatus(initial(), { type: "open" });
+      vi.advanceTimersByTime(45 * 60_000);
+
+      expect(status.mode).toBe("streaming");
+      expect(status.lastUpdateAt).toBe(null);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("formatAge", () => {
+  test.each([
+    [0, "just now"],
+    [59_000, "just now"],
+    [60_000, "1m ago"],
+    [59 * 60_000, "59m ago"],
+    [60 * 60_000, "1h ago"],
+    [23 * 60 * 60_000, "23h ago"],
+    [24 * 60 * 60_000, "1d ago"],
+    [48 * 60 * 60_000, "2d ago"],
+  ])("formats %i milliseconds as %s", (milliseconds, expected) => {
+    expect(formatAge(milliseconds)).toBe(expected);
+  });
+});

--- a/projects/monolith/frontend/src/routes/private/agents/vm-stream-status.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/vm-stream-status.test.js
@@ -1,9 +1,45 @@
 import { describe, expect, test, vi } from "vitest";
 import { formatAge, nextStatus } from "./vm-stream-status.js";
 
-const initial = () => ({ mode: "stalled", lastUpdateAt: null, error: null });
+const initial = () => ({ mode: "connecting", lastUpdateAt: null, error: null });
 
 describe("VM stream status", () => {
+  test("stays connecting when the initial event is unknown", () => {
+    expect(nextStatus(undefined, { type: "unknown" })).toEqual(initial());
+  });
+
+  test("moves from initial connecting to streaming when the stream opens", () => {
+    expect(nextStatus(undefined, { type: "open" }).mode).toBe("streaming");
+  });
+
+  test("moves from initial connecting to streaming on a successful frame", () => {
+    expect(nextStatus(undefined, { type: "frame", at: 1_000 })).toEqual({
+      mode: "streaming",
+      lastUpdateAt: 1_000,
+      error: null,
+    });
+  });
+
+  test("moves from initial connecting to stalled on an error frame", () => {
+    expect(
+      nextStatus(undefined, {
+        type: "frame",
+        at: 1_000,
+        error: "control plane unreachable",
+      }),
+    ).toEqual({
+      mode: "stalled",
+      lastUpdateAt: null,
+      error: "control plane unreachable",
+    });
+  });
+
+  test("moves from initial connecting to polling when fallback is armed", () => {
+    expect(nextStatus(undefined, { type: "fallback-armed" }).mode).toBe(
+      "polling",
+    );
+  });
+
   test("moves from open to a successful streaming frame", () => {
     const opened = nextStatus(initial(), { type: "open" });
     const framed = nextStatus(opened, { type: "frame", at: 1_000 });


### PR DESCRIPTION
Closes #4612.

Three states rendered identically in the console: stream connected, stream dead with the 2s fallback polling, and both dead. The third is the dangerous one, because a frozen chip and a genuinely idle fleet looked the same.

## Why liveness cannot come from message timing

Two properties of the existing stream rule out the obvious approach, and both are load-bearing:

- `_publish_vm_map` wakes subscribers **only when the map or the error actually changed**. A healthy idle fleet legitimately sends zero frames for an unbounded time, so "no message in N seconds means stalled" would fire constantly on a working console.
- The 15s heartbeat is `": ping\n\n"`, an SSE **comment**. It keeps the connection warm at the transport layer and never fires `onmessage`. `_run_vm_refresher` documents this exact trap: the connection looks healthy, no message arrives, and the fallback never engages.

So connection state is derived from `EventSource.readyState` and whether the fallback is armed, never from timing. A test asserts that a long idle period while streaming does not change the mode; that is the assertion that stops a time-based heuristic being reintroduced later.

## What this adds

A pure reducer in `vm-stream-status.js` (`nextStatus(prev, event)` plus `formatAge`), with the component holding the state and feeding it events from the stream handlers. Four modes: `connecting`, `streaming`, `polling`, `stalled`.

The `error` field that both `/vms` and every SSE frame already carried is now read instead of discarded, and `source.onopen` is wired as the positive signal for `streaming`.

Rendering is quiet, as the issue requires: an availability hint, not an alert. While streaming, only a muted dot renders. The mode label and the "updated 4m ago" age appear only when `polling` or `stalled`, because showing an age during healthy idle operation would read as a problem and reproduce the very confusion this issue is about. An `sr-only` span carries the full state for screen readers in all four modes.

## The map is applied unconditionally, on purpose

An earlier revision of this change gated `vms = body.vms ?? {}` on the connection being healthy. That inverts a deliberate backend guarantee. On a control plane failure `router.py` publishes an **empty** map alongside the error, and says why:

> Drop the map rather than serving the last known one. A stale entry renders as a confident "awake" chip for a guest that may be long gone, where an absent entry renders "off" alongside the error. Losing the CP means we do not know, and the honest rendering of not knowing is the one the console already had.

Gating the assignment would have kept painting confident "awake" chips for guests that may be gone, during exactly the outage this change exists to surface. Both assignment sites carry a comment saying so. The status indicator decides what to say; it never decides whether the map is applied.

## Not this issue

Reconnect strategy and fallback backoff are untouched, per the issue.

## Verification

- `ci lint` clean.
- `//projects/monolith/frontend:test` and `:build_test` with `--nocache_test_results`: `Executed 2 out of 2 tests: 2 tests pass`, including `vm-stream-status.test.js (21 tests)`.

## Not verified

The degraded modes have not been exercised against a real control plane outage. The reducer is covered by unit tests, but nothing here proves the console renders sensibly during an actual EmberVM failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)