### PR TITLE
fix(embervm): re-key claude-runtime again so the intel bases rebuild

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -575,7 +575,28 @@ claudeRuntimeWorkload:
     # condition unchanged across six minutes. Re-keying is the only route, and
     # this epoch is the documented mechanism for it. That the fix for a
     # transient timeout is a hand-edited string is the problem tracked in #4937.
-    EMBER_BASE_EPOCH: "diff-capture-1"
+    #
+    # diff-capture-2: diff-capture-1 DID deploy and DID re-key. The values source
+    # is the git ref at HEAD, not the OCI chart, so ArgoCD applied it 37 seconds
+    # after the merge with no chart bump, and a base rebuilt at 18:38:33Z. But it
+    # rebuilt for ONE vendor. The fleet is vendor-split, and after that rebuild:
+    #
+    #   snapshotRefs.amd   claude-runtime__7adf2327a376  built, punched, in S3
+    #   snapshotRefs.intel claude-runtime__a1cc8b4bb845  in NO store, on NO brick
+    #
+    # The intel bricks still hold claude-runtime__1bd56a68d7af from Aug 8 and
+    # Aug 10, so three of the four firecracker nodes boot a week-old guest image.
+    # No intel brick logged a BuildBase at any point. BaseBuilt and Ready are
+    # computed from the headline snapshotRef, which is amd's, so the workload
+    # reported healthy while the intel half was never built. Sessions 194, 195
+    # and 196 recorded the NEW image digest and still captured nothing, because
+    # the session record carries the desired digest rather than the base the
+    # guest actually restored (#4893).
+    #
+    # This re-key is paired with destroying the parked sessions that were
+    # refcount-pinning the stale intel base against retention. Vendor-blind
+    # conditions and the dangling intel ref are tracked in #4937.
+    EMBER_BASE_EPOCH: "diff-capture-2"
     # INERT, kept only as documented intent: the shim reads EMBER_PREWARM_CLIS
     # from its own environment, which never receives this, so _read_prewarm_clis
     # returns () and prewarm silently no-ops. Live turn-timing confirms it: first


### PR DESCRIPTION
## What

Bumps `claudeRuntimeWorkload.initEnv.EMBER_BASE_EPOCH` from `diff-capture-1` to `diff-capture-2`, to force a rebuild of the **intel** claude-runtime bases. Paired with destroying the parked sessions that were pinning the stale intel base against retention.

## Why: #4938 worked, for one vendor

`diff-capture-1` deployed and re-keyed correctly, faster than expected. The Application's values source is `targetRevision: HEAD` on the git repo, not the OCI chart, so ArgoCD applied it 37 seconds after merge with no chart bump:

```
revisions: ['0.14.1', '3b0de1a198091895ad5d5f4149676d054312f337']
syncedAt:  2026-08-15T18:38:55Z
```

A base rebuilt at 18:38:33Z and `BaseBuilt` flipped True. The chart version never moving is why this looked like a non-deploy.

But the fleet is vendor-split and the rebuild was not:

| | ref | exists? |
|---|---|---|
| `snapshotRefs.amd` | `claude-runtime__7adf2327a376` | yes: built 18:38:33, punched 4096 to 328 MiB, in `base/amd/` |
| `snapshotRefs.intel` | `claude-runtime__a1cc8b4bb845` | **no**: not in `base/intel/`, not in `base/amd/`, not on any of the six bricks |

What the intel bricks actually hold:

```
node-1  claude-runtime__1bd56a68d7af  2026-08-10 02:23  4096 MiB allocated
node-2  claude-runtime__1bd56a68d7af  2026-08-08 07:35  4096 MiB allocated
```

All four firecracker nodes are schedulable, so three of four boot a guest image from a week ago. No intel brick logged a `BuildBase` at any point in the window.

## Why it looked healthy

`BaseBuilt` and `Ready` are derived from the headline `snapshotRef`, which is amd's. The plural `snapshotRefs` beside it carries the per-vendor truth and nothing reads it. So a rebuild on one vendor marks the workload healthy while another vendor is never built.

## Why the capture probes were misleading

Sessions 194, 195 and 196 each recorded:

```
base_digest: ...claude@sha256:c8a38ea24d5d...   <- the NEW image
```

and still captured nothing. That is not a contradiction: the session record carries the workload's *desired* digest, not the base the guest actually restored. On an intel brick the guest restores `1bd56a68d7af` regardless. This is the conflation tracked in #4893.

That also retires the "BaseBuilt True with an absent artifact" theory: there is no `ExportArtifact ... absent or empty` warning in the control-plane log, and the amd artifact is present in the store.

## Scope

This buys a working fleet. It does not fix the defects it exposes, which belong in #4937:

- `BaseBuilt` / `Ready` are vendor-blind, so one vendor's success masks another's absence
- the control plane can record a per-vendor ref (`a1cc8b4bb845`) for a base that exists nowhere
- a per-vendor build that is never dispatched produces no log and no condition change

Hand-editing a string to force a rebuild remains the wrong mechanism, which is #4429 and #4937.

## Expected effect

Both vendors re-key. amd rebuilds (fast, ~15s last time). intel must build for the first time since Aug 10, on bricks that currently hold a 4096 MiB fully-allocated base. Since the punch is now live, the replacement should land near 330 MiB, so this should *free* roughly 3.7 GiB per intel brick rather than consume space.

Verification is a real session that captures a diff, not `BaseBuilt=True`, which is precisely the signal that misled us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)