### PR TITLE
feat(agents): strip the walkthrough to the explanation and its diff

### DIFF
--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1350,7 +1350,6 @@
           <h2>{P.labels.walkSummary}</h2>
           <WalkthroughNarrative
             turnSeq={fixture.walkthrough.turnSeq}
-            model={fixture.walkthrough.model}
             fixture={fixture.walkthrough}
           />
         </div>
@@ -1639,7 +1638,7 @@
               <WalkthroughNarrative
                 sessionId={selectedSession.id}
                 turnSeq={turn.seq}
-                model={turn.model || selectedSession.model || "luna"}
+                walkthroughTurnCount={eligibleWalkthroughTurns.length}
               />
             {:else}
               <div class="empty walkthrough-empty">

--- a/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/SessionWalkthrough.test.js
@@ -1,10 +1,62 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { mount, tick, unmount } from "svelte";
+import { RUN_LEXICON as P } from "./run-lexicon.js";
 import SessionWalkthrough from "./SessionWalkthrough.svelte";
 import WalkthroughNarrative from "./WalkthroughNarrative.svelte";
 
 const mounted = [];
+const explainedPath = "projects/monolith/swarm/unified_diff.py";
+const explanation =
+  "Added a one-line comment clarifying that parsing uses guest-captured diff text.";
+
+function narrativeFixture(steps, patches = {}) {
+  const unexplained = steps.filter(
+    (step) => step.type === "unexplained",
+  ).length;
+  const contradicted = steps.filter(
+    (step) => step.type === "contradiction",
+  ).length;
+  return {
+    model: "sonnet",
+    payload: {
+      rung: 1,
+      summary: {
+        status: "available",
+        files_changed: steps.filter((step) => step.file_change).length,
+        insertions: 1,
+        deletions: 0,
+        accounted_files: unexplained === 0 ? 1 : 0,
+        unexplained_files: unexplained,
+        contradicted_files: contradicted,
+      },
+      steps,
+      stats: { total_files: steps.length },
+    },
+    patches,
+  };
+}
+
+function explainedFixture() {
+  return narrativeFixture(
+    [
+      {
+        type: "authored",
+        file_path: explainedPath,
+        file_change: { additions: 1, deletions: 0 },
+        testimony: {
+          turn: 1,
+          attempt: 1,
+          points: [{ path: explainedPath, why: explanation }],
+        },
+      },
+    ],
+    {
+      [explainedPath]:
+        "@@ -32,6 +32,7 @@\n+# Parses diff text already captured in the guest\n def parse_unified_diff(diff: str) -> list[dict]:",
+    },
+  );
+}
 
 async function render(Component, props = {}) {
   const target = document.createElement("div");
@@ -77,10 +129,74 @@ describe("full-page narrative", () => {
       model: "luna",
     });
 
-    const renderedText = () => target.textContent.replace(/\s+/g, " ").trim();
-    await vi.waitFor(() => expect(renderedText()).toContain("1 file changed"));
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(renderedText()).toContain("leaving 0 files unexplained.");
-    expect(renderedText()).not.toContain("·");
+    expect(target.textContent).not.toContain("file changed with");
+  });
+
+  test("hides the turn label for one walkthrough and shows it for many", async () => {
+    const single = await render(WalkthroughNarrative, {
+      turnSeq: 1,
+      fixture: explainedFixture(),
+    });
+    const multiple = await render(WalkthroughNarrative, {
+      turnSeq: 2,
+      walkthroughTurnCount: 2,
+      fixture: explainedFixture(),
+    });
+
+    expect(single.querySelector(".walk-turn > h3")).toBeNull();
+    expect(
+      multiple
+        .querySelector(".walk-turn > h3")
+        ?.textContent.replace(/\s+/g, " ")
+        .trim(),
+    ).toBe("turn 2");
+  });
+
+  test("leads each file with the model prose and leaves out zero accounting", async () => {
+    const target = await render(WalkthroughNarrative, {
+      turnSeq: 1,
+      fixture: explainedFixture(),
+    });
+    const file = target.querySelector(".file-change");
+    const text = file.textContent.replace(/\s+/g, " ").trim();
+
+    expect(text.indexOf(explanation)).toBeLessThan(text.indexOf(explainedPath));
+    expect(text.indexOf(explainedPath)).toBeLessThan(text.indexOf("@@ -32"));
+    expect(file.querySelector(".hunks")).not.toBeNull();
+    expect(target.querySelector(".unexplained-files")).toBeNull();
+    expect(target.querySelector(".contradictions")).toBeNull();
+    expect(target.textContent).not.toContain(P.labels.walkUnexplainedFilesLine);
+    expect(target.textContent).not.toContain(
+      P.labels.walkContradictedFilesLine,
+    );
+    expect(target.textContent).not.toContain("file changed");
+    expect(target.textContent).not.toContain("accounted for");
+    expect(target.textContent.toLowerCase()).not.toContain("agent-authored");
+    expect(target.textContent.toLowerCase()).not.toContain("attempt");
+    expect(target.textContent.toLowerCase()).not.toContain("sonnet");
+  });
+
+  test("names every file changed without an explanation", async () => {
+    const first = "projects/monolith/swarm/queues.py";
+    const second = "projects/monolith/swarm/compare.py";
+    const unexplainedStep = (path) => ({
+      type: "unexplained",
+      file_path: path,
+      file_change: { additions: 1, deletions: 0 },
+    });
+    const target = await render(WalkthroughNarrative, {
+      turnSeq: 1,
+      fixture: narrativeFixture([
+        unexplainedStep(first),
+        unexplainedStep(second),
+      ]),
+    });
+    const alert = target.querySelector(".unexplained-files .accounting-alert");
+
+    expect(alert.textContent).toContain(P.labels.walkUnexplainedFilesLine);
+    expect(alert.textContent).toContain(first);
+    expect(alert.textContent).toContain(second);
   });
 });

