### PR TITLE
feat(moving): route friends.jomcgi.dev/moving behind the family group

### DIFF
--- a/projects/monolith/chart/templates/httproute-friends.yaml
+++ b/projects/monolith/chart/templates/httproute-friends.yaml
@@ -1,0 +1,200 @@
+{{- if .Values.cfIngress.friends.enabled }}
+{{- /*
+The moving planner's lane on friends.jomcgi.dev (ADR security/006).
+
+WHY THIS IS A SEPARATE ROUTE rather than rules added to the preview lane's
+route, or to httproute-private.yaml.
+
+A SecurityPolicy targets a WHOLE HTTPRoute, so two authorization models on one
+hostname require two routes. friends.jomcgi.dev already carries /preview/,
+gated to homelab-admin by context-forge-gateway's own route and policy. This
+app answers to a different group entirely, `family`, which contains one person
+who is not an operator. Path isolation is how the two coexist: /preview/ keeps
+its policy untouched, /moving gets its own, and neither can swallow the other.
+
+That route comes from the mcp namespace while this one comes from monolith.
+The shared Gateway listener sets allowedRoutes.namespaces.from: All and the
+two path prefixes are disjoint, so they coexist without conflict.
+
+WHY NOT ON private.jomcgi.dev. The Cloudflare Access policy that guards that
+hostname carries no `authorization` block at all: it authorizes anyone holding
+a valid team session. There is no group concept on that lane, so a narrower
+grant cannot be expressed there. It is also a hostname shared by argocd,
+signoz, longhorn and kargo, so a mistaken binding there sits one claim away
+from the cluster control plane. Here it would expose this app and nothing else.
+*/}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "monolith.fullname" . }}-moving
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+    # Descriptive only, naming the cloudflared/gateway routing tier rather than
+    # the auth mechanism. Matches the sibling /preview/ route on this hostname.
+    ingress-tier: {{ .Values.cfIngress.friends.tier }}
+spec:
+  parentRefs:
+    - name: {{ .Values.cfIngress.friends.gateway.name }}
+      namespace: {{ .Values.cfIngress.friends.gateway.namespace }}
+  hostnames:
+    - {{ .Values.cfIngress.friends.hostname | quote }}
+  rules:
+    # Browser-called JSON API, routed to the FastAPI port. Without this rule it
+    # would fall through to the SvelteKit port and come back as the SPA shell,
+    # which the browser reports as:
+    #
+    #   Unexpected token '<', "<!doctype "... is not valid JSON
+    #
+    # reading like a frontend bug while being a routing gap. Nothing in CI
+    # exercises a browser-originated path against the real ingress, so this
+    # class of mistake ships green.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/moving
+      backendRefs:
+        - name: {{ include "monolith.fullname" . }}
+          port: {{ .Values.service.apiPort | int }}
+    # SvelteKit client assets. Nothing else on this hostname claims /_app/:
+    # the preview route carries exactly one rule, for /preview/. Two routes
+    # claiming one prefix would be a genuine conflict, so re-check this if the
+    # preview lane ever grows a SvelteKit surface of its own.
+    #
+    # These sit INSIDE this route on purpose, so the SecurityPolicy below
+    # covers them. Serving the bundle unauthenticated would leak the page's
+    # structure and copy to anyone who guessed the path.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /_app/
+      backendRefs:
+        - name: {{ include "monolith.fullname" . }}
+          port: {{ .Values.cfIngress.friends.servicePort | int }}
+    # The page itself. The SvelteKit reroute hook maps friends.jomcgi.dev/moving
+    # to /friends/moving internally, so no gateway-level rewrite is needed.
+    #
+    # The OAuth callback and logout paths MUST fall inside this prefix. Envoy
+    # serves them itself rather than forwarding them, but the request has to
+    # select this route first or it 404s before the policy is ever consulted.
+    # That is why redirectURL is /moving/oauth2/callback and not /oauth2/callback.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /moving
+      backendRefs:
+        - name: {{ include "monolith.fullname" . }}
+          port: {{ .Values.cfIngress.friends.servicePort | int }}
+---
+{{- /*
+The only thing between /moving and the internet.
+
+friends.jomcgi.dev has NO Cloudflare Access application in front of it, by
+design: the two identity lanes are split by AUDIENCE, not by layer. Operator
+surfaces stay on Access so that authentik being down cannot lock the operator
+out of the tools used to fix authentik. User surfaces live here, and cost no
+Zero Trust seats.
+
+A SecurityPolicy is a separate object from the route it targets, so "the policy
+denies" and "the policy is attached" are different facts. defaultAction: Deny
+cannot protect a route the policy never bound to. Verify the deny path against
+the live URL after deploying, do not infer it from this file.
+*/}}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "monolith.fullname" . }}-moving
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "monolith.fullname" . }}-moving
+  # The oidc and jwt blocks COMPOSE, they are not alternatives:
+  #   oidc  runs the browser redirect against authentik and stores the result
+  #         in a cookie. A bare jwt block cannot: it only validates a token
+  #         already present, so a browser arriving with none gets a 401 rather
+  #         than a login page.
+  #   jwt   validates what arrives and projects a claim into a request header.
+  oidc:
+    provider:
+      issuer: {{ .Values.cfIngress.friends.authentik.issuer | quote }}
+    clientID: {{ .Values.cfIngress.friends.authentik.clientID | quote }}
+    clientSecret:
+      name: {{ .Values.cfIngress.friends.authentik.clientSecretName | quote }}
+    redirectURL: {{ printf "https://%s/moving/oauth2/callback" .Values.cfIngress.friends.hostname | quote }}
+    logoutPath: /moving/oauth2/logout
+    # This host only, never the apex. Envoy sets the cookie on the named domain
+    # AND its subdomains, and these cookies ARE the session, so at the apex they
+    # would ride along to the public site, private, mcp and auth.
+    #
+    # Widening later is safe; narrowing is not. A stale wider-domain cookie
+    # shadows the narrower one and presents as a login LOOP rather than a clean
+    # rejection, fixable only by clearing browser cookies.
+    cookieDomain: {{ .Values.cfIngress.friends.hostname | quote }}
+    # Per-lane names, distinct from the preview lane's preview-* and the dev
+    # lane's dev-*. Two OIDC policies on ONE hostname sharing cookie names
+    # shadow each other's sessions, and the failure mode is an infinite login
+    # loop rather than a clean rejection.
+    cookieNames:
+      accessToken: moving-access-token
+      idToken: moving-id-token
+    scopes:
+      - email
+      - profile
+  jwt:
+    providers:
+      - name: authentik
+        issuer: {{ .Values.cfIngress.friends.authentik.issuer | quote }}
+        remoteJWKS:
+          uri: {{ .Values.cfIngress.friends.authentik.jwksUri | quote }}
+        extractFrom:
+          # The ID token, not the access token: OIDC REQUIRES the ID token to
+          # carry `email` when that scope is granted, whereas whether an access
+          # token does is provider-specific.
+          #
+          # Cookies ONLY, no Authorization header source. This lane serves
+          # browsers at a keyboard, not agents holding bearer tokens, and
+          # naming a source replaces Envoy's default rather than adding to it.
+          cookies:
+            - moving-id-token
+        claimToHeaders:
+          - claim: email
+            header: X-Auth-Email
+        recomputeRoute: false
+  # Authorization decides on the CLAIM, never on the header projected above. A
+  # header can be sent by a caller; a claim sits inside a signature Envoy has
+  # just verified, so it cannot be forged.
+  #
+  # defaultAction: Deny means a token that validates but carries no matching
+  # group is rejected rather than falling through to whatever the route would
+  # otherwise serve. That makes this a second, independent gate rather than a
+  # restatement of authentik's own application policy binding: authentik decides
+  # who may OBTAIN a token, this decides who may USE one here, and either
+  # misconfiguration fails closed on its own.
+  authorization:
+    defaultAction: Deny
+    rules:
+      - name: allow-family
+        action: Allow
+        principal:
+          jwt:
+            provider: authentik
+            claims:
+              - name: groups
+                valueType: StringArray
+                values:
+                  {{- range .Values.cfIngress.friends.authentik.allowedGroups }}
+                  - {{ . | quote }}
+                  {{- end }}
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ .Values.cfIngress.friends.authentik.clientSecretName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.cfIngress.friends.authentik.onepassword.itemPath | quote }}
+{{- end }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1376,6 +1376,50 @@ cfIngress:
     rateLimit:
       requests: 100
       unit: Minute
+  # The moving planner's lane on friends.jomcgi.dev (ADR security/006), gated to
+  # the authentik `family` group. See templates/httproute-friends.yaml.
+  #
+  # Disabled by default so a second deployment of this chart (dev) does not
+  # claim a production hostname on the shared Gateway, the same reason
+  # shipsRedirect above is gated. Production enables it in deploy/values.yaml.
+  friends:
+    enabled: false
+    tier: public
+    hostname: friends.jomcgi.dev
+    servicePort: 3000
+    gateway:
+      name: cloudflare-ingress
+      namespace: envoy-gateway-system
+    authentik:
+      # authentik derives the OIDC issuer from the APPLICATION slug, not the
+      # provider name, so both of these track the `moving` slug in
+      # projects/platform/authentik/blueprints/moving-auth.yaml. Renaming the
+      # application there breaks token validation here, and the symptom is a
+      # 401 on every request while the discovery document still answers 200.
+      #
+      # The trailing slash is significant: `issuer` is compared as a STRING
+      # against the token's `iss` claim.
+      issuer: https://auth.jomcgi.dev/application/o/moving/
+      jwksUri: https://auth.jomcgi.dev/application/o/moving/jwks/
+      # Pinned in the blueprint rather than generated, because it is not a
+      # secret and this file has to name it.
+      clientID: moving-friends
+      # Secret synced from 1Password into THIS namespace, holding key
+      # `client-secret`. A separate 1Password item from authentik's own bundle
+      # on purpose: this namespace must not receive authentik's secret key and
+      # bootstrap credentials just to read one client secret.
+      clientSecretName: moving-oidc-client
+      # authentik group NAMES, matched against the `groups` claim rather than
+      # the projected header, because a claim inside a verified signature
+      # cannot be forged by a caller. Renaming the group in authentik stops
+      # matching here, and the symptom is a 403 AFTER a fully successful login.
+      #
+      # Empty would render an invalid policy (values requires at least one
+      # entry), which fails closed at admission rather than opening the route.
+      allowedGroups:
+        - family
+      onepassword:
+        itemPath: ""
 
 # Cilium policies for this chart. See templates/cilium-policy.yaml.
 ciliumPolicy:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -114,6 +114,26 @@ cfIngress:
       name: cloudflare-ingress
       namespace: envoy-gateway-system
     team: jomcgi
+  # The moving planner on friends.jomcgi.dev/moving, gated to the authentik
+  # `family` group (ADR security/006). Production only: the chart default is
+  # disabled so dev does not claim this hostname.
+  #
+  # This hostname has NO Cloudflare Access application in front of it, so the
+  # SecurityPolicy in templates/httproute-friends.yaml is the only thing
+  # between /moving and the internet. A SecurityPolicy is a separate object
+  # from the route it targets, so confirm the DENY path against the live URL
+  # after this deploys rather than inferring it from the manifest:
+  #
+  #   1. logged out            -> redirect to authentik, never a 200
+  #   2. authenticated, not in `family` -> 403
+  #   3. in `family`           -> the page renders
+  #   4. https://friends.jomcgi.dev/preview/ still works, and every other
+  #      path on this hostname still 404s
+  friends:
+    enabled: true
+    authentik:
+      onepassword:
+        itemPath: vaults/k8s-homelab/items/moving-oidc
   todo:
     public:
       enabled: false

--- a/projects/monolith/dev/deploy/values.yaml
+++ b/projects/monolith/dev/deploy/values.yaml
@@ -68,6 +68,13 @@ cfIngress:
   # claiming it would be a collision.
   shipsRedirect:
     enabled: false
+  # Same reason: production's values.yaml is loaded BEFORE this file, so
+  # cfIngress.friends.enabled: true arrives here inherited. Left on, dev would
+  # render a second HTTPRoute claiming friends.jomcgi.dev on the shared Gateway,
+  # a second SecurityPolicy targeting it, and a moving-oidc-client
+  # OnePasswordItem in this namespace. The planner is production only.
+  friends:
+    enabled: false
 
 postgres:
   # One instance. Dev has no availability requirement, and the cluster is not


### PR DESCRIPTION
PR 4 of #4968, implementing ADR `security/006`. **This is the PR that opens the door.**

Adds one HTTPRoute, one SecurityPolicy targeting it, and the client-secret OnePasswordItem.

## Routes

| Path | Backend | Why |
| --- | --- | --- |
| `/moving` | SvelteKit `:3000` | The page. The SvelteKit reroute hook maps it to `/friends/moving` internally, so no gateway rewrite. |
| `/api/moving` | FastAPI `:8000` | Falling through to `:3000` returns the SPA shell, which the browser reports as `Unexpected token '<'`. Nothing in CI exercises a browser-originated path against real ingress, so that class of gap ships green. |
| `/_app/` | SvelteKit `:3000` | Inside this route deliberately, so the policy covers it. Serving the bundle unauthenticated would leak the page to anyone who guessed the path. |

All three in one route so one SecurityPolicy covers them. The OAuth callback and logout paths fall inside `/moving`, because Envoy serves them itself but the request must select the route first or it 404s before the policy is consulted.

## The gate

OIDC redirect against authentik, JWT validated against its JWKS, `authorization.defaultAction: Deny`, and a single Allow rule matching the `groups` **claim** against `family`. A claim inside a signature Envoy just verified cannot be forged; the projected `X-Auth-Email` header answers only "whose view", and is trustworthy because the gateway-wide ClientTrafficPolicy strips inbound copies at the listener.

Cookies are `moving-access-token` / `moving-id-token`, distinct from the preview lane's `preview-*` on the same hostname. Shared names would shadow each other's sessions and present as an infinite login loop rather than a clean rejection.

## Why a second route rather than rules on an existing one

A SecurityPolicy targets a whole HTTPRoute, so two authorization models on one hostname require two routes. `friends.jomcgi.dev` already carries `/preview/` gated to `homelab-admin` from the **mcp** namespace; this carries `/moving` gated to `family` from **monolith**. The listener sets `allowedRoutes.namespaces.from: All` and the prefixes are disjoint.

## The dev collision this avoids

Dev's Application loads `projects/monolith/deploy/values.yaml` **and then** `dev/deploy/values.yaml`, so production's `enabled: true` arrives in dev inherited. Left alone, the dev release would render a second HTTPRoute claiming this hostname on the shared Gateway, a second SecurityPolicy, and a `moving-oidc-client` OnePasswordItem in `monolith-dev`. Explicitly disabled in dev's overlay, the same gating `shipsRedirect` and `githubWebhook` already carry.

Verified both ways: the dev release renders nothing from this template, production renders all three objects.

## Verification

`ci test`: **Executed 2 out of 725 tests: 725 tests pass.** `helm template` checked for the production release and the dev release separately. No `Chart.yaml` `version:` or `targetRevision:` touched.

**Post-deploy checks, against the live URL rather than the manifest.** A SecurityPolicy is a separate object from the route it targets, so "the policy denies" and "the policy is attached" are different facts, and `defaultAction: Deny` cannot protect a route the policy never bound to:

1. Logged out, `https://friends.jomcgi.dev/moving` redirects to authentik. Never a 200.
2. Authenticated but not in `family`, 403.
3. In `family`, the page renders and `/api/moving/state` returns JSON rather than the SPA shell.
4. `https://friends.jomcgi.dev/preview/` still works, and every other path on the hostname still 404s.

Refs #4968

🤖 Generated with [Claude Code](https://claude.com/claude-code)