### PR TITLE
feat(agents): capture each turn's diff in the guest and render from it

### DIFF
--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -53,8 +53,7 @@ def _capture_turn_base(checkout_dir):
         if not os.path.exists(os.path.join(checkout_dir, ".git")):
             return None
         result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=checkout_dir,
+            ["git", "-C", checkout_dir, "rev-parse", "HEAD"],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             check=False,
@@ -76,8 +75,7 @@ def _capture_turn_diff(checkout_dir, base_sha):
         return None
     try:
         result = subprocess.run(
-            ["git", "diff", base_sha],
-            cwd=checkout_dir,
+            ["git", "-C", checkout_dir, "diff", base_sha],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             check=False,

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
 """HTTP over vsock shim for a long-lived Claude Code CLI session."""
 
-import http.server
 import base64
 import collections
+import http.server
 import json
 import math
 import os
@@ -17,6 +17,7 @@ import sys
 import threading
 import time
 import urllib.request
+import zlib
 
 
 GUEST_HTTP_PORT = 1027
@@ -42,6 +43,61 @@ CLOCK_PATH = "/shim/clock"
 DEFAULT_WORKSPACE = "/workspace"
 VOLUME_DEVICE_ENV = "EMBER_VOLUME_DEV"
 DEFAULT_VOLUME_DEVICE = "/dev/vdb"
+MAX_TURN_DIFF_BYTES = 5 * 1024 * 1024
+MAX_TURN_DIFF_COMPRESSED_BYTES = 1024 * 1024
+
+
+def _capture_turn_base(checkout_dir):
+    """Best-effort checkout HEAD capture. A failure must not affect the turn."""
+    try:
+        if not os.path.exists(os.path.join(checkout_dir, ".git")):
+            return None
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=checkout_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        base_sha = result.stdout.decode("ascii", "strict").strip()
+        if not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_sha):
+            return None
+        return base_sha
+    except Exception:
+        return None
+
+
+def _capture_turn_diff(checkout_dir, base_sha):
+    """Return a compressed git diff record without ever failing the turn."""
+    if not base_sha:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "diff", base_sha],
+            cwd=checkout_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return None
+        raw = result.stdout
+        if len(raw) > MAX_TURN_DIFF_BYTES:
+            return {"base_sha": base_sha, "zlib_b64": None, "truncated": True}
+        compressed = zlib.compress(raw)
+        if len(compressed) > MAX_TURN_DIFF_COMPRESSED_BYTES:
+            return {"base_sha": base_sha, "zlib_b64": None, "truncated": True}
+        return {
+            "base_sha": base_sha,
+            "zlib_b64": base64.b64encode(compressed).decode("ascii"),
+            "truncated": False,
+        }
+    except Exception:
+        return None
 
 
 def _turn_timing_now():
@@ -3394,6 +3450,10 @@ class ProcessManager:
                 )
             self._hydrate_workspace(repo, branch)
         adapter = self._adapter(model)
+        checkout_dir = os.path.join(
+            getattr(self, "workspace", DEFAULT_WORKSPACE), "src"
+        )
+        turn_base = _capture_turn_base(checkout_dir)
         try:
             extra = {"progress_token": progress_token} if progress_token else {}
             prompt = {"system_prompt": system_prompt} if system_prompt else {}
@@ -3419,6 +3479,10 @@ class ProcessManager:
                     record["workspace_hydration"] = {"failed": self._hydration_error}
                 elif self._hydration_status:
                     record["workspace_hydration"] = self._hydration_status
+            if isinstance(record, dict):
+                diff = _capture_turn_diff(checkout_dir, turn_base)
+                if diff is not None:
+                    record["diff"] = diff
             return record
         finally:
             # End-of-turn quiescence point: park only happens after a completed

--- a/projects/embervm/runtimes/claude/shim_hydration_test.py
+++ b/projects/embervm/runtimes/claude/shim_hydration_test.py
@@ -465,7 +465,12 @@ def test_poisoned_directory_is_cleaned_and_recloned(manager, monkeypatch):
 
     monkeypatch.setattr(shim.subprocess, "run", fake_run)
     manager.turn("first", repo="owner/repo", branch="main")
-    assert [command[1] for command in calls] == ["-C", "clone", "-C"]
+    # Only the hydration prefix is pinned. A turn legitimately runs further git
+    # commands after the checkout is valid (diff capture reads HEAD and diffs
+    # against it), and asserting the whole sequence made this test fail for any
+    # unrelated command the shim gained. The stub above still fails on a command
+    # shape it does not recognise, so new calls cannot slip through unnoticed.
+    assert [command[1] for command in calls][:3] == ["-C", "clone", "-C"]
 
 
 def test_cloning_progress_is_pushed_before_the_clone(manager, monkeypatch):

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -1,9 +1,10 @@
 """Unit tests for the Claude guest shim using a fake stream-json CLI."""
 
