### PR TITLE
fix(embervm): re-key the claude-runtime base so diff capture reaches guests

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -562,7 +562,20 @@ claudeRuntimeWorkload:
   # nothing the guest can read. Use it as a rebuild epoch, never as a knob.
   # Making it mean what it says is tracked in #4429.
   initEnv:
-    EMBER_BASE_EPOCH: "warm-restore-3"
+    # diff-capture-1: PR #4936 put turn diff capture in shim.py, and the image
+    # built with it (verified: the pinned runtime digest contains
+    # _capture_turn_diff). The base rebuild that would carry it into guests
+    # failed at 17:29Z with {:connect, :timeout}, two minutes after the 16gi
+    # bricks started rolling for chart 0.14.1. Ready stayed True on the older
+    # restorable base, so nothing alerted and every session kept running the
+    # previous shim, capturing nothing.
+    #
+    # A failed build is not retried, and creating a session does not trigger
+    # one: a qwen probe (session 193) created and served a guest with the
+    # condition unchanged across six minutes. Re-keying is the only route, and
+    # this epoch is the documented mechanism for it. That the fix for a
+    # transient timeout is a hand-edited string is the problem tracked in #4937.
+    EMBER_BASE_EPOCH: "diff-capture-1"
     # INERT, kept only as documented intent: the shim reads EMBER_PREWARM_CLIS
     # from its own environment, which never receives this, so _read_prewarm_clis
     # returns () and prewarm silently no-ops. Live turn-timing confirms it: first


### PR DESCRIPTION
Unblocks #4936. Related: #4937.

## Why

PR #4936 added turn diff capture to the guest shim, and the runtime image built with it. Verified against the pinned digest:

```
crane export ghcr.io/.../runtimes/claude@sha256:c8a38ea... | grep -c
  _capture_turn_diff    2
  _capture_turn_base    2
  MAX_TURN_DIFF_BYTES   2
```

The base rebuild that would carry that into guests failed:

```
Ready:     True   BaseReady    "a restorable base snapshot is available"   17:29:17Z
BaseBuilt: False  BuildFailed  "{:connect, :timeout}"                      17:29:17Z
snapshotRef: claude-runtime__e847f766b497
```

17:29 is two minutes after the 16gi bricks started rolling for chart `0.14.1`, so the timeout is almost certainly collateral from that roll.

Nothing surfaced it. `Ready` stayed `True` on the older restorable base, so sessions kept succeeding while running the previous shim. Session 192 committed locally and its walkthrough still resolved rung 3 with `diff_unavailable`; `diff_blob` is null for every turn.

## Why an epoch bump rather than waiting

Both alternatives were tested rather than assumed:

- **Waiting**: the condition was unchanged 25 minutes later, same reason and same `lastTransitionTime`. A failed build is not retried.
- **Starting another session**: a qwen probe (session 193) created and served a guest. `BaseBuilt` stayed `False` with the same timestamp across six consecutive polls while the session went live and then banked. Creating a session does not trigger a rebuild.

The base signature deliberately excludes noded config, which is why `claudeRuntimeWorkload.initEnv` exists as a manual rebuild epoch. It is the documented mechanism and the only one that applies here.

## Verified

- `ci lint` clean.
- `helm template` renders the new epoch into the Workload manifest (1 occurrence), so the value actually reaches the object whose signature it re-keys.

## Not verified

That the rebuild succeeds. This re-keys the base and forces a build; if the underlying connectivity problem recurs, it will fail again the same way. I will watch `BaseBuilt` after rollout and confirm a session captures a diff before calling diff capture live.

## Note

That a transient timeout can only be cleared by hand-editing a string in a values file is the real problem, and it is filed as #4937 rather than fixed here.