### PR TITLE
feat(monolith): add the auth domain, Principal type, and token verification

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1,5 +1,6 @@
 # gazelle:exclude agent
 # gazelle:exclude agent_sessions
+# gazelle:exclude auth
 # gazelle:exclude artifact
 # gazelle:exclude chat
 # gazelle:exclude chat_public
@@ -88,6 +89,7 @@ _BACKEND_SRCS = glob(
         "agent/**/*.py",
         "agent_sessions/**/*.py",
         "app/**/*.py",
+        "auth/**/*.py",
         "core/**/*.py",
         "framework/**/*.py",
         "artifact/**/*.py",
@@ -284,6 +286,29 @@ py_venv_binary(
 # The packages in the agent/chat/home import cycle share one
 # target because Bazel deps must be acyclic; everything else is a DAG.
 py_library(
+    name = "pkg_auth",
+    srcs = glob(
+        [
+            "auth/**/*.py",
+        ],
+        exclude = [
+            "**/*_test.py",
+            "**/test_*.py",
+            "*/tests/**/*.py",
+        ],
+    ),
+    imports = ["."],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@pip//fastapi",
+        "@pip//httpx",
+        # PyJWT is currently locked transitively through mcp and semgrep.
+        "@pip//pyjwt",
+        "@pip//starlette",
+    ],
+)
+
+py_library(
     name = "pkg_core",
     srcs = glob(
         [
@@ -370,6 +395,7 @@ py_library(
     imports = ["."],
     visibility = ["//:__subpackages__"],
     deps = [
+        ":pkg_auth",
         ":pkg_core",
         "@pip//certifi",
         "@pip//fastapi",
@@ -1307,6 +1333,7 @@ py_library(
             "agent/**/*.py",
             "agent_sessions/**/*.py",
             "app/**/*.py",
+            "auth/**/*.py",
             "core/**/*.py",
             "framework/**/*.py",
             "artifact/**/*.py",
@@ -1382,6 +1409,8 @@ py_library(
         "@pip//pydantic_ai_slim",
         "@pip//python_multipart",  # trips/ingest_router.py (UploadFile / form parsing)
         "@pip//pyyaml",
+        # PyJWT is currently locked transitively through mcp and semgrep.
+        "@pip//pyjwt",
         # NOTE: semgrep_scan/report.py uploads to the Semgrep App via plain
         # authenticated HTTP (explicit Authorization: Bearer) using httpx (already
         # a dep above), not ScanHandler.
@@ -1393,6 +1422,7 @@ py_library(
         "@pip//semgrep",
         "@pip//sqlalchemy",
         "@pip//sqlmodel",
+        "@pip//starlette",
         "@pip//timelength",
         "@pip//trafilatura",
         "@pip//tzdata",
@@ -1753,6 +1783,33 @@ monolith_domain_images(
 )
 
 py_test(
+    name = "auth_verifier_test",
+    srcs = ["auth/verifier_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_auth",
+        "@pip//cryptography",
+        # PyJWT is currently locked transitively through mcp and semgrep.
+        "@pip//pyjwt",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
+    name = "auth_plumbing_test",
+    srcs = ["auth/plumbing_test.py"],
+    imports = ["."],
+    deps = [
+        ":pkg_auth",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
     name = "markers_test",
     srcs = ["shared/testing/markers_test.py"],
     imports = ["."],
@@ -1784,6 +1841,7 @@ py_test(
             "scheduler/**/*.py",
             "agent/**/*.py",
             "agent_sessions/**/*.py",
+            "auth/**/*.py",
             "goosecracker/**/*.py",
             "worldcup/**/*.py",
             "campsites/**/*.py",

--- a/projects/monolith/auth/__init__.py
+++ b/projects/monolith/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication primitives for the monolith."""

--- a/projects/monolith/auth/api.py
+++ b/projects/monolith/auth/api.py
@@ -1,0 +1,25 @@
+"""Public authentication API for monolith domains."""
+
+from auth.dependencies import (
+    auth_error_handler,
+    current_principal,
+    get_default_resolver,
+    get_principal,
+)
+from auth.errors import AuthError, AuthErrorReason
+from auth.middleware import PrincipalMiddleware
+from auth.principal import Authority, Principal, PrincipalKind, anonymous_principal
+
+__all__ = [
+    "AuthError",
+    "AuthErrorReason",
+    "Authority",
+    "Principal",
+    "PrincipalKind",
+    "anonymous_principal",
+    "current_principal",
+    "get_principal",
+    "get_default_resolver",
+    "PrincipalMiddleware",
+    "auth_error_handler",
+]

--- a/projects/monolith/auth/dependencies.py
+++ b/projects/monolith/auth/dependencies.py
@@ -1,0 +1,115 @@
+"""FastAPI and request-context authentication plumbing."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextvars import ContextVar, Token
+from functools import lru_cache
+
+from fastapi import Request
+from starlette.responses import JSONResponse
+
+from auth.errors import AuthError, AuthErrorReason
+from auth.principal import Principal, anonymous_principal
+from auth.verifier import TokenResolver, build_default_resolver
+
+logger = logging.getLogger("monolith.auth")
+
+_ANONYMOUS = anonymous_principal()
+_current_principal: ContextVar[Principal] = ContextVar(
+    "monolith_principal", default=_ANONYMOUS
+)
+
+
+@lru_cache(maxsize=1)
+def get_default_resolver() -> TokenResolver:
+    """Return the cached default token resolver built from environment.
+
+    For tests that monkeypatch AUTH_* and need a fresh resolver, call
+    get_default_resolver.cache_clear().
+    """
+    return build_default_resolver()
+
+
+def current_principal() -> Principal:
+    """Return the principal associated with the active async context."""
+
+    return _current_principal.get()
+
+
+def set_current_principal(principal: Principal) -> Token[Principal]:
+    return _current_principal.set(principal)
+
+
+def reset_current_principal(token: Token[Principal]) -> None:
+    _current_principal.reset(token)
+
+
+async def resolve_authorization(
+    authorization: str | None,
+    resolver: TokenResolver,
+) -> Principal:
+    """Resolve one Authorization value with explicit absent-token semantics."""
+
+    if authorization is None:
+        return _ANONYMOUS
+
+    parts = authorization.strip().split(None, 1)
+    if not parts:
+        return _ANONYMOUS
+
+    scheme = parts[0]
+    if scheme.lower() != "bearer":
+        logger.debug("ignoring non-bearer authorization scheme")
+        return _ANONYMOUS
+
+    credential = parts[1].strip() if len(parts) == 2 else ""
+    if not credential:
+        error = AuthError(AuthErrorReason.MALFORMED)
+        _log_failure(error)
+        raise error
+
+    try:
+        return await resolver.resolve(credential)
+    except AuthError as error:
+        _log_failure(error)
+        raise
+
+
+async def get_principal(request: Request) -> AsyncIterator[Principal]:
+    """FastAPI dependency that verifies and stores the request principal."""
+
+    existing = getattr(request.state, "principal", None)
+    if isinstance(existing, Principal):
+        principal = existing
+    else:
+        resolver = getattr(request.app.state, "auth_resolver", None)
+        if resolver is None:
+            resolver = get_default_resolver()
+        principal = await resolve_authorization(
+            request.headers.get("authorization"), resolver
+        )
+        request.state.principal = principal
+    context_token = _current_principal.set(principal)
+    try:
+        yield principal
+    finally:
+        _current_principal.reset(context_token)
+
+
+def auth_error_handler(request, exc):
+    """Handle AuthError exceptions with reason in the response body."""
+    from auth.errors import AuthError
+
+    if isinstance(exc, AuthError):
+        return JSONResponse(
+            {"detail": exc.detail, "reason": exc.reason.value},
+            status_code=exc.status_code,
+            headers=exc.headers,
+        )
+    raise exc
+
+
+def _log_failure(error: AuthError) -> None:
+    logger.warning("authentication failed: %s", error.reason.value)

--- a/projects/monolith/auth/errors.py
+++ b/projects/monolith/auth/errors.py
@@ -1,0 +1,45 @@
+"""Authentication failures classified by their owner."""
+
+from __future__ import annotations
+
+import enum
+
+from starlette.exceptions import HTTPException
+
+
+class AuthErrorReason(enum.StrEnum):
+    """Stable failure reasons for callers, logs, and tests."""
+
+    BAD_SIGNATURE = "bad_signature"
+    WRONG_ISSUER = "wrong_issuer"
+    WRONG_AUDIENCE = "wrong_audience"
+    EXPIRED = "expired"
+    NOT_YET_VALID = "not_yet_valid"
+    MALFORMED = "malformed"
+    UNKNOWN_KID = "unknown_kid"
+    UNRECOGNIZED = "unrecognized"
+    JWKS_UNREACHABLE = "jwks_unreachable"
+    JWKS_MALFORMED = "jwks_malformed"
+    UNCONFIGURED = "unconfigured"
+
+    @property
+    def is_infrastructure_fault(self) -> bool:
+        return self in {
+            AuthErrorReason.JWKS_UNREACHABLE,
+            AuthErrorReason.JWKS_MALFORMED,
+            AuthErrorReason.UNCONFIGURED,
+        }
+
+
+class AuthError(HTTPException):
+    """An explicit authentication failure with safe HTTP semantics."""
+
+    def __init__(self, reason: AuthErrorReason):
+        self.reason = reason
+        status_code = 503 if reason.is_infrastructure_fault else 401
+        headers = None if status_code == 503 else {"WWW-Authenticate": "Bearer"}
+        super().__init__(
+            status_code=status_code,
+            detail=f"authentication failed: {reason.value}",
+            headers=headers,
+        )

--- a/projects/monolith/auth/jwks.py
+++ b/projects/monolith/auth/jwks.py
@@ -1,0 +1,150 @@
+"""TTL-cached JSON Web Key Set retrieval.
+
+Every failure here is an AuthError classified as an infrastructure fault, so a
+JWKS problem renders 503 rather than escaping as an unhandled 500 or, worse,
+being mistaken for a caller fault. Nothing in this module returns a sentinel
+that a caller could read as success: a missing key returns None, which means
+exactly "this key id is not in the document I have", and never "the fetch
+failed".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+import httpx
+
+from auth.errors import AuthError, AuthErrorReason
+
+JwksDocument = Mapping[str, Any]
+JwksFetcher = Callable[[str], Awaitable[JwksDocument]]
+TimeFunction = Callable[[], float]
+
+# A JWKS fetch happens inline on the verification path while the cache lock is
+# held, so an unbounded wait stalls every other verification behind it. 5s total
+# with 2s to connect keeps a slow IdP from becoming a monolith-wide stall.
+_TIMEOUT = httpx.Timeout(5.0, connect=2.0)
+
+
+async def fetch_jwks(url: str) -> JwksDocument:
+    """Fetch a JWKS document using the process HTTP stack."""
+
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        document = response.json()
+    if not isinstance(document, Mapping):
+        raise AuthError(AuthErrorReason.JWKS_MALFORMED)
+    return document
+
+
+def _find_key(document: JwksDocument, kid: str) -> dict[str, Any] | None:
+    """Return the JWK matching kid, or None when the document does not carry it.
+
+    A structurally invalid document raises rather than reporting "not found":
+    a malformed JWKS is our fault, and reporting it as a missing key would
+    surface an infrastructure fault to the caller as a 401.
+    """
+
+    keys = document.get("keys", [])
+    if not isinstance(keys, list):
+        raise AuthError(AuthErrorReason.JWKS_MALFORMED)
+    for key in keys:
+        if isinstance(key, Mapping) and key.get("kid") == kid:
+            return dict(key)
+    return None
+
+
+class JwksCache:
+    """Cache a JWKS document, refreshing on expiry and on an unknown key id.
+
+    Two independent clocks, which is the part worth reading twice. The TTL
+    governs the ORDINARY path: a cached document is served until it expires.
+    The forced-refresh FLOOR governs the unknown-kid path, and it exists
+    because that path is caller-triggered: without it, N requests bearing
+    random key ids each cause an outbound fetch, serialized behind this lock.
+    A failed fetch is remembered for the same window, so a down IdP fails fast
+    instead of every request paying the full timeout.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        ttl_s: float,
+        *,
+        fetch: JwksFetcher = fetch_jwks,
+        now: TimeFunction = time.monotonic,
+    ) -> None:
+        self._url = url
+        self._ttl_s = ttl_s
+        self._fetch = fetch
+        # Monotonic on purpose: a wall-clock step (NTP correction, suspend)
+        # must not expire or extend the cache.
+        self._now = now
+        self._document: JwksDocument | None = None
+        self._fetched_at = 0.0
+        # Negative infinity so the FIRST forced refresh is always allowed; the
+        # floor only ever suppresses a second one inside the window.
+        self._forced_at = float("-inf")
+        self._error: AuthError | None = None
+        self._lock = asyncio.Lock()
+
+    async def get_key(
+        self, kid: str, *, force_refresh: bool = False
+    ) -> dict[str, Any] | None:
+        document = await self._document_for(force_refresh=force_refresh)
+        return _find_key(document, kid)
+
+    async def _document_for(self, *, force_refresh: bool) -> JwksDocument:
+        async with self._lock:
+            now = self._now()
+
+            if force_refresh:
+                if now - self._forced_at < self._ttl_s:
+                    # Inside the floor. Re-raise a remembered failure rather
+                    # than retrying it, and otherwise serve what we hold so the
+                    # caller gets an honest "kid not present" rather than a
+                    # second fetch.
+                    if self._error is not None:
+                        raise self._error
+                    return self._document if self._document is not None else {}
+                self._forced_at = now
+                return await self._fetch_locked(now)
+
+            if now - self._fetched_at < self._ttl_s:
+                if self._error is not None:
+                    raise self._error
+                if self._document is not None:
+                    return self._document
+
+            return await self._fetch_locked(now)
+
+    async def _fetch_locked(self, now: float) -> JwksDocument:
+        """Fetch and cache. Callers must hold the lock."""
+
+        try:
+            document = await self._fetch(self._url)
+        except AuthError as exc:
+            self._remember_failure(exc, now)
+            raise
+        except Exception as exc:
+            error = AuthError(AuthErrorReason.JWKS_UNREACHABLE)
+            self._remember_failure(error, now)
+            raise error from exc
+
+        if not isinstance(document, Mapping):
+            error = AuthError(AuthErrorReason.JWKS_MALFORMED)
+            self._remember_failure(error, now)
+            raise error
+
+        self._document = document
+        self._fetched_at = now
+        self._error = None
+        return document
+
+    def _remember_failure(self, error: AuthError, now: float) -> None:
+        self._error = error
+        self._fetched_at = now

--- a/projects/monolith/auth/middleware.py
+++ b/projects/monolith/auth/middleware.py
@@ -1,0 +1,67 @@
+"""Raw ASGI authentication middleware for mounted applications."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from starlette.responses import JSONResponse
+
+from auth.dependencies import (
+    reset_current_principal,
+    resolve_authorization,
+    set_current_principal,
+)
+from auth.errors import AuthError
+from auth.verifier import TokenResolver
+
+ASGIApp = Callable[
+    [dict[str, Any], Callable[..., Awaitable[Any]], Callable[..., Awaitable[Any]]],
+    Awaitable[None],
+]
+
+
+class PrincipalMiddleware:
+    """Resolve bearer identity before dispatching an HTTP ASGI request.
+
+    Warning: On the SSE transport, the Principal is the stream-opener's and
+    remains pinned for the entire session. Per-message POST resolution via the
+    context variable is discarded before tool dispatch. Any per-caller result
+    scoping built on current_principal() from inside a tool must account for
+    this: the identity is not re-verified for each MCP message.
+    """
+
+    def __init__(self, app: ASGIApp, resolver: TokenResolver) -> None:
+        self.app = app
+        self.resolver = resolver
+
+    async def __call__(self, scope: dict, receive: Callable, send: Callable) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        authorization = _authorization_header(scope)
+        try:
+            principal = await resolve_authorization(authorization, self.resolver)
+        except AuthError as error:
+            response = JSONResponse(
+                {"detail": error.detail, "reason": error.reason.value},
+                status_code=error.status_code,
+                headers=error.headers,
+            )
+            await response(scope, receive, send)
+            return
+
+        scope.setdefault("state", {})["principal"] = principal
+        context_token = set_current_principal(principal)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            reset_current_principal(context_token)
+
+
+def _authorization_header(scope: dict) -> str | None:
+    for name, value in scope.get("headers", []):
+        if name.lower() == b"authorization":
+            return value.decode("latin-1")
+    return None

--- a/projects/monolith/auth/plumbing_test.py
+++ b/projects/monolith/auth/plumbing_test.py
@@ -1,0 +1,331 @@
+"""Tests for shared FastAPI and mounted-ASGI request authentication."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+from fastapi import Depends, FastAPI, Request
+
+from auth.dependencies import current_principal, get_principal, resolve_authorization
+from auth.errors import AuthError, AuthErrorReason
+from auth.middleware import PrincipalMiddleware
+from auth.principal import Authority, Principal, PrincipalKind
+from auth.verifier import TokenResolver
+
+
+class MappingVerifier:
+    def __init__(self, token: str, principal: Principal) -> None:
+        self.token = token
+        self.principal = principal
+
+    async def verify(self, token: str):
+        if token == self.token:
+            return self.principal
+        return None
+
+
+@pytest.fixture
+def human_principal() -> Principal:
+    return Principal(
+        subject="human-1",
+        actor=(),
+        scope=("openid", "tools:read"),
+        groups=("friends",),
+        email="human@example.com",
+        kind=PrincipalKind.HUMAN,
+        authority=Authority.STANDING,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("authorization", [None, "Basic abc123", "Digest value"])
+async def test_absent_or_non_bearer_authorization_is_anonymous(authorization):
+    resolver = TokenResolver([])
+
+    principal = await resolve_authorization(authorization, resolver)
+
+    assert principal.authority is Authority.ANONYMOUS
+    assert principal.subject == "anonymous"
+    assert principal.groups == ()
+    assert principal.scope == ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("authorization", ["Bearer", "Bearer ", "Bearer     "])
+async def test_empty_bearer_credential_is_invalid_not_anonymous(authorization):
+    with pytest.raises(AuthError) as raised:
+        await resolve_authorization(authorization, TokenResolver([]))
+
+    assert raised.value.reason is AuthErrorReason.MALFORMED
+    assert raised.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_failure_logging_never_contains_token(caplog):
+    secret_token = "highly-secret-token-material-4942"
+    caplog.set_level(logging.DEBUG, logger="monolith.auth")
+
+    with pytest.raises(AuthError) as raised:
+        await resolve_authorization(
+            f"Bearer {secret_token}",
+            TokenResolver([]),
+        )
+
+    assert raised.value.reason is AuthErrorReason.UNRECOGNIZED
+    assert any("unrecognized" in record.message for record in caplog.records)
+    assert all(secret_token not in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_fastapi_and_mounted_asgi_paths_have_principal_parity(human_principal):
+    bearer = "same-token"
+    resolver = TokenResolver([MappingVerifier(bearer, human_principal)])
+
+    fastapi_app = FastAPI()
+    fastapi_app.state.auth_resolver = resolver
+
+    @fastapi_app.get("/whoami")
+    async def whoami(
+        request: Request,
+        principal: Principal = Depends(get_principal),
+    ):
+        assert request.state.principal == principal
+        assert current_principal() == principal
+        return _principal_dict(principal)
+
+    captured: dict = {}
+
+    async def mounted_app(scope, receive, send):
+        captured["state"] = scope["state"]["principal"]
+        captured["context"] = current_principal()
+        response = httpx.Response(200, json={"ok": True})
+        await send(
+            {
+                "type": "http.response.start",
+                "status": response.status_code,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b'{"ok":true}'})
+
+    mounted = PrincipalMiddleware(mounted_app, resolver)
+    headers = {"Authorization": f"Bearer {bearer}"}
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=fastapi_app),
+        base_url="http://test",
+    ) as client:
+        api_response = await client.get("/whoami", headers=headers)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=mounted),
+        base_url="http://test",
+    ) as client:
+        mcp_response = await client.get("/", headers=headers)
+
+    assert api_response.status_code == 200
+    assert mcp_response.status_code == 200
+    assert api_response.json() == _principal_json(human_principal)
+    assert captured["state"] == human_principal
+    assert captured["context"] == human_principal
+
+
+@pytest.mark.asyncio
+async def test_fastapi_dependency_does_not_trust_proxy_identity_headers():
+    app = FastAPI()
+    app.state.auth_resolver = TokenResolver([])
+
+    @app.get("/whoami")
+    async def whoami(principal: Principal = Depends(get_principal)):
+        return _principal_dict(principal)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/whoami",
+            headers={"X-Auth-Email": "forged@example.com"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["authority"] == Authority.ANONYMOUS.value
+    assert response.json()["email"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reason", "status"),
+    [
+        (AuthErrorReason.UNRECOGNIZED, 401),
+        (AuthErrorReason.JWKS_UNREACHABLE, 503),
+    ],
+)
+async def test_middleware_renders_auth_error_owner_status(reason, status):
+    class FailingVerifier:
+        async def verify(self, token: str):
+            raise AuthError(reason)
+
+    async def unreachable_app(scope, receive, send):
+        raise AssertionError("invalid bearer material reached the application")
+
+    app = PrincipalMiddleware(unreachable_app, TokenResolver([FailingVerifier()]))
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/",
+            headers={"Authorization": "Bearer present-token"},
+        )
+
+    assert response.status_code == status
+    assert response.json()["reason"] == reason.value
+    if status == 401:
+        assert response.headers["WWW-Authenticate"] == "Bearer"
+    else:
+        assert "WWW-Authenticate" not in response.headers
+
+
+def _principal_dict(principal: Principal) -> dict:
+    return {
+        "subject": principal.subject,
+        "actor": principal.actor,
+        "scope": principal.scope,
+        "groups": principal.groups,
+        "email": principal.email,
+        "kind": principal.kind,
+        "authority": principal.authority,
+    }
+
+
+def _principal_json(principal: Principal) -> dict:
+    return {
+        "subject": principal.subject,
+        "actor": list(principal.actor),
+        "scope": list(principal.scope),
+        "groups": list(principal.groups),
+        "email": principal.email,
+        "kind": principal.kind.value,
+        "authority": principal.authority.value,
+    }
+
+
+@pytest.mark.asyncio
+async def test_bare_token_no_scheme_logging_never_contains_token(caplog):
+    """A bare token with no scheme must not be logged even at DEBUG level."""
+    secret_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9-secret-material-4942"
+    caplog.set_level(logging.DEBUG, logger="monolith.auth")
+
+    # No exception expected; bare tokens are treated as absent headers (return anonymous).
+    principal = await resolve_authorization(secret_token, TokenResolver([]))
+
+    assert principal.authority is Authority.ANONYMOUS
+    # Verify that even at DEBUG level, no part of the token appears.
+    assert all(secret_token not in record.getMessage() for record in caplog.records)
+    assert all(
+        part not in record.getMessage()
+        for part in secret_token.split("-")
+        if len(part) > 5  # Avoid checking common words like "secret"
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_fastapi_path_auth_error_has_reason_in_body(human_principal):
+    """The handler renders `reason` on a route, GIVEN it is registered.
+
+    This test registers it itself, so it proves the handler works and NOT that
+    anything installs it. That the private app actually registers it is asserted
+    separately in framework/core_test.py, where the app is built the production
+    way.
+    """
+    from auth.api import auth_error_handler
+
+    fastapi_app = FastAPI()
+    fastapi_app.state.auth_resolver = TokenResolver([])
+    fastapi_app.add_exception_handler(AuthError, auth_error_handler)
+
+    @fastapi_app.get("/whoami")
+    async def whoami(principal: Principal = Depends(get_principal)):
+        return {"subject": principal.subject}
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=fastapi_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/whoami",
+            headers={"Authorization": "Bearer unrecognized"},
+        )
+
+    assert response.status_code == 401
+    body = response.json()
+    assert "detail" in body
+    assert "reason" in body
+    assert body["reason"] == AuthErrorReason.UNRECOGNIZED.value
+    assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+@pytest.mark.asyncio
+async def test_middleware_and_fastapi_paths_consistent_error_body(human_principal):
+    """Both paths render errors with the same body shape: detail + reason."""
+    bearer = "same-token"
+    resolver = TokenResolver([MappingVerifier(bearer, human_principal)])
+
+    fastapi_app = FastAPI()
+    fastapi_app.state.auth_resolver = resolver
+    from auth.api import auth_error_handler
+
+    fastapi_app.add_exception_handler(AuthError, auth_error_handler)
+
+    middleware_errors = []
+
+    @fastapi_app.get("/whoami")
+    async def whoami(principal: Principal = Depends(get_principal)):
+        return {"subject": principal.subject}
+
+    async def middleware_app(scope, receive, send):
+        if scope["type"] != "http":
+            await send({"type": "http.response.start", "status": 500, "headers": []})
+            return
+        middleware_errors.append(scope.get("state", {}).get("principal"))
+        response = httpx.Response(200, json={"ok": True})
+        await send(
+            {
+                "type": "http.response.start",
+                "status": response.status_code,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b'{"ok":true}'})
+
+    from auth.middleware import PrincipalMiddleware
+
+    mounted = PrincipalMiddleware(middleware_app, resolver)
+
+    # Test FastAPI 401 response
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=fastapi_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/whoami", headers={"Authorization": "Bearer bad"})
+
+    assert response.status_code == 401
+    fastapi_body = response.json()
+    assert "detail" in fastapi_body
+    assert "reason" in fastapi_body
+
+    # Test middleware 401 response
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=mounted),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/", headers={"Authorization": "Bearer bad"})
+
+    assert response.status_code == 401
+    middleware_body = response.json()
+    assert "detail" in middleware_body
+    assert "reason" in middleware_body
+    assert fastapi_body["reason"] == middleware_body["reason"]

--- a/projects/monolith/auth/principal.py
+++ b/projects/monolith/auth/principal.py
@@ -1,0 +1,55 @@
+"""Request identity facts, without resource authorization policy."""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+
+class PrincipalKind(enum.StrEnum):
+    """The class of identity represented by a principal."""
+
+    HUMAN = "human"
+    WORKLOAD = "workload"
+
+
+class Authority(enum.StrEnum):
+    """How the principal's authority was established."""
+
+    STANDING = "standing"
+    DELEGATED = "delegated"
+    ANONYMOUS = "anonymous"
+
+
+@dataclass(frozen=True, slots=True)
+class Principal:
+    """Verified identity and carried grants for one request."""
+
+    subject: str
+    actor: tuple[str, ...]
+    scope: tuple[str, ...]
+    groups: tuple[str, ...]
+    email: str | None
+    kind: PrincipalKind
+    authority: Authority
+
+    def has_group(self, name: str) -> bool:
+        return name in self.groups
+
+    def has_scope(self, name: str) -> bool:
+        return name in self.scope
+
+
+def anonymous_principal() -> Principal:
+    """Return the least-privilege principal used when no bearer token exists."""
+
+    return Principal(
+        subject="anonymous",
+        actor=(),
+        scope=(),
+        groups=(),
+        email=None,
+        # Anonymous is an authority state, not a third identity kind.
+        kind=PrincipalKind.HUMAN,
+        authority=Authority.ANONYMOUS,
+    )

--- a/projects/monolith/auth/settings.py
+++ b/projects/monolith/auth/settings.py
@@ -1,0 +1,45 @@
+"""Environment-backed authentication settings."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+logger = logging.getLogger("monolith.auth")
+
+
+@dataclass(frozen=True, slots=True)
+class AuthSettings:
+    authentik_jwks_url: str
+    authentik_issuer: str
+    authentik_audience: str
+    jwks_cache_ttl_s: float
+
+    @classmethod
+    def from_env(cls) -> AuthSettings:
+        def parse_ttl(value: str) -> float:
+            try:
+                return float(value)
+            except ValueError:
+                logger.warning(
+                    "invalid AUTH_JWKS_CACHE_TTL_S: %r, falling back to 300s", value
+                )
+                return 300.0
+
+        return cls(
+            authentik_jwks_url=os.getenv("AUTH_AUTHENTIK_JWKS_URL", ""),
+            authentik_issuer=os.getenv("AUTH_AUTHENTIK_ISSUER", ""),
+            authentik_audience=os.getenv("AUTH_AUTHENTIK_AUDIENCE", ""),
+            jwks_cache_ttl_s=parse_ttl(os.getenv("AUTH_JWKS_CACHE_TTL_S", "300")),
+        )
+
+    @property
+    def identity_is_configured(self) -> bool:
+        return all(
+            (
+                self.authentik_jwks_url,
+                self.authentik_issuer,
+                self.authentik_audience,
+            )
+        )

--- a/projects/monolith/auth/verifier.py
+++ b/projects/monolith/auth/verifier.py
@@ -1,0 +1,171 @@
+"""Bearer token verification and ordered verifier resolution."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Sequence
+from typing import Protocol
+
+import jwt
+
+from auth.errors import AuthError, AuthErrorReason
+from auth.jwks import JwksCache, JwksFetcher, TimeFunction, fetch_jwks
+from auth.principal import Authority, Principal, PrincipalKind
+from auth.settings import AuthSettings
+
+logger = logging.getLogger("monolith.auth")
+
+
+class TokenVerifier(Protocol):
+    async def verify(self, token: str) -> Principal | None:
+        """Return a verified principal, or None when the token is not recognized."""
+
+
+class AuthentikStandingVerifier:
+    """Verify standing Authentik authority using its configured JWKS."""
+
+    def __init__(
+        self,
+        settings: AuthSettings,
+        *,
+        fetch: JwksFetcher = fetch_jwks,
+        now: TimeFunction = time.monotonic,
+    ) -> None:
+        self._settings = settings
+        self._jwks = JwksCache(
+            settings.authentik_jwks_url,
+            settings.jwks_cache_ttl_s,
+            fetch=fetch,
+            now=now,
+        )
+
+    async def verify(self, token: str) -> Principal | None:
+        if not self._settings.identity_is_configured:
+            raise AuthError(AuthErrorReason.UNCONFIGURED)
+
+        try:
+            header = jwt.get_unverified_header(token)
+        except jwt.InvalidTokenError as exc:
+            raise AuthError(AuthErrorReason.MALFORMED) from exc
+
+        if header.get("alg") != "RS256":
+            raise AuthError(AuthErrorReason.MALFORMED)
+        kid = header.get("kid")
+        if not isinstance(kid, str) or not kid:
+            raise AuthError(AuthErrorReason.MALFORMED)
+
+        # Ownership check: is this token ours? Decode without verification to check iss.
+        # If the issuer does not match, decline so the next verifier can be tried.
+        try:
+            unverified_claims = jwt.decode(
+                token,
+                options={"verify_signature": False},
+                algorithms=["RS256"],
+            )
+        except jwt.InvalidTokenError:
+            # A token nobody can parse is nobody's; raise for consistency with header failures.
+            raise AuthError(AuthErrorReason.MALFORMED) from None
+
+        iss = unverified_claims.get("iss")
+        if iss != self._settings.authentik_issuer:
+            logger.debug(
+                "declining token: issuer mismatch (expected %s, got %s)",
+                self._settings.authentik_issuer,
+                iss,
+            )
+            return None
+
+        jwk = await self._jwks.get_key(kid)
+        if jwk is None:
+            jwk = await self._jwks.get_key(kid, force_refresh=True)
+        if jwk is None:
+            raise AuthError(AuthErrorReason.UNKNOWN_KID)
+
+        # The document was fetched successfully to get here, so nothing at this
+        # point can be a reachability problem: a key PyJWT cannot construct is a
+        # malformed or unsupported entry. PyJWK.from_dict raises PyJWKError or
+        # InvalidKeyError, NOT PyJWKClientError, which is a PyJWKClient concern
+        # and would never match here.
+        try:
+            key = jwt.PyJWK.from_dict(jwk, algorithm="RS256").key
+        except Exception as exc:
+            raise AuthError(AuthErrorReason.JWKS_MALFORMED) from exc
+
+        try:
+            claims = jwt.decode(
+                token,
+                key=key,
+                algorithms=["RS256"],
+                audience=self._settings.authentik_audience,
+                issuer=self._settings.authentik_issuer,
+                # PyJWT validates exp only when the claim is PRESENT, so without
+                # this a token minted without an expiry would be accepted
+                # forever. iss and aud are already implied by passing issuer and
+                # audience, and sub is checked below, but state all four so the
+                # requirement survives a future edit to either.
+                options={"require": ["exp", "iss", "aud", "sub"]},
+            )
+        except jwt.ExpiredSignatureError as exc:
+            raise AuthError(AuthErrorReason.EXPIRED) from exc
+        except jwt.ImmatureSignatureError as exc:
+            raise AuthError(AuthErrorReason.NOT_YET_VALID) from exc
+        except jwt.InvalidAudienceError as exc:
+            raise AuthError(AuthErrorReason.WRONG_AUDIENCE) from exc
+        except jwt.InvalidIssuerError as exc:
+            # This is unreachable after the ownership gate above, but kept as defence in depth.
+            raise AuthError(AuthErrorReason.WRONG_ISSUER) from exc
+        except jwt.InvalidSignatureError as exc:
+            raise AuthError(AuthErrorReason.BAD_SIGNATURE) from exc
+        except jwt.InvalidTokenError as exc:
+            raise AuthError(AuthErrorReason.MALFORMED) from exc
+
+        subject = claims.get("sub")
+        if not isinstance(subject, str) or not subject:
+            raise AuthError(AuthErrorReason.MALFORMED)
+        groups_claim = claims.get("groups", [])
+        if not isinstance(groups_claim, list) or not all(
+            isinstance(group, str) for group in groups_claim
+        ):
+            raise AuthError(AuthErrorReason.MALFORMED)
+        email_claim = claims.get("email")
+        email = email_claim if isinstance(email_claim, str) and email_claim else None
+        scope_claim = claims.get("scope", "")
+        if not isinstance(scope_claim, str):
+            raise AuthError(AuthErrorReason.MALFORMED)
+
+        # #4943 lands the authentik workload blueprints; pin this discriminator
+        # to whatever claim those blueprints guarantee rather than inferring from
+        # email absence once it exists.
+        kind = PrincipalKind.HUMAN if email is not None else PrincipalKind.WORKLOAD
+        return Principal(
+            subject=subject,
+            actor=(),
+            scope=tuple(scope_claim.split()),
+            groups=tuple(groups_claim),
+            email=email,
+            kind=kind,
+            authority=Authority.STANDING,
+        )
+
+
+class TokenResolver:
+    """Resolve bearer material against verifiers in registration order."""
+
+    def __init__(self, verifiers: Sequence[TokenVerifier]) -> None:
+        self._verifiers = tuple(verifiers)
+
+    async def resolve(self, token: str) -> Principal:
+        for verifier in self._verifiers:
+            principal = await verifier.verify(token)
+            if principal is not None:
+                return principal
+        # A present token never downgrades to anonymous when no verifier owns it.
+        raise AuthError(AuthErrorReason.UNRECOGNIZED)
+
+
+def build_default_resolver(settings: AuthSettings | None = None) -> TokenResolver:
+    configured = settings or AuthSettings.from_env()
+    # Delegation verification from #4944 registers after the standing verifier.
+    verifiers: list[TokenVerifier] = [AuthentikStandingVerifier(configured)]
+    return TokenResolver(verifiers)

--- a/projects/monolith/auth/verifier_test.py
+++ b/projects/monolith/auth/verifier_test.py
@@ -1,0 +1,555 @@
+"""Hermetic tests for standing-token verification and resolver ordering."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import replace
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from auth.errors import AuthError, AuthErrorReason
+from auth.principal import Authority, Principal, PrincipalKind
+from auth.settings import AuthSettings
+from auth.verifier import AuthentikStandingVerifier, TokenResolver
+
+ISSUER = "https://auth.example/application/o/mcp-friends/"
+AUDIENCE = "https://private.example"
+JWKS_URL = f"{ISSUER}jwks/"
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.value = 100.0
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def _settings(**overrides) -> AuthSettings:
+    settings = AuthSettings(
+        authentik_jwks_url=JWKS_URL,
+        authentik_issuer=ISSUER,
+        authentik_audience=AUDIENCE,
+        jwks_cache_ttl_s=300,
+    )
+    return replace(settings, **overrides)
+
+
+def _key_and_jwk(kid: str = "key-1"):
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(private_key.public_key()))
+    jwk.update({"kid": kid, "alg": "RS256", "use": "sig"})
+    return private_key, jwk
+
+
+def _token(private_key, *, kid: str = "key-1", **claim_overrides) -> str:
+    claims = {
+        "sub": "user-123",
+        "email": "person@example.com",
+        "groups": ["friends", "operators"],
+        "scope": "openid profile tools:read",
+        "iss": ISSUER,
+        "aud": ["another-audience", AUDIENCE],
+        "exp": int(time.time()) + 3600,
+    }
+    claims.update(claim_overrides)
+    return jwt.encode(claims, private_key, algorithm="RS256", headers={"kid": kid})
+
+
+def _fetcher(*documents):
+    calls: list[str] = []
+
+    async def fetch(url: str):
+        calls.append(url)
+        index = min(len(calls) - 1, len(documents) - 1)
+        return documents[index]
+
+    return fetch, calls
+
+
+@pytest.mark.asyncio
+async def test_valid_human_token_maps_all_identity_facts():
+    private_key, jwk = _key_and_jwk()
+    fetch, calls = _fetcher({"keys": [jwk]})
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+
+    principal = await verifier.verify(_token(private_key))
+
+    assert principal == Principal(
+        subject="user-123",
+        actor=(),
+        scope=("openid", "profile", "tools:read"),
+        groups=("friends", "operators"),
+        email="person@example.com",
+        kind=PrincipalKind.HUMAN,
+        authority=Authority.STANDING,
+    )
+    assert principal.has_group("friends")
+    assert principal.has_scope("tools:read")
+    assert calls == [JWKS_URL]
+
+
+@pytest.mark.asyncio
+async def test_valid_service_account_without_email_is_workload():
+    private_key, jwk = _key_and_jwk()
+    fetch, _ = _fetcher({"keys": [jwk]})
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+
+    principal = await verifier.verify(_token(private_key, email=None))
+
+    assert principal is not None
+    assert principal.email is None
+    assert principal.kind is PrincipalKind.WORKLOAD
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("claims", "reason"),
+    [
+        ({"exp": int(time.time()) - 60}, AuthErrorReason.EXPIRED),
+        ({"aud": ["somewhere-else"]}, AuthErrorReason.WRONG_AUDIENCE),
+    ],
+)
+async def test_invalid_registered_claims_are_caller_faults(claims, reason):
+    private_key, jwk = _key_and_jwk()
+    fetch, _ = _fetcher({"keys": [jwk]})
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(_token(private_key, **claims))
+
+    assert raised.value.reason is reason
+
+
+@pytest.mark.asyncio
+async def test_wrong_issuer_through_resolver_is_unrecognized():
+    """Wrong issuer means this token is not ours, so the resolver raises UNRECOGNIZED."""
+    private_key, jwk = _key_and_jwk()
+    fetch, _ = _fetcher({"keys": [jwk]})
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+
+    # The verifier DECLINES rather than raising, which is what lets a second
+    # verifier see the token at all. Assert both halves: the decline itself, and
+    # that a decline with nobody left to ask still fails closed.
+    assert (
+        await verifier.verify(_token(private_key, iss="https://wrong.example/")) is None
+    )
+
+    resolver = TokenResolver([verifier])
+    with pytest.raises(AuthError) as raised:
+        await resolver.resolve(_token(private_key, iss="https://wrong.example/"))
+
+    assert raised.value.reason is AuthErrorReason.UNRECOGNIZED
+
+
+@pytest.mark.asyncio
+async def test_token_without_exp_is_rejected():
+    """A token with no expiry must be refused, not accepted forever.
+
+    PyJWT validates exp only when the claim is PRESENT, so this is enforced by
+    options={"require": [...]} rather than by decode's own defaults. Without
+    that option every assertion in this file still passes while a non-expiring
+    token is honoured indefinitely, which is why this test exists.
+    """
+    private_key, jwk = _key_and_jwk()
+    fetch, _ = _fetcher({"keys": [jwk]})
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+    no_exp = jwt.encode(
+        {
+            "sub": "user-123",
+            "email": "person@example.com",
+            "iss": ISSUER,
+            "aud": [AUDIENCE],
+        },
+        private_key,
+        algorithm="RS256",
+        headers={"kid": "key-1"},
+    )
+
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(no_exp)
+
+    assert raised.value.reason is AuthErrorReason.MALFORMED
+    assert raised.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_bad_signature_is_explicit_caller_fault():
+    signing_key, _ = _key_and_jwk()
+    _, published_jwk = _key_and_jwk()
+    fetch, _ = _fetcher({"keys": [published_jwk]})
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(_token(signing_key))
+
+    assert raised.value.reason is AuthErrorReason.BAD_SIGNATURE
+
+
+@pytest.mark.asyncio
+async def test_unknown_kid_refreshes_once_and_remains_an_error():
+    private_key, _ = _key_and_jwk("missing")
+    _, other_jwk = _key_and_jwk("other")
+    fetch, calls = _fetcher({"keys": [other_jwk]})
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(_token(private_key, kid="missing"))
+
+    assert raised.value.reason is AuthErrorReason.UNKNOWN_KID
+    assert calls == [JWKS_URL, JWKS_URL]
+
+
+@pytest.mark.asyncio
+async def test_unknown_kid_refresh_can_resolve_rotated_key():
+    private_key, wanted_jwk = _key_and_jwk("rotated")
+    _, stale_jwk = _key_and_jwk("stale")
+    fetch, calls = _fetcher(
+        {"keys": [stale_jwk]},
+        {"keys": [stale_jwk, wanted_jwk]},
+    )
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+
+    principal = await verifier.verify(_token(private_key, kid="rotated"))
+
+    assert principal is not None
+    assert principal.subject == "user-123"
+    assert calls == [JWKS_URL, JWKS_URL]
+
+
+@pytest.mark.asyncio
+async def test_jwks_fetch_failure_is_infrastructure_fault():
+    private_key, _ = _key_and_jwk()
+
+    async def failing_fetch(url: str):
+        raise OSError("network unavailable")
+
+    verifier = AuthentikStandingVerifier(_settings(), fetch=failing_fetch)
+
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(_token(private_key))
+
+    assert raised.value.reason is AuthErrorReason.JWKS_UNREACHABLE
+    assert raised.value.status_code == 503
+    assert raised.value.headers is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "field",
+    ["authentik_jwks_url", "authentik_issuer", "authentik_audience"],
+)
+async def test_empty_identity_setting_is_explicit_infrastructure_fault(field):
+    private_key, jwk = _key_and_jwk()
+    fetch, calls = _fetcher({"keys": [jwk]})
+    verifier = AuthentikStandingVerifier(
+        _settings(**{field: ""}),
+        fetch=fetch,
+    )
+
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(_token(private_key))
+
+    assert raised.value.reason is AuthErrorReason.UNCONFIGURED
+    assert raised.value.status_code == 503
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_jwks_cache_honors_ttl_without_sleeping():
+    private_key, jwk = _key_and_jwk()
+    fetch, calls = _fetcher({"keys": [jwk]})
+    clock = Clock()
+    verifier = AuthentikStandingVerifier(
+        _settings(jwks_cache_ttl_s=10),
+        fetch=fetch,
+        now=clock,
+    )
+    token = _token(private_key)
+
+    await verifier.verify(token)
+    clock.advance(9)
+    await verifier.verify(token)
+    assert calls == [JWKS_URL]
+
+    clock.advance(2)
+    await verifier.verify(token)
+    assert calls == [JWKS_URL, JWKS_URL]
+
+
+class StubVerifier:
+    def __init__(self, result=None, error: AuthError | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls: list[str] = []
+
+    async def verify(self, token: str):
+        self.calls.append(token)
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_present_token_unrecognized_by_every_verifier_is_not_anonymous():
+    first = StubVerifier()
+    second = StubVerifier()
+    resolver = TokenResolver([first, second])
+
+    with pytest.raises(AuthError) as raised:
+        await resolver.resolve("opaque-token")
+
+    assert raised.value.reason is AuthErrorReason.UNRECOGNIZED
+    assert first.calls == ["opaque-token"]
+    assert second.calls == ["opaque-token"]
+
+
+@pytest.mark.asyncio
+async def test_ordered_chain_second_verifier_reached_on_first_decline():
+    """The real standing verifier declines a different-issuer token, and the stub is consulted."""
+    private_key, jwk = _key_and_jwk()
+    fetch, _ = _fetcher({"keys": [jwk]})
+    standing = AuthentikStandingVerifier(_settings(), fetch=fetch)
+
+    delegation_principal = Principal(
+        subject="delegate",
+        actor=("broker",),
+        scope=("tools:read",),
+        groups=(),
+        email=None,
+        kind=PrincipalKind.WORKLOAD,
+        authority=Authority.DELEGATED,
+    )
+    stub = StubVerifier(result=delegation_principal)
+
+    delegation_token = _token(private_key, iss="https://delegation-issuer/")
+    principal = await TokenResolver([standing, stub]).resolve(delegation_token)
+
+    assert principal is delegation_principal
+    assert stub.calls == [delegation_token]
+
+
+@pytest.mark.asyncio
+async def test_ordered_chain_stops_when_first_verifier_raises():
+    first = StubVerifier(error=AuthError(AuthErrorReason.BAD_SIGNATURE))
+    second = StubVerifier(result="must not be returned")
+
+    with pytest.raises(AuthError) as raised:
+        await TokenResolver([first, second]).resolve("bad-standing-token")
+
+    assert raised.value.reason is AuthErrorReason.BAD_SIGNATURE
+    assert first.calls == ["bad-standing-token"]
+    assert second.calls == []
+
+
+@pytest.mark.asyncio
+async def test_rs256_algorithm_pin_rejects_other_algorithms(caplog):
+    """Verify that the RS256 pin is enforced before JWKS lookup."""
+    private_key, jwk = _key_and_jwk()
+    fetch, calls = _fetcher({"keys": [jwk]})
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+    caplog.set_level(logging.DEBUG, logger="monolith.auth")
+
+    # Create a token with HS256 (symmetric key), same structure otherwise.
+    token = jwt.encode(
+        {
+            "sub": "user-123",
+            "iss": ISSUER,
+            "aud": AUDIENCE,
+            "exp": int(time.time()) + 3600,
+        },
+        "secret-key",
+        algorithm="HS256",
+        headers={"kid": "key-1"},
+    )
+
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(token)
+
+    assert raised.value.reason is AuthErrorReason.MALFORMED
+    assert calls == []  # No JWKS fetch should have been attempted
+
+
+@pytest.mark.asyncio
+async def test_not_yet_valid_token_is_caller_fault():
+    """Token with nbf in the future is caller error."""
+    private_key, jwk = _key_and_jwk()
+    fetch, _ = _fetcher({"keys": [jwk]})
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(_token(private_key, nbf=int(time.time()) + 3600))
+
+    assert raised.value.reason is AuthErrorReason.NOT_YET_VALID
+    assert raised.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_non_list_groups_is_malformed():
+    """Groups claim must be a list of strings."""
+    private_key, jwk = _key_and_jwk()
+    fetch, _ = _fetcher({"keys": [jwk]})
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(_token(private_key, groups="not-a-list"))
+
+    assert raised.value.reason is AuthErrorReason.MALFORMED
+
+
+@pytest.mark.asyncio
+async def test_non_string_scope_is_malformed():
+    """Scope claim must be a space-separated string."""
+    private_key, jwk = _key_and_jwk()
+    fetch, _ = _fetcher({"keys": [jwk]})
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(_token(private_key, scope=["list", "not", "string"]))
+
+    assert raised.value.reason is AuthErrorReason.MALFORMED
+
+
+@pytest.mark.asyncio
+async def test_forced_refresh_rate_limited_by_ttl():
+    """Multiple unknown-kid verifications within the TTL produce only one fetch."""
+    private_key, jwk = _key_and_jwk()
+    fetch, calls = _fetcher({"keys": [jwk]})
+    clock = Clock()
+    verifier = AuthentikStandingVerifier(
+        _settings(jwks_cache_ttl_s=10),
+        fetch=fetch,
+        now=clock,
+    )
+
+    # First unknown kid triggers a refresh.
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(_token(private_key, kid="missing-1"))
+    assert raised.value.reason is AuthErrorReason.UNKNOWN_KID
+    assert calls == [JWKS_URL, JWKS_URL]
+
+    # Within the TTL floor, no new fetch.
+    clock.advance(5)
+    with pytest.raises(AuthError):
+        await verifier.verify(_token(private_key, kid="missing-2"))
+    assert calls == [JWKS_URL, JWKS_URL]
+
+    # After TTL expires, a new refresh happens.
+    clock.advance(6)
+    with pytest.raises(AuthError):
+        await verifier.verify(_token(private_key, kid="missing-3"))
+    assert calls == [JWKS_URL, JWKS_URL, JWKS_URL, JWKS_URL]
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_cached_within_ttl():
+    """A failed JWKS fetch is re-raised quickly within the TTL."""
+    private_key, _ = _key_and_jwk()
+    call_count = 0
+
+    async def failing_fetch_once(url: str):
+        nonlocal call_count
+        call_count += 1
+        raise OSError("network down")
+
+    clock = Clock()
+    verifier = AuthentikStandingVerifier(
+        _settings(jwks_cache_ttl_s=10),
+        fetch=failing_fetch_once,
+        now=clock,
+    )
+
+    # First call: the cold-cache fetch fails and raises immediately. ONE attempt,
+    # not two: the unknown-kid refresh is never reached, because there is no
+    # document to miss in. Hitting a down IdP twice per request would double both
+    # its load and the caller's latency at the worst possible moment.
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(_token(private_key, kid="missing"))
+    assert raised.value.reason is AuthErrorReason.JWKS_UNREACHABLE
+    assert call_count == 1
+
+    # Within TTL: re-raise the cached error without a new fetch.
+    clock.advance(5)
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(_token(private_key, kid="another"))
+    assert raised.value.reason is AuthErrorReason.JWKS_UNREACHABLE
+    assert call_count == 1  # Negative cache served it, no new fetch
+
+
+@pytest.mark.asyncio
+async def test_jwks_malformed_is_distinct_from_unreachable():
+    """A structurally invalid JWKS is a malformed reason, not unreachable."""
+    private_key, jwk = _key_and_jwk()
+    fetch, _ = _fetcher({"keys": "not-a-list"})
+    verifier = AuthentikStandingVerifier(_settings(), fetch=fetch)
+
+    with pytest.raises(AuthError) as raised:
+        await verifier.verify(_token(private_key))
+
+    assert raised.value.reason is AuthErrorReason.JWKS_MALFORMED
+    assert raised.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_unparseable_ttl_falls_back_to_default(caplog):
+    """An unparseable AUTH_JWKS_CACHE_TTL_S falls back to 300s and logs warning."""
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="monolith.auth")
+
+    # Create a settings object with unparseable TTL
+    settings = AuthSettings(
+        authentik_jwks_url=JWKS_URL,
+        authentik_issuer=ISSUER,
+        authentik_audience=AUDIENCE,
+        jwks_cache_ttl_s=300,  # We'll test via from_env
+    )
+
+    # Test from_env behavior with monkeypatch
+    import os
+
+    original_getenv = os.getenv
+
+    def mock_getenv(key, default=None):
+        if key == "AUTH_JWKS_CACHE_TTL_S":
+            return "not-a-number"
+        return original_getenv(key, default)
+
+    os.getenv = mock_getenv
+    try:
+        settings_from_env = AuthSettings.from_env()
+        assert settings_from_env.jwks_cache_ttl_s == 300.0
+        # Check that warning was logged
+        assert any(
+            "invalid AUTH_JWKS_CACHE_TTL_S" in record.message
+            for record in caplog.records
+        )
+    finally:
+        os.getenv = original_getenv
+
+
+@pytest.mark.asyncio
+async def test_empty_ttl_falls_back_to_default():
+    """An empty AUTH_JWKS_CACHE_TTL_S falls back to 300s."""
+    import os
+
+    original_getenv = os.getenv
+
+    def mock_getenv(key, default=None):
+        if key == "AUTH_JWKS_CACHE_TTL_S":
+            return ""
+        return original_getenv(key, default)
+
+    os.getenv = mock_getenv
+    try:
+        settings_from_env = AuthSettings.from_env()
+        assert settings_from_env.jwks_cache_ttl_s == 300.0
+    finally:
+        os.getenv = original_getenv

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -503,6 +503,14 @@ spec:
             - name: ORCHESTRATOR_REPLAN_TIMEOUT_S
               value: {{ .Values.orchestrator.replanTimeoutSeconds | quote }}
             {{- end }}
+            - name: AUTH_AUTHENTIK_JWKS_URL
+              value: {{ .Values.auth.authentik.jwksUrl | quote }}
+            - name: AUTH_AUTHENTIK_ISSUER
+              value: {{ .Values.auth.authentik.issuer | quote }}
+            - name: AUTH_AUTHENTIK_AUDIENCE
+              value: {{ .Values.auth.authentik.audience | quote }}
+            - name: AUTH_JWKS_CACHE_TTL_S
+              value: {{ .Values.auth.jwksCacheTtlSeconds | quote }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -34,6 +34,17 @@ backend:
     enabled: true
     maxUnavailable: 1
 
+# Authentik derives the OIDC issuer from the APPLICATION SLUG, so these values
+# track the mcp-friends slug in projects/platform/authentik/blueprints/mcp-auth.yaml.
+# Renaming the application silently breaks verification. The issuer's trailing
+# slash is significant.
+auth:
+  authentik:
+    jwksUrl: "https://auth.jomcgi.dev/application/o/mcp-friends/jwks/"
+    issuer: "https://auth.jomcgi.dev/application/o/mcp-friends/"
+    audience: "https://private.jomcgi.dev"
+  jwksCacheTtlSeconds: 300
+
 # Progress-ingest listener (ADR agents/051): its own container and port so the
 # EmberVM egress allowlist entry exposes exactly one write-only route.
 # progress.image is injected (digest-pinned) at build time by

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -18,6 +18,15 @@ backend:
     limits:
       memory: "1Gi"
 
+# State the production verifier identity explicitly. The application slug owns
+# the Authentik issuer path, and the trailing slash is significant.
+auth:
+  authentik:
+    jwksUrl: "https://auth.jomcgi.dev/application/o/mcp-friends/jwks/"
+    issuer: "https://auth.jomcgi.dev/application/o/mcp-friends/"
+    audience: "https://private.jomcgi.dev"
+  jwksCacheTtlSeconds: 300
+
 frontend:
   otelCollectorUrl: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318"
 

--- a/projects/monolith/framework/core.py
+++ b/projects/monolith/framework/core.py
@@ -526,6 +526,7 @@ def build_app(profile: Profile, modules: Sequence[Module]) -> FastAPI:
     lifespan = build_private_lifespan(profile, modules)
 
     mcp_http_app = None
+    mcp_lifespan = None
     if profile.mcp_enabled:
         # The shared FastMCP instance lives in app/mcp_app.py (excluded from
         # the public file set); domain tool modules attach to it on import.
@@ -538,20 +539,46 @@ def build_app(profile: Profile, modules: Sequence[Module]) -> FastAPI:
         for m in modules:
             if m.register_mcp is not None:
                 m.register_mcp()
-        mcp_http_app = monolith_mcp.http_app(transport="sse", path="/")
+        raw_mcp_http_app = monolith_mcp.http_app(transport="sse", path="/")
+        mcp_lifespan = raw_mcp_http_app.lifespan
+
+        # Context Forge reaches this mount over ClusterIP, without the private
+        # ingress gate. Verify bearer material here instead of trusting proxy
+        # identity headers that this path never receives. On the SSE transport,
+        # the Principal is pinned to the stream-opener for the entire session:
+        # per-message POST resolution is discarded, so tools reading
+        # current_principal() do not see per-message identity updates.
+        from auth.api import PrincipalMiddleware, get_default_resolver
+
+        mcp_http_app = PrincipalMiddleware(
+            raw_mcp_http_app,
+            get_default_resolver(),
+        )
 
     if mcp_http_app is not None:
         app_lifespan = lifespan
+        assert mcp_lifespan is not None
 
         @asynccontextmanager
         async def combined_lifespan(app: FastAPI):
             async with app_lifespan(app):
-                async with mcp_http_app.lifespan(app):
+                async with mcp_lifespan(app):
                     yield
 
         lifespan = combined_lifespan
 
     app = FastAPI(title=profile.title, lifespan=lifespan)
+
+    # Without this, FastAPI's built-in HTTPException handler serves AuthError
+    # (which subclasses it) and emits only {"detail": ...}, while the /mcp mount
+    # emits {"detail": ..., "reason": ...} from its own middleware. Registering
+    # here is what makes the two surfaces agree, and `reason` is the operator
+    # signal that distinguishes a bad token from an unreachable JWKS. Imported
+    # function-locally: the PUBLIC tier does not ship auth/, so a module-scope
+    # import would break main_public_imports_test.
+    from auth.api import AuthError, auth_error_handler
+
+    app.add_exception_handler(AuthError, auth_error_handler)
 
     for m in modules:
         if m.register is not None:

--- a/projects/monolith/framework/core_test.py
+++ b/projects/monolith/framework/core_test.py
@@ -371,6 +371,22 @@ def test_mcp_only_module_is_valid_and_mounts_mcp():
     assert any(getattr(r, "path", "") == "/mcp" for r in app.routes)
 
 
+def test_private_app_registers_the_auth_error_handler():
+    """The handler being importable is not the same as it being installed.
+
+    Without this registration FastAPI's built-in HTTPException handler serves
+    AuthError (which subclasses it) and emits only {"detail": ...}, so HTTP
+    routes silently drop the `reason` that the /mcp mount emits. That is a
+    divergence no test of the handler in isolation can catch, because such a
+    test registers the handler itself.
+    """
+    from auth.api import AuthError
+
+    app = build_app(_PLAIN_PRIVATE, [_routed_module("m", "m")])
+
+    assert AuthError in app.exception_handlers
+
+
 def test_mcp_disabled_profile_skips_registration_and_mount():
     calls: list[str] = []
 

--- a/projects/monolith/import_boundaries_test.py
+++ b/projects/monolith/import_boundaries_test.py
@@ -15,6 +15,7 @@ import pathlib
 import pytest
 
 DOMAINS = {
+    "auth",
     "ships",
     "stars",
     "chat",


### PR DESCRIPTION
Closes #4942. Refs #4940 (design), #4569 (constraints), #4944 (next consumer).

Adds `projects/monolith/auth/`, a domain that turns bearer material into a verified Principal. It makes no authorization decisions: it answers "who is this and what do they carry", and each resource-owning domain decides what that Principal may do. A per-domain rule accumulating here is the smell.

## Fail-mode semantics, which are the point of the change

**Absent bearer material yields an anonymous least-privilege Principal, never 401.** Context Forge's tool-refresh CronJob and gateway federation call with no user context, so requiring a token would empty the tool catalogue. A missing `Authorization` header and a non-Bearer scheme both count as absent.

**Present but invalid always raises, and never downgrades to anonymous.** Caller faults (bad signature, wrong issuer, wrong audience, expired, malformed, unknown kid after refresh, unrecognised by every verifier) render 401 with `WWW-Authenticate: Bearer`. Verifier infrastructure faults (JWKS unreachable, JWKS malformed, identity settings unconfigured) render 503. Both raise the same `AuthError` carrying a `reason` enum, so the split is observable in logs and tests rather than only in the status code. A misconfigured JWKS URL breaks loudly instead of quietly de-scoping every caller to the public tier.

Tests assert `pytest.raises(AuthError)` with the reason, not merely that the result is non-anonymous, so an inversion fails them.

## What ships

- `Principal`: frozen dataclass carrying subject, an ordered actor chain, scope, groups, email, kind (human or workload) and authority (standing, delegated, anonymous), with `has_group` / `has_scope` and no policy.
- `AuthentikStandingVerifier`: RS256 against the authentik JWKS, strict issuer, audience membership, and a required `exp`. PyJWT validates `exp` only when the claim is present, so `options={"require": [...]}` is what stops a token minted without an expiry from being honoured forever.
- An ordered verifier chain. The standing verifier **declines** (returns `None`) a token whose issuer is not ours, which is what leaves a slot control can actually reach for the delegation verifier in #4944. A decline with no verifier left to ask still fails closed as `UNRECOGNIZED`.
- `JwksCache`: a TTL governing the ordinary path and a separate floor governing caller-triggered unknown-kid refreshes, so N requests bearing random key ids cannot each cause an outbound fetch serialized behind the cache lock. Failures are remembered for the same window so a down IdP fails fast rather than paying the full timeout per request. Monotonic clock, explicit httpx timeout.
- A FastAPI dependency for routers and an ASGI middleware for the FastMCP mount, both exposing the Principal request-scoped. No tool handler behaviour changes: result scoping is #4569's own work.
- Env wiring across code, chart template and `deploy/values.yaml` together, since a rename touching fewer than all three silently unrenders the block.

## Known constraint, recorded on #4569

On the SSE transport the middleware authenticates the **stream, not the message**. `handle_sse` runs the whole MCP session loop inside the stream-opening GET, while `handle_post_message` only writes to an anyio memory object stream and returns 202, and contexts do not travel through that stream. So `current_principal()` read inside a tool returns the stream-opener's identity. This is latent here because no tool reads the Principal yet, and it is documented at the mount. It stops being latent when #4569's result scoping lands, which is why it is written up there with options.

Not addressed, deliberately: delegation minting (#4944), result scoping (#4569), the GitHub broker (#4946), authentik blueprints (#4943), the Ember placeholder swap (#4945).

## Verification

`ci` green on this tree. Because a cached pass proves nothing about new targets, the auth and framework targets were force-executed:

```
ci test //projects/monolith:auth_verifier_test //projects/monolith:auth_plumbing_test \
        //projects/monolith:framework_core_test -- --nocache_test_results --test_output=all

Executed 3 out of 3 tests: 3 tests pass.
```

40 auth cases plus `framework_core_test`, including `test_private_app_registers_the_auth_error_handler`, which asserts against an app built the production way rather than one the test wires itself.

`helm template monolith projects/monolith/chart/ -f projects/monolith/deploy/values.yaml` renders all four `AUTH_*` variables into the `backend` container. `Chart.yaml` `version:` and `deploy/application.yaml` `targetRevision:` are untouched.

## Note on the JWT dependency

`pyjwt[crypto]==2.13.0` is already in `bazel/requirements/all.txt`, locked transitively via `mcp` and `semgrep`, so `@pip//pyjwt` resolves with no lock change and this PR touches neither `pyproject.toml` nor `bazel/requirements/`. Promoting it to a direct dependency is a reasonable follow-up: a transitive pin disappears if `mcp` drops it, though that fails loudly at build time rather than silently at runtime.