### PR TITLE
fix(agents): log why a guest diff payload is discarded

### DIFF
--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -124,39 +124,66 @@ class Turn(NamedTuple):
     diff: dict | None = None
 
 
-def _guest_diff(value) -> dict | None:
-    """Validate optional guest diff metadata without making it turn-critical."""
+def _reject_guest_diff(session_id, reason: str) -> None:
+    """Log why a present diff payload was discarded, then discard it.
+
+    Every rejection below returns None, which is also what an absent payload
+    returns, so without this the two are indistinguishable: a null diff_blob
+    means either the guest sent nothing or the guest sent something this
+    rejected, and the database cannot tell you which. A guest that captures
+    correctly and fails validation here would look identical to one that never
+    captured at all.
+    """
+    logger.warning("discarding guest diff for session %s: %s", session_id, reason)
+    return None
+
+
+def _guest_diff(value, session_id=None) -> dict | None:
+    """Validate optional guest diff metadata without making it turn-critical.
+
+    An absent payload is silent: guests predating diff capture send nothing and
+    that is not a fault. A payload that is present but invalid is logged.
+    """
+    if value is None:
+        return None
     if not isinstance(value, dict):
-        return None
+        return _reject_guest_diff(session_id, "payload is not a mapping")
     if not {"base_sha", "zlib_b64", "truncated"}.issubset(value):
-        return None
+        missing = sorted({"base_sha", "zlib_b64", "truncated"} - set(value))
+        return _reject_guest_diff(session_id, f"missing keys {missing}")
     base_sha = value.get("base_sha")
     truncated = value.get("truncated")
     encoded = value.get("zlib_b64")
     if not isinstance(base_sha, str) or not re.fullmatch(
         r"[0-9a-fA-F]{40,64}", base_sha
     ):
-        return None
+        return _reject_guest_diff(session_id, "base_sha is not a 40 to 64 char hex sha")
     if not isinstance(truncated, bool):
-        return None
+        return _reject_guest_diff(session_id, "truncated is not a bool")
     if truncated:
-        return value if encoded is None else None
+        if encoded is None:
+            return value
+        return _reject_guest_diff(session_id, "truncated payload carried a blob")
     if not isinstance(encoded, str):
-        return None
+        return _reject_guest_diff(session_id, "zlib_b64 is not a string")
     try:
         compressed = base64.b64decode(encoded, validate=True)
         if len(compressed) > 1024 * 1024:
-            return None
+            return _reject_guest_diff(
+                session_id, f"compressed diff is {len(compressed)} bytes, over 1 MiB"
+            )
         decompressor = zlib.decompressobj()
         raw = decompressor.decompress(compressed, 5 * 1024 * 1024 + 1)
-        if (
-            len(raw) > 5 * 1024 * 1024
-            or not decompressor.eof
-            or decompressor.unused_data
-        ):
-            return None
-    except (binascii.Error, zlib.error):
-        return None
+        if len(raw) > 5 * 1024 * 1024:
+            return _reject_guest_diff(
+                session_id, f"uncompressed diff exceeds 5 MiB at {len(raw)} bytes"
+            )
+        if not decompressor.eof:
+            return _reject_guest_diff(session_id, "zlib stream is incomplete")
+        if decompressor.unused_data:
+            return _reject_guest_diff(session_id, "zlib stream has trailing data")
+    except (binascii.Error, zlib.error) as exc:
+        return _reject_guest_diff(session_id, f"undecodable payload: {exc}")
     return value
 
 
@@ -551,7 +578,7 @@ class EmberVmShimTransport:
                         total_cost_usd=guest_data.get("total_cost_usd"),
                         duration_ms=guest_data.get("duration_ms"),
                         activities=guest_data.get("activities", []),
