### PR TITLE
feat(agents): make the walkthrough the main feature of a finished session

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1421,7 +1421,7 @@
       </header>
       <div class="turns" bind:this={turnsEl}>
         <div class="turns-inner">
-          {#each detail?.turns ?? [] as turn (turn.seq)}
+          {#each detail?.turns ?? [] as turn, turnIndex (turn.seq)}
             <!-- {@const} has to be an immediate child of the block, not of the
                  element inside it, so this sits above <article> rather than
                  next to the markup that reads it. -->
@@ -1480,6 +1480,8 @@
                   sessionId={selectedSession.id}
                   turnSeq={turn.seq}
                   model={turn.model || selectedSession.model || "luna"}
+                  prominent={vmState(selectedSession, vms) !== "awake" &&
+                    turnIndex === (detail?.turns ?? []).length - 1}
                 />
               {/if}
               <div class="turn-meta mono">

--- a/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.svelte
@@ -9,6 +9,7 @@
   // Collapsed by default; the composed payload is fetched once on first
   // open (the console polls, this never does), and per-point patches are
   // fetched lazily, on selection, desktop only.
+  import { onMount, untrack } from "svelte";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
   import { joinMeta } from "./run-format.js";
   import { walkthroughView, parsePatchHunks } from "./walkthrough.js";
@@ -17,15 +18,16 @@
     sessionId = null,
     turnSeq = null,
     model = "",
+    prominent = false,
     // Fixture preview (?fixture=walk-*): payload/patches supplied inline,
     // so the preview never fetches.
     fixture = null,
   } = $props();
 
-  let payload = $state(fixture?.payload ?? null);
+  let payload = $state(untrack(() => fixture?.payload ?? null));
   let loading = $state(false);
   let failed = $state(false);
-  let opened = $state(Boolean(fixture));
+  let opened = $state(untrack(() => Boolean(fixture || prominent)));
   let selected = $state(0);
   // Mobile pane swap: the points list and the detail pane are one column
   // under the console's 760px breakpoint, and selecting a point drills in.
@@ -126,6 +128,13 @@
     if (opened) load();
   }
 
+  // A declaratively open details element does not reliably emit a toggle
+  // event after Svelte attaches the listener. Start its one-shot load here;
+  // onToggle shares the same guards if the browser emits both paths.
+  onMount(() => {
+    if (opened) load();
+  });
+
   function selectItem(index) {
     selected = Math.max(0, Math.min(index, items.length - 1));
     drilled = true;
@@ -180,7 +189,12 @@
   );
 </script>
 
