### PR TITLE
fix(agents): stop the walkthrough contradicting an unavailable diff

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.svelte
@@ -55,6 +55,28 @@
   );
   const point = $derived(items[selected] ?? null);
 
+  function countLine(currentWalk) {
+    const parts = [
+      `${currentWalk.counts.accounted} ${P.labels.walkAccountedCount}`,
+      `${currentWalk.counts.unexplained} ${P.labels.walkUnexplainedCount}`,
+      `${currentWalk.counts.contradicted} ${P.labels.walkContradictedCount}`,
+    ];
+    if (currentWalk.counts.touched > 0) {
+      parts.push(`${currentWalk.counts.touched} ${P.labels.walkTouchedCount}`);
+    }
+    return joinMeta(...parts);
+  }
+
+  function headerCountLine(currentWalk) {
+    const parts = [countLine(currentWalk)];
+    if (currentWalk.rung <= 2) {
+      parts.push(
+        `${currentWalk.counts.files} ${currentWalk.counts.files === 1 ? P.labels.walkFileChanged : P.labels.walkFilesChanged}`,
+      );
+    }
+    return joinMeta(...parts);
+  }
+
   function basename(path) {
     return String(path || "")
       .split("/")
@@ -162,12 +184,7 @@
   <summary class="walk-summary">
     <span>{P.labels.walkSummary}</span>
     {#if walk}
-      <span class="walk-count"
-        >{joinMeta(
-          `${walk.counts.points} ${walk.counts.points === 1 ? P.labels.walkPointWord : P.labels.walkPointsWord}`,
-          `${walk.counts.files} ${walk.counts.files === 1 ? P.labels.walkFileChanged : P.labels.walkFilesChanged}`,
-        )}</span
-      >
+      <span class="walk-count">{headerCountLine(walk)}</span>
     {/if}
   </summary>
 
@@ -181,6 +198,28 @@
       >
     </div>
   {:else if walk}
+    {#if walk.summary?.status === "available"}
+      <div class="walk-fact">
+        {P.labels.walkSummaryDiffLead}{P.punct.colon}
+        {walk.summary.files}
+        {walk.summary.files === 1
+          ? P.labels.walkFileChanged
+          : P.labels.walkFilesChanged}, +{walk.summary.insertions}/&minus;{walk
+          .summary.deletions}{P.punct.dot}
+        {P.labels.walkSummaryAccountedLead}{P.punct.colon}
+        {walk.summary.accounted}
+        {walk.summary.accounted === 1
+          ? P.labels.walkFileWord
+          : P.labels.walkFilesWord}{P.punct.dot}
+        {P.labels.walkSummaryUnexplainedLead}{P.punct.colon}
+        {walk.summary.unexplained}
+        {walk.summary.unexplained === 1
+          ? P.labels.walkFileWord
+          : P.labels.walkFilesWord}{P.punct.dot}
+      </div>
+    {:else if walk.summary?.status === "diff_unavailable"}
+      <div class="walk-fact">{P.labels.walkSummaryDiffUnavailable}</div>
+    {/if}
     {#if walk.message}
       <div class="walk-fact">{walk.message}</div>
     {/if}
@@ -205,10 +244,7 @@
         <div class="wbody" class:drilled>
           <div class="points">
             <div class="pbband">
-              {joinMeta(
-                `${walk.counts.points} ${walk.counts.points === 1 ? P.labels.walkPointWord : P.labels.walkPointsWord}`,
-                `${walk.counts.files} ${walk.counts.files === 1 ? P.labels.walkFileChanged : P.labels.walkFilesChanged}`,
-              )}
+              {headerCountLine(walk)}
             </div>
             {#each items as item, index (`${item.kind}:${item.path}`)}
               <button

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -178,6 +178,15 @@ export const RUN_LEXICON = {
     walkFilesWord: "files",
     walkFileChanged: "file changed",
     walkFilesChanged: "files changed",
+    walkAccountedCount: "accounted for",
+    walkUnexplainedCount: "unexplained",
+    walkContradictedCount: "contradicted",
+    walkTouchedCount: "touched",
+    walkSummaryDiffLead: "Git diff",
+    walkSummaryAccountedLead: "Agent accounted for",
+    walkSummaryUnexplainedLead: "Unexplained",
+    walkSummaryDiffUnavailable:
+      "The diff is unavailable for this turn, so this is the agent's account only.",
     walkProvenanceLead: "Agent-authored.",
     walkProvenanceBody:
       "These points are the implementer's account of its own change. The diff beside them is from git.",

--- a/projects/monolith/frontend/src/routes/private/agents/walkthrough.js
+++ b/projects/monolith/frontend/src/routes/private/agents/walkthrough.js
@@ -12,7 +12,7 @@
 //   unexplained   {type, register:"fact", file_path, file_change, label}
 //   contradiction {type, register:"testimony", label, testimony}
 //   truncation    {type, register:"fact", label}
-// plus payload-level {rung, ephemeral, stats, message?}.
+// plus payload-level {rung, ephemeral, summary, stats, message?}.
 
 function testimonyPoints(step) {
   const points = step?.testimony?.points;
@@ -70,6 +70,17 @@ export function walkthroughView(payload, context = {}) {
   const steps = Array.isArray(payload?.steps) ? payload.steps : [];
   const stats = payload?.stats ?? {};
   const message = typeof payload?.message === "string" ? payload.message : "";
+  const summary =
+    payload?.summary != null && typeof payload.summary === "object"
+      ? {
+          status: payload.summary.status ?? null,
+          files: Number(payload.summary.files_changed || 0),
+          insertions: Number(payload.summary.insertions || 0),
+          deletions: Number(payload.summary.deletions || 0),
+          accounted: Number(payload.summary.accounted_files || 0),
+          unexplained: Number(payload.summary.unexplained_files || 0),
+        }
+      : null;
 
   const authored = steps.filter((step) => step.type === "authored");
   const unexplained = steps.filter((step) => step.type === "unexplained");
@@ -124,6 +135,12 @@ export function walkthroughView(payload, context = {}) {
   const explained = points.filter(
     (point) => point.kind === "authored" && point.why !== "",
   ).length;
+  const unexplainedCount = points.filter(
+    (point) => point.kind === "unexplained",
+  ).length;
+  const touchedCount = points.filter(
+    (point) => point.kind === "authored" && point.touched && point.why === "",
+  ).length;
   let additions = 0;
   let deletions = 0;
   for (const point of points) {
@@ -135,6 +152,7 @@ export function walkthroughView(payload, context = {}) {
     rung,
     ephemeral: payload?.ephemeral === true,
     message,
+    summary,
     points,
     mechanical: steps
       .filter((step) => step.type === "mechanical")
@@ -160,6 +178,11 @@ export function walkthroughView(payload, context = {}) {
     touched: Array.isArray(stats.activities) ? stats.activities : [],
     counts: {
       points: explained,
+      accounted: explained,
+      unexplained: unexplainedCount,
+      contradicted: steps.filter((step) => step.type === "contradiction")
+        .length,
+      touched: touchedCount,
       files: Number(stats.total_files ?? stats.authored_files ?? points.length),
       additions,
       deletions,

--- a/projects/monolith/frontend/src/routes/private/agents/walkthrough.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/walkthrough.test.js
@@ -22,6 +22,14 @@ function authored(path, additions, deletions, why = null) {
 const fullPayload = {
   rung: 1,
   ephemeral: false,
+  summary: {
+    status: "available",
+    files_changed: 146,
+    insertions: 100,
+    deletions: 16,
+    accounted_files: 2,
+    unexplained_files: 1,
+  },
   steps: [
     authored("swarm/policy.py", 46, 5, "routes on branch movement"),
     authored("swarm/workflows.py", 42, 8, "keeps the observed head"),
@@ -116,12 +124,37 @@ describe("walkthroughView rung 1", () => {
     expect(walk.hasTestimony).toBe(true);
   });
 
+  test("contradictions are counted even when there are no accounted files", () => {
+    const contradictions = Array.from({ length: 5 }, (_, index) => ({
+      type: "contradiction",
+      register: "testimony",
+      label: "Contradicted path",
+      testimony: {
+        turn: 1,
+        attempt: 1,
+        points: [{ path: `missing-${index}.py`, why: "named by the agent" }],
+      },
+    }));
+    const contradictedOnly = walkthroughView({
+      rung: 1,
+      steps: contradictions,
+    });
+
+    expect(contradictedOnly.counts.accounted).toBe(0);
+    expect(contradictedOnly.counts.unexplained).toBe(0);
+    expect(contradictedOnly.counts.contradicted).toBe(5);
+  });
+
   test("truncation renders as the server's labels, never silently", () => {
     expect(walk.truncations).toEqual(["GitHub files truncated"]);
   });
 
   test("counts: explained points, server file total, summed additions", () => {
     expect(walk.counts.points).toBe(2);
+    expect(walk.counts.accounted).toBe(2);
+    expect(walk.counts.unexplained).toBe(1);
+    expect(walk.counts.contradicted).toBe(1);
+    expect(walk.counts.touched).toBe(0);
     expect(walk.counts.files).toBe(146);
     expect(walk.counts.additions).toBe(46 + 42 + 12);
     expect(walk.counts.deletions).toBe(5 + 8 + 3);
@@ -133,6 +166,17 @@ describe("walkthroughView rung 1", () => {
     );
     const uncontexted = walkthroughView(fullPayload, {});
     expect(uncontexted.points[0].patchUrl).toBeNull();
+  });
+
+  test("passes through the server-composed factual summary", () => {
+    expect(walk.summary).toEqual({
+      status: "available",
+      files: 146,
+      insertions: 100,
+      deletions: 16,
+      accounted: 2,
+      unexplained: 1,
+    });
   });
 });
 
@@ -153,6 +197,7 @@ describe("walkthroughView degradation ladder", () => {
       {
         rung: 3,
         ephemeral: false,
+        summary: { status: "diff_unavailable" },
         steps: [
           {
             type: "authored",
@@ -185,6 +230,9 @@ describe("walkthroughView degradation ladder", () => {
     expect(walk.points[0].deviations).toEqual(["left the rollup untouched"]);
     expect(walk.points[0].patchUrl).toBeNull();
     expect(walk.points[1].touched).toBe(true);
+    expect(walk.counts.accounted).toBe(1);
+    expect(walk.counts.touched).toBe(1);
+    expect(walk.summary.status).toBe("diff_unavailable");
     expect(walk.message).toContain("Limited walkthrough");
   });
 

--- a/projects/monolith/swarm/compare_router.py
+++ b/projects/monolith/swarm/compare_router.py
@@ -11,10 +11,11 @@ from fastapi import APIRouter, HTTPException, Query
 
 from agent_sessions.rationale import parse_rationale
 
-router = APIRouter(prefix="/api/swarm/compare", tags=["swarm"])
+router = APIRouter(prefix="/compare", tags=["swarm"])
 
 _GITHUB_API = "https://api.github.com"
 _DEFAULT_REPO = "jomcgi/homelab"
+_COMPARE_BASE = "main"
 _CACHE_TTL_S = 90.0
 _cache: dict[str, tuple[float, dict]] = {}
 
@@ -160,13 +161,18 @@ async def compare_stats(session_id: int, turn_seq: int) -> dict:
         compare = await _compare(
             repo, base_sha, commit_sha, f"{base_sha}...{commit_sha}"
         )
+    elif branch == _COMPARE_BASE:
+        # A base branch compared with itself is not evidence of an empty
+        # change. Leave the diff unresolved so testimony is not contradicted
+        # by an artifact that was never available.
+        resolution_rung, diff_type = 3, None
     elif branch:
         branch_response = await _github_get(
             f"{_GITHUB_API}/repos/{repo}/branches/{quote(branch, safe='')}"
         )
         if branch_response.status_code == 200:
             resolution_rung, diff_type = 2, "branch_ephemeral"
-            compare = await _compare(repo, "main", branch, f"branch:{branch}")
+            compare = await _compare(repo, _COMPARE_BASE, branch, f"branch:{branch}")
 
     paths = {item["path"] for item in compare["files"]}
     # The cross-check is only meaningful against a diff we actually resolved.
@@ -228,6 +234,8 @@ async def compare_patch(session_id: int, turn_seq: int, path: str = Query(...)) 
             f"{data['base_sha']}...{data['commit_sha']}",
             include_patches=True,
         )
+    elif data["branch"] == _COMPARE_BASE:
+        raise HTTPException(status_code=404, detail="no_compare_available")
     elif data["branch"]:
         branch_response = await _github_get(
             f"{_GITHUB_API}/repos/{data['repo']}/branches/{quote(data['branch'], safe='')}"
@@ -236,7 +244,7 @@ async def compare_patch(session_id: int, turn_seq: int, path: str = Query(...)) 
             raise HTTPException(status_code=404, detail="no_compare_available")
         compare = await _compare(
             data["repo"],
-            "main",
+            _COMPARE_BASE,
             data["branch"],
             f"branch:{data['branch']}",
             include_patches=True,

--- a/projects/monolith/swarm/compare_router_test.py
+++ b/projects/monolith/swarm/compare_router_test.py
@@ -110,6 +110,31 @@ async def test_branch_and_absence_resolution(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_base_branch_is_not_treated_as_an_ephemeral_compare(monkeypatch):
+    mod._cache.clear()
+    calls = []
+
+    async def get(url):
+        calls.append(url)
+        return Response(200, _compare_payload())
+
+    monkeypatch.setattr(
+        mod,
+        "_turn_data",
+        lambda *_: _data(base_sha=None, commit_sha=None, branch="main"),
+    )
+    monkeypatch.setattr(mod, "_github_get", get)
+
+    result = await mod.compare_stats(1, 1)
+
+    assert result["resolution_rung"] == 3
+    assert result["cross_checked"] is False
+    assert result.get("contradicted_paths", []) == []
+    assert "contradicted_paths" not in result
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_truncation_activities_and_cross_checks(monkeypatch):
     mod._cache.clear()
     activities = [{"type": "edit", "file_path": "a.py"}] + [

--- a/projects/monolith/swarm/walkthrough_composer.py
+++ b/projects/monolith/swarm/walkthrough_composer.py
@@ -36,6 +36,43 @@ def _file_change(item: dict) -> dict:
     }
 
 
+def _agent_account_summary() -> dict:
+    return {
+        "status": "diff_unavailable",
+        "provenance": "agent_account_only",
+    }
+
+
+def _empty_summary() -> dict:
+    return {
+        "status": "not_available",
+        "provenance": "none",
+    }
+
+
+def _compare_summary(compare: dict, rationale: dict, files: list[dict]) -> dict:
+    changed_paths = {item["path"] for item in files}
+    account_paths = {
+        item.get("path")
+        for item in rationale.get("paths", [])
+        if isinstance(item, dict) and isinstance(item.get("path"), str)
+    }
+    unexplained_paths = {
+        path
+        for path in compare.get("unexplained_files", [])
+        if isinstance(path, str) and path in changed_paths
+    }
+    return {
+        "status": "available",
+        "provenance": "git_compare_and_agent_account",
+        "files_changed": int(compare.get("stats", {}).get("total_files", len(files))),
+        "insertions": sum(int(item.get("additions", 0) or 0) for item in files),
+        "deletions": sum(int(item.get("deletions", 0) or 0) for item in files),
+        "accounted_files": len(changed_paths & account_paths),
+        "unexplained_files": len(unexplained_paths),
+    }
+
+
 def _path_order(activities: list[dict]) -> list[str]:
     result = []
     for activity in activities:
@@ -99,6 +136,7 @@ def _rung4(activities: list[dict]) -> dict:
     return {
         "rung": 4,
         "ephemeral": False,
+        "summary": _empty_summary(),
         "steps": [],
         "stats": {
             "total_files": len(paths),
@@ -139,6 +177,7 @@ def compose_walkthrough(
         return {
             "rung": 5,
             "ephemeral": False,
+            "summary": _empty_summary(),
             "steps": [],
             "message": "No activity recorded",
         }
@@ -187,6 +226,7 @@ def compose_walkthrough(
         return {
             "rung": 3,
             "ephemeral": False,
+            "summary": _agent_account_summary(),
             "steps": steps,
             "stats": {"authored_files": len(_path_order(activities))},
             "message": "Limited walkthrough: testimony and activities only",
@@ -267,6 +307,7 @@ def compose_walkthrough(
     return {
         "rung": compare_rung,
         "ephemeral": compare_rung == 2,
+        "summary": _compare_summary(compare, rationale, files),
         "steps": steps,
         "stats": compare.get("stats", {}),
         **(

--- a/projects/monolith/swarm/walkthrough_composer_test.py
+++ b/projects/monolith/swarm/walkthrough_composer_test.py
@@ -39,6 +39,15 @@ def test_rungs_one_and_two_are_full_and_two_is_ephemeral():
     one = compose_walkthrough(1, 2, _compare(files), _rationale(["a.py"]), {})
     assert one["rung"] == 1
     assert one["ephemeral"] is False
+    assert one["summary"] == {
+        "status": "available",
+        "provenance": "git_compare_and_agent_account",
+        "files_changed": 1,
+        "insertions": 2,
+        "deletions": 1,
+        "accounted_files": 1,
+        "unexplained_files": 0,
+    }
     two = compose_walkthrough(1, 2, _compare(files, rung=2), _rationale(["a.py"]), {})
     assert two["rung"] == 2
     assert two["ephemeral"] is True
@@ -59,6 +68,8 @@ def test_rung_three_has_testimony_and_activities_without_diff_stats():
         },
     )
     assert result["rung"] == 3
+    assert result["summary"]["status"] == "diff_unavailable"
+    assert result["summary"]["provenance"] == "agent_account_only"
     assert result["message"].startswith("Limited walkthrough")
     assert {step.get("file_path") for step in result["steps"]} == {"a.py", "b.py"}
     assert {
@@ -79,10 +90,12 @@ def test_rungs_four_and_five_decline_or_stop():
     }
     four = compose_walkthrough(1, 1, None, {"parse_status": "none"}, activities)
     assert four["rung"] == 4
+    assert four["summary"]["status"] == "not_available"
     assert four["steps"] == []
     assert "decline" in four["message"]
     five = compose_walkthrough(1, 1, None, {"parse_status": "none"}, {})
     assert five["rung"] == 5
+    assert five["summary"]["status"] == "not_available"
     assert five["message"] == "No activity recorded"
 
 


### PR DESCRIPTION
Three defects in the session walkthrough (ADR agents/056), found while using it on a real session rather than by reading the code.

## What was wrong

**A compare against the base branch is not a compare.** `compare_stats` resolved rung 2 whenever `session.branch` named an existing branch. A session started from `main` has `session.branch` `"main"`, so it computed `main...main`, found zero files, and every path the agent named became a contradiction.

Live evidence, session 190 turn 1:

```
resolution_rung: 2   diff_type: branch_ephemeral
base_sha: null   commit_sha: null   branch: "main"
files: []   total_files: 0   contradicted_paths: 5
```

The console rendered `0 points, 0 files changed` above five rows, each reading "Contradicted path. The agent named this file; the compare does not contain it." The agent had really changed 11 files (+335/-34) on its own branch. Session 191 reproduced it independently on an unrelated task.

**The header count ignored contradictions.** The list is `[...points, ...contradictions]` but the header counted only points and files, which is how `0 points` appeared above five rows.

**The compare routes were served at a doubled prefix.** `compare_router` declared `prefix="/api/swarm/compare"` and was included into a router already prefixed `/api/swarm`, so live OpenAPI served:

```
/api/swarm/api/swarm/compare/{session_id}/{turn_seq}
/api/swarm/api/swarm/compare/{session_id}/{turn_seq}/patch
```

`walkthrough.js` builds patch URLs at the single-prefix path, which 404s in production, so every "view patch" link was dead. `walkthrough.test.js` asserted the same broken path, which is why CI was green on it.

## What changed

- A base branch compared with itself resolves rung 3 and leaves the diff unresolved, so the composer renders the agent's account as testimony instead of contradicting it. `compare_patch` gets the same guard.
- The header count describes the list actually rendered: accounted, unexplained, contradicted, touched.
- Router prefix is `/compare`, composing to `/api/swarm/compare/...`, and the test pins the composed path.
- The panel leads with a factual summary above the existing walkthrough. The composer emits counts and provenance only; every visible string comes from `run-lexicon.js`.

The two channels stay unmerged: the points are the agent's testimony, the diff is the artifact. The composer never narrates the change itself.

## Verified

- `ci lint` clean.
- `ci test //projects/monolith/frontend:test //projects/monolith/frontend:build_test //projects/monolith:swarm_compare_router_test //projects/monolith:swarm_walkthrough_composer_test` -> `Executed 3 out of 4 tests: 4 tests pass`.
- `build_test` included deliberately: vitest does not compile the app, so a Svelte template error would otherwise pass green.
- All 37 `P.labels` / `P.punct` keys used by `SessionWalkthrough.svelte` resolve against the lexicon, checked mechanically. A missing key renders `undefined` with `build_test` still green.
- Server to client summary field mapping checked by hand (`files_changed` to `files`, `accounted_files` to `accounted`, `unexplained_files` to `unexplained`).

## Not verified

The rendered result has not been seen against a live session in production. The reasoning is grounded in the payloads above, but nobody has looked at the fixed panel in a browser.

## Not fixed here

This stops the false accusation. It does not populate the diff. The session lane never records the branch or SHAs an agent pushed, so rung 1 stays unreachable for session-lane walkthroughs and the diff half remains empty. That needs new plumbing (the guest reporting its branch, or the monolith discovering it) and is filed separately.