-import json
 import ast
+import base64
 import datetime
 import io
+import json
 import os
 import signal
 import socket
@@ -1298,6 +1299,114 @@ def test_process_manager_turn_always_ensures_workspace_volume(monkeypatch):
 
     assert manager.turn("hello") == {"ok": True}
     assert calls == [True]
+
+
+@pytest.mark.parametrize("checkout_state", ["missing", "git_failure"])
+def test_process_manager_diff_capture_failure_does_not_fail_turn(
+    tmp_path, monkeypatch, checkout_state
+):
+    manager = _new_process_manager()
+    manager.workspace = str(tmp_path / "workspace")
+    manager._hydration_error = None
+    manager._hydration_status = None
+
+    class Adapter:
+        workspace = None
+
+        def turn(self, *_args, **_kwargs):
+            return {"ok": True}
+
+    manager.claude = Adapter()
+    manager.codex = Adapter()
+    manager.codex.turn_lock = threading.Lock()
+    manager.pi = Adapter()
+    manager.pi.turn_lock = threading.Lock()
+    monkeypatch.setattr(shim, "ensure_workspace_volume", lambda: None)
+    monkeypatch.setattr(shim, "apply_egress_ca_trust", lambda: None)
+    monkeypatch.setattr(shim, "_sync_session_volume", lambda: None)
+    if checkout_state == "git_failure":
+        checkout = tmp_path / "workspace" / "src"
+        (checkout / ".git").mkdir(parents=True)
+        monkeypatch.setattr(
+            shim.subprocess,
+            "run",
+            lambda *_args, **_kwargs: subprocess.CompletedProcess([], 1, b""),
+        )
+
+    assert manager.turn("hello") == {"ok": True}
+
+
+def test_turn_diff_uncompressed_cap_sets_truncated(monkeypatch, tmp_path):
+    checkout = tmp_path / "src"
+    (checkout / ".git").mkdir(parents=True)
+    raw = b"x" * (shim.MAX_TURN_DIFF_BYTES + 1)
+    monkeypatch.setattr(
+        shim.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, raw),
+    )
+
+    assert shim._capture_turn_diff(str(checkout), "a" * 40) == {
+        "base_sha": "a" * 40,
+        "zlib_b64": None,
+        "truncated": True,
+    }
+
+
+def test_process_manager_captures_diff_against_head_at_turn_start(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / "workspace"
+    checkout = workspace / "src"
+    checkout.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=checkout, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.invalid"],
+        cwd=checkout,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"], cwd=checkout, check=True
+    )
+    tracked = checkout / "tracked.txt"
+    tracked.write_text("before\n")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=checkout, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=checkout, check=True)
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=checkout,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+    manager = _new_process_manager()
+    manager.workspace = str(workspace)
+    manager._hydration_error = None
+    manager._hydration_status = None
+
+    class Adapter:
+        workspace = None
+
+        def turn(self, *_args, **_kwargs):
+            tracked.write_text("after\n")
+            return {"ok": True}
+
+    manager.claude = Adapter()
+    manager.codex = Adapter()
+    manager.codex.turn_lock = threading.Lock()
+    manager.pi = Adapter()
+    manager.pi.turn_lock = threading.Lock()
+    monkeypatch.setattr(shim, "ensure_workspace_volume", lambda: None)
+    monkeypatch.setattr(shim, "apply_egress_ca_trust", lambda: None)
+    monkeypatch.setattr(shim, "_sync_session_volume", lambda: None)
+
+    record = manager.turn("change it")
+
+    assert record["diff"]["base_sha"] == base_sha
+    assert record["diff"]["truncated"] is False
+    compressed = base64.b64decode(record["diff"]["zlib_b64"])
+    assert b"-before\n+after\n" in shim.zlib.decompress(compressed)
 
 
 def test_process_manager_without_prewarm_preserves_ready_semantics():

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -4036,6 +4036,16 @@ py_test(
 )
 
 py_test(
+    name = "swarm_unified_diff_test",
+    srcs = ["swarm/unified_diff_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_swarm",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "swarm_walkthrough_composer_test",
     srcs = ["swarm/walkthrough_composer_test.py"],
     imports = ["."],

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import BigInteger, UniqueConstraint
+from sqlalchemy import BigInteger, LargeBinary, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
 
@@ -90,6 +90,9 @@ class AgentTurn(SQLModel, table=True):
     permission_denials: str | None = Field(default=None)
     commit_sha: str | None = Field(default=None, index=True)
     base_sha: str | None = Field(default=None, index=True)
+    diff_blob: bytes | None = Field(default=None, sa_type=LargeBinary)
+    diff_truncated: bool = Field(default=False)
+    diff_base_sha: str | None = Field(default=None)
     usage_json: str | None = Field(default=None)
     cost_usd: float | None = Field(default=None)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import logging
 import secrets
@@ -206,6 +208,9 @@ def create_turn(
     cli_session_id: str | None = None,
     model: str | None = None,
     prompt_intent: str | None = None,
+    diff_blob: bytes | None = None,
+    diff_truncated: bool = False,
+    diff_base_sha: str | None = None,
 ) -> AgentTurn:
     row = AgentTurn(
         session_id=session_id,
@@ -219,6 +224,9 @@ def create_turn(
         stop_reason=stop_reason,
         permission_denials=json.dumps(permission_denials or []),
         commit_sha=commit_sha,
+        diff_blob=diff_blob,
+        diff_truncated=diff_truncated,
+        diff_base_sha=diff_base_sha,
         usage_json=json.dumps(usage or {}),
         cost_usd=cost_usd,
     )
@@ -546,6 +554,19 @@ def persist_turn_from_pending_sync(
         usage = {**turn.usage, "activities": turn.activities}
         if turn.workspace_recovery is not None:
             usage["workspace_recovery"] = turn.workspace_recovery
+        diff_blob = None
+        diff_truncated = False
+        diff_base_sha = None
+        if turn.diff is not None:
+            try:
+                diff_base_sha = turn.diff["base_sha"]
+                diff_truncated = turn.diff["truncated"]
+                if not diff_truncated:
+                    diff_blob = base64.b64decode(turn.diff["zlib_b64"], validate=True)
+            except (KeyError, TypeError, ValueError, binascii.Error):
+                diff_blob = None
+                diff_truncated = False
+                diff_base_sha = None
         row = create_turn(
             session,
             session_id,
@@ -561,6 +582,9 @@ def persist_turn_from_pending_sync(
             turn.total_cost_usd,
             cli_session_id,
             model,
+            diff_blob=diff_blob,
+            diff_truncated=diff_truncated,
+            diff_base_sha=diff_base_sha,
         )
         # The guest-reported CLI session_id is authoritative for this VM.
         if cli_session_id:

--- a/projects/monolith/agent_sessions/store_voice_test.py
+++ b/projects/monolith/agent_sessions/store_voice_test.py
@@ -50,12 +50,39 @@ def test_session_and_turn_round_trip(session):
         "abc123",
         {"input_tokens": 3, "activities": [{"tool": "Bash", "command": "git status"}]},
         0.25,
+        diff_blob=b"compressed",
+        diff_truncated=False,
+        diff_base_sha="def456",
     )
     assert json.loads(turn.permission_denials) == [{"tool": "Bash"}]
     assert json.loads(turn.usage_json)["input_tokens"] == 3
     assert isinstance(turn.created_at, datetime)
     assert store.get_turn(session, row.id, 1).commit_sha == "abc123"
+    assert turn.diff_blob == b"compressed"
+    assert turn.diff_truncated is False
+    assert turn.diff_base_sha == "def456"
     assert len(store.get_turns(session, row.id)) == 1
+
+    truncated = store.create_turn(
+        session,
+        row.id,
+        2,
+        "large change",
+        "Done",
+        "Done",
+        "completed",
+        "end_turn",
+        [],
+        None,
+        {},
+        0.0,
+        diff_blob=None,
+        diff_truncated=True,
+        diff_base_sha="fedcba",
+    )
+    assert truncated.diff_blob is None
+    assert truncated.diff_truncated is True
+    assert truncated.diff_base_sha == "fedcba"
 
 
 @pytest.mark.parametrize(

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -10,9 +10,13 @@ EMBERVM_URL, auth headers, error types, timeout shape).
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import json
 import logging
 import os
+import re
+import zlib
 from typing import Awaitable, Callable, NamedTuple, Protocol
 
 import httpx
@@ -117,6 +121,43 @@ class Turn(NamedTuple):
     duration_ms: int | None
     activities: list[dict]
     workspace_recovery: dict | None = None
+    diff: dict | None = None
+
+
+def _guest_diff(value) -> dict | None:
+    """Validate optional guest diff metadata without making it turn-critical."""
+    if not isinstance(value, dict):
+        return None
+    if not {"base_sha", "zlib_b64", "truncated"}.issubset(value):
+        return None
+    base_sha = value.get("base_sha")
+    truncated = value.get("truncated")
+    encoded = value.get("zlib_b64")
+    if not isinstance(base_sha, str) or not re.fullmatch(
+        r"[0-9a-fA-F]{40,64}", base_sha
+    ):
+        return None
+    if not isinstance(truncated, bool):
+        return None
+    if truncated:
+        return value if encoded is None else None
+    if not isinstance(encoded, str):
+        return None
+    try:
+        compressed = base64.b64decode(encoded, validate=True)
+        if len(compressed) > 1024 * 1024:
+            return None
+        decompressor = zlib.decompressobj()
+        raw = decompressor.decompress(compressed, 5 * 1024 * 1024 + 1)
+        if (
+            len(raw) > 5 * 1024 * 1024
+            or not decompressor.eof
+            or decompressor.unused_data
+        ):
+            return None
+    except (binascii.Error, zlib.error):
+        return None
+    return value
 
 
 class EmberSession(NamedTuple):
@@ -510,6 +551,7 @@ class EmberVmShimTransport:
                         total_cost_usd=guest_data.get("total_cost_usd"),
                         duration_ms=guest_data.get("duration_ms"),
                         activities=guest_data.get("activities", []),
+                        diff=_guest_diff(guest_data.get("diff")),
                     )
             except httpx.TimeoutException as exc:
                 logger.warning(

--- a/projects/monolith/agent_sessions/transport_test.py
+++ b/projects/monolith/agent_sessions/transport_test.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
+import zlib
 
 import httpx
 import pytest
@@ -208,7 +210,53 @@ def test_deliver_uses_ember_identity_and_cli_id_in_body(monkeypatch):
     assert request.headers["X-Ember-Guest-Path"] == "/shim/turn"
     assert json.loads(request.content) == {"message": "hello", "session_id": "cli-1"}
     assert turn.result == "ok"
+    assert turn.diff is None
     assert used == ember
+
+
+def test_deliver_maps_valid_guest_diff(monkeypatch):
+    captured = {
+        "base_sha": "a" * 40,
+        "zlib_b64": base64.b64encode(zlib.compress(b"diff")).decode("ascii"),
+        "truncated": False,
+    }
+
+    async def handler(request):
+        response = _turn_response(request)
+        payload = response.json()
+        payload["diff"] = captured
+        return httpx.Response(200, json=payload, request=request)
+
+    _client(monkeypatch, handler)
+    turn, _ = asyncio.run(
+        transport.EmberVmShimTransport().deliver(
+            transport.EmberSession("s1", "t1", None), "cli-1", "hello"
+        )
+    )
+
+    assert turn.diff == captured
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "bad", {}, {"base_sha": "x", "zlib_b64": "bad", "truncated": False}],
+)
+def test_deliver_ignores_absent_or_malformed_guest_diff(monkeypatch, value):
+    async def handler(request):
+        response = _turn_response(request)
+        payload = response.json()
+        if value is not None:
+            payload["diff"] = value
+        return httpx.Response(200, json=payload, request=request)
+
+    _client(monkeypatch, handler)
+    turn, _ = asyncio.run(
+        transport.EmberVmShimTransport().deliver(
+            transport.EmberSession("s1", "t1", None), "cli-1", "hello"
+        )
+    )
+
+    assert turn.diff is None
 
 
 def test_deliver_includes_model_when_present(monkeypatch):

--- a/projects/monolith/chart/migrations/20260815160000_agent_turn_diff_capture.sql
+++ b/projects/monolith/chart/migrations/20260815160000_agent_turn_diff_capture.sql
@@ -1,0 +1,13 @@
+-- Capture each turn's diff at completion instead of deriving it from the
+-- GitHub compare API at render time. The GitHub path expires with the branch,
+-- truncates at 300 files, and cannot see work that was never pushed, so across
+-- 191 sessions it never once produced a diff.
+--
+-- diff_blob holds a zlib-compressed unified diff, so it stays small enough to
+-- live beside the turn (typically single-digit KB). diff_truncated records that
+-- the guest refused to store an oversized diff, which is a different fact from
+-- there being no diff at all: null blob with the flag set means "too big to
+-- keep", null blob without it means "nothing captured".
+ALTER TABLE agent_sessions.agent_turns ADD COLUMN diff_blob BYTEA;
+ALTER TABLE agent_sessions.agent_turns ADD COLUMN diff_truncated BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE agent_sessions.agent_turns ADD COLUMN diff_base_sha TEXT;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:zNwNin5KHBTiqsRjs7IjA97Z/5sgs1gSsYh7w+YLbu4=
+h1:JYNx62UmRR8xcPvWMOejbXeRCv5ws5ygEHftn7UUHtc=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -164,3 +164,4 @@ h1:zNwNin5KHBTiqsRjs7IjA97Z/5sgs1gSsYh7w+YLbu4=
 20260813000000_swarm_recording_schema.sql h1:GP+CVZ9aczViVoM1k49RwXsF0CH6LaE4FkYKeKGigEo=
 20260813120000_agent_turn_base_sha.sql h1:AW26zU3owy+k5jqTmVXpK413P2Xy/z1dTBFMrPQhkNY=
 20260814000000_agent_turn_prompt_intent.sql h1:AaTqNlrqEiBSrbZ9xu9ZWZLAh6DdDjQ2gvsiGnGrvf8=
+20260815160000_agent_turn_diff_capture.sql h1:Ek7QqrT/UVqFHiwahvf4iX3ErK09F6UP8/fMbJLmCD4=

--- a/projects/monolith/swarm/compare_router.py
+++ b/projects/monolith/swarm/compare_router.py
@@ -4,12 +4,14 @@ import asyncio
 import json
 import os
 import time
+import zlib
 from urllib.parse import quote
 
 import httpx
 from fastapi import APIRouter, HTTPException, Query
 
 from agent_sessions.rationale import parse_rationale
+from swarm.unified_diff import parse_unified_diff
 
 router = APIRouter(prefix="/compare", tags=["swarm"])
 
@@ -43,6 +45,9 @@ def _turn_data(session_id: int, turn_seq: int):
         return {
             "base_sha": turn.base_sha,
             "commit_sha": turn.commit_sha,
+            "diff_blob": turn.diff_blob,
+            "diff_truncated": turn.diff_truncated,
+            "diff_base_sha": turn.diff_base_sha,
             "branch": session.branch,
             "repo": session.repo or _DEFAULT_REPO,
             "usage_json": turn.usage_json,
@@ -50,6 +55,29 @@ def _turn_data(session_id: int, turn_seq: int):
             "result_text": turn.result_text,
             "rationale": parse_rationale(turn.result_text),
         }
+
+
+def _stored_compare(data: dict) -> dict | None:
+    blob = data.get("diff_blob")
+    if blob is None:
+        return None
+    try:
+        decompressor = zlib.decompressobj()
+        raw_bytes = decompressor.decompress(bytes(blob), 5 * 1024 * 1024 + 1)
+        if (
+            len(raw_bytes) > 5 * 1024 * 1024
+            or not decompressor.eof
+            or decompressor.unused_data
+        ):
+            return None
+        raw = raw_bytes.decode("utf-8", "replace")
+    except (TypeError, ValueError, zlib.error):
+        return None
+    return {
+        "files": parse_unified_diff(raw),
+        "truncated": False,
+        "source": "stored",
+    }
 
 
 def _activities(data: dict) -> tuple[set[str], bool]:
@@ -156,7 +184,12 @@ async def compare_stats(session_id: int, turn_seq: int) -> dict:
     resolution_rung = 3
     diff_type = None
     compare = {"files": [], "truncated": False}
-    if base_sha and commit_sha:
+    stored = _stored_compare(data)
+    if stored is not None:
+        resolution_rung, diff_type = 1, "stored"
+        compare = stored
+        base_sha = data.get("diff_base_sha") or base_sha
+    elif base_sha and commit_sha:
         resolution_rung, diff_type = 1, "sha"
         compare = await _compare(
             repo, base_sha, commit_sha, f"{base_sha}...{commit_sha}"
@@ -226,7 +259,10 @@ async def compare_patch(session_id: int, turn_seq: int, path: str = Query(...)) 
     data = await asyncio.to_thread(_turn_data, session_id, turn_seq)
     if data is None:
         raise HTTPException(status_code=404, detail="Agent turn not found")
-    if data["base_sha"] and data["commit_sha"]:
+    stored = _stored_compare(data)
+    if stored is not None:
+        compare = stored
+    elif data["base_sha"] and data["commit_sha"]:
         compare = await _compare(
             data["repo"],
             data["base_sha"],

--- a/projects/monolith/swarm/compare_router_test.py
+++ b/projects/monolith/swarm/compare_router_test.py
@@ -1,4 +1,5 @@
 import json
+import zlib
 
 import pytest
 
@@ -9,6 +10,9 @@ def _data(**overrides):
     value = {
         "base_sha": "base",
         "commit_sha": "head",
+        "diff_blob": None,
+        "diff_truncated": False,
+        "diff_base_sha": None,
         "branch": "claude/swarm-1",
         "repo": "jomcgi/homelab",
         "usage_json": json.dumps(
@@ -73,6 +77,66 @@ async def test_sha_resolution_is_stats_first(monkeypatch):
     assert result["files"][1]["patch_url"] is None
     assert "patch" not in result["files"][0]
     assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_stored_diff_is_rung_one_without_github(monkeypatch):
+    raw = (
+        "diff --git a/a.py b/a.py\n"
+        "--- a/a.py\n"
+        "+++ b/a.py\n"
+        "@@ -1 +1,2 @@\n"
+        "-old\n"
+        "+new\n"
+        "+line\n"
+    ).encode()
+    monkeypatch.setattr(
+        mod,
+        "_turn_data",
+        lambda *_: _data(
+            diff_blob=zlib.compress(raw),
+            diff_base_sha="captured-base",
+        ),
+    )
+
+    async def fail_github(_url):
+        raise AssertionError("GitHub must not be called for a stored diff")
+
+    async def fail_compare(*_args, **_kwargs):
+        raise AssertionError("GitHub compare must not be called for a stored diff")
+
+    monkeypatch.setattr(mod, "_github_get", fail_github)
+    monkeypatch.setattr(mod, "_compare", fail_compare)
+    result = await mod.compare_stats(1, 1)
+
+    assert result["resolution_rung"] == 1
+    assert result["diff_type"] == "stored"
+    assert result["base_sha"] == "captured-base"
+    assert result["files"][0]["changes"] == 3
+
+
+@pytest.mark.asyncio
+async def test_stored_diff_patch_does_not_call_github(monkeypatch):
+    raw = (
+        "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -1 +1 @@\n-old\n+new\n"
+    ).encode()
+    monkeypatch.setattr(
+        mod,
+        "_turn_data",
+        lambda *_: _data(diff_blob=zlib.compress(raw), diff_base_sha="base"),
+    )
+
+    async def fail_github(_url):
+        raise AssertionError("GitHub must not be called for a stored diff")
+
+    async def fail_compare(*_args, **_kwargs):
+        raise AssertionError("GitHub compare must not be called for a stored diff")
+
+    monkeypatch.setattr(mod, "_github_get", fail_github)
+    monkeypatch.setattr(mod, "_compare", fail_compare)
+    result = await mod.compare_patch(1, 1, "a.py")
+
+    assert result == {"path": "a.py", "patch": "@@ -1 +1 @@\n-old\n+new\n"}
 
 
 @pytest.mark.asyncio

--- a/projects/monolith/swarm/unified_diff.py
+++ b/projects/monolith/swarm/unified_diff.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import ast
+
+
+def _path(value: str) -> str:
+    value = value.strip()
+    if value == "/dev/null":
+        return value
+    if value.startswith('"') and value.endswith('"'):
+        try:
+            value = ast.literal_eval(value)
+        except (SyntaxError, ValueError):
+            value = value[1:-1]
+    if value.startswith(("a/", "b/")):
+        return value[2:]
+    return value
+
+
+def _header_paths(line: str) -> tuple[str, str]:
+    value = line[len("diff --git ") :].rstrip("\r\n")
+    if value.startswith('"'):
+        try:
+            old, new = value.split('" "', 1)
+            return _path(old + '"'), _path('"' + new)
+        except ValueError:
+            return "", ""
+    marker = " b/"
+    if marker not in value:
+        return "", ""
+    old, new = value.rsplit(marker, 1)
+    return _path(old), _path("b/" + new)
+
+
+def parse_unified_diff(diff: str) -> list[dict]:
+    """Parse git unified diff text into per-file metadata and hunk text."""
+    lines = diff.splitlines(keepends=True)
+    starts = [
+        index for index, line in enumerate(lines) if line.startswith("diff --git ")
+    ]
+    files = []
+    for position, start in enumerate(starts):
+        end = starts[position + 1] if position + 1 < len(starts) else len(lines)
+        block = lines[start:end]
+        old_path, new_path = _header_paths(block[0])
+        status = "modified"
+        rename_to = None
+        old_header = None
+        new_header = None
+        additions = 0
+        deletions = 0
+        hunk_start = None
+
+        for index, line in enumerate(block[1:], start=1):
+            stripped = line.rstrip("\r\n")
+            # Header lines only occur before the first hunk, and they must only
+            # be read there. Inside a hunk the prefix character makes ordinary
+            # content impersonate a header: removing a line that reads
+            # "-- comment" produces "--- comment", and adding one that reads
+            # "++ x" produces "+++ x". Parsing those as headers renames the file
+            # to whatever the content happened to say, which puts a real hunk
+            # behind the wrong path. Every migration in this repo opens with
+            # "-- ", so deleting one was enough to trigger it.
+            if hunk_start is None:
+                if stripped.startswith("new file mode "):
+                    status = "added"
+                elif stripped.startswith("deleted file mode "):
+                    status = "removed"
+                elif stripped.startswith("rename from "):
+                    status = "renamed"
+                elif stripped.startswith("rename to "):
+                    status = "renamed"
+                    rename_to = _path(stripped[len("rename to ") :])
+                elif stripped.startswith("--- "):
+                    old_header = _path(stripped[4:])
+                elif stripped.startswith("+++ "):
+                    new_header = _path(stripped[4:])
+                elif stripped.startswith("@@"):
+                    hunk_start = index
+            else:
+                if line.startswith("+"):
+                    additions += 1
+                elif line.startswith("-"):
+                    deletions += 1
+
+        if old_header == "/dev/null":
+            status = "added"
+        elif new_header == "/dev/null":
+            status = "removed"
+        path = (
+            rename_to
+            or (old_header if status == "removed" else new_header)
+            or (old_path if status == "removed" else new_path)
+        )
+        patch = "".join(block[hunk_start:]) if hunk_start is not None else None
+        files.append(
+            {
+                "path": path,
+                "status": status,
+                "additions": additions,
+                "deletions": deletions,
+                "changes": additions + deletions,
+                "patch": patch,
+            }
+        )
+    return files

--- a/projects/monolith/swarm/unified_diff_test.py
+++ b/projects/monolith/swarm/unified_diff_test.py
@@ -1,0 +1,141 @@
+from swarm.unified_diff import parse_unified_diff
+
+
+def test_added_file():
+    files = parse_unified_diff(
+        "diff --git a/new.py b/new.py\n"
+        "new file mode 100644\n"
+        "--- /dev/null\n"
+        "+++ b/new.py\n"
+        "@@ -0,0 +1,2 @@\n"
+        "+one\n"
+        "+two\n"
+    )
+    assert files == [
+        {
+            "path": "new.py",
+            "status": "added",
+            "additions": 2,
+            "deletions": 0,
+            "changes": 2,
+            "patch": "@@ -0,0 +1,2 @@\n+one\n+two\n",
+        }
+    ]
+
+
+def test_removed_file():
+    files = parse_unified_diff(
+        "diff --git a/old.py b/old.py\n"
+        "deleted file mode 100644\n"
+        "--- a/old.py\n"
+        "+++ /dev/null\n"
+        "@@ -1 +0,0 @@\n"
+        "-gone\n"
+    )
+    assert files[0] == {
+        "path": "old.py",
+        "status": "removed",
+        "additions": 0,
+        "deletions": 1,
+        "changes": 1,
+        "patch": "@@ -1 +0,0 @@\n-gone\n",
+    }
+
+
+def test_renamed_file():
+    files = parse_unified_diff(
+        "diff --git a/old name.py b/new name.py\n"
+        "similarity index 80%\n"
+        "rename from old name.py\n"
+        "rename to new name.py\n"
+        "--- a/old name.py\n"
+        "+++ b/new name.py\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+    assert files[0]["path"] == "new name.py"
+    assert files[0]["status"] == "renamed"
+    assert files[0]["changes"] == 2
+
+
+def test_binary_file():
+    files = parse_unified_diff(
+        "diff --git a/image.png b/image.png\n"
+        "index 123..456 100644\n"
+        "Binary files a/image.png and b/image.png differ\n"
+    )
+    assert files[0] == {
+        "path": "image.png",
+        "status": "modified",
+        "additions": 0,
+        "deletions": 0,
+        "changes": 0,
+        "patch": None,
+    }
+
+
+def test_empty_diff():
+    assert parse_unified_diff("") == []
+
+
+def test_no_trailing_newline():
+    files = parse_unified_diff(
+        "diff --git a/a.txt b/a.txt\n"
+        "--- a/a.txt\n"
+        "+++ b/a.txt\n"
+        "@@ -1 +1 @@\n"
+        "-before\n"
+        "+after\n"
+        "\\ No newline at end of file"
+    )
+    assert files[0]["patch"].endswith("\\ No newline at end of file")
+    assert files[0]["additions"] == 1
+    assert files[0]["deletions"] == 1
+
+
+def test_content_that_looks_like_file_headers_is_counted():
+    files = parse_unified_diff(
+        "diff --git a/a.txt b/a.txt\n"
+        "--- a/a.txt\n"
+        "+++ b/a.txt\n"
+        "@@ -1 +1 @@\n"
+        "---- removed content\n"
+        "++++ added content\n"
+    )
+    assert files[0]["additions"] == 1
+    assert files[0]["deletions"] == 1
+
+
+def test_removed_sql_comment_does_not_become_the_path():
+    # A removed line reading "-- comment" appears as "--- comment", which is a
+    # valid old-file header shape. Every migration in this repo opens that way,
+    # so deleting one must not rename the file to its own first comment.
+    files = parse_unified_diff(
+        "diff --git a/chart/migrations/x.sql b/chart/migrations/x.sql\n"
+        "deleted file mode 100644\n"
+        "--- a/chart/migrations/x.sql\n"
+        "+++ /dev/null\n"
+        "@@ -1,2 +0,0 @@\n"
+        "--- Store the server-owned intent separately.\n"
+        "-ALTER TABLE agent_sessions.agent_turns ADD COLUMN prompt_intent TEXT;\n"
+    )
+    assert files[0]["path"] == "chart/migrations/x.sql"
+    assert files[0]["status"] == "removed"
+    assert files[0]["deletions"] == 2
+
+
+def test_added_line_starting_with_plus_plus_does_not_retarget_the_file():
+    # An added line reading "++ x" appears as "+++ x", a valid new-file header.
+    # Reading it as one would attach this hunk to a different file entirely,
+    # which is the worst failure available here: a real diff under a wrong path.
+    files = parse_unified_diff(
+        "diff --git a/docs/example.md b/docs/example.md\n"
+        "--- a/docs/example.md\n"
+        "+++ b/docs/example.md\n"
+        "@@ -1 +1,2 @@\n"
+        " intro\n"
+        "+++ b/some/other/file.py\n"
+    )
+    assert files[0]["path"] == "docs/example.md"
+    assert files[0]["additions"] == 1


### PR DESCRIPTION
Closes #4934.

## Why

The session walkthrough derived its diff from the GitHub compare API at render time. That has never once worked in production. Scanning every session:

```
sessions=191   with repo=68   swarm-lane=7
rung distribution: {3: 6, 5: 97}
```

Rung 1 and rung 2 have never occurred, so no walkthrough has ever shown a diff. The reasons are structural, not incidental:

- The compare expires with the branch (`ephemeral: rung == 2`, and the console said so out loud).
- GitHub truncates compare at 300 files.
- Work that was never pushed is invisible. Session 191 committed `94a5b6b97` inside its guest and never pushed, so no compare was possible even in principle.

## What changed

The guest records the checkout HEAD when a turn starts, then captures `git diff <base>` at the end. Diffing the working tree against the recorded base picks up committed and uncommitted work in one command, which is what "what this turn changed" means. The result is zlib compressed and stored beside the turn.

**Compression is zlib, not zstd.** The guest shim is deliberately stdlib-only Python (`runtimes/claude/apko.yaml` says so) and `zstandard` is absent from the monolith requirements. A dependency in the guest runtime would have cost more than the compression ratio is worth.

A stored diff resolves as `resolution_rung` 1 with `diff_type: "stored"` and `ephemeral` false, because it is authoritative and does not expire. `compare_stats` and `compare_patch` both prefer it and fall back to the GitHub path for turns predating capture. Parsing is a tested pure function, not a shell out to git.

**Capture cannot fail a turn.** A missing checkout or a git error yields a turn with no diff, and a guest predating this change is unaffected: an absent or malformed `diff` payload behaves exactly as before.

The two nulls are kept distinct deliberately. `diff_blob` null with `diff_truncated` true means the diff was too large to keep; null without it means nothing was captured. This feature has already been bitten once by reporting a missing artifact as a positive claim, and collapsing those two would do it again.

## Review found a real defect in the parser

The first implementation parsed `---` / `+++` header lines regardless of whether it was inside a hunk. Inside a hunk, content impersonates a header: removing a line reading `-- comment` produces `--- comment`, and adding one reading `++ x` produces `+++ x`. Since those headers decide the reported path, this misattributed files. Demonstrated against the real parser:

```
DELETED SQL   -> path: 'Store the server-owned intent separately.'   (should be the .sql path)
ADDS ++ LINE  -> path: 'some/other/file.py'                          (should be docs/example.md)
```

The second is the dangerous one: a real hunk served under a completely different file's name. Every migration in this repo opens with `-- `, and `run-fixtures.js` embeds diff text, so both shapes are reachable.

Fixed by only reading headers before the first hunk, with two regression tests. The pre-existing test used `----` and `++++` (four characters), which do not match `"--- "`, so it passed while the bug was live.

## Verified

- `ci lint` clean.
- `ci test` across `swarm_compare_router_test`, `swarm_unified_diff_test`, `agent_sessions_transport_test`, `embervm shim_test`, `frontend:build_test` -> `Executed 2 out of 5 tests: 5 tests pass`.
- Re-run after the parser fix -> `Executed 2 out of 2 tests: 2 tests pass`.
- Acceptance checked by hand, not from the implementer's report: no zstd anywhere, shim imports only `zlib`/`base64`, exactly one migration, all three columns on `AgentTurn` and persisted by `create_turn`, `Turn.diff` defaults to None.
- The rung-1 test monkeypatches both `_github_get` and `_compare` to raise, so any GitHub call fails the test. The capture-failure test asserts the turn still returns `{"ok": True}` with git exiting 1.

## Not verified

The end-to-end path has not run against a live session, because until this lands there is nothing that can produce a stored diff. The first real session after rollout is the actual test: parser correctness is proven, but the guest capturing the right base, the blob round-tripping through Postgres, and the patch endpoint serving the right file's hunk are not.

## Not in scope

Retention and deletion of stored diffs. No backfill, because no turn has ever had a diff to backfill.