### PR TITLE
fix(embervm): parse member-suffixed group_set keys and hold partially-parsed prefixes

### DIFF
--- a/projects/embervm/control/lib/embervm/s3_warmth_gc.ex
+++ b/projects/embervm/control/lib/embervm/s3_warmth_gc.ex
@@ -38,6 +38,8 @@ defmodule Embervm.S3WarmthGc do
       uptime is additionally required before any sweep.
     * Ambiguous key parses (a workload literally named like a vendor) are
       skipped, never guessed.
+    * A candidate prefix with any unparsed sibling key below it is held whole,
+      so a parsed subset is never deleted.
     * Deletes: hard allowlist {stateful/, session/, serving/,
       session-workspace/, group_set/}; every DELETE targets one
       fully-qualified LISTED key (never a prefix, never bucket-wide); meta.json
@@ -236,8 +238,9 @@ defmodule Embervm.S3WarmthGc do
          {:ok, group_keys} <- list_or_abort(state, "group_set/"),
          {:ok, snapshot} <- cp_snapshot(state),
          :ok <- check_empty_cp_state(snapshot, stateful_keys, session_keys, serving_keys, workspace_keys, group_keys, state.allow_empty_kinds) do
-      {candidates, ambiguous} = parse_candidates(state, stateful_keys, session_keys, serving_keys, workspace_keys, group_keys)
+      {candidates, shadowed, ambiguous} = parse_candidates(state, stateful_keys, session_keys, serving_keys, workspace_keys, group_keys)
       {eligible, held} = build_plan(state, snapshot, candidates)
+      held = shadowed ++ held
       plan = apply_caps(state, eligible)
       log_plan(state, plan, eligible, held, ambiguous)
 
@@ -462,7 +465,7 @@ defmodule Embervm.S3WarmthGc do
   # segment-2 membership in the known vendor set. Anything else (a workload
   # named like a vendor, an unexpected depth) is AMBIGUOUS: the whole key is
   # held aside and never composed into a deletable prefix (fail-closed).
-  # Returns {candidates_by_prefix, ambiguous_keys}.
+  # Returns {candidates_by_prefix, shadowed_prefixes, ambiguous_keys}.
   defp parse_candidates(state, stateful_keys, session_keys, serving_keys, workspace_keys, group_keys) do
     {s_parsed, s_ambiguous} = split_parsed(state, stateful_keys, "stateful")
     {se_parsed, se_ambiguous} = split_parsed(state, session_keys, "session")
@@ -485,7 +488,19 @@ defmodule Embervm.S3WarmthGc do
         })
       end)
 
-    {candidates, s_ambiguous ++ se_ambiguous ++ sv_ambiguous ++ w_ambiguous ++ g_ambiguous}
+    ambiguous = s_ambiguous ++ se_ambiguous ++ sv_ambiguous ++ w_ambiguous ++ g_ambiguous
+
+    {shadowed_candidates, candidates} =
+      Enum.split_with(candidates, fn candidate ->
+        Enum.any?(ambiguous, &String.starts_with?(&1, candidate.prefix <> "/"))
+      end)
+
+    shadowed =
+      Enum.map(shadowed_candidates, fn candidate ->
+        %{prefix: candidate.prefix, kind: candidate.kind, bytes: candidate.bytes, reason: "sibling_key_ambiguous"}
+      end)
+
+    {candidates, shadowed, ambiguous}
   end
 
   defp split_parsed(state, entries, kind) do
@@ -514,8 +529,19 @@ defmodule Embervm.S3WarmthGc do
           :ambiguous
         end
 
+      ["group_set", vendor, group_instance_id, set_id, _member, file]
+      when kind == "group_set" and file != "" ->
+        if vendor in state.vendors and group_instance_id not in state.vendors do
+          {:ok, prefix_meta(kind, vendor, group_instance_id, set_id)}
+        else
+          :ambiguous
+        end
+
       # Legacy pre-R7: <kind>/<owner>/<ref>/<file>. An owner named like a vendor
       # would collide with a vendored key missing its file segment: ambiguous.
