### PR TITLE
fix(embervm): let the warmth reaper reclaim pre-sidecar group orphans

### DIFF
--- a/projects/embervm/control/lib/embervm/warmth_reaper.ex
+++ b/projects/embervm/control/lib/embervm/warmth_reaper.ex
@@ -125,6 +125,9 @@ defmodule Embervm.WarmthReaper do
     remote_stateful_index_fun =
       Keyword.get(opts, :remote_stateful_index_fun, &default_remote_stateful_index/0)
 
+    remote_group_index_fun =
+      Keyword.get(opts, :remote_group_index_fun, &default_remote_group_index/0)
+
     # 0 disables the timer entirely (the unit-test default, so a test drives
     # :sweep_now explicitly and asserts deterministically); production uses the
     # module default.
@@ -144,6 +147,7 @@ defmodule Embervm.WarmthReaper do
       evict_snapshot_fun: evict_snapshot_fun,
       evict_artifact_fun: evict_artifact_fun,
       remote_stateful_index_fun: remote_stateful_index_fun,
+      remote_group_index_fun: remote_group_index_fun,
       sweep_interval_ms: sweep_interval_ms,
       sweep_enabled: sweep_enabled
     }
@@ -258,9 +262,10 @@ defmodule Embervm.WarmthReaper do
   defp apply_plan(state, plan) do
     {stateful, group} = Enum.split_with(plan, &(&1.kind == :stateful))
     stateful_index = remote_stateful_index(state, stateful)
+    group_index = remote_group_index(state, group)
 
     log_and_evict(state, :stateful, stateful, stateful_index)
-    log_and_evict(state, :group, group, nil)
+    log_and_evict(state, :group, group, group_index)
     :ok
   end
 
@@ -309,8 +314,9 @@ defmodule Embervm.WarmthReaper do
   # uses); the single remote EvictArtifact{remote: true, kind: GROUP_SET, workload:
   # group_instance_id, ref: set_id} that drops the whole set prefix at once fires
   # ONLY when EVERY member's local eviction succeeded.
-  # GROUP_SET is not searchable by the same ref in this reaper. Its remote layout
-  # is keyed by group_instance_id, so the conservative empty-binding skip remains.
+  # Empty on-disk group_instance_id bindings are recovered from a remote GROUP_SET
+  # index keyed by set_id. The indexed value supplies the vendor and
+  # group_instance_id needed to address the remote prefix safely.
 
   defp evict_entry(state, %{kind: :stateful, id: ref, workload: workload} = entry, {:ok, index})
        when workload in [nil, ""] do
@@ -340,9 +346,29 @@ defmodule Embervm.WarmthReaper do
     :ok
   end
 
-  defp evict_entry(_state, %{kind: :group, id: set_id, workload: gid}, _index) when gid in [nil, ""] do
+  defp evict_entry(state, %{kind: :group, id: set_id, workload: gid} = entry, {:ok, index})
+       when gid in [nil, ""] do
+    case Map.get(index, set_id) do
+      %{vendor: vendor, group_instance_id: recovered_gid} ->
+        Logger.info(
+          "embervm warmth reaper: recovered binding for orphaned group set #{inspect(set_id)} from remote index (vendor #{inspect(vendor)}, group_instance_id #{inspect(recovered_gid)})"
+        )
+
+        evict_group(state, %{entry | workload: recovered_gid}, vendor)
+
+      nil ->
+        Logger.info(
+          "embervm warmth reaper: evicting local-only orphaned group set #{inspect(set_id)} (not found in remote index; no remote copy can be stranded)"
+        )
+
+        evict_group(state, entry, nil, false)
+    end
+  end
+
+  defp evict_entry(_state, %{kind: :group, id: set_id, workload: gid}, {:error, reason})
+       when gid in [nil, ""] do
     Logger.info(
-      "embervm warmth reaper: SKIP orphaned group set #{inspect(set_id)} (no group_instance_id binding on disk; cannot evict remote copy safely, leaving whole)"
+      "embervm warmth reaper: SKIP orphaned group set #{inspect(set_id)} (remote index lookup failed: #{inspect(reason)}; leaving whole)"
     )
 
     :ok
