### PR TITLE
feat(agents): give the walkthrough its own full-page view

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -33,6 +33,13 @@
   } from "./workspace-recovery.js";
   import PaneHeader from "./PaneHeader.svelte";
   import SessionWalkthrough from "./SessionWalkthrough.svelte";
+  import WalkthroughNarrative from "./WalkthroughNarrative.svelte";
+  import {
+    defaultSessionView,
+    SESSION_VIEW_CONVERSATION,
+    SESSION_VIEW_WALKTHROUGH,
+    walkthroughTurns,
+  } from "./session-view.js";
   import { periodForHour } from "$lib/private/period.js";
 
   const MOBILE_MEDIA_QUERY = "(max-width: 760px)";
@@ -89,6 +96,8 @@
   let runDetail = $state(null);
   let runRequestSequence = 0;
   let detail = $state(null);
+  let sessionView = $state(SESSION_VIEW_CONVERSATION);
+  let sessionViewInitializedFor = $state(null);
   let searchQuery = $state("");
   let searchResults = $state(null);
   let searchLoading = $state(false);
@@ -145,6 +154,7 @@
   let requestSequence = 0;
   let renderedPending = $state({});
   let vms = $state({});
+  let vmSnapshotReceived = $state(false);
   let vmStreamStatus = $state({
     mode: "connecting",
     lastUpdateAt: null,
@@ -167,6 +177,7 @@
   const composerModel = $derived(
     composerModelOverride ?? selectedSession?.model ?? "",
   );
+  const eligibleWalkthroughTurns = $derived(walkthroughTurns(detail?.turns));
   const hasRuns = $derived(runs.length > 0);
   const runNeedsAttention = $derived(runs.filter((run) => run.needs).length);
   const runSpend = $derived(
@@ -672,6 +683,7 @@
       });
       // Apply every backend map regardless of indicator mode; see router.py:246-254.
       vms = body?.vms ?? {};
+      vmSnapshotReceived = true;
     } catch (error) {
       // VM state is advisory; keep the last known map on transient failures.
       if (!vmFallbackArmed) return;
@@ -971,6 +983,11 @@
     const wasSessionId = previousSessionId;
     previousSessionId = sessionId;
 
+    if (String(sessionId) !== String(wasSessionId)) {
+      sessionView = SESSION_VIEW_CONVERSATION;
+      sessionViewInitializedFor = null;
+    }
+
     requestSequence += 1;
     runRequestSequence += 1;
     detail = null;
@@ -1004,6 +1021,21 @@
           ?.focus({ preventScroll: true }),
       );
     }
+  });
+
+  $effect(() => {
+    const sessionId = selectedId;
+    const turns = detail?.turns;
+    if (
+      sessionId == null ||
+      turns == null ||
+      !vmSnapshotReceived ||
+      String(sessionViewInitializedFor) === String(sessionId)
+    ) {
+      return;
+    }
+    sessionView = defaultSessionView(vmState(selectedSession, vms), turns);
+    sessionViewInitializedFor = sessionId;
   });
 
   $effect(() => {
@@ -1130,6 +1162,7 @@
         });
         // Apply every backend map regardless of indicator mode; see router.py:246-254.
         vms = body?.vms ?? {};