+      # There is deliberately no legacy unvendored group member shape here.
+      # Its five segments are indistinguishable from a vendored flat key with
+      # an unknown vendor, and guessing could delete every set in that group.
       [^kind, owner, ref, file] when file != "" ->
         if owner in state.vendors, do: :ambiguous, else: {:ok, prefix_meta(kind, "", owner, ref)}
 

--- a/projects/embervm/control/test/embervm/s3_warmth_gc_test.exs
+++ b/projects/embervm/control/test/embervm/s3_warmth_gc_test.exs
@@ -852,6 +852,29 @@ defmodule Embervm.S3WarmthGcTest do
 
   # -- groups ------------------------------------------------------------------
 
+  # The real group-set layout: noded walks the set dir recursively, so every
+  # member's files key under their own subdirectory. meta.json stays at the SET
+  # level, which is the 5-segment key the parser already handled.
+  defp group_set_artifact(prefix, created_at_ms, members \\ ["agent-0", "agent-1"], payload_bytes \\ 1_000) do
+    meta = :json.encode(%{"createdAtUnixMs" => created_at_ms}) |> IO.iodata_to_binary()
+
+    Enum.reduce(
+      members,
+      %{
+        (prefix <> "/meta.json") => {byte_size(meta), created_at_ms, meta}
+      },
+      fn member, acc ->
+        Map.merge(
+          acc,
+          %{
+            (prefix <> "/" <> member <> "/memfile") => {payload_bytes, created_at_ms, "payload"},
+            (prefix <> "/" <> member <> "/snapfile") => {payload_bytes, created_at_ms, "snapshot"}
+          }
+        )
+      end
+    )
+  end
+
   describe "group sets" do
     test "a terminal group's old legacy-layout set deletes; a live group's set is held" do
       objects =
@@ -902,6 +925,195 @@ defmodule Embervm.S3WarmthGcTest do
         )
 
       assert {:ok, %{deleted: [], held: [%{reason: "desired_set"}]}} = S3WarmthGc.sweep_now(gc)