-<details class="walk" open={Boolean(fixture)} ontoggle={onToggle}>
+<details
+  class="walk"
+  class:prominent
+  open={Boolean(fixture || prominent)}
+  ontoggle={onToggle}
+>
   <summary class="walk-summary">
     <span>{P.labels.walkSummary}</span>
     {#if walk}
@@ -399,6 +413,36 @@
   }
   .walk-count {
     color: var(--text-soft);
+  }
+  /* A finished session promotes only its final walkthrough. The heavy ink
+     frame gives the explanation more weight than the turn separators while
+     keeping it in the transcript column and in the normal scroll flow. */
+  .walk.prominent {
+    margin-top: 16px;
+    padding-top: 0;
+    border: 4px solid var(--ink);
+    border-radius: var(--radius-lg);
+    background: var(--panel-bg);
+  }
+  .walk.prominent .walk-summary {
+    box-sizing: border-box;
+    width: 100%;
+    padding: 12px 16px;
+    color: var(--text);
+    font-size: var(--size-body);
+    font-weight: 700;
+  }
+  .walk.prominent[open] .walk-summary {
+    border-bottom: 1px solid var(--line);
+  }
+  .walk.prominent .walk-count {
+    margin-left: auto;
+  }
+  .walk.prominent > .walk-fact {
+    margin-inline: 16px;
+  }
+  .walk.prominent > .walk-frame {
+    margin: 12px;
   }
   .walk-fact {
     margin-top: 8px;

--- a/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.test.js
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { mount, tick, unmount } from "svelte";
+import SessionWalkthrough from "./SessionWalkthrough.svelte";
+import pageSource from "./+page.svelte?raw";
+import { vmState } from "./status.js";
+
+const mounted = [];
+
+function isProminent(session, vms, turnIndex, turnCount) {
+  return vmState(session, vms) !== "awake" && turnIndex === turnCount - 1;
+}
+
+async function renderWalkthrough(prominent) {
+  const target = document.createElement("div");
+  document.body.append(target);
+  const props = { sessionId: 17, turnSeq: 3, model: "luna" };
+  if (prominent !== undefined) props.prominent = prominent;
+  const component = mount(SessionWalkthrough, {
+    target,
+    props,
+  });
+  mounted.push({ component, target });
+  await tick();
+  return target.querySelector("details");
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  for (const { component, target } of mounted.splice(0)) {
+    await unmount(component);
+    target.remove();
+  }
+});
+
+describe("finished-session prominence", () => {
+  const session = { ember_session_id: "vm-1" };
+
+  test("the turn loop combines VM state with the last-turn check", () => {
+    expect(pageSource).toContain(
+      'prominent={vmState(selectedSession, vms) !== "awake" &&',
+    );
+    expect(pageSource).toContain(
+      "turnIndex === (detail?.turns ?? []).length - 1}",
+    );
+  });
+
+  test("opens the last turn when the VM is not awake and loads once", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ rung: 5, steps: [], stats: {} }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const prominent = isProminent(
+      session,
+      { "vm-1": { state: "asleep" } },
+      2,
+      3,
+    );
+    const details = await renderWalkthrough(prominent);
+
+    expect(details.open).toBe(true);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    details.dispatchEvent(new Event("toggle"));
+    await tick();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    ["an omitted prominence prop", undefined, 0, 0],
+    ["a non-last turn", { "vm-1": { state: "asleep" } }, 1, 3],
+    [
+      "the last turn while the VM is awake",
+      { "vm-1": { state: "awake" } },
+      2,
+      3,
+    ],
+  ])("stays closed for %s", async (_label, vms, turnIndex, turnCount) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const prominent = vms
+      ? isProminent(session, vms, turnIndex, turnCount)
+      : undefined;
+    const details = await renderWalkthrough(prominent);
+
+    expect(details.open).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/projects/monolith/frontend/vitest.config.js
+++ b/projects/monolith/frontend/vitest.config.js
@@ -1,8 +1,11 @@
 import { defineConfig } from "vitest/config";
 import { fileURLToPath } from "node:url";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 export default defineConfig({
+  plugins: [svelte()],
   resolve: {
+    conditions: ["browser"],
     alias: {
       // SvelteKit's `$lib` alias, for tests that exercise modules importing
       // through it (the agents markdown wrapper does).


### PR DESCRIPTION
Follows #4933, which added the summary and fixed the counts but left the panel collapsed. This is the half that was still missing: prominence.

## Why

The walkthrough was a collapsed `<details>` behind a one-line `<summary>`, so a finished session showed a wall of transcript and a small closed strip. Once the work is over, the explanation of what the turn changed is the thing the reader came for.

## What changed

The last turn of a session whose VM is not awake renders open and full width, framed so it carries more weight than the turn separators:

```svelte
prominent={vmState(selectedSession, vms) !== "awake" &&
  turnIndex === (detail?.turns ?? []).length - 1}
```

It stays in the transcript column and in the normal scroll flow. This is not a modal, a takeover, or a route change: the conversation remains the spine of the page and getting back to it is just scrolling.

**Only the last turn is promoted.** A ten turn session that expanded ten two-pane panels would be worse than the disclosure it replaces. Earlier turns and awake sessions are unchanged.

## The subtle part

A declaratively open `<details>` does not reliably emit a `toggle` event after Svelte attaches its listener, so the existing one-shot load in `onToggle` would never fire for a panel that starts open. The load now also fires from `onMount`, sharing the same guards.

Without that, the panel renders open and never fetches, showing a permanent empty state, and `build_test` passes happily. The tests cover it: one asserts the payload loads exactly once when it renders open.

`opened` initialises under `untrack()` so it stays genuine local state the reader's clicks own, while `open={Boolean(fixture || prominent)}` remains reactive. A session that finishes while the page is open therefore still opens the panel, and that path fires the load through the normal toggle route.

## Verified

- `ci lint` clean.
- `ci test //projects/monolith/frontend:test //projects/monolith/frontend:build_test -- --nocache_test_results` -> `Executed 2 out of 2 tests: 2 tests pass`.
- The first run returned `Executed 0 out of 2`, both cached. That was a legitimate hit on the implementer's identical run through the shared action cache, but it proves nothing, so it was re-run uncached. Judging by the summary line rather than the exit code is the rule here for good reason.
- Confirmed the new test is genuinely in the target: `test_lib` globs `src/**/*.test.js` and lists `vitest.config.js` in `srcs`, so both the new file and the config change are real inputs rather than files that merely exist on disk.
- All six CSS custom properties used by the prominent styles resolve in `agents-theme.css`. An undefined `var(--ink)` would render the 4px border as nothing, shipping prominence as an invisible no-op with every test green.
- No new visible strings, so no lexicon changes were needed.

## Blast radius worth naming

`vitest.config.js` gains the Svelte plugin and `conditions: ["browser"]`, which is what makes component-level tests possible at all. That changes module resolution for **every** frontend test, not just the new ones, which is why the full suite was run uncached rather than trusting a targeted pass.

## Not verified

Nobody has looked at the promoted panel in a browser. The behaviour is covered by tests and the tokens are confirmed to resolve, but the visual weight is a judgment call that needs eyes.

Also worth stating plainly: diff capture is still inert, so a promoted walkthrough currently shows the agent's testimony and an honest "the diff is unavailable for this turn". The structure is right; the diff fills in when capture works.