### PR TITLE
fix(embervm): read the checkout as its owner so turn diff capture works

### DIFF
--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -63,21 +63,56 @@ def _emit_turn_diff_outcome(checkout_dir, phase, outcome):
         pass
 
 
+def _git_read_argv(checkout_dir, *args):
+    """git argv for reading a checkout the shim does not own.
+
+    The shim runs as root while hydration clones under _cli_privilege_kwargs, so
+    the checkout belongs to the CLI uid. git refuses to operate on a repository
+    owned by another user ("detected dubious ownership") and exits non-zero,
+    which is why capture reported rev_parse_failed on every turn while the agent
+    used the same repo without trouble.
+
+    safe.directory is scoped to this one path and passed per invocation, so
+    nothing is written to any git config. Dropping to the CLI uid instead would
+    only move the mismatch: the checkout is not always owned by that user
+    either, and a read as root is the one thing that works in both directions.
+    """
+    return [
+        "git",
+        "-c",
+        "safe.directory=%s" % checkout_dir,
+        "-C",
+        checkout_dir,
+        *args,
+    ]
+
+
 def _capture_turn_base(checkout_dir):
     """Best-effort checkout HEAD capture. A failure must not affect the turn."""
     try:
         if not os.path.exists(os.path.join(checkout_dir, ".git")):
             _emit_turn_diff_outcome(checkout_dir, "base", "no_git_dir")
             return None
+        # Run git as the CLI user, exactly as hydration does. The shim is root
+        # and hydration clones under these kwargs, so the checkout is owned by
+        # the CLI uid. Calling git as root against it trips git's dubious
+        # ownership check, which exits non-zero with the reason on stderr. That
+        # is why capture reported rev_parse_failed on every turn while the agent
+        # cloned, committed and pushed the same repo without trouble.
         result = subprocess.run(
-            ["git", "-C", checkout_dir, "rev-parse", "HEAD"],
+            _git_read_argv(checkout_dir, "rev-parse", "HEAD"),
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             check=False,
             timeout=10,
         )
         if result.returncode != 0:
-            _emit_turn_diff_outcome(checkout_dir, "base", "rev_parse_failed")
+            _emit_turn_diff_outcome(
+                checkout_dir,
+                "base",
+                "rev_parse_failed:%s"
+                % (result.stderr or b"").decode("utf-8", "replace").strip()[:200],
+            )
             return None
         base_sha = result.stdout.decode("ascii", "strict").strip()
         if not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_sha):
@@ -96,15 +131,22 @@ def _capture_turn_diff(checkout_dir, base_sha):
         _emit_turn_diff_outcome(checkout_dir, "diff", "no_base_sha")
         return None
     try:
+        # Same privileges as the rev-parse above and as hydration's clone: the
+        # checkout belongs to the CLI user, not to root.
         result = subprocess.run(
-            ["git", "-C", checkout_dir, "diff", base_sha],
+            _git_read_argv(checkout_dir, "diff", base_sha),
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             check=False,
             timeout=30,
         )
         if result.returncode != 0:
-            _emit_turn_diff_outcome(checkout_dir, "diff", "diff_failed")
+            _emit_turn_diff_outcome(
+                checkout_dir,
+                "diff",
+                "diff_failed:%s"
+                % (result.stderr or b"").decode("utf-8", "replace").strip()[:200],
+            )
             return None
         raw = result.stdout
         if len(raw) > MAX_TURN_DIFF_BYTES:

--- a/projects/embervm/runtimes/claude/shim_hydration_test.py
+++ b/projects/embervm/runtimes/claude/shim_hydration_test.py
@@ -459,9 +459,13 @@ def test_poisoned_directory_is_cleaned_and_recloned(manager, monkeypatch):
         if command[1] == "clone":
             os.makedirs(os.path.join(checkout_dir, ".git"), exist_ok=True)
             return _GitProcess()
-        if command[1:3] == ["-C", checkout_dir]:
+        # Recognise the checkout by "-C <dir>" wherever it appears rather than
+        # by fixed positions. Diff capture prefixes "-c safe.directory=<dir>"
+        # because it reads a checkout the shim does not own, and pinning the
+        # position made this stub reject a legitimate command shape.
+        if ["-C", checkout_dir] in [list(pair) for pair in zip(command, command[1:])]:
             return _GitProcess(returncode=1 if len(calls) == 1 else 0)
-        pytest.fail("unexpected git command")
+        pytest.fail("unexpected git command: %r" % (command,))
 
     monkeypatch.setattr(shim.subprocess, "run", fake_run)
     manager.turn("first", repo="owner/repo", branch="main")

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -4465,3 +4465,66 @@ def test_apply_egress_ca_trust_sets_nothing_without_a_ca(monkeypatch):
     monkeypatch.delenv("SSL_CERT_FILE", raising=False)
     assert shim.apply_egress_ca_trust() is None
     assert "SSL_CERT_FILE" not in os.environ
