### PR TITLE
fix(embervm): clear vendors that drop out of the fleet's reported base refs

### DIFF
--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -2830,8 +2830,12 @@ defmodule Embervm.BaseBuilder do
   # would stay listed until the next event.
   #
   # Patching only on a CHANGE keeps a converged fleet from generating a status
-  # write per workload per tick. An empty map never patches, for the same
-  # anti-clobber reason put_snapshot_refs/3 skips it.
+  # write per workload per tick. JSON merge-patch retains keys absent from the
+  # patch, which left claude-runtime's long-gone intel ref in status while only
+  # amd nodes still reported a base. On a non-empty fleet read, vendors missing
+  # from the new map therefore need an explicit nil so merge-patch deletes them.
+  # The map_size(refs) == 0 guard remains the transient-wipe boundary: a total
+  # capacity-fact gap or brick roll is not evidence that every live base vanished.
   defp refresh_snapshot_refs(state) do
     Enum.reduce(state.workloads, state, fn {name, w}, acc ->
       refs = snapshot_refs_by_vendor(acc, w)
@@ -2844,7 +2848,11 @@ defmodule Embervm.BaseBuilder do
           acc
 
         true ->
-          case acc.status_writer.(w.namespace, w.name, %{"snapshotRefs" => refs}) do
+          stale_vendors = Map.keys(w.last_snapshot_refs || %{}) -- Map.keys(refs)
+          stale_clears = Map.new(stale_vendors, &{&1, nil})
+          patch_refs = Map.merge(refs, stale_clears)
+
+          case acc.status_writer.(w.namespace, w.name, %{"snapshotRefs" => patch_refs}) do
             :ok ->
               put_in(acc.workloads[name].last_snapshot_refs, refs)
 

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -2553,6 +2553,105 @@ defmodule Embervm.BaseBuilderTest do
     end)
   end
 
+  test "the periodic reconcile explicitly clears a missing vendor once and preserves survivors" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd", "amd")
+    put_vendor_fact(table, "node-1", "ds", "w", "w__intel", "intel")
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        export_reconcile_interval_ms: 0
+      )
+
+    build_current(builder, agent, "w__amd")
+
+    # Establish the last successfully written effective map, then discard setup
+    # calls so the assertions below inspect only the stale-clear patch.
+    send(builder, :export_reconcile)
+    _ = :sys.get_state(builder)
+    Agent.update(agent, fn _calls -> [] end)
+
+    NodeCapacity.drop(table, {"node-1", "ds"})
+    send(builder, :export_reconcile)
+    _ = :sys.get_state(builder)
+
+    assert recorded(agent) == [
+             {"embervm", "w",
+              %{"snapshotRefs" => %{"amd" => ["w__amd"], "intel" => nil}}}
+           ]
+
+    # last_snapshot_refs tracks the effective desired map, not the patch body,
+    # so the explicit clear is not emitted again on the next identical tick.
+    send(builder, :export_reconcile)
+    _ = :sys.get_state(builder)
+
+    assert recorded(agent) == [
+             {"embervm", "w",
+              %{"snapshotRefs" => %{"amd" => ["w__amd"], "intel" => nil}}}
+           ]
+  end
+
+  test "the periodic reconcile writes nothing during a total capacity-fact gap" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd", "amd")
+    put_vendor_fact(table, "node-1", "ds", "w", "w__intel", "intel")
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        export_reconcile_interval_ms: 0
+      )
+
+    build_current(builder, agent, "w__amd")
+    send(builder, :export_reconcile)
+    _ = :sys.get_state(builder)
+    Agent.update(agent, fn _calls -> [] end)
+
+    NodeCapacity.drop(table, {"node-4", "ds"})
+    NodeCapacity.drop(table, {"node-1", "ds"})
+    send(builder, :export_reconcile)
+    _ = :sys.get_state(builder)
+
+    assert recorded(agent) == []
+  end
+
+  test "the periodic reconcile writes nothing when the effective map is unchanged" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd", "amd")
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        export_reconcile_interval_ms: 0
+      )
+
+    build_current(builder, agent, "w__amd")
+    send(builder, :export_reconcile)
+    _ = :sys.get_state(builder)
+    Agent.update(agent, fn _calls -> [] end)
+
+    send(builder, :export_reconcile)
+    _ = :sys.get_state(builder)
+
+    assert recorded(agent) == []
+  end
+
   test "the periodic reconcile does not re-patch status when the fleet view is unchanged" do
     agent = start_recorder()
     table = new_cap_table()


### PR DESCRIPTION
## What

`snapshotRefs` can never lose a vendor. This adds an explicit `nil` for vendors that vanish from a non-empty fleet read, so merge-patch deletes them.

## Why

`refresh_snapshot_refs` writes via `Embervm.K8s.patch_workload_status/3`, which uses `application/merge-patch+json`. Under merge-patch an absent key is **left alone**; only an explicit null removes one.

Observed on `claude-runtime` in production:

```
snapshotRefs: {"amd":   ["claude-runtime__62c362524fec"],
               "intel": ["claude-runtime__a1cc8b4bb845"]}
```

`claude-runtime` declares `memMib: 4096`, so it only fits the 16gi bricks, and both live on node-4 (amd). No intel node can host it, so none reports a base for it, so the computed map has no `intel` key at all.

That stale entry survived **two** epoch re-keys unchanged while amd moved `a1cc` to `7adf` to `62c3`. And it points at nothing:

| checked | result |
|---|---|
| `base/intel/` in the store | absent |
| `base/amd/` in the store | absent |
| all six brick scratch dirs | absent |

A dangling reference to a base reaped long ago, published in status as though current.

## The part that needed care

The naive fix is to make the write authoritative and let absent vendors vanish. That is wrong here. `snapshotRefs` is what other code trusts for per-vendor truth, so a false wipe is worse than a stale entry.

The distinction this PR draws:

- a vendor missing from a **non-empty** read is **evidence** (other vendors reported, so the read is live)
- a vendor missing from an **empty** read is **silence** (a brick roll, a capacity-fact gap)

So the existing `map_size(refs) == 0 -> acc` early return is deliberately untouched and is now documented as the transient-wipe boundary. Same observation, opposite meaning, separated only by context.

`last_snapshot_refs` still tracks the effective map rather than the patch body, so the unchanged-read short-circuit keeps working and a clear is emitted once rather than every tick.

## Testing

`ci lint` clean. `ci test` green:

```
1311 tests, 0 failures, 6 skipped
```

That is +3 on this branch's base (`faf6008d6`, before #4939's 4 tests landed). Note the Elixir suite runs as the `//bazel/erlang:mix_test_smoke` **genrule**, so Bazel's `Executed N out of M tests` line reads `0 out of 719` and is not the signal for this change.

Three tests, each asserting the exact patch body captured by an injected `status_writer`, not a return value:

1. a vendor missing from a non-empty read is patched with an explicit `nil` while survivors keep their exact ref lists, **and** a second identical tick emits no further write
2. a total capacity-fact gap writes nothing at all
3. an unchanged read short-circuits and writes nothing

Test 1's double-tick is the regression that matters: had the bookkeeping stored the patch body instead of the effective map, the clear would re-fire forever.

## Out of scope

`BaseBuilt` and `Ready` are still vendor-blind, derived from the headline `snapshotRef` (amd's), which is how a workload reported healthy tonight while another vendor's entry was a dangling reference. That is the larger defect and stays in #4937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)