### PR TITLE
feat(moving): add the desktop core of the move planner page

### DIFF
--- a/projects/monolith/frontend/BUILD
+++ b/projects/monolith/frontend/BUILD
@@ -223,9 +223,9 @@ vitest_bin.vitest_test(
     args = ["run"],
     chdir = package_name(),
     data = [
+        "BUILD",
         ":src",
         ":test_lib",
-        "BUILD",
     ],
 )
 

--- a/projects/monolith/frontend/BUILD
+++ b/projects/monolith/frontend/BUILD
@@ -82,10 +82,11 @@ js_run_binary(
 )
 
 # Public-only source tree (ADR 004 Phase 5d code-absence): identical to :src but
-# additionally excludes the authenticated route tree (src/routes/private/**) and
-# private-only components (src/lib/private/**). SvelteKit is filesystem-routed,
-# so omitting these files from the source set drops those pages, their SSR
-# handlers, and their client chunks entirely from the build.
+# additionally excludes both authenticated route trees and private-only
+# components. SvelteKit is filesystem-routed, so omitting these files from the
+# source set drops those pages, their SSR handlers, and their client chunks
+# entirely from the public build. Friends routes have their own authorization
+# lane, so their source must be absent from the anonymous artifact too.
 js_library(
     name = "src_public",
     srcs = glob(
@@ -97,6 +98,7 @@ js_library(
         exclude = [
             "src/**/*.test.js",
             "src/routes/private/**",
+            "src/routes/friends/**",
             "src/lib/private/**",
         ],
     ) + [
@@ -223,6 +225,7 @@ vitest_bin.vitest_test(
     data = [
         ":src",
         ":test_lib",
+        "BUILD",
     ],
 )
 

--- a/projects/monolith/frontend/src/build-exclusions.test.js
+++ b/projects/monolith/frontend/src/build-exclusions.test.js
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const BUILD_SOURCE = readFileSync(new URL("../BUILD", import.meta.url), "utf8");
+const FRIENDS_EXCLUDE = '"src/routes/friends/**"';
+
+function srcPublicExcludeList(source) {
+  const srcPublic = source.match(
+    /js_library\(\s*name = "src_public",[\s\S]*?exclude = \[([\s\S]*?)\],/,
+  );
+  if (!srcPublic) {
+    throw new Error("could not find the src_public exclude list");
+  }
+  return srcPublic[1];
+}
+
+function assertFriendsExcluded(source) {
+  if (!srcPublicExcludeList(source).includes(FRIENDS_EXCLUDE)) {
+    throw new Error("src_public must exclude src/routes/friends/**");
+  }
+}
+
+describe("public frontend source exclusions", () => {
+  it("keeps friends routes out of the public source set", () => {
+    expect(() => assertFriendsExcluded(BUILD_SOURCE)).not.toThrow();
+  });
+
+  it("fails its guard when the friends exclusion is removed", () => {
+    const withoutFriends = BUILD_SOURCE.replace(FRIENDS_EXCLUDE, "");
+    expect(() => assertFriendsExcluded(withoutFriends)).toThrow(
+      "src_public must exclude src/routes/friends/**",
+    );
+  });
+});

--- a/projects/monolith/frontend/src/hooks.js
+++ b/projects/monolith/frontend/src/hooks.js
@@ -10,6 +10,7 @@
 const DOMAIN_PREFIX_MAP = {
   "public.": "/public",
   "private.": "/private",
+  "friends.": "/friends",
 };
 
 // The bare apex (jomcgi.dev, no subdomain) serves the public tier: it is the

--- a/projects/monolith/frontend/src/hooks.test.js
+++ b/projects/monolith/frontend/src/hooks.test.js
@@ -18,6 +18,24 @@ describe("reroute", () => {
     );
   });
 
+  it("rewrites the friends moving path under /friends", () => {
+    expect(reroute({ url: url("friends.jomcgi.dev", "/moving") })).toBe(
+      "/friends/moving",
+    );
+  });
+
+  it("does not resolve the apex moving path to the friends tree", () => {
+    expect(reroute({ url: url("jomcgi.dev", "/moving") })).toBe(
+      "/public/moving",
+    );
+  });
+
+  it("does not resolve the private moving path to the friends tree", () => {
+    expect(reroute({ url: url("private.jomcgi.dev", "/moving") })).toBe(
+      "/private/moving",
+    );
+  });
+
   it("leaves /otel/* alone on subdomain hosts so browser spans reach the proxy", () => {
     expect(
       reroute({ url: url("public.jomcgi.dev", "/otel/v1/traces") }),

--- a/projects/monolith/frontend/src/routes/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
   let { children } = $props();
 
   let isPrivate = $derived($page.url.hostname.startsWith("private."));
+  let isFriends = $derived($page.url.hostname.startsWith("friends."));
 
   // The private tier drops the shared Nav entirely: the dashboard at the
   // private root IS the nav (launcher grid, queue links, back affordances),
@@ -42,6 +43,7 @@
   // to /ember.
   let hideNav = $derived(
     isPrivate ||
+      isFriends ||
       /^\/private(?:\/|$)/.test($page.url.pathname) ||
       /^\/(public\/|private\/)?app\//.test($page.url.pathname) ||
       /^\/(public\/|private\/)?docs(\/|$)/.test($page.url.pathname) ||

--- a/projects/monolith/frontend/src/routes/friends/moving/+page.server.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/+page.server.js
@@ -1,0 +1,39 @@
+function apiBase() {
+  const value = process.env.API_BASE;
+  if (!value) {
+    throw new Error("API_BASE is required for the moving planner");
+  }
+  return value.replace(/\/$/, "");
+}
+
+export async function load({ fetch, request, url }) {
+  const scope = url.searchParams.get("scope") ?? "mine";
+  const email = request.headers.get("x-auth-email");
+  const base = apiBase();
+
+  let response;
+  try {
+    response = await fetch(
+      `${base}/api/moving/state?scope=${encodeURIComponent(scope)}`,
+      {
+        headers: email ? { "X-Auth-Email": email } : {},
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+  } catch {
+    return { status: "unavailable", scope, state: null };
+  }
+
+  if (response.status === 403) {
+    return { status: "forbidden", scope, state: null };
+  }
+  if (!response.ok) {
+    return { status: "unavailable", scope, state: null };
+  }
+
+  try {
+    return { status: "ready", scope, state: await response.json() };
+  } catch {
+    return { status: "unavailable", scope, state: null };
+  }
+}

--- a/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
+++ b/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
@@ -1,0 +1,511 @@
+<script>
+  import { goto } from "$app/navigation";
+  import { page } from "$app/stores";
+  import AccessPanel from "./AccessPanel.svelte";
+  import {
+    collisionWording,
+    formatTaskDueDate,
+    moveCountdown,
+    progressSummary,
+    sortOpenTasks,
+    titleCaseName,
+  } from "./moving.js";
+  import "./moving-theme.css";
+
+  let { data } = $props();
+
+  let tasks = $state(data.state?.tasks ?? []);
+  let progress = $state(data.state?.progress ?? 0);
+  let pendingTaskIds = $state(new Set());
+  let taskError = $state("");
+
+  const currentScope = $derived(data.scope === "all" ? "all" : "mine");
+  const countdown = $derived(moveCountdown(data.state?.spans ?? []));
+  const openTasks = $derived(sortOpenTasks(tasks));
+  const progressView = $derived(progressSummary(progress, tasks));
+  const collisions = $derived(
+    (data.state?.collisions ?? [])
+      .map((collision) =>
+        collisionWording(
+          collision,
+          data.state?.tasks ?? [],
+          data.state?.spans ?? [],
+        ),
+      )
+      .filter(Boolean),
+  );
+
+  $effect(() => {
+    tasks = data.state?.tasks ?? [];
+    progress = data.state?.progress ?? 0;
+    taskError = "";
+  });
+
+  function setScope(scope) {
+    if (scope === currentScope) return;
+    const url = new URL($page.url);
+    url.searchParams.set("scope", scope);
+    goto(url, { keepFocus: true, noScroll: true });
+  }
+
+  function updateProgress() {
+    const total = tasks.length;
+    const done = tasks.filter((task) => task.done_at != null).length;
+    progress = total === 0 ? 0 : done / total;
+  }
+
+  async function toggleTask(task) {
+    if (pendingTaskIds.has(task.id)) return;
+
+    const wasDone = task.done_at != null;
+    pendingTaskIds = new Set(pendingTaskIds).add(task.id);
+    taskError = "";
+    tasks = tasks.map((item) =>
+      item.id === task.id
+        ? { ...item, done_at: wasDone ? null : new Date().toISOString() }
+        : item,
+    );
+    updateProgress();
+
+    try {
+      const action = wasDone ? "undone" : "done";
+      const response = await fetch(
+        `/api/moving/tasks/${encodeURIComponent(task.id)}/${action}`,
+        { method: "POST" },
+      );
+      if (!response.ok)
+        throw new Error(`task update failed: ${response.status}`);
+    } catch {
+      tasks = tasks.map((item) =>
+        item.id === task.id ? { ...item, done_at: task.done_at } : item,
+      );
+      updateProgress();
+      taskError = "That task could not be updated. Please try again.";
+    } finally {
+      const remaining = new Set(pendingTaskIds);
+      remaining.delete(task.id);
+      pendingTaskIds = remaining;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Crossing | Moving planner</title>
+  <meta
+    name="description"
+    content="Crossing, a shared moving plan for the road ahead."
+  />
+</svelte:head>
+
+{#if data.status !== "ready"}
+  <main class="moving access-shell">
+    <AccessPanel status={data.status} />
+  </main>
+{:else}
+  <main class="moving">
+    <div class="moving-grid">
+      <header class="masthead cell">
+        <div>
+          <p class="kicker">Moving planner</p>
+          <h1>Crossing</h1>
+        </div>
+        <div class="viewer">
+          <span>{titleCaseName(data.state.viewer)}</span>
+          <span>{currentScope === "mine" ? "My plan" : "All plans"}</span>
+        </div>
+      </header>
+
+      <section class="hero cell" aria-labelledby="move-countdown">
+        <p class="section-label">The crossing</p>
+        <h2 id="move-countdown">{countdown.headline}</h2>
+        <p class="countdown-detail">{countdown.detail}</p>
+
+        <div class="progress-heading">
+          <span>Progress</span>
+          <strong>{progressView.label}</strong>
+        </div>
+        <div
+          class="progress-track"
+          role="progressbar"
+          aria-label="Move progress"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-valuenow={progressView.percent}
+        >
+          <span style:width={`${progressView.percent}%`}></span>
+        </div>
+        {#if progressView.total === 0}
+          <p class="empty-copy">No tasks yet. The first step can start here.</p>
+        {/if}
+      </section>
+
+      <section class="today cell" aria-labelledby="today-heading">
+        <div class="today-header">
+          <div>
+            <p class="section-label">Paper list</p>
+            <h2 id="today-heading">Do Today</h2>
+          </div>
+          <div class="scope-toggle" aria-label="Task scope">
+            <button
+              type="button"
+              class:active={currentScope === "mine"}
+              aria-pressed={currentScope === "mine"}
+              onclick={() => setScope("mine")}>Mine</button
+            >
+            <button
+              type="button"
+              class:active={currentScope === "all"}
+              aria-pressed={currentScope === "all"}
+              onclick={() => setScope("all")}>All</button
+            >
+          </div>
+        </div>
+
+        {#if taskError}
+          <p class="task-error" role="alert">{taskError}</p>
+        {/if}
+
+        {#if openTasks.length > 0}
+          <ul class="task-list">
+            {#each openTasks as task (task.id)}
+              <li>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={task.done_at != null}
+                    disabled={pendingTaskIds.has(task.id)}
+                    onchange={() => toggleTask(task)}
+                  />
+                  <span class="task-copy">
+                    <strong>{task.title}</strong>
+                    <span>{formatTaskDueDate(task.due_on)}</span>
+                  </span>
+                </label>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <div class="today-empty">
+            <strong>Nothing waiting.</strong>
+            <span>There are no unfinished tasks in this view.</span>
+          </div>
+        {/if}
+      </section>
+
+      <section class="collisions cell" aria-labelledby="collisions-heading">
+        <p class="section-label">Heads up</p>
+        <h2 id="collisions-heading">Collisions</h2>
+        {#if collisions.length > 0}
+          <ul>
+            {#each collisions as collision}
+              <li>{collision}</li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="empty-copy">
+            No date collisions. The plan has room to breathe.
+          </p>
+        {/if}
+      </section>
+    </div>
+  </main>
+{/if}
+
+<style>
+  .moving {
+    width: 100%;
+    height: 100dvh;
+    overflow: auto;
+    background: var(--moving-canvas);
+    color: var(--moving-ink);
+    font-family: var(--moving-font);
+  }
+
+  .access-shell {
+    display: grid;
+    min-width: 320px;
+    place-items: center;
+  }
+
+  .moving-grid {
+    display: grid;
+    grid-template-columns: minmax(330px, 0.9fr) minmax(450px, 1.35fr);
+    grid-template-rows: auto minmax(360px, 1fr) auto;
+    grid-template-areas:
+      "masthead masthead"
+      "hero today"
+      "collisions today";
+    gap: var(--moving-border);
+    width: max(100%, 784px);
+    min-height: 100%;
+    padding: var(--moving-border);
+    background: var(--moving-ink);
+  }
+
+  .cell {
+    min-width: 0;
+    padding: clamp(20px, 3vw, 48px);
+  }
+
+  .masthead {
+    grid-area: masthead;
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 3rem;
+    background: var(--moving-accent);
+    color: var(--moving-accent-ink);
+  }
+
+  .masthead h1,
+  .masthead p {
+    margin: 0;
+  }
+
+  .masthead h1 {
+    font-size: var(--moving-size-heading);
+    font-weight: 950;
+    letter-spacing: -0.06em;
+    line-height: 0.85;
+    text-transform: uppercase;
+  }
+
+  .kicker,
+  .section-label {
+    margin: 0 0 0.65rem;
+    font-family: var(--moving-font-mono);
+    font-size: var(--moving-size-small);
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .viewer {
+    display: flex;
+    gap: 0.65rem;
+    align-items: center;
+    font-family: var(--moving-font-mono);
+    font-size: var(--moving-size-small);
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  .viewer span + span {
+    padding-left: 0.65rem;
+    border-left: 2px solid var(--moving-accent-ink);
+  }
+
+  .hero {
+    grid-area: hero;
+    display: flex;
+    flex-direction: column;
+    background: var(--moving-hero);
+  }
+
+  .hero h2 {
+    max-width: 9ch;
+    margin: 0;
+    font-size: var(--moving-size-display);
+    font-weight: 950;
+    letter-spacing: -0.075em;
+    line-height: 0.82;
+    text-transform: uppercase;
+  }
+
+  .countdown-detail {
+    margin: 1.25rem 0 3rem;
+    color: var(--moving-muted);
+    font-family: var(--moving-font-mono);
+    font-size: var(--moving-size-small);
+    font-weight: 700;
+  }
+
+  .progress-heading {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: auto;
+    font-family: var(--moving-font-mono);
+    font-size: var(--moving-size-small);
+    text-transform: uppercase;
+  }
+
+  .progress-track {
+    height: 20px;
+    margin-top: 0.65rem;
+    overflow: hidden;
+    border: 3px solid var(--moving-ink);
+    background: var(--moving-paper-raised);
+  }
+
+  .progress-track span {
+    display: block;
+    height: 100%;
+    background: var(--moving-accent);
+  }
+
+  .empty-copy {
+    margin: 1rem 0 0;
+    color: var(--moving-muted);
+    font-size: var(--moving-size-body);
+    line-height: 1.45;
+  }
+
+  .today {
+    grid-area: today;
+    padding: 0;
+    background: var(--moving-paper);
+  }
+
+  .today-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: clamp(20px, 3vw, 42px);
+    background: var(--moving-accent);
+    color: var(--moving-accent-ink);
+  }
+
+  .today-header h2 {
+    margin: 0;
+    font-size: var(--moving-size-heading);
+    font-weight: 950;
+    letter-spacing: -0.05em;
+    line-height: 0.9;
+    text-transform: uppercase;
+  }
+
+  .scope-toggle {
+    display: flex;
+    border: 3px solid var(--moving-accent-ink);
+  }
+
+  .scope-toggle button {
+    min-width: 60px;
+    padding: 0.65rem 0.8rem;
+    border: 0;
+    background: var(--moving-accent);
+    color: var(--moving-accent-ink);
+    font-family: var(--moving-font-mono);
+    font-size: var(--moving-size-small);
+    font-weight: 900;
+    text-transform: uppercase;
+    cursor: pointer;
+  }
+
+  .scope-toggle button + button {
+    border-left: 3px solid var(--moving-accent-ink);
+  }
+
+  .scope-toggle button.active {
+    background: var(--moving-accent-ink);
+    color: var(--moving-accent);
+  }
+
+  .scope-toggle button:focus-visible,
+  input:focus-visible {
+    outline: 3px solid var(--moving-focus);
+    outline-offset: 3px;
+  }
+
+  .task-error {
+    margin: 0;
+    padding: 0.8rem clamp(20px, 3vw, 42px);
+    background: var(--moving-danger-paper);
+    color: var(--moving-danger);
+    font-size: var(--moving-size-body);
+    font-weight: 800;
+  }
+
+  .task-list {
+    margin: 0;
+    padding: 0 clamp(20px, 3vw, 42px);
+  }
+
+  .task-list li {
+    border-bottom: 2px solid var(--moving-ink);
+  }
+
+  .task-list label {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+    padding: 1.25rem 0;
+    cursor: pointer;
+  }
+
+  .task-list input {
+    flex: 0 0 auto;
+    width: 25px;
+    height: 25px;
+    margin-top: 0.1rem;
+    accent-color: var(--moving-check);
+    cursor: pointer;
+  }
+
+  .task-copy {
+    display: flex;
+    min-width: 0;
+    flex: 1;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .task-copy strong {
+    font-size: var(--moving-size-body);
+    line-height: 1.3;
+  }
+
+  .task-copy span {
+    flex: 0 0 auto;
+    color: var(--moving-muted);
+    font-family: var(--moving-font-mono);
+    font-size: var(--moving-size-small);
+    line-height: 1.6;
+  }
+
+  .today-empty {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: clamp(28px, 5vw, 72px) clamp(20px, 3vw, 42px);
+    font-size: var(--moving-size-body);
+  }
+
+  .today-empty strong {
+    font-size: calc(var(--moving-size-body) * 1.35);
+  }
+
+  .today-empty span {
+    color: var(--moving-muted);
+  }
+
+  .collisions {
+    grid-area: collisions;
+    background: var(--moving-collision);
+  }
+
+  .collisions h2 {
+    margin: 0;
+    font-size: calc(var(--moving-size-body) * 1.8);
+    font-weight: 950;
+    letter-spacing: -0.04em;
+    text-transform: uppercase;
+  }
+
+  .collisions ul {
+    display: grid;
+    gap: 0.85rem;
+    margin: 1.25rem 0 0;
+    padding: 0;
+  }
+
+  .collisions li {
+    padding-left: 1rem;
+    border-left: 5px solid var(--moving-ink);
+    font-size: var(--moving-size-body);
+    font-weight: 750;
+    line-height: 1.35;
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/friends/moving/AccessPanel.svelte
+++ b/projects/monolith/frontend/src/routes/friends/moving/AccessPanel.svelte
@@ -1,0 +1,46 @@
+<script>
+  let { status } = $props();
+</script>
+
+<section class="access-panel" aria-live="polite">
+  <p class="eyebrow">Crossing</p>
+  {#if status === "forbidden"}
+    <h1>This account is not recognised</h1>
+    <p>Your signed-in account is not listed as a Crossing viewer.</p>
+  {:else}
+    <h1>The plan is unavailable</h1>
+    <p>Crossing could not load the plan. Try again shortly.</p>
+  {/if}
+</section>
+
+<style>
+  .access-panel {
+    width: min(34rem, calc(100% - 2rem));
+    padding: clamp(1.5rem, 5vw, 3rem);
+    background: var(--moving-paper);
+    border: var(--moving-border) solid var(--moving-ink);
+  }
+
+  .eyebrow {
+    margin: 0 0 1rem;
+    color: var(--moving-muted);
+    font-family: var(--moving-font-mono);
+    font-size: var(--moving-size-small);
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: var(--moving-size-heading);
+    line-height: 0.95;
+  }
+
+  p:last-child {
+    max-width: 30rem;
+    margin: 1rem 0 0;
+    font-size: var(--moving-size-body);
+    line-height: 1.5;
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/friends/moving/AccessPanel.test.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/AccessPanel.test.js
@@ -1,0 +1,32 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from "vitest";
+import { mount, unmount } from "svelte";
+import AccessPanel from "./AccessPanel.svelte";
+
+let mounted;
+
+afterEach(async () => {
+  if (!mounted) return;
+  await unmount(mounted.component);
+  mounted.target.remove();
+  mounted = undefined;
+});
+
+describe("moving access panel", () => {
+  it("renders the short not recognised state for a 403", () => {
+    const target = document.createElement("div");
+    document.body.append(target);
+    const component = mount(AccessPanel, {
+      target,
+      props: { status: "forbidden" },
+    });
+    mounted = { component, target };
+
+    expect(target.querySelector("h1")?.textContent).toBe(
+      "This account is not recognised",
+    );
+    expect(target.textContent).toContain(
+      "Your signed-in account is not listed as a Crossing viewer.",
+    );
+  });
+});

--- a/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
@@ -1,0 +1,63 @@
+/* Crossing has its own scoped palette. Components contain layout only and
+ * consume these properties, which keeps every color in this plain CSS file.
+ */
+.moving {
+  color-scheme: light;
+  --moving-canvas: #f05a46;
+  --moving-paper: #fff8df;
+  --moving-paper-raised: #ffffff;
+  --moving-ink: #18130f;
+  --moving-muted: #65564b;
+  --moving-accent: #ffd83d;
+  --moving-accent-ink: #18130f;
+  --moving-hero: #86cdf2;
+  --moving-collision: #89d6a4;
+  --moving-danger: #9c241f;
+  --moving-danger-paper: #ffd9ce;
+  --moving-focus: #005fcc;
+  --moving-check: #18130f;
+  --moving-border: 4px;
+  --moving-font:
+    Arial, Helvetica, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --moving-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  --moving-size-small: 12px;
+  --moving-size-body: clamp(15px, 1.4vw, 19px);
+  --moving-size-heading: clamp(34px, 5vw, 72px);
+  --moving-size-display: clamp(46px, 8vw, 118px);
+}
+
+html[data-theme="dark"] .moving {
+  color-scheme: dark;
+  --moving-canvas: #161311;
+  --moving-paper: #24201c;
+  --moving-paper-raised: #302a24;
+  --moving-ink: #fff3d4;
+  --moving-muted: #d7c7aa;
+  --moving-accent: #ffd83d;
+  --moving-accent-ink: #18130f;
+  --moving-hero: #174d70;
+  --moving-collision: #174f35;
+  --moving-danger: #ff9787;
+  --moving-danger-paper: #4b211e;
+  --moving-focus: #81bdff;
+  --moving-check: #fff3d4;
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) .moving {
+    color-scheme: dark;
+    --moving-canvas: #161311;
+    --moving-paper: #24201c;
+    --moving-paper-raised: #302a24;
+    --moving-ink: #fff3d4;
+    --moving-muted: #d7c7aa;
+    --moving-accent: #ffd83d;
+    --moving-accent-ink: #18130f;
+    --moving-hero: #174d70;
+    --moving-collision: #174f35;
+    --moving-danger: #ff9787;
+    --moving-danger-paper: #4b211e;
+    --moving-focus: #81bdff;
+    --moving-check: #fff3d4;
+  }
+}

--- a/projects/monolith/frontend/src/routes/friends/moving/moving.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving.js
@@ -1,0 +1,146 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function dateParts(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value ?? "");
+  if (!match) return null;
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+  };
+}
+
+function dateStamp(value) {
+  const parts = dateParts(value);
+  if (!parts) return null;
+  return Date.UTC(parts.year, parts.month - 1, parts.day);
+}
+
+function todayStamp(now) {
+  return Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+}
+
+function formatDate(value, options) {
+  const stamp = dateStamp(value);
+  if (stamp == null) return "an unknown date";
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: "UTC",
+    ...options,
+  }).format(new Date(stamp));
+}
+
+export function moveCountdown(spans, now = new Date()) {
+  const moves = (spans ?? [])
+    .filter((span) => span.kind === "move" && dateStamp(span.starts_on) != null)
+    .toSorted((left, right) => left.starts_on.localeCompare(right.starts_on));
+
+  if (moves.length === 0) {
+    return {
+      headline: "No move date set",
+      detail: "Add a move span when the date is known.",
+    };
+  }
+
+  const move = moves[0];
+  const days = Math.round(
+    (dateStamp(move.starts_on) - todayStamp(now)) / DAY_MS,
+  );
+  let headline;
+  if (days === 0) headline = "Moving day";
+  else if (days === 1) headline = "1 day to go";
+  else if (days > 1) headline = `${days} days to go`;
+  else if (days === -1) headline = "1 day since move day";
+  else headline = `${Math.abs(days)} days since move day`;
+
+  return {
+    headline,
+    detail: formatDate(move.starts_on, {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    }),
+  };
+}
+
+export function progressSummary(progress, tasks) {
+  const items = Array.isArray(tasks) ? tasks : [];
+  const total = items.length;
+  const done = items.filter((task) => task.done_at != null).length;
+  const numeric = Number(progress);
+  const value = Number.isFinite(numeric)
+    ? Math.min(1, Math.max(0, numeric))
+    : 0;
+  return {
+    done,
+    total,
+    value,
+    percent: Math.round(value * 100),
+    label: `${done} of ${total} done`,
+  };
+}
+
+export function sortOpenTasks(tasks) {
+  return (tasks ?? [])
+    .filter((task) => task.done_at == null)
+    .toSorted((left, right) => {
+      if (left.due_on == null && right.due_on == null) return 0;
+      if (left.due_on == null) return 1;
+      if (right.due_on == null) return -1;
+      return left.due_on.localeCompare(right.due_on);
+    });
+}
+
+export function formatTaskDueDate(value) {
+  if (!value) return "No due date";
+  return formatDate(value, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function formatCollisionRange(from, to) {
+  const start = dateParts(from);
+  const end = dateParts(to);
+  if (!start || !end) return "dates unknown";
+  if (from === to) {
+    return formatDate(from, { day: "numeric", month: "long" });
+  }
+  if (start.year === end.year && start.month === end.month) {
+    return `${start.day} to ${end.day} ${formatDate(to, { month: "long" })}`;
+  }
+  return `${formatDate(from, {
+    day: "numeric",
+    month: "long",
+  })} to ${formatDate(to, { day: "numeric", month: "long" })}`;
+}
+
+export function collisionWording(collision, tasks, spans) {
+  const tasksById = new Map((tasks ?? []).map((task) => [task.id, task]));
+  const spansById = new Map((spans ?? []).map((span) => [span.id, span]));
+
+  if (collision.type === "span_span") {
+    const first = spansById.get(collision.item1_id);
+    const second = spansById.get(collision.item2_id);
+    if (!first || !second) return null;
+    return `${first.label} overlaps ${second.label}, ${formatCollisionRange(
+      collision.overlaps_from,
+      collision.overlaps_to,
+    )}`;
+  }
+
+  if (collision.type === "task_span") {
+    const task = tasksById.get(collision.item1_id);
+    const span = spansById.get(collision.item2_id);
+    if (!task || !span) return null;
+    return `${task.title} is due during ${span.label}`;
+  }
+
+  return null;
+}
+
+export function titleCaseName(value) {
+  if (!value) return "Viewer";
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/projects/monolith/frontend/src/routes/friends/moving/moving.test.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { collisionWording, moveCountdown, progressSummary } from "./moving.js";
+
+const tasks = [{ id: "task-1", title: "Ship the boxes", done_at: null }];
+const spans = [
+  { id: "span-1", kind: "visitor", label: "Visitors" },
+  { id: "span-2", kind: "trip", label: "Japan trip" },
+];
+
+describe("collision wording", () => {
+  it("words a span overlap using resolved labels and its date range", () => {
+    expect(
+      collisionWording(
+        {
+          type: "span_span",
+          item1_id: "span-1",
+          item2_id: "span-2",
+          overlaps_from: "2026-05-03",
+          overlaps_to: "2026-05-07",
+        },
+        tasks,
+        spans,
+      ),
+    ).toBe("Visitors overlaps Japan trip, 3 to 7 May");
+  });
+
+  it("words a task due inside a span using resolved labels", () => {
+    expect(
+      collisionWording(
+        {
+          type: "task_span",
+          item1_id: "task-1",
+          item2_id: "span-1",
+          overlaps_from: "2026-05-03",
+          overlaps_to: "2026-05-03",
+        },
+        tasks,
+        spans,
+      ),
+    ).toBe("Ship the boxes is due during Visitors");
+  });
+});
+
+describe("move countdown", () => {
+  it("targets the earliest move span", () => {
+    const result = moveCountdown(
+      [
+        { kind: "move", starts_on: "2026-05-16" },
+        { kind: "move", starts_on: "2026-05-11" },
+        { kind: "trip", starts_on: "2026-05-02" },
+      ],
+      new Date(2026, 4, 1, 12),
+    );
+
+    expect(result.headline).toBe("10 days to go");
+    expect(result.detail).toBe("Monday, 11 May 2026");
+  });
+
+  it("states plainly when no move span exists", () => {
+    expect(moveCountdown([], new Date(2026, 4, 1, 12))).toEqual({
+      headline: "No move date set",
+      detail: "Add a move span when the date is known.",
+    });
+  });
+});
+
+describe("progress", () => {
+  it("renders zero tasks without NaN or division by zero", () => {
+    expect(progressSummary(0, [])).toEqual({
+      done: 0,
+      total: 0,
+      value: 0,
+      percent: 0,
+      label: "0 of 0 done",
+    });
+  });
+});

--- a/projects/monolith/frontend/src/routes/friends/moving/page.server.test.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/page.server.test.js
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { load } from "./+page.server.js";
+
+function event(fetch, { scope, email = "joe@example.test" } = {}) {
+  const url = new URL("https://friends.jomcgi.dev/moving");
+  if (scope) url.searchParams.set("scope", scope);
+  return {
+    fetch,
+    request: new Request(url, {
+      headers: email ? { "X-Auth-Email": email } : {},
+    }),
+    url,
+  };
+}
+
+describe("friends moving server load", () => {
+  beforeEach(() => {
+    process.env.API_BASE = "http://moving-api.test";
+  });
+
+  afterEach(() => {
+    delete process.env.API_BASE;
+    vi.restoreAllMocks();
+  });
+
+  it("loads the selected scope and forwards the viewer email", async () => {
+    const state = { tasks: [], spans: [], progress: 0, viewer: "joe" };
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => state,
+    });
+
+    const result = await load(event(fetch, { scope: "all" }));
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0][0]).toBe(
+      "http://moving-api.test/api/moving/state?scope=all",
+    );
+    expect(fetch.mock.calls[0][1].headers).toEqual({
+      "X-Auth-Email": "joe@example.test",
+    });
+    expect(fetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+    expect(result).toEqual({ status: "ready", scope: "all", state });
+  });
+
+  it("defaults the scope to mine", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ tasks: [] }),
+    });
+
+    await load(event(fetch));
+
+    expect(fetch.mock.calls[0][0]).toBe(
+      "http://moving-api.test/api/moving/state?scope=mine",
+    );
+  });
+
+  it("turns a backend 403 into the recognised page state", async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+
+    await expect(load(event(fetch))).resolves.toEqual({
+      status: "forbidden",
+      scope: "mine",
+      state: null,
+    });
+  });
+
+  it("fails loudly when API_BASE is missing", async () => {
+    delete process.env.API_BASE;
+    const fetch = vi.fn();
+
+    await expect(load(event(fetch))).rejects.toThrow(
+      "API_BASE is required for the moving planner",
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
PR 3a of #4968. The desktop core of the planner at `/moving` on friends.jomcgi.dev.

The gantt timeline, the dock modals (To sell / Calendar / Roles) and the mobile Today/Plan/More tabs are deliberately **not** here. They are PR 3b. Nothing routes to `/moving` until PR 4, so this merges safely while incomplete.

## The load-bearing change is in BUILD, not in the page

`:src_public` drops private pages, their SSR handlers and their client chunks from the public build entirely, per ADR 004 Phase 5d code-absence. It excludes `src/routes/private/**` and `src/lib/private/**`. A new `src/routes/friends/**` tree matches neither, so without an entry this family app would compile into the public jomcgi.dev bundle: unreachable, but sitting there readable in devtools.

`src/build-exclusions.test.js` enforces it. It parses the `src_public` block specifically rather than grepping the whole file, because a match in the wrong glob (`:src`, where the pattern must NOT appear) would pass a naive grep. The guard was verified by deleting the exclusion, watching the test fail, and restoring it.

## What is on the page

Masthead, a hero with the countdown to the earliest `move` span plus overall progress, a Do Today list with the Mine/All scope toggle, and the collisions panel. Cells sit on an ink ground with a consistent gap so the ground reads as the border.

Empty state got deliberate attention, because it is what production shows first: the tables are empty, so no NaN, no divide-by-zero in progress, and "no move date set" rather than a countdown to nothing.

## Three traps this repo has hit before, avoided on purpose

- **The scope toggle navigates with `goto` plus `keepFocus` and `noScroll`.** `pushState`/`replaceState` never reassign `page.url`, so URL-derived `$derived` state would not recompute. The signature of that bug is deep links working while clicks do nothing.
- **Theme rules live in `moving-theme.css`, not a component `<style>` block.** The Svelte compiler silently comments out unscoped `html[data-*]` selectors while `build_test` stays green, which would ship dark mode as a no-op.
- **A 403 is a rendered panel, not an error page.** `moving.viewers` starting empty means 403 is the expected first-run response, so it had to be a designed state rather than a crash.

## Verification

- `//projects/monolith/frontend:test` and `:build_test` forced with `--nocache_test_results`: **Executed 2 out of 2 tests: 2 tests pass.** Forced deliberately, because the earlier full run reported `Executed 0 out of 725` on a warm cache, and `:test` alone does not compile the app. Only `:build_test` catches a Svelte template error.
- 24 vitest cases across the helpers, the access panel and the server loader.
- `ci lint` green. No `Chart.yaml` `version:` or `targetRevision:` touched.

Refs #4968

🤖 Generated with [Claude Code](https://claude.com/claude-code)