+
+
+def test_turn_base_scopes_safe_directory_to_the_checkout(monkeypatch, tmp_path):
+    # The shim is root and hydration clones as the CLI uid, so git sees a
+    # repository owned by someone else and refuses. safe.directory is passed per
+    # invocation and scoped to this checkout, never written to a git config.
+    checkout = tmp_path / "src"
+    (checkout / ".git").mkdir(parents=True)
+    seen = {}
+
+    def fake_run(args, **kwargs):
+        seen["args"] = args
+        return subprocess.CompletedProcess(args, 0, b"a" * 40 + b"\n", b"")
+
+    monkeypatch.setattr(shim.subprocess, "run", fake_run)
+
+    assert shim._capture_turn_base(str(checkout)) == "a" * 40
+    assert seen["args"][:3] == [
+        "git",
+        "-c",
+        "safe.directory=%s" % checkout,
+    ]
+    assert "rev-parse" in seen["args"]
+
+
+def test_turn_diff_scopes_safe_directory_to_the_checkout(monkeypatch, tmp_path):
+    checkout = tmp_path / "src"
+    (checkout / ".git").mkdir(parents=True)
+    seen = {}
+
+    def fake_run(args, **kwargs):
+        seen["args"] = args
+        return subprocess.CompletedProcess(args, 0, b"diff --git a/a b/a\n", b"")
+
+    monkeypatch.setattr(shim.subprocess, "run", fake_run)
+
+    assert shim._capture_turn_diff(str(checkout), "b" * 40) is not None
+    assert seen["args"][:3] == [
+        "git",
+        "-c",
+        "safe.directory=%s" % checkout,
+    ]
+    assert "diff" in seen["args"]
+
+
+def test_turn_base_failure_reason_includes_git_stderr(monkeypatch, tmp_path, capsys):
+    # git already writes the reason. Discarding it via DEVNULL is what made
+    # rev_parse_failed unactionable for hours: the outcome named which guard
+    # fired, never why.
+    checkout = tmp_path / "src"
+    (checkout / ".git").mkdir(parents=True)
+    monkeypatch.setattr(
+        shim.subprocess,
+        "run",
+        lambda *_a, **_k: subprocess.CompletedProcess(
+            [], 128, b"", b"fatal: detected dubious ownership in repository"
+        ),
+    )
+
+    assert shim._capture_turn_base(str(checkout)) is None
+    captured = capsys.readouterr().err
+    assert "outcome=rev_parse_failed" in captured
+    assert "dubious ownership" in captured


### PR DESCRIPTION
Fixes the root cause behind #4934. Diff capture has never produced a diff in production; this is why.

## The evidence

With the outcome instrumentation from `33fe69c8e` in place, the guest named it on the first session:

```
ember-claude-shim: turn-diff phase=base outcome=rev_parse_failed checkout_dir=/workspace/src
ember-claude-shim: turn-diff phase=diff outcome=no_base_sha checkout_dir=/workspace/src
```

`git rev-parse HEAD` exits non-zero, so no base sha is captured and the diff never runs.

## Why that is strange, and what it means

The same guest clones, edits, commits and pushes the same repository without trouble. Session 190 pushed `codex/noded-test-audit` at `dcdde14c9`; 192 and 196 committed locally. Notably the outcome is `rev_parse_failed`, not `no_git_dir`, so `.git` exists.

The difference is **who runs git**:

```python
# hydration's validation, works
["git", "-C", checkout_dir, "rev-parse", "--verify", "HEAD"],
capture_output=True, **_cli_privilege_kwargs(),

# capture, fails
["git", "-C", checkout_dir, "rev-parse", "HEAD"],
stderr=subprocess.DEVNULL,
```

`_cli_privilege_kwargs()` returns uid/gid **only when the shim is root**. The shim is root, hydration clones under those kwargs, so the checkout belongs to the CLI uid. Capture called git as root against it and tripped git's dubious-ownership check. The agent runs as the CLI user, which is why every path except capture worked.

The observed asymmetry is itself the proof the shim runs as root: if it did not, `_cli_privilege_kwargs()` would return `{}`, both calls would be identical, and capture would succeed.

## Why not just drop privileges

That was the first attempt and it failed a test in a way worth recording. `test_process_manager_captures_diff_against_head_at_turn_start` builds a **real** git repository as root, so running capture as uid 65532 reproduced the same ownership refusal with the roles swapped. There is no single uid that owns the checkout in both contexts, so any fix that picks a uid breaks one of them.

Reading as root with `safe.directory` scoped to that one path works in both directions: root can always read, and the ownership check is the only obstacle. It is passed per invocation via `-c`, so nothing is written to any git config in the guest and no persistent weakening of the check occurs.

## git's stderr now reaches the log

It was going to `DEVNULL`. The instrumentation could say which guard fired but never why, which is exactly what made `rev_parse_failed` unactionable. git had already written the reason and it was being thrown away. The failure outcomes now carry it, bounded to 200 chars.

## Test stub

`shim_hydration_test`'s stub recognised the checkout by fixed argv positions (`command[1:3] == ["-C", dir]`), so it rejected the new shape. It now matches `-C <dir>` wherever it appears, which is what "targets our checkout" actually means, and reports the offending command when it fails rather than a bare "unexpected git command".

## Verified

- `ci lint` clean.
- `ci test //projects/embervm/runtimes/claude:shim_test //projects/embervm/runtimes/claude:shim_hydration_test -- --nocache_test_results` -> `Executed 2 out of 2 tests: 2 tests pass`.
- Run uncached and across **both** shim targets deliberately: running only `shim_test` is how a hydration break slipped through earlier today.
- New tests assert both capture calls scope `safe.directory` to the checkout, and that git's stderr reaches the outcome line.

## Not verified

That capture actually produces a diff in production. That needs this image built, a base rebuild to carry it into guests, and a session. The guest instrumentation will say `phase=base outcome=success` when it works, and will name any new reason if it does not.