+        vmSnapshotReceived = true;
       } catch (error) {
         // Retain the last snapshot and expose that the advisory frame failed.
         updateVmStreamStatus({
@@ -1312,15 +1345,14 @@
     {#if fixture?.walkthrough}
       <!-- Walkthrough visual states are reviewed via ?fixture=walk-*; the
            component gets its payload inline and never fetches. -->
-      <div class="turns">
-        <div class="turns-inner">
-          <article class="turn">
-            <SessionWalkthrough
-              turnSeq={fixture.walkthrough.turnSeq}
-              model={fixture.walkthrough.model}
-              fixture={fixture.walkthrough}
-            />
-          </article>
+      <div class="walkthrough-page">
+        <div class="walkthrough-inner">
+          <h2>{P.labels.walkSummary}</h2>
+          <WalkthroughNarrative
+            turnSeq={fixture.walkthrough.turnSeq}
+            model={fixture.walkthrough.model}
+            fixture={fixture.walkthrough}
+          />
         </div>
       </div>
     {:else if fixture && !fixture.home}
@@ -1346,6 +1378,26 @@
                 : "no live microVM; the next prompt boots fresh"}
               >vm {vmState(selectedSession, vms)}</span
             >
+            <span
+              class="session-view-toggle"
+              role="group"
+              aria-label={P.labels.sessionViewLabel}
+            >
+              <button
+                type="button"
+                class:on={sessionView === SESSION_VIEW_CONVERSATION}
+                aria-pressed={sessionView === SESSION_VIEW_CONVERSATION}
+                onclick={() => (sessionView = SESSION_VIEW_CONVERSATION)}
+                >{P.labels.conversationView}</button
+              >
+              <button
+                type="button"
+                class:on={sessionView === SESSION_VIEW_WALKTHROUGH}
+                aria-pressed={sessionView === SESSION_VIEW_WALKTHROUGH}
+                onclick={() => (sessionView = SESSION_VIEW_WALKTHROUGH)}
+                >{P.labels.walkthroughView}</button
+              >
+            </span>
             <span
               class={`vm-stream-state ${vmStreamStatus.mode}`}
               title={vmStreamStatus.mode === "connecting"
@@ -1419,42 +1471,138 @@
             "luna"} · {shortId(selectedSession)}
         </div>
       </header>
-      <div class="turns" bind:this={turnsEl}>
-        <div class="turns-inner">
-          {#each detail?.turns ?? [] as turn, turnIndex (turn.seq)}
-            <!-- {@const} has to be an immediate child of the block, not of the
+      {#if sessionView === SESSION_VIEW_CONVERSATION}
+        <div class="turns" bind:this={turnsEl}>
+          <div class="turns-inner">
+            {#each detail?.turns ?? [] as turn (turn.seq)}
+              <!-- {@const} has to be an immediate child of the block, not of the
                  element inside it, so this sits above <article> rather than
                  next to the markup that reads it. -->
-            {@const hasIntent =
-              turn.prompt_intent !== null && turn.prompt_intent !== undefined}
-            <article class="turn">
-              <div class="prompt">
-                <span class="role">you</span>
-                {#if hasIntent}
-                  <div class="prompt-text intent-prompt">
-                    <span class="intent-label">{P.labels.promptIntent}</span>
-                    <div>{turn.prompt_intent}</div>
-                  </div>
-                  {#if turnProtocol(turn)}
-                    <details class="prompt-protocol">
-                      <summary>{P.labels.viewProtocol}</summary>
-                      <pre>{turnProtocol(turn)}</pre>
-                    </details>
+              {@const hasIntent =
+                turn.prompt_intent !== null && turn.prompt_intent !== undefined}
+              <article class="turn">
+                <div class="prompt">
+                  <span class="role">you</span>
+                  {#if hasIntent}
+                    <div class="prompt-text intent-prompt">
+                      <span class="intent-label">{P.labels.promptIntent}</span>
+                      <div>{turn.prompt_intent}</div>
+                    </div>
+                    {#if turnProtocol(turn)}
+                      <details class="prompt-protocol">
+                        <summary>{P.labels.viewProtocol}</summary>
+                        <pre>{turnProtocol(turn)}</pre>
+                      </details>
+                    {/if}
+                  {:else}
+                    <div class="prompt-text">{turn.prompt}</div>
                   {/if}
-                {:else}
-                  <div class="prompt-text">{turn.prompt}</div>
+                </div>
+                {#if turn.usage?.activities?.length}
+                  <details class="steps">
+                    <summary
+                      >{turn.usage.activities.length}
+                      {turn.usage.activities.length === 1
+                        ? "step"
+                        : "steps"}</summary
+                    >
+                    <ol class="step-list">
+                      {#each turn.usage.activities as activity}
+                        <li>
+                          <span class="step-verb"
+                            >{activityParts(activity).verb}</span
+                          >
+                          <span class="step-detail"
+                            >{activityParts(activity).detail}</span
+                          >
+                        </li>
+                      {/each}
+                    </ol>
+                  </details>
                 {/if}
-              </div>
-              {#if turn.usage?.activities?.length}
-                <details class="steps">
-                  <summary
-                    >{turn.usage.activities.length}
-                    {turn.usage.activities.length === 1
-                      ? "step"
-                      : "steps"}</summary
-                  >
-                  <ol class="step-list">
-                    {#each turn.usage.activities as activity}
+                {#if turnFailed(turn)}
+                  <pre class="turn-error">{resultWithoutTrailer(turn) ||
+                      "The turn failed without output."}</pre>
+                {:else if turn.result_text}
+                  <div class="result-md">
+                    {@html renderAgentMarkdown(resultWithoutTrailer(turn))}
+                  </div>
+                {/if}
+                {#if selectedSession.repo}
+                  <SessionWalkthrough
+                    sessionId={selectedSession.id}
+                    turnSeq={turn.seq}
+                    model={turn.model || selectedSession.model || "luna"}
+                  />
+                {/if}
+                <div class="turn-meta mono">
+                  <span>{turn.model || selectedSession.model || "luna"}</span>
+                  <span>{relativeTime(turn.created_at)}</span>
+                  {#if cost(turn.cost_usd)}<span>{cost(turn.cost_usd)}</span
+                    >{/if}
+                  {#if turn.stop_reason && turn.stop_reason !== "end_turn"}
+                    <span>{turn.stop_reason}</span>
+                  {/if}
+                  {#if turnFailed(turn)}<span class="badge-failed"
+                      >{P.labels.turnFailed}</span
+                    >{/if}
+                </div>
+              </article>
+              {@const degradedCause = workspaceRecoveryMessage(turn)}
+              {#if degradedCause}
+                <div
+                  class="turn-degraded"
+                  title={P.workspaceRecoveryCauses[degradedCause]}
+                >
+                  {P.labels.workspaceRecovery}
+                </div>
+              {/if}
+            {/each}
+
+            {#each detail?.pending_queue ?? [] as entry, index (entry.seq)}
+              {@const partial = renderedPending[entry.seq]}
+              {@const state = liveStateLabel(entry, index)}
+              <article class="turn live">
+                <div class="prompt">
+                  <span class="role">you</span>
+                  <div class="prompt-text">{entry.prompt}</div>
+                </div>
+                <div class={`live-line ${state === "working" ? "" : "quiet"}`}>
+                  <span class="live-dot" aria-hidden="true"></span>
+                  {#if state === "working"}
+                    {#if partial?.partial_activities?.length}
+                      <span class="live-latest"
+                        >{activityLine(
+                          partial.partial_activities[
+                            partial.partial_activities.length - 1
+                          ],
+                        )}</span
+                      >
+                    {:else if partial?.partial_text}
+                      <span class="live-latest">{P.labels.working}</span>
+                    {:else if vmRunning(selectedSession, vms)}
+                      <!-- Claimed, VM confirmed running, no output yet: the
+                         CLI is spinning up / the model has the prompt. -->
+                      <span class="live-latest">{P.labels.startingAgent}</span>
+                    {:else}
+                      <!-- Claimed but the control plane does not report the
+                         guest running yet: park rejoin or cold boot. -->
+                      <span class="live-latest">{P.labels.wakingVm}</span>
+                    {/if}
+                  {:else if state === "starting"}
+                    <span class="live-latest">{P.labels.startingUp}</span>
+                  {:else}
+                    <span class="live-latest">{P.labels.waitingForTurn}</span>
+                  {/if}
+                </div>
+                {#if partial?.partial_activities?.length > 1}
+                  <ol class="step-list live-steps" aria-label="Agent activity">
+                    {#if partial.partial_activities.length > 6}
+                      <li class="step-earlier">
+                        … {partial.partial_activities.length - 6} earlier steps
+                      </li>
+                    {/if}
+                    {#each partial.partial_activities.slice(-6) as activity}
                       <li>
                         <span class="step-verb"
                           >{activityParts(activity).verb}</span
@@ -1465,120 +1613,42 @@
                       </li>
                     {/each}
                   </ol>
-                </details>
-              {/if}
-              {#if turnFailed(turn)}
-                <pre class="turn-error">{resultWithoutTrailer(turn) ||
-                    "The turn failed without output."}</pre>
-              {:else if turn.result_text}
-                <div class="result-md">
-                  {@html renderAgentMarkdown(resultWithoutTrailer(turn))}
-                </div>
-              {/if}
-              {#if selectedSession.repo}
-                <SessionWalkthrough
-                  sessionId={selectedSession.id}
-                  turnSeq={turn.seq}
-                  model={turn.model || selectedSession.model || "luna"}
-                  prominent={vmState(selectedSession, vms) !== "awake" &&
-                    turnIndex === (detail?.turns ?? []).length - 1}
-                />
-              {/if}
-              <div class="turn-meta mono">
-                <span>{turn.model || selectedSession.model || "luna"}</span>
-                <span>{relativeTime(turn.created_at)}</span>
-                {#if cost(turn.cost_usd)}<span>{cost(turn.cost_usd)}</span>{/if}
-                {#if turn.stop_reason && turn.stop_reason !== "end_turn"}
-                  <span>{turn.stop_reason}</span>
                 {/if}
-                {#if turnFailed(turn)}<span class="badge-failed"
-                    >{P.labels.turnFailed}</span
-                  >{/if}
-              </div>
-            </article>
-            {@const degradedCause = workspaceRecoveryMessage(turn)}
-            {#if degradedCause}
-              <div
-                class="turn-degraded"
-                title={P.workspaceRecoveryCauses[degradedCause]}
-              >
-                {P.labels.workspaceRecovery}
+                {#if partial?.partial_text}
+                  <div class="result-md">
+                    {@html renderAgentMarkdown(partial.partial_text)}
+                  </div>
+                {/if}
+              </article>
+            {/each}
+
+            {#if !(detail?.turns ?? []).length && !(detail?.pending_queue ?? []).length}
+              <div class="empty transcript-empty">
+                {detail
+                  ? "No turns yet. Send a prompt below."
+                  : P.labels.loadingSession}
               </div>
             {/if}
-          {/each}
-
-          {#each detail?.pending_queue ?? [] as entry, index (entry.seq)}
-            {@const partial = renderedPending[entry.seq]}
-            {@const state = liveStateLabel(entry, index)}
-            <article class="turn live">
-              <div class="prompt">
-                <span class="role">you</span>
-                <div class="prompt-text">{entry.prompt}</div>
-              </div>
-              <div class={`live-line ${state === "working" ? "" : "quiet"}`}>
-                <span class="live-dot" aria-hidden="true"></span>
-                {#if state === "working"}
-                  {#if partial?.partial_activities?.length}
-                    <span class="live-latest"
-                      >{activityLine(
-                        partial.partial_activities[
-                          partial.partial_activities.length - 1
-                        ],
-                      )}</span
-                    >
-                  {:else if partial?.partial_text}
-                    <span class="live-latest">{P.labels.working}</span>
-                  {:else if vmRunning(selectedSession, vms)}
-                    <!-- Claimed, VM confirmed running, no output yet: the
-                         CLI is spinning up / the model has the prompt. -->
-                    <span class="live-latest">{P.labels.startingAgent}</span>
-                  {:else}
-                    <!-- Claimed but the control plane does not report the
-                         guest running yet: park rejoin or cold boot. -->
-                    <span class="live-latest">{P.labels.wakingVm}</span>
-                  {/if}
-                {:else if state === "starting"}
-                  <span class="live-latest">{P.labels.startingUp}</span>
-                {:else}
-                  <span class="live-latest">{P.labels.waitingForTurn}</span>
-                {/if}
-              </div>
-              {#if partial?.partial_activities?.length > 1}
-                <ol class="step-list live-steps" aria-label="Agent activity">
-                  {#if partial.partial_activities.length > 6}
-                    <li class="step-earlier">
-                      … {partial.partial_activities.length - 6} earlier steps
-                    </li>
-                  {/if}
-                  {#each partial.partial_activities.slice(-6) as activity}
-                    <li>
-                      <span class="step-verb"
-                        >{activityParts(activity).verb}</span
-                      >
-                      <span class="step-detail"
-                        >{activityParts(activity).detail}</span
-                      >
-                    </li>
-                  {/each}
-                </ol>
-              {/if}
-              {#if partial?.partial_text}
-                <div class="result-md">
-                  {@html renderAgentMarkdown(partial.partial_text)}
-                </div>
-              {/if}
-            </article>
-          {/each}
-
-          {#if !(detail?.turns ?? []).length && !(detail?.pending_queue ?? []).length}
-            <div class="empty transcript-empty">
-              {detail
-                ? "No turns yet. Send a prompt below."
-                : P.labels.loadingSession}
-            </div>
-          {/if}
+          </div>
         </div>
-      </div>
+      {:else}
+        <div class="walkthrough-page">
+          <div class="walkthrough-inner">
+            <h2>{P.labels.walkSummary}</h2>
+            {#each eligibleWalkthroughTurns as turn (turn.seq)}
+              <WalkthroughNarrative
+                sessionId={selectedSession.id}
+                turnSeq={turn.seq}
+                model={turn.model || selectedSession.model || "luna"}
+              />
+            {:else}
+              <div class="empty walkthrough-empty">
+                {P.labels.walkthroughUnavailableForSession}
+              </div>
+            {/each}
+          </div>
+        </div>
+      {/if}
 
       <form
         class="composer"
@@ -2260,6 +2330,7 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
+    overflow-x: hidden;
     background: var(--panel-bg);
   }
   .transcript-head {
@@ -2315,6 +2386,32 @@
     color: var(--info);
     background: var(--info-soft);
   }
+  .session-view-toggle {
+    display: inline-flex;
+    overflow: hidden;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-md);
+    background: var(--panel-bg);
+  }
+  .session-view-toggle button {
+    min-height: 24px;
+    padding: 3px 8px;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: var(--text-soft);
+    font: var(--size-meta) var(--font-mono);
+  }
+  .session-view-toggle button + button {
+    border-left: 1px solid var(--line-strong);
+  }
+  .session-view-toggle button:hover {
+    background: var(--hover);
+  }
+  .session-view-toggle button.on {
+    background: var(--ink);
+    color: var(--ink-text);
+  }
   .vm-stream-state {
     display: inline-flex;
     align-items: center;
@@ -2366,6 +2463,29 @@
   .turns-inner {
     max-width: 860px;
     margin: 0 auto;
+  }
+  .walkthrough-page {
+    flex: 1;
+    min-width: 0;
+    padding: 20px 28px;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+  .walkthrough-inner {
+    width: 100%;
+    max-width: 1040px;
+    min-width: 0;
+    margin: 0 auto;
+  }
+  .walkthrough-inner > h2 {
+    margin: 0;
+    color: var(--text);
+    font: 700 var(--size-body) var(--font-mono);
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+  }
+  .walkthrough-empty {
+    margin-top: 24px;
   }
   .turn {
     padding: 16px 0 12px;
@@ -2875,9 +2995,13 @@
     }
     .transcript-head,
     .turns,
+    .walkthrough-page,
     .composer {
       padding-left: 16px;
       padding-right: 16px;
+    }
+    .session-view-toggle button {
+      min-height: 32px;
     }
   }
   .sr-only {

--- a/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.svelte
@@ -18,7 +18,6 @@
     sessionId = null,
     turnSeq = null,
     model = "",
-    prominent = false,
     // Fixture preview (?fixture=walk-*): payload/patches supplied inline,
     // so the preview never fetches.
     fixture = null,
@@ -27,7 +26,7 @@
   let payload = $state(untrack(() => fixture?.payload ?? null));
   let loading = $state(false);
   let failed = $state(false);
-  let opened = $state(untrack(() => Boolean(fixture || prominent)));
+  let opened = $state(untrack(() => Boolean(fixture)));
   let selected = $state(0);
   // Mobile pane swap: the points list and the detail pane are one column
   // under the console's 760px breakpoint, and selecting a point drills in.
@@ -189,12 +188,7 @@
   );
 </script>
 
-<details
-  class="walk"
-  class:prominent
-  open={Boolean(fixture || prominent)}
-  ontoggle={onToggle}
->
+<details class="walk" open={Boolean(fixture)} ontoggle={onToggle}>
   <summary class="walk-summary">
     <span>{P.labels.walkSummary}</span>
     {#if walk}
@@ -214,22 +208,31 @@
   {:else if walk}
     {#if walk.summary?.status === "available"}
       <div class="walk-fact">
-        {P.labels.walkSummaryDiffLead}{P.punct.colon}
         {walk.summary.files}
         {walk.summary.files === 1
           ? P.labels.walkFileChanged
-          : P.labels.walkFilesChanged}, +{walk.summary.insertions}/&minus;{walk
-          .summary.deletions}{P.punct.dot}
-        {P.labels.walkSummaryAccountedLead}{P.punct.colon}
+          : P.labels.walkFilesChanged}
+        {P.labels.walkSummaryWith}
+        {walk.summary.insertions}
+        {walk.summary.insertions === 1
+          ? P.labels.walkInsertion
+          : P.labels.walkInsertions}
+        {P.labels.walkSummaryAnd}
+        {walk.summary.deletions}
+        {walk.summary.deletions === 1
+          ? P.labels.walkDeletion
+          : P.labels.walkDeletions}{P.punct.semicolon}
+        {P.labels.walkAgentAccountedSentence}
         {walk.summary.accounted}
         {walk.summary.accounted === 1
           ? P.labels.walkFileWord
-          : P.labels.walkFilesWord}{P.punct.dot}
-        {P.labels.walkSummaryUnexplainedLead}{P.punct.colon}
+          : P.labels.walkFilesWord}{P.punct.comma}
+        {P.labels.walkSummaryLeaving}
         {walk.summary.unexplained}
         {walk.summary.unexplained === 1
           ? P.labels.walkFileWord
-          : P.labels.walkFilesWord}{P.punct.dot}
+          : P.labels.walkFilesWord}
+        {P.labels.walkSummaryUnexplainedEnd}{P.punct.period}
       </div>
     {:else if walk.summary?.status === "diff_unavailable"}
       <div class="walk-fact">{P.labels.walkSummaryDiffUnavailable}</div>
@@ -257,9 +260,6 @@
         {/if}
         <div class="wbody" class:drilled>
           <div class="points">
-            <div class="pbband">
-              {headerCountLine(walk)}
-            </div>
             {#each items as item, index (`${item.kind}:${item.path}`)}
               <button
                 class="point"
@@ -414,36 +414,6 @@
   .walk-count {
     color: var(--text-soft);
   }
-  /* A finished session promotes only its final walkthrough. The heavy ink
-     frame gives the explanation more weight than the turn separators while
-     keeping it in the transcript column and in the normal scroll flow. */
-  .walk.prominent {
-    margin-top: 16px;
-    padding-top: 0;
-    border: 4px solid var(--ink);
-    border-radius: var(--radius-lg);
-    background: var(--panel-bg);
-  }
-  .walk.prominent .walk-summary {
-    box-sizing: border-box;
-    width: 100%;
-    padding: 12px 16px;
-    color: var(--text);
-    font-size: var(--size-body);
-    font-weight: 700;
-  }
-  .walk.prominent[open] .walk-summary {
-    border-bottom: 1px solid var(--line);
-  }
-  .walk.prominent .walk-count {
-    margin-left: auto;
-  }
-  .walk.prominent > .walk-fact {
-    margin-inline: 16px;
-  }
-  .walk.prominent > .walk-frame {
-    margin: 12px;
-  }
   .walk-fact {
     margin-top: 8px;
     color: var(--muted);
@@ -493,15 +463,6 @@
     background: var(--page-bg);
     max-height: 420px;
     overflow: auto;
-  }
-  .pbband {
-    position: sticky;
-    top: 0;
-    padding: 8px 12px 6px;
-    background: var(--page-bg);
-    border-bottom: 1px solid var(--line);
-    font: var(--size-meta) var(--font-mono);
-    color: var(--muted);
   }
   .point {
     display: grid;

--- a/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.test.js
@@ -2,27 +2,17 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { mount, tick, unmount } from "svelte";
 import SessionWalkthrough from "./SessionWalkthrough.svelte";
-import pageSource from "./+page.svelte?raw";
-import { vmState } from "./status.js";
+import WalkthroughNarrative from "./WalkthroughNarrative.svelte";
 
 const mounted = [];
 
-function isProminent(session, vms, turnIndex, turnCount) {
-  return vmState(session, vms) !== "awake" && turnIndex === turnCount - 1;
-}
-
-async function renderWalkthrough(prominent) {
+async function render(Component, props = {}) {
   const target = document.createElement("div");
   document.body.append(target);
-  const props = { sessionId: 17, turnSeq: 3, model: "luna" };
-  if (prominent !== undefined) props.prominent = prominent;
-  const component = mount(SessionWalkthrough, {
-    target,
-    props,
-  });
+  const component = mount(Component, { target, props });
   mounted.push({ component, target });
   await tick();
-  return target.querySelector("details");
+  return target;
 }
 
 afterEach(async () => {
@@ -34,59 +24,63 @@ afterEach(async () => {
   }
 });
 
-describe("finished-session prominence", () => {
-  const session = { ember_session_id: "vm-1" };
-
-  test("the turn loop combines VM state with the last-turn check", () => {
-    expect(pageSource).toContain(
-      'prominent={vmState(selectedSession, vms) !== "awake" &&',
-    );
-    expect(pageSource).toContain(
-      "turnIndex === (detail?.turns ?? []).length - 1}",
-    );
-  });
-
-  test("opens the last turn when the VM is not awake and loads once", async () => {
+describe("conversation disclosure", () => {
+  test("stays collapsed and does not fetch until opened", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ rung: 5, steps: [], stats: {} }),
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const prominent = isProminent(
-      session,
-      { "vm-1": { state: "asleep" } },
-      2,
-      3,
-    );
-    const details = await renderWalkthrough(prominent);
+    const target = await render(SessionWalkthrough, {
+      sessionId: 17,
+      turnSeq: 3,
+      model: "luna",
+    });
+    const details = target.querySelector("details");
 
-    expect(details.open).toBe(true);
+    expect(details.open).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    details.open = true;
+    details.dispatchEvent(new Event("toggle"));
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     details.dispatchEvent(new Event("toggle"));
     await tick();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+});
 
-  test.each([
-    ["an omitted prominence prop", undefined, 0, 0],
-    ["a non-last turn", { "vm-1": { state: "asleep" } }, 1, 3],
-    [
-      "the last turn while the VM is awake",
-      { "vm-1": { state: "awake" } },
-      2,
-      3,
-    ],
-  ])("stays closed for %s", async (_label, vms, turnIndex, turnCount) => {
-    const fetchMock = vi.fn();
+describe("full-page narrative", () => {
+  test("loads once on mount because it renders open", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        rung: 1,
+        summary: {
+          status: "available",
+          files_changed: 1,
+          insertions: 1,
+          deletions: 0,
+          accounted_files: 1,
+          unexplained_files: 0,
+        },
+        steps: [],
+        stats: { total_files: 1 },
+      }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
-    const prominent = vms
-      ? isProminent(session, vms, turnIndex, turnCount)
-      : undefined;
-    const details = await renderWalkthrough(prominent);
+    const target = await render(WalkthroughNarrative, {
+      sessionId: 17,
+      turnSeq: 3,
+      model: "luna",
+    });
 
-    expect(details.open).toBe(false);
-    expect(fetchMock).not.toHaveBeenCalled();
+    const renderedText = () => target.textContent.replace(/\s+/g, " ").trim();
+    await vi.waitFor(() => expect(renderedText()).toContain("1 file changed"));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(renderedText()).toContain("leaving 0 files unexplained.");
+    expect(renderedText()).not.toContain("·");
   });
 });

--- a/projects/monolith/frontend/src/routes/private/agents/WalkthroughNarrative.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/WalkthroughNarrative.svelte
@@ -1,0 +1,520 @@
+<script>
+  import { onMount, untrack } from "svelte";
+  import { RUN_LEXICON as P } from "./run-lexicon.js";
+  import { joinMeta } from "./run-format.js";
+  import { parsePatchHunks, walkthroughView } from "./walkthrough.js";
+
+  let {
+    sessionId = null,
+    turnSeq = null,
+    model = "",
+    fixture = null,
+  } = $props();
+
+  let payload = $state(untrack(() => fixture?.payload ?? null));
+  let loading = $state(false);
+  let failed = $state(false);
+  let patches = $state({});
+
+  const walk = $derived(
+    payload ? walkthroughView(payload, { sessionId, turnSeq }) : null,
+  );
+  const accounted = $derived(
+    walk?.points.filter((item) => item.kind === "authored") ?? [],
+  );
+  const unexplained = $derived(
+    walk?.points.filter((item) => item.kind === "unexplained") ?? [],
+  );
+
+  function attributionLine(item) {
+    return joinMeta(
+      P.labels.walkAccountLabel,
+      item.attribution?.turn != null
+        ? `${P.labels.turn} ${item.attribution.turn}`
+        : "",
+      item.attribution?.attempt != null
+        ? `${P.labels.attempt} ${item.attribution.attempt}`
+        : "",
+      model,
+    );
+  }
+
+  async function load() {
+    if (payload || loading || fixture) return;
+    loading = true;
+    failed = false;
+    try {
+      const response = await fetch(
+        `/api/swarm/walkthrough/${encodeURIComponent(sessionId)}/${encodeURIComponent(turnSeq)}`,
+      );
+      if (!response.ok) throw new Error("walkthrough unavailable");
+      payload = await response.json();
+    } catch {
+      failed = true;
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadPatch(item) {
+    const path = item?.path;
+    if (!path || patches[path]) return;
+    if (fixture?.patches?.[path] !== undefined) {
+      patches[path] = { hunks: parsePatchHunks(fixture.patches[path]) };
+      return;
+    }
+    if (!item.patchUrl) return;
+    patches[path] = { loading: true };
+    try {
+      const response = await fetch(item.patchUrl);
+      if (!response.ok) throw new Error("patch unavailable");
+      const body = await response.json();
+      patches[path] = { hunks: parsePatchHunks(body.patch) };
+    } catch {
+      patches[path] = { failed: true };
+    }
+  }
+
+  // The full-page view is open by definition. Keep the one-shot onMount load
+  // because a declaratively visible panel has no disclosure toggle to trigger.
+  onMount(load);
+
+  $effect(() => {
+    if (!walk) return;
+    for (const item of walk.points) loadPatch(item);
+  });
+
+  function retry() {
+    payload = null;
+    load();
+  }
+</script>
+
+{#snippet diff(item)}
+  {#if item.patchUrl || fixture?.patches?.[item.path] !== undefined}
+    <div class="hunks">
+      {#if patches[item.path]?.loading}
+        <div class="walk-fact pad">{P.labels.walkDiffLoading}</div>
+      {:else if patches[item.path]?.failed}
+        <div class="walk-fact pad">{P.labels.walkDiffUnavailable}</div>
+      {:else if patches[item.path]?.hunks}
+        {#each patches[item.path].hunks as hunk, hunkIndex (hunkIndex)}
+          <div class="hunk">
+            <div class="hunk-inner">
+              {#if hunk.header}
+                <div class="hunk-head">{hunk.header}</div>
+              {/if}
+              {#each hunk.lines as line, lineIndex (lineIndex)}
+                <span class={`dl ${line.kind}`}
+                  ><span class="g">{line.gutter}</span>{line.text}</span
+                >
+              {/each}
+            </div>
+          </div>
+        {/each}
+      {/if}
+    </div>
+  {/if}
+{/snippet}
+
+{#snippet fileHeading(item)}
+  <header class="file-heading">
+    <h4>{item.path}</h4>
+    <span class="file-stat">
+      <span class="plus">+{item.additions}</span>
+      <span class="minus">&minus;{item.deletions}</span>
+    </span>
+  </header>
+{/snippet}
+
+<section class="walk-turn" aria-labelledby={`walk-turn-${turnSeq}`}>
+  <h3 id={`walk-turn-${turnSeq}`}>
+    {P.labels.turn}
+    {turnSeq}
+  </h3>
+
+  {#if loading}
+    <div class="walk-fact">{P.labels.walkLoading}</div>
+  {:else if failed}
+    <div class="walk-fact">
+      {P.labels.walkUnavailable}
+      <button class="walk-retry" type="button" onclick={retry}
+        >{P.labels.walkRetry}</button
+      >
+    </div>
+  {:else if walk}
+    {#if walk.summary?.status === "available"}
+      <p class="summary-sentence">
+        {walk.summary.files}
+        {walk.summary.files === 1
+          ? P.labels.walkFileChanged
+          : P.labels.walkFilesChanged}
+        {P.labels.walkSummaryWith}
+        {walk.summary.insertions}
+        {walk.summary.insertions === 1
+          ? P.labels.walkInsertion
+          : P.labels.walkInsertions}
+        {P.labels.walkSummaryAnd}
+        {walk.summary.deletions}
+        {walk.summary.deletions === 1
+          ? P.labels.walkDeletion
+          : P.labels.walkDeletions}{P.punct.semicolon}
+        {P.labels.walkAgentAccountedSentence}
+        {walk.summary.accounted}
+        {walk.summary.accounted === 1
+          ? P.labels.walkFileWord
+          : P.labels.walkFilesWord}{P.punct.comma}
+        {P.labels.walkSummaryLeaving}
+        {walk.summary.unexplained}
+        {walk.summary.unexplained === 1
+          ? P.labels.walkFileWord
+          : P.labels.walkFilesWord}
+        {P.labels.walkSummaryUnexplainedEnd}{P.punct.period}
+      </p>
+    {:else if walk.summary?.status === "diff_unavailable"}
+      <p class="summary-sentence">{P.labels.walkSummaryDiffUnavailable}</p>
+    {/if}
+
+    {#if walk.message}<div class="walk-fact">{walk.message}</div>{/if}
+    {#each walk.truncations as reason (reason)}
+      <div class="walk-fact">{reason}</div>
+    {/each}
+
+    {#if walk.hasTestimony}
+      <div class="provenance">
+        <b>{P.labels.walkProvenanceLead}</b>
+        <span>{P.labels.walkNarrativeProvenanceBody}</span>
+      </div>
+    {/if}
+
+    <div class="files">
+      {#each accounted as item, index (`accounted:${item.path}:${index}`)}
+        <article class="file-change">
+          {@render fileHeading(item)}
+          {#if item.why}
+            <div class="account">
+              <div class="account-label">{attributionLine(item)}</div>
+              <p>{item.why}</p>
+            </div>
+          {:else}
+            <div class="no-account">{P.labels.walkNoAccount}</div>
+          {/if}
+          {#each item.deviations as deviation (deviation)}
+            <div class="deviation">
+              <span>{P.labels.deviationWord}</span>
+              {deviation}
+            </div>
+          {/each}
+          {@render diff(item)}
+        </article>
+      {/each}
+
+      {#if walk.mechanical.length > 0}
+        <section class="supporting" aria-label={P.labels.walkMechanicalHeading}>
+          <h4>{P.labels.walkMechanicalHeading}</h4>
+          {#each walk.mechanical as mech, index (index)}
+            <p>
+              {P.labels.walkMechanicalStep}{P.punct.colon}
+              {mech.count}
+              {mech.count === 1
+                ? P.labels.walkFileWord
+                : P.labels.walkFilesWord}
+              {#if mech.generator}<code>{mech.generator}</code>{/if}
+            </p>
+          {/each}
+        </section>
+      {/if}
+
+      {#if unexplained.length > 0}
+        <section
+          class="unexplained-files"
+          aria-labelledby={`walk-unexplained-${turnSeq}`}
+        >
+          <h4 id={`walk-unexplained-${turnSeq}`}>
+            {P.labels.walkUnexplainedFilesHeading}
+          </h4>
+          <p class="unexplained-intro">
+            {P.labels.walkUnexplainedBody}
+          </p>
+          {#each unexplained as item, index (`unexplained:${item.path}:${index}`)}
+            <article class="file-change unexplained-change">
+              {@render fileHeading(item)}
+              {@render diff(item)}
+            </article>
+          {/each}
+        </section>
+      {/if}
+
+      {#if walk.contradictions.length > 0}
+        <section
+          class="contradictions"
+          aria-labelledby={`walk-contradictions-${turnSeq}`}
+        >
+          <h4 id={`walk-contradictions-${turnSeq}`}>
+            {P.labels.walkContradictedFilesHeading}
+          </h4>
+          <p>{P.labels.walkContradictedBody}</p>
+          {#each walk.contradictions as item, index (`contradiction:${item.path}:${index}`)}
+            <article class="claim">
+              <code>{item.path}</code>
+              {#if item.why}<p>{item.why}</p>{/if}
+            </article>
+          {/each}
+        </section>
+      {/if}
+
+      {#if walk.rung === 4 && walk.touched.length > 0}
+        <section class="supporting" aria-label={P.labels.walkTouchedLabel}>
+          <h4>{P.labels.walkTouchedLabel}</h4>
+          <ul>
+            {#each walk.touched as path (path)}<li>
+                <code>{path}</code>
+              </li>{/each}
+          </ul>
+        </section>
+      {/if}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .walk-turn {
+    min-width: 0;
+    padding: 24px 0 36px;
+    border-top: 4px solid var(--line);
+  }
+  .walk-turn:first-child {
+    border-top: 0;
+  }
+  .walk-turn > h3 {
+    margin: 0 0 8px;
+    color: var(--muted);
+    font: var(--size-meta) var(--font-mono);
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+  }
+  .summary-sentence {
+    max-width: 760px;
+    margin: 0;
+    color: var(--text);
+    font-size: var(--size-title);
+    font-weight: 600;
+    line-height: 1.35;
+    text-wrap: pretty;
+  }
+  .walk-fact {
+    margin-top: 8px;
+    color: var(--muted);
+    font-size: var(--size-detail);
+  }
+  .walk-fact.pad {
+    padding: 12px 16px;
+  }
+  .walk-retry {
+    margin-left: 8px;
+    padding: 0 8px;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--text-soft);
+    font: var(--size-meta) var(--font-mono);
+  }
+  .provenance {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    max-width: 760px;
+    margin-top: 16px;
+    padding: 8px 12px;
+    background: var(--attn-soft);
+    color: var(--text);
+    font-size: var(--size-meta);
+  }
+  .provenance b {
+    color: var(--attn-text);
+  }
+  .files {
+    min-width: 0;
+    margin-top: 24px;
+  }
+  .file-change {
+    min-width: 0;
+    padding: 20px 0 28px;
+    border-top: 1px solid var(--line);
+  }
+  .file-heading {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+  }
+  .file-heading h4 {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+    font: 600 var(--size-body-mono) var(--font-mono);
+  }
+  .file-stat {
+    display: flex;
+    flex: none;
+    gap: 8px;
+    margin-left: auto;
+    font: var(--size-body-mono) var(--font-mono);
+    font-variant-numeric: tabular-nums;
+  }
+  .plus {
+    color: var(--diff-add-mark);
+  }
+  .minus {
+    color: var(--diff-del-mark);
+  }
+  .account {
+    max-width: 760px;
+    margin: 16px 0;
+    padding-left: 12px;
+    border-left: 2px solid var(--attn);
+  }
+  .account-label {
+    color: var(--muted);
+    font: var(--size-meta) var(--font-mono);
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+  }
+  .account p {
+    margin: 6px 0 0;
+    color: var(--text);
+    font-size: var(--size-detail);
+    line-height: 1.6;
+    text-wrap: pretty;
+  }
+  .no-account,
+  .deviation {
+    max-width: 760px;
+    margin: 12px 0;
+    color: var(--text-soft);
+    font-size: var(--size-detail);
+  }
+  .deviation span {
+    margin-right: 8px;
+    color: var(--attn-text);
+    font: var(--size-meta) var(--font-mono);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .hunks {
+    max-width: 100%;
+    margin-top: 16px;
+    overflow-x: auto;
+    background: var(--code-bg);
+  }
+  .hunk + .hunk {
+    border-top: 1px solid var(--line);
+  }
+  .hunk-inner {
+    width: max-content;
+    min-width: 100%;
+  }
+  .hunk-head {
+    position: sticky;
+    left: 0;
+    padding: 4px 16px;
+    color: var(--muted);
+    font: var(--size-meta) var(--font-mono);
+  }
+  .dl {
+    display: block;
+    padding: 1px 16px 1px 30px;
+    color: var(--text-soft);
+    font: var(--size-body-mono) var(--font-mono);
+    line-height: 1.6;
+    text-indent: -14px;
+    white-space: pre;
+  }
+  .dl.add {
+    background: var(--diff-add-bg);
+    color: var(--text);
+  }
+  .dl.del {
+    background: var(--diff-del-bg);
+    color: var(--text);
+  }
+  .g {
+    display: inline-block;
+    width: 14px;
+    color: var(--muted);
+  }
+  .dl.add .g {
+    color: var(--diff-add-mark);
+  }
+  .dl.del .g {
+    color: var(--diff-del-mark);
+  }
+  .supporting,
+  .unexplained-files,
+  .contradictions {
+    margin-top: 24px;
+    padding-top: 20px;
+    border-top: 4px solid var(--line);
+  }
+  .supporting > h4,
+  .unexplained-files > h4,
+  .contradictions > h4 {
+    margin: 0;
+    color: var(--muted);
+    font: var(--size-meta) var(--font-mono);
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+  }
+  .supporting p,
+  .unexplained-intro,
+  .contradictions > p {
+    max-width: 760px;
+    margin: 8px 0 0;
+    color: var(--text-soft);
+    font-size: var(--size-detail);
+  }
+  .supporting code {
+    display: block;
+    margin-top: 4px;
+    overflow-wrap: anywhere;
+  }
+  .supporting ul {
+    margin: 8px 0 0;
+    padding-left: 20px;
+  }
+  .unexplained-files > h4,
+  .contradictions > h4 {
+    color: var(--err);
+  }
+  .unexplained-change {
+    margin-top: 16px;
+    padding-left: 12px;
+    border-left: 4px solid var(--err-line);
+  }
+  .claim {
+    max-width: 760px;
+    margin-top: 12px;
+    padding: 10px 12px;
+    background: var(--err-bg);
+  }
+  .claim code {
+    overflow-wrap: anywhere;
+    color: var(--err);
+  }
+  .claim p {
+    margin: 6px 0 0;
+    color: var(--text);
+    font-size: var(--size-detail);
+  }
+  @media (max-width: 760px) {
+    .walk-turn {
+      padding-top: 20px;
+    }
+    .summary-sentence {
+      font-size: var(--size-body);
+    }
+    .provenance {
+      display: grid;
+      gap: 2px;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/private/agents/lexicon.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/lexicon.test.js
@@ -15,6 +15,7 @@ const SURFACES = [
   "MasterView.svelte",
   "PaneHeader.svelte",
   "SessionWalkthrough.svelte",
+  "WalkthroughNarrative.svelte",
 ];
 
 function allValues(section) {

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -168,6 +168,11 @@ export const RUN_LEXICON = {
     sessionsRegion: "Agent sessions",
     transcriptRegion: "Agent transcript",
     backToSessions: "Back to agent sessions",
+    sessionViewLabel: "Session view",
+    conversationView: "Conversation",
+    walkthroughView: "Walkthrough",
+    walkthroughUnavailableForSession:
+      "No walkthrough is available for this session yet.",
     // Session walkthrough (ADR 056). Server-composed sentences (the payload
     // `message`, rationale quotes, truncation labels) are data, not lexicon;
     // these are the interface's own words only.
@@ -185,12 +190,24 @@ export const RUN_LEXICON = {
     walkSummaryDiffLead: "Git diff",
     walkSummaryAccountedLead: "Agent accounted for",
     walkSummaryUnexplainedLead: "Unexplained",
+    walkSummaryWith: "with",
+    walkSummaryAnd: "and",
+    walkInsertion: "insertion",
+    walkInsertions: "insertions",
+    walkDeletion: "deletion",
+    walkDeletions: "deletions",
+    walkAgentAccountedSentence: "the agent accounted for",
+    walkSummaryLeaving: "leaving",
+    walkSummaryUnexplainedEnd: "unexplained",
     walkSummaryDiffUnavailable:
       "The diff is unavailable for this turn, so this is the agent's account only.",
     walkProvenanceLead: "Agent-authored.",
     walkProvenanceBody:
       "These points are the implementer's account of its own change. The diff beside them is from git.",
+    walkNarrativeProvenanceBody:
+      "This prose is the implementer's account of its own change. The diff below it is from git.",
     walkAccountLabel: "agent's account",
+    walkNoAccount: "No agent account was recorded for this file.",
     walkUnexplainedMark: "!",
     walkContradictedMark: "×",
     walkUnexplainedTitle: "Unexplained change.",
@@ -200,6 +217,9 @@ export const RUN_LEXICON = {
     walkContradictedBody:
       "The agent named this file; the compare does not contain it.",
     walkMechanicalStep: "produced by tooling this turn",
+    walkMechanicalHeading: "tool-produced changes",
+    walkUnexplainedFilesHeading: "unexplained files",
+    walkContradictedFilesHeading: "contradicted paths",
     walkTouchedLabel: "files touched by tools this turn",
     walkDiffLoading: "loading diff…",
     walkDiffUnavailable: "diff unavailable",
@@ -208,7 +228,14 @@ export const RUN_LEXICON = {
     walkRetry: "retry",
     walkLoading: "loading…",
   },
-  punct: { dot: "·", arrow: "→", colon: ":" },
+  punct: {
+    dot: "·",
+    arrow: "→",
+    colon: ":",
+    comma: ",",
+    semicolon: ";",
+    period: ".",
+  },
   // Operator-register detail for a degraded workspace restore, surfaced as the
   // banner's title. Keyed by the message key workspace-recovery.js returns.
   // This console is repo-facing, so naming the backend cause is the right

--- a/projects/monolith/frontend/src/routes/private/agents/session-view.js
+++ b/projects/monolith/frontend/src/routes/private/agents/session-view.js
@@ -1,0 +1,25 @@
+export const SESSION_VIEW_CONVERSATION = "conversation";
+export const SESSION_VIEW_WALKTHROUGH = "walkthrough";
+
+// The detail response does not carry a synthetic "has walkthrough" flag.
+// These are the same durable inputs the composer can turn into something
+// useful: agent rationale, a recorded compare range, or tool activity.
+export function turnHasWalkthrough(turn) {
+  return Boolean(
+    turn &&
+    (turn.rationale?.parse_status === "parsed" ||
+      (turn.base_sha && turn.commit_sha) ||
+      (Array.isArray(turn.usage?.activities) &&
+        turn.usage.activities.length > 0)),
+  );
+}
+
+export function walkthroughTurns(turns) {
+  return Array.isArray(turns) ? turns.filter(turnHasWalkthrough) : [];
+}
+
+export function defaultSessionView(currentVmState, turns) {
+  return currentVmState !== "awake" && walkthroughTurns(turns).length > 0
+    ? SESSION_VIEW_WALKTHROUGH
+    : SESSION_VIEW_CONVERSATION;
+}

--- a/projects/monolith/frontend/src/routes/private/agents/session-view.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/session-view.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import {
+  defaultSessionView,
+  SESSION_VIEW_CONVERSATION,
+  SESSION_VIEW_WALKTHROUGH,
+  turnHasWalkthrough,
+  walkthroughTurns,
+} from "./session-view.js";
+
+const walkthroughTurn = {
+  seq: 2,
+  rationale: { parse_status: "parsed", paths: [{ path: "app.py" }] },
+};
+
+describe("session view", () => {
+  test("a sleeping session with a walkthrough opens on the walkthrough", () => {
+    expect(defaultSessionView("asleep", [walkthroughTurn])).toBe(
+      SESSION_VIEW_WALKTHROUGH,
+    );
+  });
+
+  test("an awake session with a walkthrough opens on the conversation", () => {
+    expect(defaultSessionView("awake", [walkthroughTurn])).toBe(
+      SESSION_VIEW_CONVERSATION,
+    );
+  });
+
+  test("a sleeping session without a walkthrough opens on the conversation", () => {
+    expect(
+      defaultSessionView("asleep", [
+        { seq: 1, rationale: { parse_status: "none" }, usage: {} },
+      ]),
+    ).toBe(SESSION_VIEW_CONVERSATION);
+  });
+
+  test("walkthrough turns retain session order and all composer inputs count", () => {
+    const turns = [
+      walkthroughTurn,
+      { seq: 3, rationale: { parse_status: "none" } },
+      { seq: 4, base_sha: "base", commit_sha: "head" },
+      { seq: 5, usage: { activities: [{ type: "write", path: "b.py" }] } },
+    ];
+
+    expect(turns.map(turnHasWalkthrough)).toEqual([true, false, true, true]);
+    expect(walkthroughTurns(turns).map((turn) => turn.seq)).toEqual([2, 4, 5]);
+  });
+});


### PR DESCRIPTION
Replaces the `prominent` disclosure from #4957. Diff capture works now, so a finished session has a real explanation worth reading, and it was rendering as a bordered panel inside the transcript scroll.

## What changed

A header toggle switches the main pane between **Conversation** and **Walkthrough**:

```
SESSION  vm asleep      [ Conversation | Walkthrough ]
```

- Defaults to Walkthrough when the VM is not awake and at least one turn has a walkthrough; a live session opens on the conversation.
- The composer stays mounted in both views, so a finished session can still be sent a follow-up.
- No route change and no URL state, so no `pushState` and none of the shallow-routing trap where `page.url` never reassigns.

The walkthrough view drops the two-pane split for one column reading top to bottom: a summary sentence, then per file its path and counts, the agent's account, and its diff hunks. One section per turn that has a walkthrough, in order.

## The four defects, all fixed

Visible in the previous panel:

1. **Punctuation** rendered as `Git diff: 1 file changed, +1/-0· Agent accounted for: 1 file· Unexplained: 0 files·` because a separator was appended after every clause including the last. It is a composed sentence now.
2. **Counts printed twice**, in the panel header and again in the points list. Once now.
3. **Diff truncated mid-word** with no affordance. Hunks scroll in their own `overflow-x: auto` container; the page body never scrolls horizontally.
4. **Nested frames**, a heavy border wrapping a panel containing another bordered box. In a full-page view the walkthrough is the page.

## Replaces rather than layers

`prominent` is removed entirely; two mechanisms for making a walkthrough visible would drift apart. In conversation view it is a collapsed disclosure per turn again, as before #4957.

The `onMount` one-shot load from #4957 **stays**. A view that renders open by definition must still fetch, and without it the page would render permanently empty with every test green.

## Reverted implementer churn worth naming

My acceptance criterion said `rg 'html\[data-'` must return nothing. I meant "do not introduce *unscoped* `html[data-*]` in a component style block", which is the real trap: the Svelte compiler silently deletes those. The implementer satisfied the literal grep by rewriting 15 already-`:global()`-wrapped selectors in `+page.svelte` and 3 in `agents-theme.css`, a plain CSS file where the trap does not apply.

That is not cosmetic. `:root[data-x]` has higher specificity than `html[data-x]`, so it changes cascade resolution, and it landed on the night/dawn/dusk palette from #4683. All 18 lines reverted; this PR contains zero theme churn.

## Verified

- `ci lint` clean.
- `ci test //projects/monolith/frontend:test //projects/monolith/frontend:build_test -- --nocache_test_results` -> `Executed 2 out of 2 tests: 2 tests pass`. Uncached deliberately.
- All 138 `P.labels` / `P.punct` keys used across `WalkthroughNarrative.svelte`, `SessionWalkthrough.svelte` and `+page.svelte` resolve against the lexicon. A missing key renders `undefined` and compiles clean.
- No unscoped `html[data-*]` introduced; `prominent` returns no hits anywhere in the agents route.
- Tests cover both default-view cases and the toggle.

## Known gap

`turnHasWalkthrough` decides the default view from parsed rationale, a `base_sha`+`commit_sha` pair, or activities. It cannot see a **stored diff**, because the session detail payload does not expose `diff_base_sha`. A turn with a real captured diff and no RATIONALE trailer would therefore default to Conversation. Session 198 is unaffected since its rationale parses. Worth a follow-up to expose that flag rather than widening this change.

## Not verified

How it looks. The payload is correct, the tokens resolve, and the tests cover behaviour, but the narrative layout is a judgment call that needs eyes on a real session.