### PR TITLE
feat(authentik): add the moving authorization lane and the family group

### DIFF
--- a/projects/platform/authentik/blueprints/moving-auth.yaml
+++ b/projects/platform/authentik/blueprints/moving-auth.yaml
@@ -1,0 +1,173 @@
+version: 1
+metadata:
+  name: homelab - moving auth
+  labels:
+    blueprints.goauthentik.io/description: |
+      OAuth2 provider and application for the move-planner app at
+      https://friends.jomcgi.dev/moving. Envoy Gateway runs the OIDC redirect
+      flow against this provider, authorizes on the `family` group claim, and
+      projects the caller's email into a request header so the app can tell
+      whose view to render. See docs/decisions/security/006.
+entries:
+  # ── 1. The group, declared here to own it ──────────────────────────────────
+  # The NAME is load-bearing, not the id: authentik emits group names (not ids)
+  # in the `groups` claim, and the SecurityPolicy that guards /moving matches
+  # this literal string. Renaming it here is a 403 after a fully successful
+  # login, with nothing in the flow itself looking wrong.
+  #
+  # This group must NEVER be bound to another application. It is the entire
+  # boundary between "two people can see the move plan" and "two people can see
+  # whatever else that application guards".
+  #
+  # Membership is added by hand in the authentik UI. No enrollment or invitation
+  # flow is deployed: a self-service enrollment surface on a hostname with no
+  # Cloudflare Access in front of it is a poor trade for a two-person group.
+  - model: authentik_core.group
+    id: family
+    identifiers:
+      name: family
+    attrs:
+      is_superuser: false
+
+  # ── 2. The provider Envoy Gateway authenticates against ────────────────────
+  # Separate from the preview provider even though both guard the SAME hostname,
+  # friends.jomcgi.dev. They are split by path and audience: /preview/ answers to
+  # homelab-admin, /moving answers to family, and each path has its own
+  # route-scoped SecurityPolicy. One provider serving both would make the group
+  # distinction the only thing separating them, and a token minted for one path
+  # would validate on the other. Also separate from mcp-friends, which carries a
+  # multi-audience scope mapping naming the monolith as a second `aud` so
+  # Context Forge can forward a caller's token. A browser session cookie for a
+  # family move plan has no business carrying an audience a backend will accept
+  # as a credential.
+  #
+  # client_secret comes from the environment, never from Git and never from
+  # authentik's own generator. One value lives in 1Password and reaches both
+  # ends of the handshake from there:
+  #
+  #   vaults/k8s-homelab/items/authentik   field MOVING_OIDC_CLIENT_SECRET
+  #     -> authentik-secrets Secret -> envFrom on both authentik pods -> !Env here
+  #   vaults/k8s-homelab/items/moving-oidc  field client-secret
+  #     -> moving-oidc-client Secret in the MONOLITH namespace -> SecurityPolicy
+  #
+  # The monolith namespace, not mcp: /moving's HTTPRoute and SecurityPolicy are
+  # rendered by the monolith chart, even though /preview/ on the same hostname
+  # comes from the mcp namespace. The shared Gateway listener allows routes from
+  # all namespaces, so the two lanes coexist on one host from two charts.
+  #
+  # Two 1Password items rather than one on purpose: the monolith namespace must
+  # not receive authentik's whole secret bundle (its secret key and bootstrap
+  # credentials) just to read one client secret.
+  #
+  # Letting authentik generate it instead would mean a value that exists only
+  # in its database, copied by hand into 1Password, and copied again on every
+  # rotation. This way rotation is one field edit: the OnePasswordItem carries
+  # operator.1password.io/auto-restart, so the pods restart, this blueprint
+  # re-applies, and the provider is updated.
+  #
+  # SCALAR form, not `!Env [KEY]`. The one-element sequence does not exist:
+  # authentik's Env tag reads node.value[1] with no length check, so a
+  # one-element list raises IndexError. blueprints_find() catches only
+  # YAMLError, so that IndexError escapes and aborts blueprints_discovery for
+  # the ENTIRE /blueprints tree, including authentik's own bundled defaults and
+  # mcp-auth.yaml. One malformed tag here silently stops every blueprint in the
+  # instance from reconciling. The valid forms are `!Env KEY` and
+  # `!Env [KEY, default]`.
+  #
+  # No default, deliberately: a missing variable resolves to None and authentik
+  # rejects the provider, rather than an empty-string default quietly creating a
+  # provider whose secret nobody holds.
+  #
+  # client_id IS pinned, because it is not a secret and the SecurityPolicy that
+  # consumes it lives in Git. Leaving it generated would put a value only
+  # readable from the authentik UI into a chart value.
+  - model: authentik_providers_oauth2.oauth2provider
+    id: moving-provider
+    identifiers:
+      name: moving
+    attrs:
+      client_type: confidential
+      client_id: moving-friends
+      client_secret: !Env MOVING_OIDC_CLIENT_SECRET
+      # Both of these are REQUIRED when a provider is created from a blueprint,
+      # and neither is obvious, because every provider made in the UI gets them
+      # filled in by the form. Only providers born in Git need them stated, and
+      # mcp-friends (made in the UI, then patched by mcp-auth.yaml) is why that
+      # is easy to miss when reading that file as the example.
+      #
+      # grant_types defaults to an EMPTY LIST on the model, and both the
+      # authorize and token views reject anything not in it, so a provider
+      # without this supports no grant at all and fails on the first hop.
+      grant_types:
+        - authorization_code
+        - refresh_token
+      # Without a signing_key authentik falls back to HS256 signed with the
+      # client secret, and the JWKS endpoint emits no keys at all. Envoy
+      # validates via remoteJWKS, so it would have no key to validate with and
+      # would 401 every request. Note this failure is invisible to the
+      # discovery-document check: /.well-known/openid-configuration still
+      # answers 200 with an empty JWKS behind it.
+      signing_key:
+        !Find [
+          authentik_crypto.certificatekeypair,
+          [name, authentik Self-signed Certificate],
+        ]
+      # Must match the SecurityPolicy's redirectURL exactly, and that URL must
+      # fall inside the target HTTPRoute's path prefix or the callback 404s
+      # before Envoy ever sees it.
+      redirect_uris:
+        - matching_mode: strict
+          url: https://friends.jomcgi.dev/moving/oauth2/callback
+      authorization_flow:
+        !Find [
+          authentik_flows.flow,
+          [slug, default-provider-authorization-implicit-consent],
+        ]
+      invalidation_flow:
+        !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # The three managed defaults, restated. Binding REPLACES the list rather
+      # than appending (the same trap mcp-auth.yaml documents), and dropping
+      # `email` here would leave the projected X-Auth-Email header empty while
+      # every other part of the flow still looked healthy.
+      property_mappings:
+        - !Find [
+            authentik_providers_oauth2.scopemapping,
+            [managed, goauthentik.io/providers/oauth2/scope-openid],
+          ]
+        - !Find [
+            authentik_providers_oauth2.scopemapping,
+            [managed, goauthentik.io/providers/oauth2/scope-email],
+          ]
+        - !Find [
+            authentik_providers_oauth2.scopemapping,
+            [managed, goauthentik.io/providers/oauth2/scope-profile],
+          ]
+
+  # ── 3. The application, whose SLUG is the issuer URL ─────────────────────
+  # authentik derives the OIDC issuer from the APPLICATION slug, not the
+  # provider name: https://auth.jomcgi.dev/application/o/<slug>/. The
+  # SecurityPolicy helper builds both issuer and JWKS URI from this same slug,
+  # so renaming the application silently breaks token validation.
+  - model: authentik_core.application
+    id: moving-app
+    identifiers:
+      slug: moving
+    attrs:
+      name: Crossing
+      provider: !KeyOf moving-provider
+      meta_description: Family move planner and shared logistics.
+
+  # ── 4. Gate it ───────────────────────────────────────────────────────────
+  # Without a policy binding authentik lets EVERY authenticated account
+  # authorize the application, which mcp-auth.yaml entry 3 records as the same
+  # trap. Bound to family, the group declared in entry 1. Only hand-added
+  # members may authorize.
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf moving-app
+      group: !KeyOf family
+      order: 0
+    attrs:
+      enabled: true
+      negate: false
+      timeout: 30