@@ -369,16 +395,22 @@ defmodule Embervm.WarmthReaper do
     :ok
   end
 
-  defp evict_entry(state, %{kind: :group, id: set_id, workload: group_instance_id, node_id: node_id, member_refs: member_refs}, _index) do
+  defp evict_entry(state, %{kind: :group} = entry, _index), do: evict_group(state, entry)
+
+  defp evict_group(
+         state,
+         %{id: set_id, workload: group_instance_id, node_id: node_id, member_refs: member_refs},
+         vendor \\ nil,
+         remote \\ true
+       ) do
     dial_key = WakeInstance.dial_for_group(state.capacity_table, node_id, group_instance_id)
 
-    remote =
-      {:artifact,
-       %EvictArtifactRequest{
-         artifact: %ArtifactRef{kind: :ARTIFACT_KIND_GROUP_SET, workload: group_instance_id, ref: set_id},
-         remote: true,
-         trace: %Trace{workload: group_instance_id}
-       }}
+    remote_request = %EvictArtifactRequest{
+      artifact: %ArtifactRef{kind: :ARTIFACT_KIND_GROUP_SET, workload: group_instance_id, ref: set_id},
+      remote: true,
+      vendor: vendor || "",
+      trace: %Trace{workload: group_instance_id}
+    }
 
     per_member = for ref <- member_refs, do: {:snapshot, %EvictSnapshotRequest{trace: %Trace{}, snapshot_ref: ref}}
 
@@ -387,7 +419,7 @@ defmodule Embervm.WarmthReaper do
         # The single remote GROUP_SET evict (drops the whole S3 set prefix at once)
         # fires ONLY if EVERY member's local evict succeeded: one refused/failed
         # member (e.g. a live relit member) leaves the set's recovery copy intact.
-        run_evict(state, channel, per_member, remote)
+        run_evict(state, channel, per_member, if(remote, do: {:artifact, remote_request}, else: nil))
         release_channel(state, channel)
       end
     end)
@@ -409,6 +441,20 @@ defmodule Embervm.WarmthReaper do
     kind, reason -> {:error, {:lookup_thrown, {kind, reason}}}
   end
 
+  defp remote_group_index(_state, []), do: {:ok, %{}}
+
+  defp remote_group_index(state, entries) do
+    if Enum.any?(entries, &(&1.workload in [nil, ""])) do
+      state.remote_group_index_fun.()
+    else
+      {:ok, %{}}
+    end
+  rescue
+    e -> {:error, {:lookup_raised, e}}
+  catch
+    kind, reason -> {:error, {:lookup_thrown, {kind, reason}}}
+  end
+
   defp log_dry_run_entry(%{kind: :stateful, id: ref, workload: workload}, {:ok, index})
        when workload in [nil, ""] do
     action = if Map.has_key?(index, ref), do: "local and remote", else: "local-only"
@@ -418,6 +464,17 @@ defmodule Embervm.WarmthReaper do
   defp log_dry_run_entry(%{kind: :stateful, id: ref, workload: workload}, {:error, reason})
        when workload in [nil, ""] do
     Logger.info("embervm warmth reaper: DRY RUN WOULD skip empty-binding stateful bundle #{inspect(ref)} because remote index lookup failed: #{inspect(reason)}")
+  end
+
+  defp log_dry_run_entry(%{kind: :group, id: set_id, workload: gid}, {:ok, index})
+       when gid in [nil, ""] do
+    action = if Map.has_key?(index, set_id), do: "local and remote", else: "local-only"
+    Logger.info("embervm warmth reaper: DRY RUN WOULD evict #{action} for empty-binding group set #{inspect(set_id)}")
+  end
+
+  defp log_dry_run_entry(%{kind: :group, id: set_id, workload: gid}, {:error, reason})
+       when gid in [nil, ""] do
+    Logger.info("embervm warmth reaper: DRY RUN WOULD skip empty-binding group set #{inspect(set_id)} because remote index lookup failed: #{inspect(reason)}")
   end
 
   defp log_dry_run_entry(_entry, _index), do: :ok