-                        diff=_guest_diff(guest_data.get("diff")),
+                        diff=_guest_diff(guest_data.get("diff"), current.session_id),
                     )
             except httpx.TimeoutException as exc:
                 logger.warning(

--- a/projects/monolith/agent_sessions/transport_test.py
+++ b/projects/monolith/agent_sessions/transport_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 import zlib
 
 import httpx
@@ -1058,3 +1059,52 @@ def test_destroy_session_keeps_403_and_500_as_plain_failures(monkeypatch):
         with pytest.raises(EmberVMTransportError) as caught:
             asyncio.run(transport.EmberVmShimTransport().destroy_session("s-404xyz"))
         assert not isinstance(caught.value, EmberSessionGone), status
+
+
+def test_guest_diff_logs_a_distinct_reason_per_rejection(caplog):
+    # A present-but-invalid payload and an absent one both yield None, so the
+    # database cannot tell them apart. The reason is the only thing that can.
+    good = base64.b64encode(zlib.compress(b"diff --git a/a b/a\n")).decode()
+    sha = "a" * 40
+    cases = [
+        (
+            {"base_sha": sha, "zlib_b64": good, "truncated": "no"},
+            "truncated is not a bool",
+        ),
+        ({"base_sha": "nothex", "zlib_b64": good, "truncated": False}, "base_sha"),
+        ({"base_sha": sha, "truncated": False}, "missing keys"),
+        (
+            {"base_sha": sha, "zlib_b64": "!!!not base64!!!", "truncated": False},
+            "undecodable",
+        ),
+        (
+            {"base_sha": sha, "zlib_b64": good, "truncated": True},
+            "truncated payload carried a blob",
+        ),
+        ("not a mapping", "not a mapping"),
+    ]
+    for payload, expected in cases:
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger=transport.logger.name):
+            assert transport._guest_diff(payload, 42) is None
+        assert expected in caplog.text, f"{payload!r} did not log {expected!r}"
+        assert "42" in caplog.text
+
+
+def test_guest_diff_is_silent_when_absent(caplog):
+    # Guests predating diff capture send nothing. That is not a fault and must
+    # not produce a warning on every single turn they take.
+    with caplog.at_level(logging.WARNING, logger=transport.logger.name):
+        assert transport._guest_diff(None, 42) is None
+    assert caplog.text == ""
+
+
+def test_guest_diff_accepts_a_valid_payload(caplog):
+    payload = {
+        "base_sha": "b" * 40,
+        "zlib_b64": base64.b64encode(zlib.compress(b"diff --git a/a b/a\n")).decode(),
+        "truncated": False,
+    }
+    with caplog.at_level(logging.WARNING, logger=transport.logger.name):
+        assert transport._guest_diff(payload, 42) == payload
+    assert caplog.text == ""


### PR DESCRIPTION
Supports #4934. Complements the guest-side instrumentation being added separately: this is the same blind spot on the monolith side of the wire.

## Why

`_guest_diff` returns `None` on eight separate conditions and logs nothing on any of them:

- payload is not a mapping
- missing one of `base_sha` / `zlib_b64` / `truncated`
- `base_sha` fails the 40 to 64 char hex check
- `truncated` is not a bool
- a truncated payload carried a blob anyway
- `zlib_b64` is not a string
- compressed over 1 MiB, or uncompressed over 5 MiB
- undecodable base64, or a zlib stream that is incomplete or has trailing data

An absent payload also returns `None`. So the two are indistinguishable in the database: a null `diff_blob` means either the guest sent nothing, or the guest sent something that was rejected here, and the row cannot tell you which.

That matters right now. Diff capture is inert in production and the remaining hypotheses are that the guest's `_capture_turn_diff` returns None, or that the payload is rejected after it arrives. Guest-side instrumentation alone cannot separate those: a guest that captures correctly and trips one of the eight conditions above would log success while the column stays null.

Worth noting what this rules out. The wire itself is not a suspect: the shim sends the whole record (`self._send(200, record)`, no key whitelist), noded carries it as `bytes body` described in the proto as "forwarded verbatim", and the control plane's `send_guest_result` does `send_resp(conn, status_code, body)` and filters headers only. Nothing between the guest and this function can drop a JSON key, which is what makes this function the only remaining place a present payload can vanish.

## What changed

Each rejection logs a distinct reason with the session id. Sizes are included where relevant, so an over-cap diff reports its actual size rather than just failing.

An absent payload stays silent. Guests predating diff capture send nothing, that is not a fault, and warning on every turn they take would be noise that trains you to ignore the log.

Behaviour is unchanged: every path returns exactly what it returned before, including the truncated-with-blob case that returns `None` and the truncated-without-blob case that returns the value.

## Verified

- `ci lint` clean.
- `ci test //projects/monolith:agent_sessions_transport_test` -> `Executed 1 out of 1 test: 1 test passes`.
- New tests assert a distinct reason per rejection shape, that the session id appears in the log, that an absent payload logs nothing, and that a valid payload is returned unchanged and silently.

## Not verified

That this fires in production, because it only fires when a guest sends a diff at all, and no guest is currently known to be doing so. If diff capture starts working, this is silent; if capture works and validation rejects, this is the line that says so.