### PR TITLE
test(embervm): harden noded failure coverage

### DIFF
--- a/projects/embervm/noded/egress/forwarder_test.go
+++ b/projects/embervm/noded/egress/forwarder_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -95,6 +96,17 @@ func TestEgressListenPath(t *testing.T) {
 	want := "/run/vsock.sock_" + itoa(int(vsockproto.EgressPort))
 	if got != want {
 		t.Fatalf("egressListenPath = %q, want %q", got, want)
+	}
+}
+
+func TestServeEgressReturnsListenFailure(t *testing.T) {
+	udsPath := filepath.Join(t.TempDir(), "missing", "vsock.sock")
+	err := ServeEgress(context.Background(), slog.Default(), udsPath, "127.0.0.1:1")
+	if err == nil {
+		t.Fatal("ServeEgress should fail when the socket parent does not exist")
+	}
+	if !strings.Contains(err.Error(), "listen") {
+		t.Fatalf("ServeEgress error = %v, want listen context", err)
 	}
 }
 

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -21,9 +21,11 @@ import (
 // the snapfile + memfile to disk so the bundle layout and Restore's existence
 // checks are exercised end to end.
 type fakeLauncher struct {
-	mu       sync.Mutex
-	launched int
-	requests []string
+	mu        sync.Mutex
+	launched  int
+	requests  []string
+	failPath  string
+	processes []*fakeProcess
 }
 
 type fakeProcess struct {
@@ -46,13 +48,17 @@ func (l *fakeLauncher) Launch(_ context.Context, _ string, socketPath string) (P
 		return nil, err
 	}
 	mux := http.NewServeMux()
-	record := func(r *http.Request) {
+	record := func(r *http.Request) bool {
 		l.mu.Lock()
+		defer l.mu.Unlock()
 		l.requests = append(l.requests, r.Method+" "+r.URL.Path)
-		l.mu.Unlock()
+		return l.failPath != "" && r.URL.Path == l.failPath
 	}
 	mux.HandleFunc("/snapshot/create", func(w http.ResponseWriter, r *http.Request) {
-		record(r)
+		if record(r) {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		var body map[string]any
 		b, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(b, &body)
@@ -66,18 +72,39 @@ func (l *fakeLauncher) Launch(_ context.Context, _ string, socketPath string) (P
 		w.WriteHeader(http.StatusNoContent)
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		record(r)
+		if record(r) {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		w.WriteHeader(http.StatusNoContent)
 	})
 	srv := &http.Server{Handler: mux}
 	go func() { _ = srv.Serve(ln) }()
-	return &fakeProcess{srv: srv}, nil
+	proc := &fakeProcess{srv: srv}
+	l.mu.Lock()
+	l.processes = append(l.processes, proc)
+	l.mu.Unlock()
+	return proc, nil
 }
 
 func (l *fakeLauncher) requestPaths() []string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return append([]string(nil), l.requests...)
+}
+
+func (l *fakeLauncher) allProcessesKilled() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.processes) == 0 {
+		return false
+	}
+	for _, proc := range l.processes {
+		if !proc.killed {
+			return false
+		}
+	}
+	return true
 }
 
 // shortTempDir returns a temp dir under /tmp with a short path. The fake
@@ -146,6 +173,67 @@ func TestDriverClaimBootsMicroVM(t *testing.T) {
 	}
 	if d.LiveCount() != 1 {
 		t.Fatalf("LiveCount = %d, want 1", d.LiveCount())
+	}
+}
+
+func TestDriverColdBootAPIFailureKillsPartialVM(t *testing.T) {
+	for _, failPath := range []string{"/machine-config", "/boot-source", "/drives/rootfs", "/vsock", "/actions"} {
+		t.Run(failPath, func(t *testing.T) {
+			launcher := &fakeLauncher{failPath: failPath}
+			d := New(Config{
+				KernelImagePath: "/opt/kata/vmlinux",
+				RootfsPath:      "/dev/mapper/thread",
+				SnapshotRoot:    shortTempDir(t),
+				Node:            "node-4",
+				Arch:            "amd64",
+			}, launcher, nil)
+			if _, err := d.Claim(context.Background(), substrate.ClaimSpec{ThreadID: "partial"}); err == nil {
+				t.Fatal("Claim should fail when Firecracker rejects a boot API request")
+			}
+			if d.LiveCount() != 0 {
+				t.Fatalf("failed Claim left %d live VMs, want 0", d.LiveCount())
+			}
+			if !launcher.allProcessesKilled() {
+				t.Fatal("failed Claim did not kill the launched Firecracker process")
+			}
+		})
+	}
+}
+
+func TestDriverWarmRestoreAPIFailureKillsPartialVM(t *testing.T) {
+	for _, failPath := range []string{"/snapshot/load", "/drives/volume", "/vm"} {
+		t.Run(failPath, func(t *testing.T) {
+			launcher := &fakeLauncher{failPath: failPath}
+			root := shortTempDir(t)
+			d := New(Config{
+				KernelImagePath:       "/opt/kata/vmlinux",
+				RootfsPath:            "/dev/mapper/thread",
+				SnapshotRoot:          root,
+				Node:                  "node-4",
+				Arch:                  "amd64",
+				WarmRestoreWithVolume: true,
+			}, launcher, nil)
+			if err := os.MkdirAll(d.baseDir("base"), 0o750); err != nil {
+				t.Fatalf("mkdir base: %v", err)
+			}
+			if err := os.WriteFile(d.baseSnapfile("base"), []byte("snap"), 0o600); err != nil {
+				t.Fatalf("write snapfile: %v", err)
+			}
+			_, err := d.Claim(context.Background(), substrate.ClaimSpec{
+				ThreadID:        "partial-restore",
+				BaseSnapshotRef: substrate.SnapshotRef{ID: "base", Arch: "amd64"},
+				VolumeDiskPath:  "/sessions/s1/workspace.img",
+			})
+			if err == nil {
+				t.Fatal("Claim should fail when Firecracker rejects a restore API request")
+			}
+			if d.LiveCount() != 0 {
+				t.Fatalf("failed restore left %d live VMs, want 0", d.LiveCount())
+			}
+			if !launcher.allProcessesKilled() {
+				t.Fatal("failed restore did not kill the launched Firecracker process")
+			}
+		})
 	}
 }
 

--- a/projects/embervm/noded/fcvm/fcclient/client_test.go
+++ b/projects/embervm/noded/fcvm/fcclient/client_test.go
@@ -3,6 +3,7 @@ package fcclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -10,16 +11,18 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 )
 
 // fakeFC is an in-process Firecracker API stub listening on a unix socket. It
 // records every request so tests can assert the controller drives the API in
 // the right order with the right bodies.
 type fakeFC struct {
-	mu       sync.Mutex
-	requests []recordedReq
-	srv      *http.Server
-	failPath string // if set, return 400 for this path
+	mu        sync.Mutex
+	requests  []recordedReq
+	srv       *http.Server
+	failPath  string // if set, return 400 for this path
+	blockPath string // if set, wait for request cancellation on this path
 }
 
 type recordedReq struct {
@@ -46,7 +49,12 @@ func startFakeFC(t *testing.T) (*fakeFC, string) {
 		f.mu.Lock()
 		f.requests = append(f.requests, recordedReq{Method: r.Method, Path: r.URL.Path, Body: body})
 		fail := f.failPath != "" && r.URL.Path == f.failPath
+		block := f.blockPath != "" && r.URL.Path == f.blockPath
 		f.mu.Unlock()
+		if block {
+			<-r.Context().Done()
+			return
+		}
 		if fail {
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte(`{"fault_message":"boom"}`))
@@ -196,6 +204,23 @@ func TestClientPropagatesAPIError(t *testing.T) {
 	}
 	if !contains(err.Error(), "status 400") || !contains(err.Error(), "boom") {
 		t.Fatalf("error = %v, want status 400 + fault message", err)
+	}
+}
+
+func TestClientHonorsRequestContextWhenAPINeverAnswers(t *testing.T) {
+	fake, sock := startFakeFC(t)
+	fake.blockPath = "/actions"
+	c := New(sock)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := c.Start(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Start error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Start returned after %v, want prompt context cancellation", elapsed)
 	}
 }
 

--- a/projects/embervm/noded/groupclock/clock_test.go
+++ b/projects/embervm/noded/groupclock/clock_test.go
@@ -38,7 +38,7 @@ func (c *fakeConn) SetWriteDeadline(time.Time) error { return nil }
 
 // fakeDialer returns a scripted fakeConn (or a dial error).
 type fakeDialer struct {
-	conn    *fakeConn
+	conn    net.Conn
 	dialErr error
 }
 
@@ -149,6 +149,34 @@ func TestResyncReadError(t *testing.T) {
 	err := Resync(context.Background(), dialer, "/uds", time.Now)
 	if err == nil {
 		t.Fatal("a read error (no response frame) must fail Resync")
+	}
+}
+
+func TestResyncSilentGuestHonorsDeadline(t *testing.T) {
+	host, guest := net.Pipe()
+	defer guest.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	requestRead := make(chan struct{})
+	go func() {
+		var req syncClockRequest
+		_ = readFrame(guest, &req)
+		close(requestRead)
+		<-ctx.Done()
+	}()
+
+	start := time.Now()
+	err := Resync(ctx, &fakeDialer{conn: host}, "/uds", time.Now)
+	if err == nil {
+		t.Fatal("a guest that never answers must fail Resync")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Resync returned after %v, want the context deadline to bound it", elapsed)
+	}
+	select {
+	case <-requestRead:
+	default:
+		t.Fatal("silent-guest test never delivered the sync request")
 	}
 }
 

--- a/projects/embervm/noded/guestagent/agent_test.go
+++ b/projects/embervm/noded/guestagent/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"testing"
+	"time"
 )
 
 // fakeClock is a table-testable Clock: SetRealtime records the last value (and
