### PR TITLE
fix(monolith): gate verifier ownership before rejection, fetch JWKS in-cluster

### DIFF
--- a/bazel/requirements/runtime.txt
+++ b/bazel/requirements/runtime.txt
@@ -3086,6 +3086,7 @@ pyjwt[crypto]==2.13.0 \
     --hash=sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728
     # via
     #   --override bazel/requirements/overrides.txt
+    #   homelab (pyproject.toml)
     #   mcp
 pyobjc-core==10.3.2 ; sys_platform == 'darwin' \
     --hash=sha256:16644a92fb9661de841ba6115e5354db06a1d193a5e239046e840013c7b3874d \

--- a/projects/monolith/auth/verifier.py
+++ b/projects/monolith/auth/verifier.py
@@ -41,9 +41,44 @@ class AuthentikStandingVerifier:
         )
 
     async def verify(self, token: str) -> Principal | None:
+        # Deliberately ahead of the ownership gate, and the only check that is.
+        # An unconfigured verifier cannot know what it owns, so declining would
+        # turn a deployment mistake into "no verifier recognized this token",
+        # which renders 401 and hides an operator fault behind a caller one.
         if not self._settings.identity_is_configured:
             raise AuthError(AuthErrorReason.UNCONFIGURED)
 
+        # ── Ownership gate ───────────────────────────────────────────────────
+        # This runs BEFORE any check that raises, which is the load-bearing
+        # ordering. A verifier that raises on a token it does not own makes its
+        # own opinion final for the whole chain, so the next verifier is never
+        # consulted. #4944 registers the delegation verifier after this one, and
+        # its tokens need not be RS256-with-kid, so an algorithm or header check
+        # ahead of this gate would reject them at slot 1 with a 401 that no
+        # later slot could revisit. Only `iss` decides ownership; everything
+        # that judges a token's validity belongs below.
+        try:
+            unverified_claims = jwt.decode(token, options={"verify_signature": False})
+        except jwt.InvalidTokenError:
+            # Not a decodable JWT, so not ours: a later verifier may own an
+            # opaque or non-JWT credential. If none does, TokenResolver raises
+            # UNRECOGNIZED, so a present token still never becomes anonymous.
+            logger.debug("declining token: not a decodable JWT")
+            return None
+
+        iss = unverified_claims.get("iss")
+        if iss != self._settings.authentik_issuer:
+            logger.debug(
+                "declining token: issuer mismatch (expected %s, got %s)",
+                self._settings.authentik_issuer,
+                iss,
+            )
+            return None
+
+        # ── The token claims to be ours, so from here every failure raises ───
+        # Reading `iss` above came from an unverified decode, which is safe
+        # because it only routes. Nothing is trusted until the signature is
+        # checked against the JWKS below.
         try:
             header = jwt.get_unverified_header(token)
         except jwt.InvalidTokenError as exc:
@@ -54,27 +89,6 @@ class AuthentikStandingVerifier:
         kid = header.get("kid")
         if not isinstance(kid, str) or not kid:
             raise AuthError(AuthErrorReason.MALFORMED)
-
-        # Ownership check: is this token ours? Decode without verification to check iss.
-        # If the issuer does not match, decline so the next verifier can be tried.
-        try:
-            unverified_claims = jwt.decode(
-                token,
-                options={"verify_signature": False},
-                algorithms=["RS256"],
-            )
-        except jwt.InvalidTokenError:
-            # A token nobody can parse is nobody's; raise for consistency with header failures.
-            raise AuthError(AuthErrorReason.MALFORMED) from None
-
-        iss = unverified_claims.get("iss")
-        if iss != self._settings.authentik_issuer:
-            logger.debug(
-                "declining token: issuer mismatch (expected %s, got %s)",
-                self._settings.authentik_issuer,
-                iss,
-            )
-            return None
 
         jwk = await self._jwks.get_key(kid)
         if jwk is None:

--- a/projects/monolith/auth/verifier_test.py
+++ b/projects/monolith/auth/verifier_test.py
@@ -349,6 +349,107 @@ async def test_ordered_chain_stops_when_first_verifier_raises():
     assert second.calls == []
 
 