@@ -440,6 +497,33 @@ defmodule Embervm.WarmthReaper do
                   nil -> {:cont, {:ok, Map.put(index, ref, binding)}}
                   ^binding -> {:cont, {:ok, index}}
                   _ -> {:halt, {:error, {:conflicting_bindings, ref}}}
+                end
+
+              _ -> {:cont, {:ok, index}}
+            end
+          end)
+        end
+    end
+  end
+
+  defp default_remote_group_index do
+    endpoint = System.get_env("EMBERVM_STORE_ENDPOINT", "") |> String.trim()
+    bucket = System.get_env("EMBERVM_STORE_BUCKET", "embervm")
+
+    case S3Client.new(endpoint, bucket) do
+      nil -> {:error, :store_disabled}
+      client ->
+        with {:ok, entries} <- S3Client.list_all(client, "group_set/") do
+          Enum.reduce_while(entries, {:ok, %{}}, fn %{key: key}, {:ok, index} ->
+            case String.split(key, "/") do
+              ["group_set", vendor, gid, set_id, member, file]
+              when vendor != "" and gid != "" and set_id != "" and member != "" and file != "" ->
+                binding = %{vendor: vendor, group_instance_id: gid}
+
+                case Map.get(index, set_id) do
+                  nil -> {:cont, {:ok, Map.put(index, set_id, binding)}}
+                  ^binding -> {:cont, {:ok, index}}
+                  _ -> {:halt, {:error, {:conflicting_bindings, set_id}}}
                 end
 
               _ -> {:cont, {:ok, index}}

--- a/projects/embervm/control/test/embervm/warmth_reaper_test.exs
+++ b/projects/embervm/control/test/embervm/warmth_reaper_test.exs
@@ -1,5 +1,5 @@
 defmodule Embervm.WarmthReaperTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Embervm.{NodeCapacity, WarmthReaper}
 
@@ -15,6 +15,13 @@ defmodule Embervm.WarmthReaperTest do
     def init(instances), do: {:ok, instances}
     @impl true
     def handle_call(:all, _from, instances), do: {:reply, instances, instances}
+  end
+
+  defmodule S3ListPlug do
+    import Plug.Conn
+
+    def init(body), do: body
+    def call(conn, body), do: send_resp(conn, 200, body)
   end
 
   defp start_store(instances) do
@@ -301,6 +308,151 @@ defmodule Embervm.WarmthReaperTest do
     end
   end
 
+  describe "empty-binding group orphan lookup" do
+    defp empty_binding_group_reaper(table, artifact_fun, snapshot_fun, index_fun) do
+      start_reaper(
+        capacity_table: table,
+        stateful_store: start_store([]),
+        group_store: start_store([group_instance(:destroyed, "orphan-nobind-set")]),
+        evict_artifact_fun: artifact_fun,
+        evict_snapshot_fun: snapshot_fun,
+        channel_fun: fake_channel_fun(),
+        remote_group_index_fun: index_fun,
+        sweep_enabled: true
+      )
+    end
+
+    test "remote hit recovers vendor and group instance id, then evicts local members before remote" do
+      test_pid = self()
+      table = new_cap_table()
+      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
+
+      put_warmth_fact(table, "node-4", [], [
+        group_set("orphan-nobind-set", "", [member("a", "m-nb-a", 1_000), member("b", "m-nb-b", 2_000)])
+      ])
+
+      reaper =
+        empty_binding_group_reaper(table, artifact_fun, snapshot_fun, fn ->
+          {:ok, %{"orphan-nobind-set" => %{vendor: "amd", group_instance_id: "grp-recovered"}}}
+        end)
+
+      WarmthReaper.sweep_now(reaper)
+
+      assert_receive {:evict_snapshot, "m-nb-a"}, 1_000
+      assert_receive {:evict_snapshot, "m-nb-b"}, 1_000
+
+      assert_receive {:evict_artifact_req,
+                      %{
+                        remote: true,
+                        vendor: "amd",
+                        artifact: %{
+                          kind: :ARTIFACT_KIND_GROUP_SET,
+                          workload: "grp-recovered",
+                          ref: "orphan-nobind-set"
+                        }
+                      }},
+                     1_000
+    end
+
+    test "remote miss evicts local members only" do
+      test_pid = self()
+      table = new_cap_table()
+      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
+
+      put_warmth_fact(table, "node-4", [], [
+        group_set("orphan-nobind-set", nil, [member("a", "m-nb-a", 1_000), member("b", "m-nb-b", 2_000)])
+      ])
+
+      reaper = empty_binding_group_reaper(table, artifact_fun, snapshot_fun, fn -> {:ok, %{}} end)
+      WarmthReaper.sweep_now(reaper)
+
+      assert_receive {:evict_snapshot, "m-nb-a"}, 1_000
+      assert_receive {:evict_snapshot, "m-nb-b"}, 1_000
+      refute_receive {:evict_artifact, :ARTIFACT_KIND_GROUP_SET, "orphan-nobind-set", true}, 300
+    end
+
+    test "remote index failure preserves local members and the remote set" do
+      test_pid = self()
+      table = new_cap_table()
+      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
+
+      put_warmth_fact(table, "node-4", [], [
+        group_set("orphan-nobind-set", "", [member("a", "m-nb-a", 1_000), member("b", "m-nb-b", 2_000)])
+      ])
+
+      reaper = empty_binding_group_reaper(table, artifact_fun, snapshot_fun, fn -> {:error, :timeout} end)
+      WarmthReaper.sweep_now(reaper)
+
+      refute_receive {:evict_snapshot, "m-nb-a"}, 300
+      refute_receive {:evict_snapshot, "m-nb-b"}, 200
+      refute_receive {:evict_artifact, :ARTIFACT_KIND_GROUP_SET, "orphan-nobind-set", true}, 200
+    end
+
+    test "non-empty group instance id keeps the existing local then remote behavior" do
+      test_pid = self()
+      table = new_cap_table()
+      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
+
+      put_warmth_fact(table, "node-4", [], [
+        group_set("orphan-nobind-set", "grp-on-disk", [member("a", "m-nb-a", 1_000), member("b", "m-nb-b", 2_000)])
+      ])
+
+      reaper =
+        empty_binding_group_reaper(table, artifact_fun, snapshot_fun, fn ->
+          send(test_pid, :remote_group_index_lookup)
+          {:error, :unexpected_lookup}
+        end)
+
+      WarmthReaper.sweep_now(reaper)
+
+      assert_receive {:evict_snapshot, "m-nb-a"}, 1_000
+      assert_receive {:evict_snapshot, "m-nb-b"}, 1_000
+
+      assert_receive {:evict_artifact_req,
+                      %{
+                        remote: true,
+                        vendor: "",
+                        artifact: %{
+                          kind: :ARTIFACT_KIND_GROUP_SET,
+                          workload: "grp-on-disk",
+                          ref: "orphan-nobind-set"
+                        }
+                      }},
+                     1_000
+
+      refute_receive :remote_group_index_lookup, 300
+    end
+
+    test "the default remote index rejects conflicting bindings for one set id" do
+      body = """
+      <ListBucketResult>
+        <IsTruncated>false</IsTruncated>
+        <Contents><Key>group_set/amd/grp-one/shared-set/a/memfile</Key><Size>1</Size></Contents>
+        <Contents><Key>group_set/nvidia/grp-two/shared-set/b/memfile</Key><Size>1</Size></Contents>
+      </ListBucketResult>
+      """
+
+      port = 18_091
+      start_supervised!({Bandit, plug: {S3ListPlug, body}, scheme: :http, port: port})
+
+      previous_endpoint = System.get_env("EMBERVM_STORE_ENDPOINT")
+      previous_bucket = System.get_env("EMBERVM_STORE_BUCKET")
+
+      on_exit(fn ->
+        restore_system_env("EMBERVM_STORE_ENDPOINT", previous_endpoint)
+        restore_system_env("EMBERVM_STORE_BUCKET", previous_bucket)
+      end)
+
+      System.put_env("EMBERVM_STORE_ENDPOINT", "http://127.0.0.1:#{port}")
+      System.put_env("EMBERVM_STORE_BUCKET", "embervm-test")
+
+      reaper = start_reaper([])
+      index_fun = :sys.get_state(reaper).remote_group_index_fun
+
+      assert {:error, {:conflicting_bindings, "shared-set"}} = index_fun.()
+    end
+  end
+
   describe "group warmth retention" do
     test "evicts an orphaned group set: per-member local + one remote set evict (gate ON)" do
       test_pid = self()
@@ -521,10 +673,8 @@ defmodule Embervm.WarmthReaperTest do
     end
   end
 
-  # #38 fix C remains fail-safe when the remote index is unavailable. The group
-  # layout is not searchable by set id in the same way, so its empty binding still
-  # skips both copies.
-  describe "empty-binding lookup failures and groups remain fail-safe (#38 fix C)" do
+  # #38 fix C remains fail-safe when the remote stateful index is unavailable.
+  describe "empty-binding stateful lookup failures remain fail-safe (#38 fix C)" do
     test "a stateful orphan with no workload binding and no remote store runs no evict" do
       test_pid = self()
       table = new_cap_table()
@@ -554,37 +704,8 @@ defmodule Embervm.WarmthReaperTest do
       refute_receive {:evict_artifact, :ARTIFACT_KIND_STATEFUL, "orphan-nobind", _}, 300
     end
 
-    test "a group orphan with no group_instance_id binding runs no member local and no remote evict" do
-      test_pid = self()
-      table = new_cap_table()
-      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
-
-      # set with group_instance_id "" (pre-sidecar). group_set/3 takes the gid as
-      # arg 2; pass "".
-      put_warmth_fact(table, "node-4", [], [
-        group_set("orphan-nobind-set", "", [member("a", "m-nb-a", 1_000), member("b", "m-nb-b", 2_000)])
-      ])
-
-      stateful = start_store([])
-      group = start_store([group_instance(:destroyed, "orphan-nobind-set")])
-
-      reaper =
-        start_reaper(
-          capacity_table: table,
-          stateful_store: stateful,
-          group_store: group,
-          evict_artifact_fun: artifact_fun,
-          evict_snapshot_fun: snapshot_fun,
-          channel_fun: fake_channel_fun(),
-          sweep_enabled: true
-        )
-
-      plan = WarmthReaper.sweep_now(reaper)
-      assert Enum.any?(plan, &(&1.id == "orphan-nobind-set"))
-      # No per-member local evict, no whole-set remote evict.
-      refute_receive {:evict_snapshot, "m-nb-a"}, 300
-      refute_receive {:evict_snapshot, "m-nb-b"}, 200
-      refute_receive {:evict_artifact, :ARTIFACT_KIND_GROUP_SET, "orphan-nobind-set", true}, 200
-    end
   end
+
+  defp restore_system_env(key, nil), do: System.delete_env(key)
+  defp restore_system_env(key, value), do: System.put_env(key, value)
 end


### PR DESCRIPTION
## What

Gives `:group` the same empty-binding recovery that PR #4905 gave `:stateful`.

## Why

#4905 removed the empty-binding skip for stateful bundles and left the identical clause for group sets, with a stated reason:

> GROUP_SET is not searchable by the same ref in this reaper. Its remote layout is keyed by group_instance_id, so the conservative empty-binding skip remains.

Both sentences are true. The conclusion only follows if the index must be shared. The stateful index parses `stateful/<vendor>/<workload>/<ref>/<file>` into `ref => binding`, and group keys genuinely do not fit that shape. But the store key is `<kind>/<vendor>/<workload>/<ref>`, so a group set is `group_set/<vendor>/<gid>/<set_id>/<member>/<file>`, and a second index keyed by `set_id` recovers exactly the binding the skip calls unrecoverable.

## Measured in production today

On the node-4 brick:

| | |
|---|---|
| local group sets | **6**, 18 memfiles, **60 GiB** |
| created | 2026-07-16 |
| `group_instance_id` binding files present | **0**, so every set hits the skip |
| local group ids | `grp-01KXVQ...`, `grp-01KXVV...`, `grp-01KXW0...` |
| group ids in the store | `grp-01KY8Y...`, `grp-01KY91...`, `grp-01KY92...`, `grp-01KY97...` |
| **overlap** | **ZERO** |

Same shape as #4905's stateful finding: the skip protects nothing while costing 60 GiB indefinitely, and it cannot resolve itself because nothing else will supply the missing binding.

Note what this implies for the reclaim itself. Every one of the six sets misses the index, so they all take the local-only path: this PR's practical effect is a pure local reclaim with nothing deleted from the store. The branch that deletes remotely is the one that has a binding to address it with.

## How

Mirrors the stateful implementation clause for clause:

- `default_remote_group_index/0` lists `group_set/` and folds it into `set_id => %{vendor, group_instance_id}`, with the same conflicting-binding `:halt`
- `remote_group_index/2` with the same "only look up when some entry has an empty binding" gate and the same `rescue`/`catch` wrappers
- three-way `evict_entry`: recovered binding evicts local then remote; index miss evicts local only; lookup failure still skips
- the inline group eviction body is extracted to `evict_group/4`, symmetric with `evict_stateful/4`
- `log_dry_run_entry/2` gains group clauses so a gate-off sweep reports which path each orphan would take

`run_evict/4` is untouched, so the single remote GROUP_SET evict still fires only when **every** member's local eviction succeeded.

`vendor: vendor || ""` on the remote request is a no-op for the existing path: the old request omitted the field, which protobuf renders as `""`.

## Not in this PR

**Arming.** `warmthRetention.sweepEnabled` is unchanged. The dry-run lines now report what would be reclaimed and by which path; reading those and arming is a separate supervised step, the way the S3 GC was armed on 2026-08-04 after its dry-run manifest was read.

## Flagged: is `group` retired or active?

`deploy/values.yaml` sets `warmthS3Gc.allowEmptyKinds: "group"` as the operator statement that the scratch-k8s demo is retired and `GroupStore` legitimately tracks zero instances. But the four group ids in the store are dated 2026-08-14, and those same keys are the 16 entries the S3 sweep reports as `ambiguous_keys`.

That matters for what this PR is. If group is genuinely dead, this is a one-time 60 GiB reclaim. If something is still producing group sets, the skip is an ongoing leak and this fix stops it accruing. I have not resolved which, and it does not block the fix either way, but it should be settled before arming.

## Known behaviour worth recording

`dial_for_group` requires a non-empty gid and otherwise falls open to the bare `node_id`. In the recovered path the entry's workload is rewritten, but the node's fact still reports an empty `group_instance_id` (that is what made it an orphan), so the dial falls back to `node_id` in both new paths. That is safe here because co-located bricks share one scratch mount, so either instance's evict removes the same file. It would misroute on a node whose siblings did not share scratch.

## Testing

`ci lint` clean. `ci test` green:

```
1312 tests, 0 failures, 6 skipped
```

Note the Elixir suite runs as the `//bazel/erlang:mix_test_smoke` **genrule**, so it never appears in Bazel's `Executed N out of M tests` line (that line reads `0 out of 719` here and is not the signal for this change). The ExUnit summary above is.

Test count in `warmth_reaper_test.exs` goes 16 to 20: five added, one removed. The removed test asserted the old skip ("runs no member local and no remote evict"), which is exactly the behaviour this changes; the remaining no-evict case is covered by the index-failure test.

All four paths assert on the captured requests rather than on the return value, because every clause returns `:ok` including the skip, so a return-value assertion would pass against the bug:

- remote hit: local members evicted, then remote with the recovered vendor and gid
- remote miss: `assert_receive` both members, `refute_receive` the remote GROUP_SET evict
- index failure: nothing evicted
- non-empty gid: unchanged behaviour
- plus `{:error, {:conflicting_bindings, set_id}}` for two bindings on one set id

🤖 Generated with [Claude Code](https://claude.com/claude-code)