+      assert deleted(agent) == []
+    end
+
+    test "a terminal group's member-suffixed set deletes whole, meta.json first" do
+      prefix = "group_set/amd/grp-X/set-X"
+      objects = group_set_artifact(prefix, @wall - 30 * @day)
+      {agent, s3} = new_s3(objects)
+      table = new_cap_table()
+      put_node_fact(table, "node-4", [], [])
+      group = start_store([group_row(:destroyed, "grp-X", nil)])
+
+      gc =
+        start_gc(s3,
+          enabled: true,
+          capacity_table: table,
+          stateful_store: start_store([]),
+          group_store: group,
+          volume_fun: fn _ -> nil end
+        )
+
+      assert {:ok, result} = S3WarmthGc.sweep_now(gc)
+      assert result.deleted == [prefix]
+
+      assert deleted(agent) == [
+               prefix <> "/meta.json",
+               prefix <> "/agent-0/memfile",
+               prefix <> "/agent-0/snapfile",
+               prefix <> "/agent-1/memfile",
+               prefix <> "/agent-1/snapfile"
+             ]
+
+      assert result.ambiguous == []
+      assert [entry] = result.plan
+      assert entry.prefix == prefix
+      assert entry.bytes == objects |> Map.values() |> Enum.map(&elem(&1, 0)) |> Enum.sum()
+    end
+
+    test "member-suffixed set bytes sum all member files and meta.json" do
+      prefix = "group_set/amd/grp-bytes/set-bytes"
+      objects = group_set_artifact(prefix, @wall - 30 * @day, ["agent-0", "agent-1"], 1_000)
+      {agent, s3} = new_s3(objects)
+      table = new_cap_table()
+      put_node_fact(table, "node-4", [], [])
+      group = start_store([group_row(:destroyed, "grp-bytes", nil)])
+
+      gc =
+        start_gc(s3,
+          enabled: true,
+          capacity_table: table,
+          stateful_store: start_store([]),
+          group_store: group,
+          volume_fun: fn _ -> nil end
+        )
+
+      assert {:ok, %{plan: [entry]}} = S3WarmthGc.sweep_now(gc)
+      {meta_bytes, _, _} = Map.fetch!(objects, prefix <> "/meta.json")
+      assert entry.bytes == meta_bytes + 2 * 2 * 1_000
+      assert deleted(agent) != []
+    end
+
+    test "well-formed member-suffixed set has no ambiguous keys" do
+      prefix = "group_set/amd/grp-clear/set-clear"
+      objects = group_set_artifact(prefix, @wall - 30 * @day)
+      {agent, s3} = new_s3(objects)
+      table = new_cap_table()
+      put_node_fact(table, "node-4", [], [])
+      group = start_store([group_row(:destroyed, "grp-clear", nil)])
+
+      gc =
+        start_gc(s3,
+          enabled: true,
+          capacity_table: table,
+          stateful_store: start_store([]),
+          group_store: group,
+          volume_fun: fn _ -> nil end
+        )
+
+      assert {:ok, result} = S3WarmthGc.sweep_now(gc)
+      assert result.ambiguous == []
+      assert deleted(agent) != []
+    end
+
+    test "a live group instance's member-suffixed set is held" do
+      prefix = "group_set/amd/grp-Y/set-Y"
+      objects = group_set_artifact(prefix, @wall - 30 * @day)
+      {agent, s3} = new_s3(objects)
+      table = new_cap_table()
+      put_node_fact(table, "node-4", [], [])
+      group = start_store([group_row(:running, "grp-Y", nil)])
+
+      gc =
+        start_gc(s3,
+          enabled: true,
+          capacity_table: table,
+          stateful_store: start_store([]),
+          group_store: group,
+          volume_fun: fn _ -> nil end
+        )
+
+      assert {:ok, %{held: [held]}} = S3WarmthGc.sweep_now(gc)
+      assert held.prefix == prefix
+      assert held.reason == "group_instance_live"
+      assert deleted(agent) == []
+    end
+
+    test "member-suffixed set without meta.json still parses and deletes" do
+      prefix = "group_set/amd/grp-no-meta/set-no-meta"
+
+      objects =
+        group_set_artifact(prefix, @wall - 30 * @day)
+        |> Map.delete(prefix <> "/meta.json")
+
+      {agent, s3} = new_s3(objects)
+      table = new_cap_table()
+      put_node_fact(table, "node-4", [], [])
+      group = start_store([group_row(:destroyed, "grp-no-meta", nil)])
+
+      gc =
+        start_gc(s3,
+          enabled: true,
+          capacity_table: table,
+          stateful_store: start_store([]),
+          group_store: group,
+          volume_fun: fn _ -> nil end
+        )
+
+      assert {:ok, result} = S3WarmthGc.sweep_now(gc)
+      assert result.deleted == [prefix]
+
+      assert deleted(agent) == [
+               prefix <> "/agent-0/memfile",
+               prefix <> "/agent-0/snapfile",
+               prefix <> "/agent-1/memfile",
+               prefix <> "/agent-1/snapfile"
+             ]
+    end
+
+    test "legacy un-vendored member shape group_set/grp-x/set-y/agent-0/memfile stays ambiguous" do
+      prefix = "group_set/grp-dead/set-1/agent-0"
+      key = prefix <> "/memfile"
+      objects = artifact(prefix, @wall - 30 * @day) |> Map.take([key])
+      {agent, s3} = new_s3(objects)
+      table = new_cap_table()
+      put_node_fact(table, "node-4", [], [])
+      group = start_store([group_row(:destroyed, "grp-dead", nil)])
+
+      gc =
+        start_gc(s3,
+          enabled: true,
+          capacity_table: table,
+          stateful_store: start_store([]),
+          group_store: group,
+          volume_fun: fn _ -> nil end
+        )
+
+      assert {:ok, result} = S3WarmthGc.sweep_now(gc)
+      assert result.ambiguous == [key]
+      assert result.plan == []
+      assert deleted(agent) == []
+    end
+
+    test "prefix with ambiguous sibling key is held with reason sibling_key_ambiguous" do
+      prefix = "group_set/amd/grp-Z/set-7"
+      member_key = prefix <> "/agent-0/memfile"
+      ambiguous_key = prefix <> "/not-a-member/x/y/z"
+
+      objects = %{
+        member_key => {1_000, @wall - 30 * @day, "payload"},
+        ambiguous_key => {1_000, @wall - 30 * @day, "payload"}
+      }
+
+      {agent, s3} = new_s3(objects)
+      table = new_cap_table()
+      put_node_fact(table, "node-4", [], [])
+      group = start_store([group_row(:destroyed, "grp-Z", nil)])
+
+      gc =
+        start_gc(s3,
+          enabled: true,
+          capacity_table: table,
+          stateful_store: start_store([]),
+          group_store: group,
+          volume_fun: fn _ -> nil end
+        )
+
+      assert {:ok, result} = S3WarmthGc.sweep_now(gc)
+      assert [%{prefix: ^prefix, reason: "sibling_key_ambiguous"}] = result.held
+      assert result.ambiguous == [ambiguous_key]
+      assert result.plan == []
       assert deleted(agent) == []
     end
   end