+def _delegation_principal() -> Principal:
+    """Stand in for what #4944's verifier will return."""
+
+    return Principal(
+        subject="delegate",
+        actor=("broker",),
+        scope=("tools:read",),
+        groups=(),
+        email=None,
+        kind=PrincipalKind.WORKLOAD,
+        authority=Authority.DELEGATED,
+    )
+
+
+def _foreign_token(
+    algorithm: str = "HS256", *, iss: str = "https://delegation-issuer/"
+) -> str:
+    """A token a LATER verifier owns, deliberately not RS256-with-kid."""
+
+    return jwt.encode(
+        {"sub": "delegate", "iss": iss}, "shared-secret", algorithm=algorithm
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_jwt_credential_declines_to_the_next_verifier():
+    """Undecodable is not the same as invalid, and only one of them is ours to say.
+
+    This verifier used to raise MALFORMED for anything it could not decode,
+    which made slot 1's opinion final for the whole chain: a later verifier
+    owning an opaque credential would never be consulted.
+    """
+    fetch, calls = _fetcher({"keys": []})
+    standing = AuthentikStandingVerifier(_settings(), fetch=fetch)
+    delegated = _delegation_principal()
+    stub = StubVerifier(result=delegated)
+
+    principal = await TokenResolver([standing, stub]).resolve("opaque-not-a-jwt")
+
+    assert principal is delegated
+    assert stub.calls == ["opaque-not-a-jwt"]
+    # Ownership was settled without an outbound fetch.
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_foreign_issuer_token_of_another_algorithm_declines():
+    """The algorithm pin must not gate ownership, only validity.
+
+    #4944's delegation tokens need not be RS256-with-kid. With the pin ahead of
+    the ownership gate they would 401 at slot 1, and no later slot could revisit
+    that, so the chain would be unreachable for exactly the tokens it exists for.
+    """
+    fetch, calls = _fetcher({"keys": []})
+    standing = AuthentikStandingVerifier(_settings(), fetch=fetch)
+    delegated = _delegation_principal()
+    stub = StubVerifier(result=delegated)
+    foreign = _foreign_token()
+
+    principal = await TokenResolver([standing, stub]).resolve(foreign)
+
+    assert principal is delegated
+    assert stub.calls == [foreign]
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_token_claiming_our_issuer_is_judged_here_not_passed_on():
+    """The gate decides ownership only. A token claiming our issuer is ours to reject."""
+    fetch, _ = _fetcher({"keys": []})
+    standing = AuthentikStandingVerifier(_settings(), fetch=fetch)
+    stub = StubVerifier(result=_delegation_principal())
+    owned_but_wrong_algorithm = _foreign_token(iss=ISSUER)
+
+    with pytest.raises(AuthError) as raised:
+        await TokenResolver([standing, stub]).resolve(owned_but_wrong_algorithm)
+
+    assert raised.value.reason is AuthErrorReason.MALFORMED
+    assert stub.calls == []
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_verifier_raises_even_for_a_token_it_does_not_own():
+    """The one deliberate exception to gate-before-raise.
+
+    An unconfigured verifier cannot know what it owns, so declining would let a
+    deployment mistake read as "nobody recognized this token" (401) instead of
+    the infrastructure fault it is (503).
+    """
+    fetch, _ = _fetcher({"keys": []})
+    standing = AuthentikStandingVerifier(_settings(authentik_issuer=""), fetch=fetch)
+    stub = StubVerifier(result=_delegation_principal())
+
+    with pytest.raises(AuthError) as raised:
+        await TokenResolver([standing, stub]).resolve(_foreign_token())
+
+    assert raised.value.reason is AuthErrorReason.UNCONFIGURED
+    assert raised.value.status_code == 503
+    assert stub.calls == []
+
+
 @pytest.mark.asyncio
 async def test_rs256_algorithm_pin_rejects_other_algorithms(caplog):
     """Verify that the RS256 pin is enforced before JWKS lookup."""

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -38,9 +38,30 @@ backend:
 # track the mcp-friends slug in projects/platform/authentik/blueprints/mcp-auth.yaml.
 # Renaming the application silently breaks verification. The issuer's trailing
 # slash is significant.
+#
+# jwksUrl and issuer point at the SAME authentik by two different routes, and
+# that asymmetry is deliberate rather than a copy-paste error:
+#
+#   issuer  is a STRING COMPARED against the token's `iss` claim. It must be
+#           what authentik mints (issuer_mode `per_provider`, the public URL),
+#           so it can never become the in-cluster address.
+#   jwksUrl is a URL FETCHED. Nothing requires it to match `iss`, so it takes
+#           the shortest path to the same keys.
+#
+# Fetching over the public hostname made verification depend on egress to
+# Cloudflare and back through the tunnel: a WAN blip would 503 the whole /mcp
+# surface, held for the full jwksCacheTtlSeconds by the negative cache. The
+# ClusterIP has no such dependency.
+#
+# The port is plaintext because authentik serves its ClusterIP with a
+# self-signed certificate, so https here would mean disabling verification,
+# which is worse. JWKS is public key material, so confidentiality is not the
+# concern; integrity is, and it now rests on the cluster network rather than
+# on TLS. Anything able to MITM pod-to-pod traffic could serve substituted
+# keys, which is a strictly smaller set of attackers than before.
 auth:
   authentik:
-    jwksUrl: "https://auth.jomcgi.dev/application/o/mcp-friends/jwks/"
+    jwksUrl: "http://authentik-server.authentik.svc.cluster.local/application/o/mcp-friends/jwks/"
     issuer: "https://auth.jomcgi.dev/application/o/mcp-friends/"
     audience: "https://private.jomcgi.dev"
   jwksCacheTtlSeconds: 300

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -20,9 +20,11 @@ backend:
 
 # State the production verifier identity explicitly. The application slug owns
 # the Authentik issuer path, and the trailing slash is significant.
+# jwksUrl is fetched in-cluster while issuer stays the public string authentik
+# mints into `iss`; see the chart values for why those two must differ.
 auth:
   authentik:
-    jwksUrl: "https://auth.jomcgi.dev/application/o/mcp-friends/jwks/"
+    jwksUrl: "http://authentik-server.authentik.svc.cluster.local/application/o/mcp-friends/jwks/"
     issuer: "https://auth.jomcgi.dev/application/o/mcp-friends/"
     audience: "https://private.jomcgi.dev"
   jwksCacheTtlSeconds: 300

--- a/projects/monolith/framework/core_test.py
+++ b/projects/monolith/framework/core_test.py
@@ -371,6 +371,31 @@ def test_mcp_only_module_is_valid_and_mounts_mcp():
     assert any(getattr(r, "path", "") == "/mcp" for r in app.routes)
 
 
+def test_mcp_mount_is_wrapped_in_principal_middleware():
+    """A route existing at /mcp is not the same as that route authenticating.
+
+    build_app keeps the unwrapped app in scope as `raw_mcp_http_app`, because
+    the lifespan has to come off it (PrincipalMiddleware is a plain callable
+    with no .lifespan). So the unauthenticated app is reachable by name at the
+    mount, and mounting it instead is a one-word edit.
+
+    Nothing else catches that. The middleware's own tests construct it
+    directly, which proves it works rather than that it is installed, and the
+    mount test above passes for a route that authenticates nothing. Mounting
+    `raw_mcp_http_app` here leaves the ENTIRE suite green (verified: 721 pass)
+    while serving the whole tool catalogue to any unauthenticated caller that
+    reaches the ClusterIP, which Context Forge does without traversing the
+    ingress gate.
+    """
+    from auth.api import PrincipalMiddleware
+
+    profile = dataclasses.replace(_PLAIN_PRIVATE, mcp_enabled=True)
+    app = build_app(profile, [Module(name="tools", register_mcp=lambda: None)])
+
+    mcp_route = next(r for r in app.routes if getattr(r, "path", "") == "/mcp")
+    assert isinstance(mcp_route.app, PrincipalMiddleware)
+
+
 def test_private_app_registers_the_auth_error_handler():
     """The handler being importable is not the same as it being installed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,12 @@ dependencies = [
     "pydantic-settings~=2.1",
     "pydantic-extra-types~=2.0",
     "pydantic-sqlite~=0.3.0",
+    # projects/monolith/auth verifies authentik RS256 tokens with this. It was
+    # previously present only because mcp and semgrep happened to pull it in, so
+    # an upstream dropping it would have broken token verification through a
+    # dependency this repo never named. The [crypto] extra is required: without
+    # it PyJWT has no RSA backend and RS256 verification raises at runtime.
+    "pyjwt[crypto]>=2.13.0",
     "httpx~=0.28.1",
     # curl_cffi impersonates a browser TLS/JA3 fingerprint. The BC Parks
     # (camping.bcparks.ca) reservation API sits behind an Azure WAF that 403s


### PR DESCRIPTION
Three hardenings found while reviewing #4955 after it merged. All verified against the live cluster, not just tests.

## 1. The verifier rejected tokens before deciding whether it owned them

`AuthentikStandingVerifier` ran every check that *raises* (`alg != RS256`, missing `kid`, undecodable) **before** the `iss` gate that *declines*. That makes slot 1's opinion final for the whole chain: a token belonging to a later verifier gets a 401 no later slot can revisit.

This matters because `build_default_resolver` states that #4944's delegation verifier registers after this one, and those tokens need not be RS256-with-kid. The chain existed for exactly the token shape that could not reach it.

The ownership gate now runs first, and only `iss` decides ownership. `UNCONFIGURED` deliberately stays ahead of the gate: a verifier that does not know its own settings cannot know what it owns, and declining there would render an operator fault (503) as a caller fault (401).

**Falsified, not assumed.** Against the old verifier with the new tests, 2 of 4 fail with exactly `401: authentication failed: malformed`:

| test | old code | why |
|---|---|---|
| `test_non_jwt_credential_declines_to_the_next_verifier` | FAILED | opaque credential raised instead of declining |
| `test_foreign_issuer_token_of_another_algorithm_declines` | FAILED | HS256 token raised at the alg pin |
| `test_token_claiming_our_issuer_is_judged_here_not_passed_on` | PASSED | guards against over-correcting |
| `test_unconfigured_verifier_raises_even_for_a_token_it_does_not_own` | PASSED | documents the deliberate exception |

## 2. JWKS was fetched over the public internet

`https://auth.jomcgi.dev/...` from a pod hairpins out to Cloudflare and back through the tunnel, so a WAN blip would 503 the entire `/mcp` surface, held for the full `jwksCacheTtlSeconds` by the negative cache. `authentik-server` is a ClusterIP with no such dependency.

Verified in-cluster: `http://authentik-server.authentik.svc.cluster.local/application/o/mcp-friends/jwks/` returns 200 and serves the **same `kid`** that signed a real issued access token. Nothing blocks the path (no clusterwide policy, no netpol in `authentik`, monolith has no egress policy).

`jwksUrl` and `issuer` now deliberately differ, and the values file explains why so nobody "fixes" it: `issuer` is a **string compared** against `iss` and must stay what authentik mints (`issuer_mode: per_provider`); `jwksUrl` is a **URL fetched** and is not required to match.

Plaintext because authentik serves its ClusterIP with a self-signed certificate, so https would mean disabling verification. JWKS is public key material, so integrity is the concern, and it now rests on the cluster network rather than TLS: a strictly smaller attacker set than before.

## 3. PyJWT was never declared

It reached the build only because `mcp` and `semgrep` pulled it in; no `.in` named it. An upstream dropping it would have broken token verification through a dependency this repo never asked for. Now `pyjwt[crypto]>=2.13.0` in `pyproject.toml`. The `[crypto]` extra is required or RS256 has no RSA backend at runtime. Lock regen is a single provenance line, no version churn.

## Not addressed

- No test asserts the `/mcp` mount is actually wrapped by `PrincipalMiddleware`. The wiring is correct today, but a refactor could unwrap it with every test green.
- `projects/mcp/ARCHITECTURE.md` still says token forwarding "is inert until the monolith validates the token" and that `aud` is the client id rather than the monolith. Both were superseded.

Refs #4955, #4942, #4944, #4569