@@ -171,6 +172,51 @@ func TestServeReturnsOnClose(t *testing.T) {
 	_ = ln.Close()
 	if err := <-done; err == nil {
 		t.Fatal("expected Serve to return an error after listener close")
+	}
+}
+
+func TestServeStalledPeerDoesNotBlockAnotherConnection(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	clock := &fakeClock{readBack: 99}
+	agent := New(clock, nil)
+	go func() { _ = agent.Serve(ln) }()
+
+	stalled, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial stalled peer: %v", err)
+	}
+	defer stalled.Close()
+
+	active, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial active peer: %v", err)
+	}
+	defer active.Close()
+	if err := active.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set active deadline: %v", err)
+	}
+	body, err := json.Marshal(request{Cmd: syncClockCmd, EpochNs: 42})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if err := writeFrame(active, body); err != nil {
+		t.Fatalf("write active frame: %v", err)
+	}
+	respBody, err := readFrame(active)
+	if err != nil {
+		t.Fatalf("read active response while another peer is stalled: %v", err)
+	}
+	var resp response
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Err != "" || resp.ClockRealtimeNs != 99 {
+		t.Fatalf("response = %+v, want clock 99 with no error", resp)
 	}
 }
 

--- a/projects/embervm/noded/server/activator_test.go
+++ b/projects/embervm/noded/server/activator_test.go
@@ -17,6 +17,19 @@ import (
 
 type activatorRoundTripper func(*http.Request) (*http.Response, error)
 
+var activatorHopByHopHeaders = []string{
+	"Content-Length",
+	"Transfer-Encoding",
+	"Connection",
+	"Keep-Alive",
+	"Upgrade",
+	"Host",
+	"Te",
+	"Trailer",
+	"Proxy-Authorization",
+	"Proxy-Authenticate",
+}
+
 func (f activatorRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
@@ -126,7 +139,7 @@ func TestActivatorColdBootAndProxyFiltersHeaders(t *testing.T) {
 	})}
 	req := httptest.NewRequest(http.MethodPost, "/invoke", bytes.NewBufferString("request body"))
 	req.Header.Set("x-ember-workload", "wl-serve")
