### PR TITLE
feat(agents): explain a degraded workspace restore in the transcript

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -27,6 +27,10 @@
   import { setupVisualViewport } from "./visual-viewport.js";
   import { formatAge, nextStatus } from "./vm-stream-status.js";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
+  import {
+    workspaceRecoveryMessage,
+    workspaceRecoveryTitle,
+  } from "./workspace-recovery.js";
   import PaneHeader from "./PaneHeader.svelte";
   import SessionWalkthrough from "./SessionWalkthrough.svelte";
   import { periodForHour } from "$lib/private/period.js";
@@ -1490,6 +1494,15 @@
                   >{/if}
               </div>
             </article>
+            {@const degradedCause = workspaceRecoveryMessage(turn)}
+            {#if degradedCause}
+              <div
+                class="turn-degraded"
+                title={P.workspaceRecoveryCauses[degradedCause]}
+              >
+                {P.labels.workspaceRecovery}
+              </div>
+            {/if}
           {/each}
 
           {#each detail?.pending_queue ?? [] as entry, index (entry.seq)}
@@ -2529,6 +2542,21 @@
     color: var(--err);
     white-space: pre-wrap;
     overflow-wrap: anywhere;
+    line-height: 1.5;
+  }
+  /* --attn-text, not --attn: --attn on --attn-soft is 4.09:1 in the day
+     palette and 3.91:1 at night, both under the 4.5:1 AA floor for body
+     text. --attn-text is the role token for text on this fill, at 6.01:1
+     and 7.34:1. The border keeps --attn, where the 3:1 UI-boundary floor
+     applies. Same pairing as .session-state.warn. */
+  .turn-degraded {
+    margin: 8px 0 0;
+    padding: 8px 12px;
+    background: var(--attn-soft);
+    border: 4px solid var(--attn);
+    border-radius: var(--radius-lg);
+    color: var(--attn-text);
+    font-size: var(--size-meta);
     line-height: 1.5;
   }
   .turn-meta {

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -127,6 +127,11 @@ export const RUN_LEXICON = {
     loadingSession: "Loading session…",
     loadingRun: "Loading run…",
     turnFailed: "failed",
+    // One visible sentence for every degrade: the user consequence is the same
+    // in all three cases. The differing cause is carried in the title instead
+    // (see workspaceRecoveryCauses), so the transcript stays plain.
+    workspaceRecovery:
+      "The agent started with an empty workspace and cannot see files or changes from earlier turns.",
     promptIntent: "intent",
     viewProtocol: "view protocol",
     hideProtocol: "hide protocol",
@@ -195,6 +200,20 @@ export const RUN_LEXICON = {
     walkLoading: "loading…",
   },
   punct: { dot: "·", arrow: "→", colon: ":" },
+  // Operator-register detail for a degraded workspace restore, surfaced as the
+  // banner's title. Keyed by the message key workspace-recovery.js returns.
+  // This console is repo-facing, so naming the backend cause is the right
+  // register here (docs/writing.md) while the visible sentence stays plain.
+  // These must stay distinct: identical strings would make the three keys
+  // pointless and leave the cause unrecoverable from the UI.
+  workspaceRecoveryCauses: {
+    workspaceRecoveryRestoreDenied:
+      "restore_denied: the restore request was denied or timed out, so this turn fell back to a blank session",
+    workspaceRecoveryRestoreFallback:
+      "restore_fallback: the session was created but the control plane reported the workspace was not restored",
+    workspaceRecoveryUnknown:
+      "the control plane reported a workspace degrade this console does not recognise",
+  },
   deviationCodes: {
     retry_taken: "retry taken",
     budget_exceeded: "budget exceeded",

--- a/projects/monolith/frontend/src/routes/private/agents/workspace-recovery.js
+++ b/projects/monolith/frontend/src/routes/private/agents/workspace-recovery.js
@@ -1,0 +1,30 @@
+export function workspaceRecoveryMessage(turnOrUsage) {
+  const usage = turnOrUsage?.usage ?? turnOrUsage;
+  const degraded = usage?.workspace_recovery?.degraded;
+
+  if (degraded == null) return null;
+
+  if (degraded === "restore_denied") {
+    return "workspaceRecoveryRestoreDenied";
+  }
+  if (degraded === "restore_fallback") {
+    return "workspaceRecoveryRestoreFallback";
+  }
+  return typeof degraded === "string" ? "workspaceRecoveryUnknown" : null;
+}
+
+export function workspaceRecoveryTitle(turnOrUsage) {
+  const usage = turnOrUsage?.usage ?? turnOrUsage;
+  const degraded = usage?.workspace_recovery?.degraded;
+
+  if (degraded === "restore_denied") {
+    return "Workspace restore create was denied or timed out";
+  }
+  if (degraded === "restore_fallback") {
+    return "Workspace restore completed without restoring the session";
+  }
+  if (typeof degraded === "string") {
+    return "Workspace degradation cause unknown";
+  }
+  return null;
+}

--- a/projects/monolith/frontend/src/routes/private/agents/workspace-recovery.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/workspace-recovery.test.js
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "vitest";
+import {
+  workspaceRecoveryMessage,
+  workspaceRecoveryTitle,
+} from "./workspace-recovery.js";
+
+describe("workspaceRecoveryMessage", () => {
+  test("returns null without workspace recovery data", () => {
+    expect(workspaceRecoveryMessage({ usage: {} })).toBeNull();
+  });
+
+  test("returns null when recovery was not degraded", () => {
+    expect(
+      workspaceRecoveryMessage({
+        workspace_recovery: { created: true, restored: true, degraded: null },
+      }),
+    ).toBeNull();
+  });
+
+  test("maps a denied restore", () => {
+    expect(
+      workspaceRecoveryMessage({
+        usage: {
+          workspace_recovery: {
+            created: true,
+            restored: false,
+            degraded: "restore_denied",
+          },
+        },
+      }),
+    ).toBe("workspaceRecoveryRestoreDenied");
+  });
+
+  test("maps a restore fallback", () => {
+    expect(
+      workspaceRecoveryMessage({
+        workspace_recovery: {
+          created: true,
+          restored: false,
+          degraded: "restore_fallback",
+        },
+      }),
+    ).toBe("workspaceRecoveryRestoreFallback");
+  });
+
+  test("maps an unknown degraded value", () => {
+    expect(
+      workspaceRecoveryMessage({
+        workspace_recovery: { degraded: "future_degraded_state" },
+      }),
+    ).toBe("workspaceRecoveryUnknown");
+  });
+
+  test("returns null when a turn has no usage", () => {
+    expect(workspaceRecoveryMessage({ seq: 1 })).toBeNull();
+  });
+
+  test.each([null, undefined])("returns null for %s", (turn) => {
+    expect(workspaceRecoveryMessage(turn)).toBeNull();
+  });
+});
+
+describe("workspaceRecoveryTitle", () => {
+  test("returns null without workspace recovery data", () => {
+    expect(workspaceRecoveryTitle({ usage: {} })).toBeNull();
+  });
+
+  test("returns null when recovery was not degraded", () => {
+    expect(
+      workspaceRecoveryTitle({
+        workspace_recovery: { created: true, restored: true, degraded: null },
+      }),
+    ).toBeNull();
+  });
+
+  test("provides title for denied restore", () => {
+    expect(
+      workspaceRecoveryTitle({
+        usage: {
+          workspace_recovery: {
+            created: true,
+            restored: false,
+            degraded: "restore_denied",
+          },
+        },
+      }),
+    ).toBe("Workspace restore create was denied or timed out");
+  });
+
+  test("provides title for restore fallback", () => {
+    expect(
+      workspaceRecoveryTitle({
+        workspace_recovery: {
+          created: true,
+          restored: false,
+          degraded: "restore_fallback",
+        },
+      }),
+    ).toBe("Workspace restore completed without restoring the session");
+  });
+
+  test("provides generic title for unknown degraded value", () => {
+    expect(
+      workspaceRecoveryTitle({
+        workspace_recovery: { degraded: "future_degraded_state" },
+      }),
+    ).toBe("Workspace degradation cause unknown");
+  });
+
+  test("returns null when a turn has no usage", () => {
+    expect(workspaceRecoveryTitle({ seq: 1 })).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #4329.

When a restore degrades, the transport falls back to a blank session and the turn still succeeds, so the user meets an agent with amnesia and no explanation.

## Most of this issue already shipped

The issue body is stale. Scoping it found:

- **Persistence: already done.** `store.py:547-548` writes `usage["workspace_recovery"]` into `usage_json`, assembled in `transport.py` and covered by four tests at `transport_test.py:804-879`.
- **API exposure: already done.** `router.py:466` returns the whole `usage` blob, so `workspace_recovery` already reached the client.
- **The dead `statusClass` branches: already fixed.** `status.js` no longer tests for `error` / `failed` / `failure`.

So this is frontend only. No migration, no schema change, no Python. The column-versus-`usage_json` question in the issue is moot for the banner; the only thing a column would add is queryability, which is filed separately.

## Placement and register

Rendered inline per turn inside the existing turn loop, not as a session-level banner. A degraded restore is a property of the specific turn whose workspace was lost, so the explanation belongs at the point in the transcript where the amnesia starts.

Attention register, not error. The turn succeeded: `transport.py` deliberately falls back to a blank session rather than failing it, so styling it like `.turn-error` would misreport a working degradation as a failure.

## Contrast

The banner uses `color: var(--attn-text)`, not `var(--attn)`. Measured against `--attn-soft`:

| | `--attn` | `--attn-text` |
|---|---|---|
| day | 4.09:1 | 6.01:1 |
| night | 3.91:1 | 7.34:1 |

`--attn` fails the 4.5:1 AA floor for body text in both periods. `agents-theme.css` documents this exact pairing as the reason `--attn-text` exists, and `.session-state.warn` already uses the correct combination. The border keeps `--attn`, where the 3:1 UI-boundary floor applies.

## Copy

One visible sentence covers all three degrades, because the user consequence is identical in each:

> The agent started with an empty workspace and cannot see files or changes from earlier turns.

The differing cause is carried in the `title`, in operator register, since this console is a repo-facing surface. Three distinct strings naming `restore_denied`, `restore_fallback`, and the unrecognised case. An unknown degrade renders the generic message rather than nothing, so a new backend state cannot silently reintroduce the invisibility this issue is about.

Joe writes final wording; treat the sentence above as a draft.

## Verification

- `ci lint` clean.
- `//projects/monolith/frontend:test` and `:build_test` with `--nocache_test_results`: `Executed 2 out of 2 tests: 2 tests pass`, including `workspace-recovery.test.js (14 tests)`.
- Separately verified that every lexicon reference the template makes actually resolves, and that the three titles are distinct. `build_test` cannot catch this: an undefined property lookup is a runtime miss, not a template syntax error, so a missing lexicon key compiles green and renders `undefined`.

## Not verified

The banner has not been seen against real degraded data. No session in the current database is known to carry `workspace_recovery.degraded`, so this is verified by unit test and by reasoning about the payload shape, not by observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)