--- a/projects/embervm/control/test/embervm/s3_warmth_gc_test.exs
+++ b/projects/embervm/control/test/embervm/s3_warmth_gc_test.exs
@@ -948,13 +948,17 @@ defmodule Embervm.S3WarmthGcTest do
       assert {:ok, result} = S3WarmthGc.sweep_now(gc)
       assert result.deleted == [prefix]
 
-      assert deleted(agent) == [
-               prefix <> "/meta.json",
-               prefix <> "/agent-0/memfile",
-               prefix <> "/agent-0/snapfile",
-               prefix <> "/agent-1/memfile",
-               prefix <> "/agent-1/snapfile"
-             ]
+      deleted_keys = deleted(agent)
+      assert length(deleted_keys) == 5
+      assert Enum.at(deleted_keys, 0) == prefix <> "/meta.json"
+
+      assert MapSet.new(Enum.drop(deleted_keys, 1)) ==
+               MapSet.new([
+                 prefix <> "/agent-0/memfile",
+                 prefix <> "/agent-0/snapfile",
+                 prefix <> "/agent-1/memfile",
+                 prefix <> "/agent-1/snapfile"
+               ])
 
       assert result.ambiguous == []
       assert [entry] = result.plan
@@ -1054,12 +1058,16 @@ defmodule Embervm.S3WarmthGcTest do
       assert {:ok, result} = S3WarmthGc.sweep_now(gc)
       assert result.deleted == [prefix]
 
-      assert deleted(agent) == [
-               prefix <> "/agent-0/memfile",
-               prefix <> "/agent-0/snapfile",
-               prefix <> "/agent-1/memfile",
-               prefix <> "/agent-1/snapfile"
-             ]
+      deleted_keys = deleted(agent)
+      assert length(deleted_keys) == 4
+
+      assert MapSet.new(deleted_keys) ==
+               MapSet.new([
+                 prefix <> "/agent-0/memfile",
+                 prefix <> "/agent-0/snapfile",
+                 prefix <> "/agent-1/memfile",
+                 prefix <> "/agent-1/snapfile"
+               ])
     end
 
     test "legacy un-vendored member shape group_set/grp-x/set-y/agent-0/memfile stays ambiguous" do


### PR DESCRIPTION
Closes #4334.

`Embervm.S3WarmthGc` is armed and destructive in production. Its `parse_key/3` handled at most 5 path segments, and group sets are the one artifact kind whose files live under per-member subdirectories, so every group key fell through to the `_ -> :ambiguous` catch-all. 16 objects, about 18 GiB, have been skipped on every hourly sweep since 2026-08-04, invisible in both `held` and `eligible_beyond_caps`.

## Verified before the fix, not after

Walked the SeaweedFS filer directly rather than trusting the issue text, because a pre-R7 backlog could plausibly have been un-vendored, which would have made these keys five segments and this fix wrong. All 16 are the vendored member-suffixed shape:

```
group_set/amd/<gid>/<set_id>/<member>/<file>
```