### PR DESCRIPTION
PR 1 of #4968. Implements the authentik half of ADR `security/006`.

One new file, `projects/platform/authentik/blueprints/moving-auth.yaml`. The chart's ConfigMap template globs `blueprints/*.yaml`, so no values change is needed.

## What it declares

1. Group `family`, `is_superuser: false`.
2. OAuth2 provider `moving`, `client_id: moving-friends`, secret from `!Env MOVING_OIDC_CLIENT_SECRET`.
3. Application slug `moving`, which is what the OIDC issuer is derived from (`https://auth.jomcgi.dev/application/o/moving/`).
4. A policy binding restricting authorization to `family`.

Nothing is routed to this provider yet. The HTTPRoute and SecurityPolicy that consume it land in a later PR, so merging this creates an application nobody can reach.

## Deliberately not included

No enrolment or invitation flow. Anna's account is created by hand in the authentik UI and added to `family`. A self-service enrolment surface on a hostname that has no Cloudflare Access in front of it is a poor trade for a two-person group, and nothing in this repo has an enrolment flow to model it on.

## Traps this file has to avoid, all inherited from `preview-auth.yaml`

- `client_secret` uses the **scalar** `!Env KEY` form. The one-element sequence `!Env [KEY]` raises an uncaught IndexError inside authentik's Env tag, and `blueprints_find()` catches only YAMLError, so one malformed tag aborts blueprint discovery for the entire `/blueprints` tree including authentik's own bundled defaults. Verified: the only real `!Env` in the file is scalar, and the two bracket forms present are inside the comment documenting the trap.
- `grant_types` stated explicitly, because the model defaults it to an empty list and every grant is then rejected.
- `signing_key` stated explicitly, because without it authentik falls back to HS256 and the JWKS endpoint emits no keys, which Envoy's `remoteJWKS` validation cannot work with. That failure is invisible to a discovery-document check, which still answers 200.
- All three managed property mappings restated, because binding replaces the list rather than appending, and dropping `email` would leave the projected `X-Auth-Email` empty while everything else looked healthy.

## Verification

`helm template` renders `moving-auth.yaml` as a key in the `authentik-mcp-blueprints` ConfigMap alongside the four existing blueprints. `ci lint` green. No `Chart.yaml` `version:` or `targetRevision:` touched.

Note this chart deploys on `targetRevision: HEAD`, so this lands live on merge.

**Prerequisite:** `MOVING_OIDC_CLIENT_SECRET` must be present on `vaults/k8s-homelab/items/authentik` and synced into the `authentik-secrets` Secret. If it is absent the variable resolves to None and authentik rejects this one provider, which is the safe failure rather than the discovery-wide one above.

Refs #4968

🤖 Generated with [Claude Code](https://claude.com/claude-code)