-	for denied := range activatorDeniedHeaders {
+	for _, denied := range activatorHopByHopHeaders {
 		req.Header.Set(denied, "removed")
 	}
 	rec := httptest.NewRecorder()
@@ -141,7 +154,7 @@ func TestActivatorColdBootAndProxyFiltersHeaders(t *testing.T) {
 	if gotBody != "request body" {
 		t.Errorf("guest body = %q, want request body", gotBody)
 	}
-	for denied := range activatorDeniedHeaders {
+	for _, denied := range activatorHopByHopHeaders {
 		if forwarded.Get(denied) != "" {
 			t.Errorf("forwarded deny-listed header %q = %q", denied, forwarded.Get(denied))
 		}
@@ -155,12 +168,12 @@ func TestActivatorColdBootAndProxyFiltersHeaders(t *testing.T) {
 }
 
 func TestActivatorDenyListFiltersBothDirections(t *testing.T) {
-	headers := make(http.Header, len(activatorDeniedHeaders)+1)
-	for denied := range activatorDeniedHeaders {
+	headers := make(http.Header, len(activatorHopByHopHeaders)+1)
+	for _, denied := range activatorHopByHopHeaders {
 		headers.Set(denied, "removed")
 	}
 	headers.Set("X-Allowed", "kept")
-	for key := range activatorDeniedHeaders {
+	for _, key := range activatorHopByHopHeaders {
 		if got := allowedHeaders(headers).Get(key); got != "" {
 			t.Errorf("allowedHeaders retained %q = %q", key, got)
 		}
@@ -296,9 +309,17 @@ func TestActivatorAndControlPlaneOrigins(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("StartServing: %v", err)
 	}
+	var controlPlaneVM *nodev1.ServingVm
 	for _, vm := range s.servingVMsStatus() {
-		if vm.GetWorkload() == "cp-workload" && vm.GetOrigin() != nodev1.InstanceOrigin_INSTANCE_ORIGIN_CONTROL_PLANE {
-			t.Errorf("control-plane origin = %v, want CONTROL_PLANE", vm.GetOrigin())
+		if vm.GetWorkload() == "cp-workload" {
+			controlPlaneVM = vm
+			break
 		}
+	}
+	if controlPlaneVM == nil {
+		t.Fatal("control-plane StartServing did not publish a serving VM")
+	}
+	if controlPlaneVM.GetOrigin() != nodev1.InstanceOrigin_INSTANCE_ORIGIN_CONTROL_PLANE {
+		t.Errorf("control-plane origin = %v, want CONTROL_PLANE", controlPlaneVM.GetOrigin())
 	}
 }

--- a/projects/embervm/noded/server/stateful_activator_test.go
+++ b/projects/embervm/noded/server/stateful_activator_test.go
@@ -283,10 +283,18 @@ func TestStatefulActivatorAndControlPlaneOrigins(t *testing.T) {
 		t.Fatalf("StopStateful(destroy): %v", err)
 	}
 	startFreshStateful(t, s, port, "cp-workload")
+	var controlPlaneVM *nodev1.StatefulVm
 	for _, vm := range s.statefulVMsStatus() {
-		if vm.GetWorkload() == "cp-workload" && vm.GetOrigin() != nodev1.InstanceOrigin_INSTANCE_ORIGIN_CONTROL_PLANE {
-			t.Errorf("control-plane origin = %v, want CONTROL_PLANE", vm.GetOrigin())
+		if vm.GetWorkload() == "cp-workload" {
+			controlPlaneVM = vm
+			break
 		}
+	}
+	if controlPlaneVM == nil {
+		t.Fatal("control-plane StartStateful did not publish a stateful VM")
+	}
+	if controlPlaneVM.GetOrigin() != nodev1.InstanceOrigin_INSTANCE_ORIGIN_CONTROL_PLANE {
+		t.Errorf("control-plane origin = %v, want CONTROL_PLANE", controlPlaneVM.GetOrigin())
 	}
 }
 

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -442,10 +442,18 @@ func TestExportArtifactStateful(t *testing.T) {
 		t.Fatalf("store missing %q after export", prefix)
 	}
 	// NodeStatus reports the bundle exported.
+	var reported *nodev1.StatefulBundle
 	for _, b := range s.nodeStatus().GetStatefulBundles() {
-		if b.GetSnapshotRef() == ref && !b.GetExported() {
-			t.Fatal("stateful bundle should report exported=true")
+		if b.GetSnapshotRef() == ref {
+			reported = b
+			break
 		}
+	}
+	if reported == nil {
+		t.Fatal("exported stateful bundle is absent from NodeStatus")
+	}
+	if !reported.GetExported() {
+		t.Fatal("stateful bundle should report exported=true")
 	}
 }
 
@@ -473,7 +481,7 @@ func TestExportArtifactBaseReportsExported(t *testing.T) {
 	writeBundleFiles(t, dir, map[string]string{"imageref": "img", "memfile": "mem", "snapfile": "snap"})
 
 	// Before export, the base is present but NOT exported.
-	if exported := baseExportedInStatus(s, workload, ref); exported {
+	if exported := baseExportedInStatus(t, s, workload, ref); exported {
 		t.Fatal("base should report exported=false before export")
 	}
 
@@ -492,7 +500,7 @@ func TestExportArtifactBaseReportsExported(t *testing.T) {
 	}
 
 	// After export, the workload capacity reports exported=true.
-	if exported := baseExportedInStatus(s, workload, ref); !exported {
+	if exported := baseExportedInStatus(t, s, workload, ref); !exported {
 		t.Fatal("base should report exported=true after export")
 	}
 
@@ -618,10 +626,10 @@ func TestExportArtifactBaseSkipsWhenSiblingVendorCopyExists(t *testing.T) {
 
 	// The queue worker settles into "already durable" and flips the exported flag.
 	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) && !baseExportedInStatus(s, workload, ref) {
+	for time.Now().Before(deadline) && !baseExportedInStatus(t, s, workload, ref) {
 		time.Sleep(5 * time.Millisecond)
 	}
-	if !baseExportedInStatus(s, workload, ref) {
+	if !baseExportedInStatus(t, s, workload, ref) {
 		t.Fatal("base should report exported=true once a same-vendor sibling copy is durable")
 	}
 
@@ -757,10 +765,11 @@ func TestListArtifactsOmitsAnArtifactWithNoMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListArtifacts: %v", err)
 	}
-	for _, e := range resp.GetEntries() {
-		if e.GetRef() == "bazel-query__partial" {
-			t.Fatal("an artifact with no readable meta.json must be omitted, not reported")
-		}
+	if len(resp.GetEntries()) != 1 {
+		t.Fatalf("entries = %+v, want only the complete artifact", resp.GetEntries())
+	}
+	if got := resp.GetEntries()[0].GetRef(); got != "bazel-query__good" {
+		t.Fatalf("listed ref = %q, want bazel-query__good", got)
 	}
 }
 
@@ -1098,13 +1107,16 @@ func TestLocalBasesStatusReportsIncompleteRegisteredBaseAsAbsent(t *testing.T) {
 }
 
 // baseExportedInStatus finds the workload's capacity entry in NodeStatus whose
-// snapshot_ref matches and returns its exported flag; false if not reported.
-func baseExportedInStatus(s *Server, workload, ref string) bool {
+// snapshot_ref matches and returns its exported flag. A missing entry fails the
+// caller so a false assertion cannot pass on an absent capacity.
+func baseExportedInStatus(t *testing.T, s *Server, workload, ref string) bool {
+	t.Helper()
 	for _, wc := range s.nodeStatus().GetWorkloads() {
 		if wc.GetWorkload() == workload && wc.GetSnapshotRef() == ref {
 			return wc.GetExported()
 		}
 	}
+	t.Fatalf("workload capacity %q with snapshot_ref %q was not reported", workload, ref)
 	return false
 }
 

--- a/projects/embervm/noded/serving/probe_test.go
+++ b/projects/embervm/noded/serving/probe_test.go
@@ -1,7 +1,10 @@
 package serving
 
 import (
+	"context"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -100,5 +103,26 @@ func TestProbeHandleStartsHealthy(t *testing.T) {
 	}
 	if h.Result().LastProbeUnixMs == 0 {
 		t.Error("a freshly started probe handle should carry a last-probe timestamp")
+	}
+}
+
+func TestProbeOnceReportsHTTPAndTransportFailures(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ready" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	prober := NewProber(0, 0)
+	if !prober.probeOnce(context.Background(), server.URL+"/ready") {
+		t.Error("2xx health response should be healthy")
+	}
+	if prober.probeOnce(context.Background(), server.URL+"/unready") {
+		t.Error("non-2xx health response should be unhealthy")
+	}
+	server.Close()
+	if prober.probeOnce(context.Background(), server.URL+"/ready") {
+		t.Error("connection failure should be unhealthy")
 	}
 }

--- a/projects/embervm/noded/store/store_test.go
+++ b/projects/embervm/noded/store/store_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // fakeObjectStore is an in-memory S3-API stand-in: a map from object path
@@ -185,6 +186,32 @@ func TestRawRoundTrip(t *testing.T) {
 	// Get of an absent key is ErrNotPresent.
 	if _, _, err := s.Get(ctx, key); err != ErrNotPresent {
 		t.Fatalf("Get absent = %v, want ErrNotPresent", err)
+	}
+}
+
+func TestGetHonorsContextWhenStoreNeverAnswers(t *testing.T) {
+	requestStarted := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+	s := New(srv.URL, "embervm", false)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, _, err := s.Get(ctx, "stateful/wl/ref/snapfile")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Get error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Get returned after %v, want prompt context cancellation", elapsed)
+	}
+	select {
+	case <-requestStarted:
+	default:
+		t.Fatal("timeout test never reached the object store")
 	}
 }
 

--- a/projects/embervm/noded/volume/volume_test.go
+++ b/projects/embervm/noded/volume/volume_test.go
@@ -31,6 +31,13 @@ func TestSessionVolumePathsArePerLineageAndProvisioned(t *testing.T) {
 	if err := m.CreateSession("claude-runtime", "session-abc123", 2<<20); err != nil {
 		t.Fatalf("idempotent CreateSession: %v", err)
 	}
+	info, err = os.Stat(a)
+	if err != nil {
+		t.Fatalf("stat session image after repeat create: %v", err)
+	}
+	if info.Size() != 1<<20 {
+		t.Fatalf("repeat CreateSession resized workspace to %d, want original size %d", info.Size(), 1<<20)
+	}
 }
 
 func TestRetirementIntentIsDurableAndSeparateFromWorkspace(t *testing.T) {
@@ -49,6 +56,9 @@ func TestRetirementIntentIsDurableAndSeparateFromWorkspace(t *testing.T) {
 	}
 	if m.HasRetirementIntent("wl", "lineage") {
 		t.Fatal("retirement intent should be removable")
+	}
+	if _, err := os.Stat(m.SessionVolumePath("wl", "lineage")); err != nil {
+		t.Fatalf("clearing retirement intent changed the workspace: %v", err)
 	}
 }
 


### PR DESCRIPTION
Summary:
- make noded status and activator assertions fail when expected entries are absent
- cover partial Firecracker launch and restore cleanup, stalled store and guest calls, and probe failures
- strengthen header filtering and volume idempotency checks

Validation:
- gofumpt v0.9.2 applied to all changed files
- git diff --check passed
- bazel/tools/ci/ci test -- //projects/embervm/noded/... attempted, but no tests ran because BuildBuddy rejected the unauthenticated remote request with API key not set

This PR is draft because the required Linux Bazel test gate has not yet been verified.