### PR TITLE
fix(agents): count a trailer-named file as accounted for, not mechanical

### DIFF
--- a/projects/monolith/swarm/compare_router.py
+++ b/projects/monolith/swarm/compare_router.py
@@ -177,9 +177,24 @@ async def compare_stats(session_id: int, turn_seq: int) -> dict:
         raise HTTPException(status_code=404, detail="Agent turn not found")
     base_sha, commit_sha, branch = data["base_sha"], data["commit_sha"], data["branch"]
     repo = data["repo"]
-    authored, activities_truncated = _activities(data)
+    observed, activities_truncated = _activities(data)
     rationale = parse_rationale(data["result_text"])
     trailer_paths = {item["path"] for item in rationale.get("paths", [])}
+    # A file is accounted for if the activity stream shows it being edited OR
+    # the agent's trailer names it. Observation alone is not enough: several
+    # adapters record no edit/write activities at all, so `observed` is empty
+    # for their turns and every changed file fell through as mechanical. With
+    # no `run` activities either, _mechanical_steps also returns nothing, so a
+    # turn with a real diff and a parsed trailer produced zero steps and the
+    # console rendered an empty panel beside correct counts.
+    #
+    # This does not merge the two channels. The diff still comes from git and
+    # the testimony still from the agent; the composer attaches testimony only
+    # where the trailer actually has a point. What changes is that the claim no
+    # longer needs a third signal to corroborate it before it can be shown.
+    # `authored_file_paths` below stays the OBSERVED set, so the distinction
+    # between seen and claimed is still reportable.
+    authored = observed | trailer_paths
 
     resolution_rung = 3
     diff_type = None
@@ -236,7 +251,7 @@ async def compare_stats(session_id: int, turn_seq: int) -> dict:
             ),
         },
         "trailer_parsed": rationale.get("parse_status") == "parsed",
-        "authored_file_paths": sorted(authored),
+        "authored_file_paths": sorted(observed),
         **(
             {
                 "unexplained_files": sorted(paths - trailer_paths),

--- a/projects/monolith/swarm/compare_router_test.py
+++ b/projects/monolith/swarm/compare_router_test.py
@@ -242,3 +242,45 @@ async def test_lazy_patch_and_cache(monkeypatch):
 
 async def _async_response(response):
     return response
+
+
+@pytest.mark.asyncio
+async def test_trailer_named_file_is_authored_without_activities(monkeypatch):
+    # Several adapters record no edit/write activities, so the observed set is
+    # empty for their turns. Before this, every changed file fell through as
+    # mechanical, _mechanical_steps needed run activities it did not have
+    # either, and the walkthrough rendered zero steps beside a correct count.
+    raw = (
+        "diff --git a/swarm/policy.py b/swarm/policy.py\n"
+        "--- a/swarm/policy.py\n"
+        "+++ b/swarm/policy.py\n"
+        "@@ -1 +1,2 @@\n"
+        " keep\n"
+        "+added\n"
+    ).encode()
+    monkeypatch.setattr(
+        mod,
+        "_turn_data",
+        lambda *_: _data(
+            diff_blob=zlib.compress(raw),
+            diff_base_sha="c" * 40,
+            result_text=(
+                "done\n\nRATIONALE\n- path: swarm/policy.py · why: adds the guard\n"
+            ),
+            usage_json="{}",
+        ),
+    )
+
+    async def fail_github(*_a, **_k):
+        raise AssertionError("GitHub must not be called for a stored diff")
+
+    monkeypatch.setattr(mod, "_github_get", fail_github)
+    monkeypatch.setattr(mod, "_compare", fail_github)
+    result = await mod.compare_stats(1, 1)
+
+    assert result["resolution_rung"] == 1
+    assert result["files"][0]["classification"] == "authored"
+    # The observed set stays reportable and separate from the claim.
+    assert result["authored_file_paths"] == []
+    assert result["unexplained_files"] == []
+    assert result["contradicted_paths"] == []


### PR DESCRIPTION
Follows #4959, which made diff capture work. The first turn to produce a real diff rendered an **empty walkthrough beside correct counts**.

## What session 198 produced

Capture succeeded:

```
diff_base_sha = fb50f73c3e4ed4ed2756a9fd2e9ab4f504eeeeba
diff_blob     = 324 bytes
rung = 1   diff_type = stored   ephemeral = false
compare: projects/monolith/swarm/unified_diff.py  modified  +1/-0
```

And the walkthrough rendered nothing:

```
summary: {status: available, files_changed: 1, accounted_files: 1, unexplained_files: 0}
steps  : {}
file classification: "mechanical"
authored_file_paths: []
trailer_parsed: true
```

## Why

The compare classified files using only the activity stream. `_activities` collects `file_path` from activities of type `edit` or `write`. Several adapters record no activities at all, so that set was empty and every changed file fell through as `mechanical`.

Then every remaining branch that could produce a step also came up empty:

- `ordered` is built from `classification == "authored"` -> empty
- `_mechanical_steps` returns `[]` unless there are `run` activities to group files under -> there were none
- `unexplained_files` is `paths - trailer_paths` -> empty, correctly, because the trailer *did* name the file
- `contradicted_paths` is `trailer_paths - paths` -> empty, also correct

So a turn with a real diff and a parsed trailer produced zero steps. The summary was right because `_compare_summary` intersects trailer paths with changed paths directly; the steps were empty because they went through `classification`. Two code paths answering "which files did the agent account for" and disagreeing.

This could not have surfaced before today: `classification` only matters at rung 1 or 2, and neither had ever occurred in production.

## What changed

A file is accounted for if the activity stream shows it edited **or** the agent's trailer names it.

This does not merge the two channels. The diff still comes from git, the testimony still from the agent, and the composer attaches `testimony` only where the trailer has a point for that path. What changes is that a claim no longer needs a third signal to corroborate it before the console will display it.

`authored_file_paths` keeps reporting the **observed** set, and the local variable is renamed to `observed` so the distinction stays legible. Seen and claimed remain separable in the payload.

## Verified

- `ci lint` clean.
- `ci test //projects/monolith:swarm_compare_router_test //projects/monolith:swarm_walkthrough_composer_test -- --nocache_test_results` -> `Executed 2 out of 2 tests: 2 tests pass`.
- Run uncached deliberately: a cached pass proves nothing about a change like this.
- New test asserts a trailer-named file classifies as `authored` when the activity stream is empty, that GitHub is never called on the stored path, and that `authored_file_paths` stays empty so the observed set is still reported separately.

## Not verified

That the console now renders the points list and diff for session 198. That needs this deployed, and #4957 (prominence) merged so the panel is open rather than a collapsed disclosure that never fetches.