--- a/projects/monolith/frontend/src/routes/private/agents/WalkthroughNarrative.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/WalkthroughNarrative.svelte
@@ -1,13 +1,12 @@
 <script>
   import { onMount, untrack } from "svelte";
   import { RUN_LEXICON as P } from "./run-lexicon.js";
-  import { joinMeta } from "./run-format.js";
   import { parsePatchHunks, walkthroughView } from "./walkthrough.js";
 
   let {
     sessionId = null,
     turnSeq = null,
-    model = "",
+    walkthroughTurnCount = 1,
     fixture = null,
   } = $props();
 
@@ -25,19 +24,7 @@
   const unexplained = $derived(
     walk?.points.filter((item) => item.kind === "unexplained") ?? [],
   );
-
-  function attributionLine(item) {
-    return joinMeta(
-      P.labels.walkAccountLabel,
-      item.attribution?.turn != null
-        ? `${P.labels.turn} ${item.attribution.turn}`
-        : "",
-      item.attribution?.attempt != null
-        ? `${P.labels.attempt} ${item.attribution.attempt}`
-        : "",
-      model,
-    );
-  }
+  const showTurnLabel = $derived(walkthroughTurnCount > 1);
 
   async function load() {
     if (payload || loading || fixture) return;
@@ -127,11 +114,16 @@
   </header>
 {/snippet}
 
-<section class="walk-turn" aria-labelledby={`walk-turn-${turnSeq}`}>
-  <h3 id={`walk-turn-${turnSeq}`}>
-    {P.labels.turn}
-    {turnSeq}
-  </h3>
+<section
+  class="walk-turn"
+  aria-labelledby={showTurnLabel ? `walk-turn-${turnSeq}` : undefined}
+>
+  {#if showTurnLabel}
+    <h3 id={`walk-turn-${turnSeq}`}>
+      {P.labels.turn}
+      {turnSeq}
+    </h3>
+  {/if}
 
   {#if loading}
     <div class="walk-fact">{P.labels.walkLoading}</div>
@@ -143,35 +135,7 @@
       >
     </div>
   {:else if walk}
-    {#if walk.summary?.status === "available"}
-      <p class="summary-sentence">
-        {walk.summary.files}
-        {walk.summary.files === 1
-          ? P.labels.walkFileChanged
-          : P.labels.walkFilesChanged}
-        {P.labels.walkSummaryWith}
-        {walk.summary.insertions}
-        {walk.summary.insertions === 1
-          ? P.labels.walkInsertion
-          : P.labels.walkInsertions}
-        {P.labels.walkSummaryAnd}
-        {walk.summary.deletions}
-        {walk.summary.deletions === 1
-          ? P.labels.walkDeletion
-          : P.labels.walkDeletions}{P.punct.semicolon}
-        {P.labels.walkAgentAccountedSentence}
-        {walk.summary.accounted}
-        {walk.summary.accounted === 1
-          ? P.labels.walkFileWord
-          : P.labels.walkFilesWord}{P.punct.comma}
-        {P.labels.walkSummaryLeaving}
-        {walk.summary.unexplained}
-        {walk.summary.unexplained === 1
-          ? P.labels.walkFileWord
-          : P.labels.walkFilesWord}
-        {P.labels.walkSummaryUnexplainedEnd}{P.punct.period}
-      </p>
-    {:else if walk.summary?.status === "diff_unavailable"}
+    {#if walk.summary?.status === "diff_unavailable"}
       <p class="summary-sentence">{P.labels.walkSummaryDiffUnavailable}</p>
     {/if}
 
@@ -180,25 +144,15 @@
       <div class="walk-fact">{reason}</div>
     {/each}
 
-    {#if walk.hasTestimony}
-      <div class="provenance">
-        <b>{P.labels.walkProvenanceLead}</b>
-        <span>{P.labels.walkNarrativeProvenanceBody}</span>
-      </div>
-    {/if}
-
     <div class="files">
       {#each accounted as item, index (`accounted:${item.path}:${index}`)}
         <article class="file-change">
-          {@render fileHeading(item)}
           {#if item.why}
-            <div class="account">
-              <div class="account-label">{attributionLine(item)}</div>
-              <p>{item.why}</p>
-            </div>
+            <p class="account">{item.why}</p>
           {:else}
             <div class="no-account">{P.labels.walkNoAccount}</div>
           {/if}
+          {@render fileHeading(item)}
           {#each item.deviations as deviation (deviation)}
             <div class="deviation">
               <span>{P.labels.deviationWord}</span>
@@ -230,11 +184,9 @@
           class="unexplained-files"
           aria-labelledby={`walk-unexplained-${turnSeq}`}
         >
-          <h4 id={`walk-unexplained-${turnSeq}`}>
-            {P.labels.walkUnexplainedFilesHeading}
-          </h4>
-          <p class="unexplained-intro">
-            {P.labels.walkUnexplainedBody}
+          <p class="accounting-alert" id={`walk-unexplained-${turnSeq}`}>
+            <strong>{P.labels.walkUnexplainedFilesLine}</strong>
+            {unexplained.map((item) => item.path).join(P.punct.commaSpace)}
           </p>
           {#each unexplained as item, index (`unexplained:${item.path}:${index}`)}
             <article class="file-change unexplained-change">
@@ -250,16 +202,12 @@
           class="contradictions"
           aria-labelledby={`walk-contradictions-${turnSeq}`}
         >
-          <h4 id={`walk-contradictions-${turnSeq}`}>
-            {P.labels.walkContradictedFilesHeading}
-          </h4>
-          <p>{P.labels.walkContradictedBody}</p>
-          {#each walk.contradictions as item, index (`contradiction:${item.path}:${index}`)}
-            <article class="claim">
-              <code>{item.path}</code>
-              {#if item.why}<p>{item.why}</p>{/if}
-            </article>
-          {/each}
+          <p class="accounting-alert" id={`walk-contradictions-${turnSeq}`}>
+            <strong>{P.labels.walkContradictedFilesLine}</strong>
+            {walk.contradictions
+              .map((item) => item.path)
+              .join(P.punct.commaSpace)}
+          </p>
         </section>
       {/if}
 
@@ -319,23 +267,9 @@
     color: var(--text-soft);
     font: var(--size-meta) var(--font-mono);
   }
-  .provenance {
-    display: flex;
-    align-items: baseline;
-    gap: 8px;
-    max-width: 760px;
-    margin-top: 16px;
-    padding: 8px 12px;
-    background: var(--attn-soft);
-    color: var(--text);
-    font-size: var(--size-meta);
-  }
-  .provenance b {
-    color: var(--attn-text);
-  }
   .files {
     min-width: 0;
-    margin-top: 24px;
+    margin-top: 8px;
   }
   .file-change {
     min-width: 0;
@@ -369,21 +303,10 @@
   }
   .account {
     max-width: 760px;
-    margin: 16px 0;
-    padding-left: 12px;
-    border-left: 2px solid var(--attn);
-  }
-  .account-label {
-    color: var(--muted);
-    font: var(--size-meta) var(--font-mono);
-    letter-spacing: 0.13em;
-    text-transform: uppercase;
-  }
-  .account p {
-    margin: 6px 0 0;
+    margin: 0 0 20px;
     color: var(--text);
-    font-size: var(--size-detail);
-    line-height: 1.6;
+    font-size: var(--size-body);
+    line-height: 1.65;
     text-wrap: pretty;
   }
   .no-account,
@@ -455,9 +378,7 @@
     padding-top: 20px;
     border-top: 4px solid var(--line);
   }
-  .supporting > h4,
-  .unexplained-files > h4,
-  .contradictions > h4 {
+  .supporting > h4 {
     margin: 0;
     color: var(--muted);
     font: var(--size-meta) var(--font-mono);
@@ -465,12 +386,16 @@
     text-transform: uppercase;
   }
   .supporting p,
-  .unexplained-intro,
-  .contradictions > p {
+  .accounting-alert {
     max-width: 760px;
     margin: 8px 0 0;
-    color: var(--text-soft);
-    font-size: var(--size-detail);
+    color: var(--text);
+    font-size: var(--size-body);
+    line-height: 1.5;
+  }
+  .accounting-alert strong {
+    margin-right: 6px;
+    color: var(--err);
   }
   .supporting code {
     display: block;
@@ -481,29 +406,10 @@
     margin: 8px 0 0;
     padding-left: 20px;
   }
-  .unexplained-files > h4,
-  .contradictions > h4 {
-    color: var(--err);
-  }
   .unexplained-change {
     margin-top: 16px;
     padding-left: 12px;
     border-left: 4px solid var(--err-line);
-  }
-  .claim {
-    max-width: 760px;
-    margin-top: 12px;
-    padding: 10px 12px;
-    background: var(--err-bg);
-  }
-  .claim code {
-    overflow-wrap: anywhere;
-    color: var(--err);
-  }
-  .claim p {
-    margin: 6px 0 0;
-    color: var(--text);
-    font-size: var(--size-detail);
   }
   @media (max-width: 760px) {
     .walk-turn {
@@ -511,10 +417,6 @@
     }
     .summary-sentence {
       font-size: var(--size-body);
-    }
-    .provenance {
-      display: grid;
-      gap: 2px;
     }
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -204,8 +204,6 @@ export const RUN_LEXICON = {
     walkProvenanceLead: "Agent-authored.",
     walkProvenanceBody:
       "These points are the implementer's account of its own change. The diff beside them is from git.",
-    walkNarrativeProvenanceBody:
-      "This prose is the implementer's account of its own change. The diff below it is from git.",
     walkAccountLabel: "agent's account",
     walkNoAccount: "No agent account was recorded for this file.",
     walkUnexplainedMark: "!",
@@ -218,8 +216,8 @@ export const RUN_LEXICON = {
       "The agent named this file; the compare does not contain it.",
     walkMechanicalStep: "produced by tooling this turn",
     walkMechanicalHeading: "tool-produced changes",
-    walkUnexplainedFilesHeading: "unexplained files",
-    walkContradictedFilesHeading: "contradicted paths",
+    walkUnexplainedFilesLine: "Changed without explanation:",
+    walkContradictedFilesLine: "Claimed but absent from the diff:",
     walkTouchedLabel: "files touched by tools this turn",
     walkDiffLoading: "loading diff…",
     walkDiffUnavailable: "diff unavailable",
@@ -233,6 +231,7 @@ export const RUN_LEXICON = {
     arrow: "→",
     colon: ":",
     comma: ",",
+    commaSpace: ", ",
     semicolon: ";",
     period: ".",
   },


### PR DESCRIPTION
Follows #4965. The walkthrough is **not a pull request**: it is the model saying it wants to explain a change, with the reason and the evidence. Per-file review belongs on a PR. Everything else on the page was bookkeeping *about* the explanation rather than the explanation.

## Removed

- `TURN N` on single-turn sessions (kept when there is more than one, where it is the only way to tell sections apart)
- The counts sentence: *"1 file changed with 1 insertion and 0 deletions; the agent accounted for 1 file, leaving 0 files unexplained"*
- The `Agent-authored` provenance banner
- The `AGENT'S ACCOUNT · TURN 1 · ATTEMPT 1 · SONNET` chrome. The session header already names the model; attempt numbers are operator trivia.

## Leads with

The model's prose, at reading size with a 760px measure, **before** the path and the diff. It is the one thing the page exists to show and it was rendered as a quoted aside.

```
added a one-line comment above parse_unified_diff clarifying
it parses guest-captured diff text and never shells out to git.

projects/monolith/swarm/unified_diff.py                +1 -0

@@ -32,6 +32,7 @@
+ # Parses diff text already captured in the guest; ...
  def parse_unified_diff(diff: str) -> list[dict]:
```

## The honesty property, moved rather than dropped

The banner existed so a reader could not mistake a claim for verified fact. That guarantee now lives in the layout: prose reads as prose in the model's voice, the diff is monospace with its own background and `+`/`-` colouring, unmistakably machine output.

**Accounting appears only when it is non-zero.** This is the organising rule. "0 files unexplained" is noise that trains a reader to skip the exact region where "2 files the agent never mentioned" would appear. Removing the zero state makes the non-zero state more visible, not less.

When something is unexplained or contradicted, the line names those files in the fact register **and renders their diffs**. That asymmetry is deliberate: a file changed without explanation is the one you most need to see.

## Verified

- `ci lint` clean.
- `ci test //projects/monolith/frontend:test //projects/monolith/frontend:build_test -- --nocache_test_results` -> `Executed 2 out of 2 tests: 2 tests pass`.
- Tests cover single vs multi-turn labels, that nothing renders about unexplained or contradicted when both are zero, that the unexplained line does render and names files when there is at least one, and prose-before-diff ordering.
- All 119 lexicon keys across the three components resolve.
- `--err` measured against every period and background it renders on: 5.48:1 and 4.80:1 day, 5.38:1 and 5.90:1 night. Body text needs 4.5:1, so it clears everywhere. This matters because the console has a live trap here: `--attn` fails at 4.09:1 and `--attn-text` exists for exactly that reason.
- `agents-theme.css` unmodified and zero `:global(` selector rewrites, after a previous pass churned 18 working selectors to satisfy an over-broad grep.

## Not verified

How it reads. Layout is a judgment call and needs eyes on a real session.