Four group instances, one set each, two members each, files `memfile` / `snapfile` / `member.json` / `group_instance_id`. Six 3 GiB memfiles plus sidecars is 18.0 GiB across exactly 16 objects, matching the `16 ambiguous keys skipped` the sweep still logged at 2026-08-15T22:01Z. The writer side agrees: `store.go` `Export` PUTs to `prefix + "/" + name` and `enumerateArtifactFiles` walks the set dir recursively, so a member's relative name carries its own segment.

## Defect 1: the missing parse clause

One clause for the 6-segment vendored shape, dropping the member segment so the delete unit stays the whole set. Every member's files then group into one candidate alongside the set's own `meta.json`, which lives at 5 segments and already parsed.

The legacy un-vendored member shape is deliberately NOT claimed. It is five segments, indistinguishable from a vendored flat key under a vendor token this build does not know (`@vendors` is `["amd", "intel"]`). Guessing there would compose a delete prefix one level too wide, `group_set/<vendor>/<gid>` instead of `.../<set_id>`, deleting every set belonging to that group instance. In an armed destructive sweep that is a fail-open, so it stays ambiguous and a test pins the gap.

## Defect 2: a partial parse produced a partial delete reported as complete

Not in the issue. Found while verifying, and it is why there is no `meta.json` left anywhere under `group_set/`.

`parse_candidates/6` grouped PARSED keys into candidate prefixes and set ambiguous keys aside separately, while `delete_prefix/2` deletes `entry.files`, only the parsed subset. A prefix with some parsed and some ambiguous keys therefore got a partial delete, logged as `DELETED prefix=... bytes=...` for the whole prefix. That is what the first armed sweep did: each set's 5-segment `meta.json` parsed alone and was deleted, so "the one 5-segment group prefix in the plan deleted fine" reclaimed about 100 bytes while reporting a set.

Nothing wanted was destroyed (the orphan predicate had already cleared those sets), but the module's moduledoc claims it is fail-closed everywhere and here it was not.

Now any candidate prefix that is a parent of an ambiguous key is held WHOLE, with reason `sibling_key_ambiguous`, and surfaced in the manifest instead of silently discarded. The trailing slash in the prefix test is load-bearing: it stops `session/amd/wl/ref` from shadowing on an ambiguous `session/amd/wl/ref-2/...`.

## Tests

The existing group fixtures used `artifact("group_set/amd/grp-1/set-9", ...)`, a FLAT layout the writer never produces, which is why the six-segment case was never exercised. Worse, because that fixture's meta.json and payload always parse together, the partial-delete path was unreachable in test, so an unsound path looked proven. They stay (they still cover the flat and meta paths) and a `group_set_artifact/4` helper builds the real layout alongside.

Seven new tests: whole-set delete with meta.json first, bytes summing every member's files, no ambiguous keys for a well-formed set, a live group instance holding its set, a set with NO meta.json (production's current state) ageing off `newest_modified_ms`, the legacy shape staying ambiguous, and the `sibling_key_ambiguous` guard.

## Verification

`//bazel/erlang:mix_test_smoke` is a genrule, not a test rule, so `bazel test` on it emits no `Executed N out of M` line and exits 4 with "No test targets were found" even when the suite passes. Judge it by the mix summary and the process count instead.

Baseline, unmodified `origin/main`:

```
1315 tests, 0 failures, 6 skipped
5 processes: 358 action cache hit, 4 internal, 1 remote.
```

This branch:

```
1322 tests, 0 failures, 6 skipped
5 processes: 358 action cache hit, 4 internal, 1 remote.
```

Delta is exactly the 7 new tests, and `1 remote` on both runs proves the genrule executed rather than replaying a cached result.

## Expected effect once deployed

The next sweep should report 0 ambiguous keys and plan four group prefixes totalling about 18 GiB. Their `meta.json` is already gone, so created-at comes from `newest_modified_ms` (2026-07-24), well past the 7 day group TTL.

`Chart.yaml` `version:` and `deploy/application.yaml` `targetRevision:` are untouched. No values changed: the flag is already armed.
