### PR TITLE
feat(embervm): add a pi-only guest image and a 256 MiB pi-runtime workload

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -529,7 +529,11 @@ apko.translate_lock(
     name = "embervm_runtime_claude_lock",
     lock = "//projects/embervm/runtimes/claude:apko.lock.json",
 )
-use_repo(apko, "embervm_lock", "embervm_noded_lock", "embervm_runtime_bazel_lock", "embervm_runtime_claude_lock", "embervm_runtime_k3s_agent_lock", "embervm_runtime_k3s_server_lock", "embervm_runtime_postgres_lock", "embervm_runtime_python_lock", "embervm_scratch_prep_lock", "embervm_tokenbroker_lock", "embervm_xds_lock", "monolith_frontend_lock", "rootfs_builder_lock", "sandbox_guest_lock", "semgrep_guest_lock", "whatsapp_lock")
+apko.translate_lock(
+    name = "embervm_runtime_pi_lock",
+    lock = "//projects/embervm/runtimes/pi:apko.lock.json",
+)
+use_repo(apko, "embervm_lock", "embervm_noded_lock", "embervm_runtime_bazel_lock", "embervm_runtime_claude_lock", "embervm_runtime_k3s_agent_lock", "embervm_runtime_k3s_server_lock", "embervm_runtime_pi_lock", "embervm_runtime_postgres_lock", "embervm_runtime_python_lock", "embervm_scratch_prep_lock", "embervm_tokenbroker_lock", "embervm_xds_lock", "monolith_frontend_lock", "rootfs_builder_lock", "sandbox_guest_lock", "semgrep_guest_lock", "whatsapp_lock")
 
 # Download multiarch archives (binaries from zip files)
 multiarch_http_archive = use_repo_rule("//bazel/tools/http:multiarch_http_archive.bzl", "multiarch_http_archive")

--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -36,6 +36,7 @@ multirun(
         "//projects/embervm/runtimes/claude:image.push",
         "//projects/embervm/runtimes/k3s/k3s-agent:image.push",
         "//projects/embervm/runtimes/k3s/k3s-server:image.push",
+        "//projects/embervm/runtimes/pi:image.push",
         "//projects/embervm/runtimes/postgres:image.push",
         "//projects/embervm/runtimes/python:image.push",
         "//projects/embervm/scratch-prep:image.push",

--- a/bazel/images/digests/BUILD
+++ b/bazel/images/digests/BUILD
@@ -18,6 +18,7 @@ oci_digest_manifest(
         "//projects/embervm/runtimes/claude:image.info": "//projects/embervm/runtimes/claude:image.push",
         "//projects/embervm/runtimes/k3s/k3s-agent:image.info": "//projects/embervm/runtimes/k3s/k3s-agent:image.push",
         "//projects/embervm/runtimes/k3s/k3s-server:image.info": "//projects/embervm/runtimes/k3s/k3s-server:image.push",
+        "//projects/embervm/runtimes/pi:image.info": "//projects/embervm/runtimes/pi:image.push",
         "//projects/embervm/runtimes/postgres:image.info": "//projects/embervm/runtimes/postgres:image.push",
         "//projects/embervm/runtimes/python:image.info": "//projects/embervm/runtimes/python:image.push",
         "//projects/embervm/scratch-prep:image.info": "//projects/embervm/scratch-prep:image.push",

--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -41,6 +41,13 @@ helm_chart(
         # EMBERVM_NODED_IMAGES entry, and the Workload's source.image.ref all
         # resolve to the same digest.
         "runtimeClaude.guestImage": "//projects/embervm/runtimes/claude:image.info",
+        # The runtime-pi base image: the same session guest as runtime-claude
+        # carrying only the pi CLI, so a qwen turn runs at 256 MiB instead of
+        # 4096. Distinct FLAT top-level key (D14a.6), digest-pinned from its
+        # .info so the rootfs-builder GUEST_IMAGE, the EMBERVM_NODED_IMAGES
+        # entry, and the Workload's source.image.ref all resolve to the same
+        # digest.
+        "runtimePi.guestImage": "//projects/embervm/runtimes/pi:image.info",
         # R4 stateful consumer (D-R4.PR-11.1): the scratch-postgres base image.
         # Distinct FLAT top-level key (D14a.6), digest-pinned from its .info.
         "scratchPostgres.guestImage": "//projects/embervm/runtimes/postgres:image.info",

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -245,19 +245,35 @@ containers:
         value: "true"
       - name: EMBERVM_NODED_EGRESS_SIDECAR_ADDR
         value: "127.0.0.1:8888"
-      # The allowlist is DERIVED from the workload that actually consumes the
+      # The allowlist is DERIVED from the workloads that actually consume the
       # lane, never hand-copied. An explicit egress.workloads wins; otherwise the
-      # claude runtime's own name is used. A second copy of a name, policed by
-      # nothing, is the coupling this chart deleted when placeholder substitution
-      # went away.
+      # enabled runtime workloads' own names are used. A second copy of a name,
+      # policed by nothing, is the coupling this chart deleted when placeholder
+      # substitution went away.
       #
       # This covers the CR and the allowlist, which move together. It does NOT
       # cover sessions banked before a rename: session.workload is durable and is
       # replayed as the relight trace, so those resume under the old name, miss
       # the new allowlist, and come back with no egress lane.
       {{- $egressWorkloads := $ctx.Values.egress.workloads }}
-      {{- if and (not $egressWorkloads) $ctx.Values.claudeRuntimeWorkload.enabled }}
-      {{- $egressWorkloads = list $ctx.Values.claudeRuntimeWorkload.name }}
+      {{- if not $egressWorkloads }}
+      {{- $derived := list }}
+      {{- if $ctx.Values.claudeRuntimeWorkload.enabled }}
+      {{- $derived = append $derived $ctx.Values.claudeRuntimeWorkload.name }}
+      {{- end }}
+      {{- /*
+        pi-runtime is the second consumer of the lane and needs it for the SAME
+        reason the claude runtime does: its guest points a client at an egress
+        URL (the in-cluster vLLM endpoint on egress.internal.allowlist). A
+        runtime workload enabled but missing from this list gets no forwarder,
+        which does not deny loudly, it dial-times-out inside the guest.
+        Derived from the enabled workloads rather than hand-listed, so a new
+        runtime workload cannot be added without its lane.
+      */}}
+      {{- if $ctx.Values.piRuntimeWorkload.enabled }}
+      {{- $derived = append $derived $ctx.Values.piRuntimeWorkload.name }}
+      {{- end }}
+      {{- $egressWorkloads = $derived }}
       {{- end }}
       {{- if not $egressWorkloads }}
       {{- $egressWorkloads = list "__no_workload__" }}

--- a/projects/embervm/chart/templates/workload-pi-runtime.yaml
+++ b/projects/embervm/chart/templates/workload-pi-runtime.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.piRuntimeWorkload.enabled }}
+# The pi-runtime workload: the small session lane, carrying only the pi CLI.
+#
+# Session class like claude-runtime, and addressed the same way: the monolith
+# POSTs to /v1/workloads/{name}/sessions and then /v1/sessions/{id}/invoke with
+# X-Ember-Guest-Path: /shim/turn, so the name here is a cross-service contract
+# with agent_sessions, not a local label.
+#
+# Egress is not a field here, but this workload's NAME is load-bearing for it.
+# The lane is gated per workload (EMBERVM_NODED_EGRESS_WORKLOADS) and the chart
+# DERIVES that allowlist from the enabled runtime workloads' names, so this CR
+# and the allowlist move together (see _noded-pod.tpl). A pi guest outside the
+# allowlist reaches the in-cluster vLLM endpoint through nothing at all and the
+# turn dies as a dial timeout with no denial logged anywhere useful.
+#
+# persistence is deliberately absent rather than set false: at 256 MiB this
+# workload uses the ADR 027 memory:true quadrant (bank a memory snapshot when
+# idle, relight on the next invoke), which is what the CRD means by no
+# persistence block. See piRuntimeWorkload in values.yaml for why the volume
+# quadrant is not worth its coupling at this size.
+apiVersion: embervm.dev/v1alpha1
+kind: Workload
+metadata:
+  name: {{ .Values.piRuntimeWorkload.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # Apply after the CRD (wave 0) establishes, like every other workload.
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    {{- include "embervm.labels" . | nindent 4 }}
+spec:
+  class: session
+  source:
+    image:
+      # Bazel-pinned from the runtime-pi guest image's .info provider, the same
+      # digest the rootfs-builder initContainer bakes onto node scratch, so the
+      # Workload and the rootfs on disk can never disagree.
+      ref: "{{ .Values.runtimePi.guestImage.repository }}@{{ .Values.runtimePi.guestImage.digest }}"
+      port: {{ .Values.piRuntimeWorkload.port }}
+      readyPath: {{ .Values.piRuntimeWorkload.readyPath | quote }}
+      invokePath: {{ .Values.piRuntimeWorkload.invokePath | quote }}
+      # Part of the workload signature (base_builder signature/1 includes sorted
+      # init_env), so any entry re-keys and rebuilds THIS workload's base alone.
+      # The shared hypervisor epoch rides along so a vendored Firecracker bump
+      # re-keys this base together with every other workload (#4389): a new
+      # hypervisor must never load a previous version's snapshot.
+      initEnv:
+        EMBER_HYPERVISOR_EPOCH: {{ .Values.hypervisorEpoch | quote }}
+        {{- with .Values.piRuntimeWorkload.initEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  resources:
+    vcpus: {{ .Values.piRuntimeWorkload.vcpus }}
+    memMib: {{ .Values.piRuntimeWorkload.memMib }}
+  concurrency:
+    floor: {{ .Values.piRuntimeWorkload.floor }}
+    cap: {{ .Values.piRuntimeWorkload.cap }}
+  session:
+    idleBankSeconds: {{ .Values.piRuntimeWorkload.session.idleBankSeconds }}
+    maxLifetimeSeconds: {{ .Values.piRuntimeWorkload.session.maxLifetimeSeconds }}
+    bankedTtlSeconds: {{ .Values.piRuntimeWorkload.session.bankedTtlSeconds }}
+    maxSessions: {{ .Values.piRuntimeWorkload.session.maxSessions }}
+    invokeQueueCap: {{ .Values.piRuntimeWorkload.session.invokeQueueCap }}
+  invocation:
+    timeoutSeconds: {{ .Values.piRuntimeWorkload.invocation.timeoutSeconds }}
+{{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -619,6 +619,16 @@ workloads:
   runtimeClaude:
     rootfsPath: /var/lib/embervm/scratch/embervm-noded/runtime-claude/rootfs.ext4
     harnessInit: /usr/local/bin/ember-runtime-guest-init
+  # The pi-only sibling of runtimeClaude: the SAME guest-init and the SAME shim,
+  # from an image that carries only the pi CLI (runtimes/pi). harnessInit is
+  # therefore identical, and must stay so: both images ship the one
+  # guest_init_tar_amd64 artifact from the claude runtime package. The key must
+  # match the top-level `runtimePi` block below, and it is kebabcased into the
+  # build-runtime-pi-rootfs initContainer name, which has to be a valid RFC 1123
+  # label.
+  runtimePi:
+    rootfsPath: /var/lib/embervm/scratch/embervm-noded/runtime-pi/rootfs.ext4
+    harnessInit: /usr/local/bin/ember-runtime-guest-init
   # R4 scratch-postgres stateful base (ADR embervm/001, D-R4.PR-11.1). Its PID-1
   # ember-postgres-init mounts the writable volume, decodes POSTGRES_PASSWORD from
   # the mmds_env boot-args, and runs initdb-if-empty then postgres. The key must
@@ -695,6 +705,23 @@ runtimePython:
 runtimeClaude:
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/claude
+    tag: latest
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+
+# The runtime-pi base image: the same session-class guest as runtimeClaude (same
+# shim, same guest-init, same vsock contract) carrying ONLY the pi coding agent,
+# so a qwen turn stops paying for the claude and codex CLIs it can never invoke.
+# Bazel-pinned (helm_chart images="runtimePi.guestImage") from its .info
+# provider. Distinct FLAT top-level key (never nested), per D14a.6, and the key
+# matches the `workloads.runtimePi` entry above because the deployment ranges
+# over `workloads` and looks the image up by the same key.
+#
+# amd64 only, like every other guest image here. Setting this repository to ""
+# is what un-renders the base builder, which is a SEPARATE switch from
+# piRuntimeWorkload.enabled (the CR): dev turns off both.
+runtimePi:
+  guestImage:
+    repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/pi
     tag: latest
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
 
@@ -1495,4 +1522,89 @@ claudeRuntimeWorkload:
   invocation:
     # Total duration for a session invoke. CRD maximum is 900s (workload-crd.yaml:868).
     # Ordering: shim per-event 600s < CP total 900s < monolith outer 1800s.
+    timeoutSeconds: 900
+
+# The pi-runtime session workload: the small lane. Same frozen guest contract as
+# claude-runtime (vsock 1027, /shim/ready, invoke at /shim/turn) served by the
+# SAME shim, from an image carrying only the pi CLI (runtimes/pi).
+#
+# THE NAMED CONSUMER IS THE SYNTHETIC PROBE. The monolith maps model `qwen` to
+# family `pi` (agent_sessions/__init__.py), and ember_public's probe_qwen runs
+# one trivial turn every five minutes forever. Served on claude-runtime that is
+# a 4096 MiB cold boot of a guest holding a 262 MB Node ELF and a 114 MB codex
+# binary the turn can never invoke. Here it is 256 MiB.
+#
+# WHY 256 MiB HOLDS, and where it stops holding. What lives in guest RAM is the
+# Bun-compiled pi binary, the stdlib-python shim, and the tmpfs the guest-init
+# mounts over /tmp and /workspace. The pi binary's code pages are mmapped from
+# the rootfs BLOCK DEVICE, so they are reclaimable page cache rather than a
+# resident cost, and pi's context is bounded hard at 30000 tokens
+# (PI_CONTEXT_WINDOW in the shim) against Qwen's 32768 window, so the JS heap
+# has a ceiling rather than a frontier model's appetite. The CRD floors memMib
+# at 128 (chart/crds/workload-crd.yaml:215), so this is legal, not a special
+# case.
+#
+# It stops holding the moment a session hydrates a repository. With persistence
+# off (below) /workspace IS the tmpfs, so a checkout is spent out of these same
+# 256 MiB with no disk to fall back on. THIS IS THE SMALL-TASK LANE: probes and
+# short conversational turns, not repo-attached work. A repo-attached qwen
+# session belongs on claude-runtime until this workload is given a volume.
+# Raising it is a values-only change; the honest ladder is 256 -> 512 -> a
+# persistenceEnabled flip with a workspaceSizeBytes, in that order.
+piRuntimeWorkload:
+  enabled: false
+  name: pi-runtime
+  port: 1027
+  readyPath: /shim/ready
+  invokePath: /shim/turn
+  # Same base-signature epoch mechanism as claudeRuntimeWorkload: entries here
+  # re-key and rebuild ONLY this workload's base and reach the guest's
+  # environment through NOTHING (the control plane sends the map as
+  # BuildBaseRequest.init_env and noded never reads that field, #4429). Use it as
+  # a rebuild epoch, never as a knob.
+  initEnv: {}
+  # 1 vcpu, not the claude runtime's 2. A turn here is one bounded-context model
+  # round trip against the in-cluster vLLM endpoint, so the guest is waiting on
+  # the network, not computing. A guest still pays full boot cost regardless, so
+  # this is the floor rather than a saving worth pushing further.
+  vcpus: 1
+  memMib: 256
+  # persistence OFF, so this is ADR 027's memory:true quadrant: an idle session
+  # banks a memory snapshot and relights from it. That quadrant was expensive
+  # enough at claude-runtime's 4096 MiB to be worth replacing with volumes; at
+  # 256 MiB a bank is 256 MiB of snapshot, which is cheap enough that the simple
+  # path is the right one. It also keeps this workload clear of the placeholder
+  # volume drive coupling (warmRestoreWithVolumeClasses plus a base epoch, which
+  # MUST move together) that the claude runtime carries.
+  persistenceEnabled: false
+  # floor 0 for the same reason claude-runtime uses it, and more so: the floor is
+  # applied PER BRICK INSTANCE, and a cold spawn to first request is ~250ms
+  # against a model API leg measured in seconds. Warmth would buy a few percent
+  # of a turn for a permanently resident guest on every brick.
+  floor: 0
+  # cap bounds NEW session VMs at create time. 2 covers the */5 probe overlapping
+  # with one interactive session; the probe destroys its session before
+  # returning, so steady state is 0.
+  cap: 2
+  session:
+    # 20s: a probe session is created, served and destroyed inside one call, and
+    # an interactive qwen turn is a fast round trip. A longer idle window would
+    # hold cap slots for conversations that have already ended.
+    idleBankSeconds: 20
+    maxLifetimeSeconds: 21600
+    # 1h, matching claude-runtime: a failed or abandoned turn leaves a banked
+    # zombie counting against maxSessions, and at a 6h TTL a handful of retries
+    # saturates a cap this small.
+    bankedTtlSeconds: 3600
+    # Live + banked. 4 x 256 MiB = 1 GiB of snapshot worst case, against
+    # claude-runtime's 8 x 4 GiB = 32 GiB.
+    maxSessions: 4
+    invokeQueueCap: 4
+  invocation:
+    # 900s, the same as claude-runtime, and deliberately NOT tightened even
+    # though a bounded-context Qwen turn is far shorter than a frontier one. The
+    # ordering shim per-event 600s < CP total 900s < monolith outer 1800s is
+    # load-bearing: the INNERMOST timeout has to fire first so a wedged CLI
+    # returns a specific shim error instead of a generic transport cancel.
+    # Dropping this below 600 inverts that for a few minutes of a held cap slot.
     timeoutSeconds: 900

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -627,6 +627,23 @@ claudeRuntimeWorkload:
   # /var/lib/embervm/scratch on node-1/2/3 rather than on node-4.
   persistenceEnabled: true
 
+# The pi-runtime workload: the small session lane (256 MiB), carrying only the
+# pi CLI. Sizing and the "why 256 holds" arithmetic are in chart/values.yaml.
+#
+# ON, but NOTHING ROUTES TO IT YET. The monolith still sends every model family,
+# qwen included, to claude-runtime (agent_sessions/transport.py defaults its
+# workload to "claude-runtime"), so enabling this here builds the base and
+# stands the CR up without changing a single live turn. That ordering is
+# deliberate: embervm and monolith are separate ArgoCD apps with independent
+# rollouts, so shipping the routing flip in the same change would mean whichever
+# app synced first decided whether qwen sessions 404 on an unknown workload for
+# a few minutes. It also means the 256 MiB sizing is proven by a real session
+# create here BEFORE the */5 synthetic probe depends on it.
+#
+# The follow-up that routes model=qwen here is a monolith-side change.
+piRuntimeWorkload:
+  enabled: true
+
 # SpecTrace gate for spec validation (GitHub issue #4770). Debug-gated, spec-shaped
 # trace that validates TLA+ specs against real behaviour. Deliberately OFF in production.
 # Chart defaults are all OFF; flip specTrace.enabled=true locally or in a dev values

--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -113,6 +113,29 @@ bazelQueryWorkload:
 claudeRuntimeWorkload:
   enabled: false
 
+# The ONE session workload dev runs, and the exception to the paragraph above.
+#
+# It earns its place by being the thing dev is for: this workload is the first
+# in the fleet sized at 256 MiB, and the only question that cannot be answered
+# by reading is whether a guest actually boots and reports /shim/ready in that
+# much RAM. Dev's 1gi brick has 768 MiB guest-schedulable, so one fits with
+# headroom, and its base is the ~100 MB pi image rather than the 300 MB claude
+# one that cost the first dev brick three of its four minutes.
+#
+# WHAT DEV CAN AND CANNOT PROVE HERE. Dev does not enable the egress lane
+# (egress.enabled defaults false and dev is silent on it), and a pi turn reaches
+# the in-cluster vLLM endpoint through that lane, so dev proves base build, cold
+# boot, readiness and session create/destroy at 256 MiB. It does NOT prove a
+# turn. That is production's to prove, which is why the CR ships enabled there
+# with nothing routed to it yet.
+#
+# Watch for `pressure:mem` on create: admission compares raw cgroup headroom
+# against need (256) plus the reject floor (512), and a brick that has baked a
+# base carries page cache in memory.current. If dev flaps on admission, that is
+# a real finding about small guests on small bricks, not a dev-only artifact.
+piRuntimeWorkload:
+  enabled: true
+
 # scratchPostgres carries BOTH of its dev settings here, deliberately. It also
 # needs an empty guest image (the base-builder block below empties one repository
 # per unused workload), but a second `scratchPostgres:` key at that level is a
@@ -234,6 +257,14 @@ workloads:
     rootfsPath: /var/lib/embervm/scratch/dev/embervm-noded/runtime-python/rootfs.ext4
   runtimeClaude:
     rootfsPath: /var/lib/embervm/scratch/dev/embervm-noded/runtime-claude/rootfs.ext4
+  # MANDATORY even though dev may not run the workload: every workload's path
+  # has to move, including the ones whose CRs are disabled, because the base
+  # BUILDERS are gated separately from the Workload CRs. Left at the inherited
+  # production path this is UNBACKED inside the container (only nvmeRoot is
+  # mounted), so mkfs writes a multi-GB base image to node-4's ROOT filesystem,
+  # which is where production's bricks live. See the block comment above.
+  runtimePi:
+    rootfsPath: /var/lib/embervm/scratch/dev/embervm-noded/runtime-pi/rootfs.ext4
   scratchPostgres:
     rootfsPath: /var/lib/embervm/scratch/dev/embervm-noded/scratch-postgres/rootfs.ext4
   bazelQuery:
@@ -268,9 +299,11 @@ servingEnvoy:
 # not claude-runtime"), for a workload no session can ever use. Measured: the
 # first dev brick spent roughly three of its four minutes on that one builder.
 #
-# Only `sandbox` keeps its builder, because it is the only Workload CR dev
-# enables. Emptying the repository is what the loop's `if` tests, so the init
-# container is not rendered at all.
+# `sandbox` and `runtimePi` keep their builders, because they are the Workload
+# CRs dev enables. Emptying the repository is what the loop's `if` tests, so the
+# init container is not rendered at all. There is deliberately NO `runtimePi:`
+# entry below: emptying it would leave the CR enabled with no base to restore,
+# which reports as a workload that never goes Ready.
 semgrep:
   guestImage:
     repository: ""

--- a/projects/embervm/runtimes/claude/BUILD
+++ b/projects/embervm/runtimes/claude/BUILD
@@ -30,6 +30,19 @@ tar(
     mtree = [
         "./usr/local/bin/ember-claude-shim type=file content=$(execpath shim.py) mode=0755 uid=0 gid=0",
     ],
+    # The pi runtime image ships this SAME artifact rather than rebuilding its
+    # own, so the two guests can never drift in the shim. Same reasoning for
+    # guest_config_tar and guest_init_tar_amd64 below.
+    visibility = ["//projects/embervm/runtimes/pi:__pkg__"],
+)
+
+# The apko config as a data dependency, so the pi runtime's package-parity guard
+# can read this image's package list. Exported rather than duplicated: the guard
+# exists precisely to catch the two lists drifting.
+filegroup(
+    name = "apko_yaml",
+    srcs = ["apko.yaml"],
+    visibility = ["//projects/embervm/runtimes/pi:__pkg__"],
 )
 
 # The CLI reads its source bundle at runtime, so patch it as a Bazel artifact
@@ -82,6 +95,11 @@ tar(
     mtree = [
         "./usr/share/ember-claude/claude.json type=file content=$(execpath guest-config/claude.json) mode=0644 uid=0 gid=0",
     ],
+    # Shared with the pi runtime image, which carries no claude CLI but still
+    # needs this file: guest-init's seedTrustRecord reads it UNCONDITIONALLY and
+    # errors if it is absent (volume_linux.go), so a pi guest without it never
+    # finishes boot.
+    visibility = ["//projects/embervm/runtimes/pi:__pkg__"],
 )
 
 apko_image(
@@ -167,6 +185,10 @@ tar(
     mtree = [
         "./usr/local/bin/ember-runtime-guest-init type=file content=$(execpath :guest_init_amd64_bin) mode=0755 uid=0 gid=0",
     ],
+    # Shared with the pi runtime image. Both workloads name the same
+    # harnessInit path (/usr/local/bin/ember-runtime-guest-init) in the chart's
+    # `workloads` table, so they must be the same binary.
+    visibility = ["//projects/embervm/runtimes/pi:__pkg__"],
 )
 
 # Guard (#4458): the ENOSPC reclaim deletes base bundles on a wedged brick, so

--- a/projects/embervm/runtimes/pi/BUILD
+++ b/projects/embervm/runtimes/pi/BUILD
@@ -1,0 +1,66 @@
+# gazelle:ignore
+load("//bazel/tools/oci:apko_image.bzl", "apko_image")
+load("//bazel/tools/pytest:defs.bzl", "py_test")
+
+# EmberVM pi runtime base image. A session-class guest whose PID 1 is the SAME
+# stdlib-python shim the claude runtime uses, answering the same frozen
+# HTTP-over-vsock guest contract on port 1027, but carrying ONLY the pi coding
+# agent.
+#
+# Every layer except the pi tar is reused verbatim from ../claude rather than
+# rebuilt here, so the two images cannot drift in the shim, the trust-record
+# seed, or the guest-init binary. That reuse is the point: the shim already
+# constructs its claude, codex and pi adapters lazily (ProcessManager only
+# spawns the CLI a turn actually selects), so a pi-only image needs no shim
+# fork, and forking one would be a second copy of 3700 lines policed by nothing.
+
+apko_image(
+    name = "image",
+    # amd64-only. Unlike ../claude this is not forced by the CLI (pi ships
+    # dual-arch), but by the guest-init tar below, which is built through an
+    # amd64 platform transition, and by there being no aarch64 node to run it.
+    # See apko.yaml. arm64 = False with a per-arch `tars` entry is the supported
+    # combination; arm64 = False with multiarch_tars fails at PUSH time, after
+    # PR CI is already green.
+    arm64 = False,
+    config = "apko.yaml",
+    contents = "@embervm_runtime_pi_lock//:contents",
+    repository = "ghcr.io/jomcgi/homelab/projects/embervm/runtimes/pi",
+    tars = [
+        # The shared shim, trust-record seed and guest-init, taken from the
+        # claude runtime package as built artifacts so both images ship byte
+        # identical copies.
+        "//projects/embervm/runtimes/claude:shim_tar",
+        "//projects/embervm/runtimes/claude:guest_config_tar",
+        "//projects/embervm/runtimes/claude:guest_init_tar_amd64",
+        # The pi coding agent, a self-contained Bun-compiled ELF from the GitHub
+        # release (see pi_coding_agent in MODULE.bazel), plus the theme JSONs and
+        # wasm sidecar it loads relative to argv0. The ONLY CLI in this image:
+        # claude_code_patched_tar_amd64 and @codex_cli//:tar_amd64 are
+        # deliberately absent, and that absence is this image's entire reason to
+        # exist (200 MB of the claude runtime's 300 MB compressed).
+        "@pi_coding_agent//:tar_amd64",
+    ],
+)
+
+# Guard: this image's package set is documented as deliberately IDENTICAL to the
+# claude runtime's, so that the only difference between the two guests is which
+# CLIs exist. A package added to one and not the other silently breaks that
+# claim, and the failure would surface as a pi turn missing a binary the claude
+# runtime has, inside a guest, which is the most expensive place to see it.
+# Divergence is allowed, it just has to be deliberate: add the package to the
+# EXPECTED_DIVERGENCE set in the test with a reason.
+# Hand-registered: gazelle does not generate py_test targets in this repo.
+py_test(
+    name = "package_parity_test",
+    srcs = ["package_parity_test.py"],
+    data = [
+        "apko.yaml",
+        "//projects/embervm/runtimes/claude:apko_yaml",
+    ],
+    imports = ["."],
+    deps = [
+        "@pip//pytest",
+        "@pip//pyyaml",
+    ],
+)

--- a/projects/embervm/runtimes/pi/apko.lock.json
+++ b/projects/embervm/runtimes/pi/apko.lock.json
@@ -1,0 +1,1072 @@
+{
+  "version": "v1",
+  "config": {
+    "name": "projects/embervm/runtimes/pi/apko.yaml",
+    "checksum": "sha256-Rx8UtGkFwvBnEclh3G0Cf5R0slrIGDUChMDdZa5bMRc="
+  },
+  "contents": {
+    "keyring": [
+      {
+        "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "content": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA5qQUHmzqX9oa/RS3OSgL\nYTYB1mzvVmnWC0JXsAafdgRkavJ9xRhsXMKXWPKMghZw6UnkxuxQCZlB9UhaFqed\nX7SWfQ8qRgECFmdGUjoeV7P3VUkg17RU0mUKsXZZF/2mU+jCGyk5eweKcLWrk6bn\nlNNF1vBJ9EXbHdfvbQsA5GfLku5tJhqRJ4FVQAGCw+1JoSKu+o3q+6xP7z6kMfR9\ncp54FSj48rTJUibbAv+cPtZ3AnbpjdyarV7SYMfxp14Q/KR0CJYDihG3CFoU+TaM\ndr7LUrgXaYw7m7g8hA2PY1jF8aqDqVFjVu/csPKnKVQSqNHfm4C4gljwT6TDVhPe\n6xKSGKfAUNvHx2RIqSsZJCh68Af+VnfuimbHMYzGhzV4/efihpJlYsDnOXJj/PeY\nSbEIYG2yoI3AYvDFyFX2OAOtQ9d4TPs4zS4aDg4R3UseXLib46FX3ZTfIi1/W0IO\neC3AFU5mK+02jq+7swcGbgzem30dFA/B3n8NQExJjF2WlGNJxFw2WnJQqKIkIh0s\nkm5jaxJ28xYgik+bEgxy1LsilKTowdkbEPRKv36JGdap4dOEGR+LwZsM+ontF1AO\nwY6tvwtZKJWhgj7ES3BdtiC1GA2htFnP90lA7KnKbSMOxwWtSCH8spitdPdzgI8G\nSxrOb0SZs6ZFAxYYe3GlvS0CAwEAAQ==\n-----END PUBLIC KEY-----\n"
+      }
+    ],
+    "build_repositories": [],
+    "runtime_repositories": [],
+    "repositories": [
+      {
+        "name": "packages.wolfi.dev/os/x86_64",
+        "url": "https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz",
+        "architecture": "x86_64"
+      }
+    ],
+    "packages": [
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1932",
+          "checksum": "sha1-mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+        },
+        "data": {
+          "range": "bytes=1933-13952",
+          "checksum": "sha256-5jOBVeXTWJEbL+Cnxj5Nu4klEL4SEB7IDMzT96rbkkA="
+        },
+        "checksum": "Q1mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20260413-r1.apk",
+        "version": "20260413-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8322",
+          "checksum": "sha1-u3xyVyewNfx7ZzTDikWdOlY9Tt8="
+        },
+        "data": {
+          "range": "bytes=8323-137882",
+          "checksum": "sha256-FfsoSAq28t7qTE1H+hPbrozu3BjgGiACoDMkS37a2G0="
+        },
+        "checksum": "Q1u3xyVyewNfx7ZzTDikWdOlY9Tt8="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-r13.apk",
+        "version": "2.43-r13",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13894",
+          "checksum": "sha1-1r5jeZwjbaY6zH3ne5YLs8l/snc="
+        },
+        "data": {
+          "range": "bytes=13895-148125",
+          "checksum": "sha256-q9CKt6E5CknoVG1++3Ggasgiper58dhYbb7I6KKAZAU="
+        },
+        "checksum": "Q11r5jeZwjbaY6zH3ne5YLs8l/snc="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9951",
+          "checksum": "sha1-v4FvRKA29cOT2WtAXaWZBCzRXaU="
+        },
+        "data": {
+          "range": "bytes=9952-105490",
+          "checksum": "sha256-ExYZSr5G/sH+fzFe+TjVUTTj/GQ1Qbjx8MMEh+6ZxE0="
+        },
+        "checksum": "Q1v4FvRKA29cOT2WtAXaWZBCzRXaU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.43-r13.apk",
+        "version": "2.43-r13",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13847",
+          "checksum": "sha1-CGPlUnu0Faw2u47/1gZyhEG6E4s="
+        },
+        "data": {
+          "range": "bytes=13848-90588",
+          "checksum": "sha256-H7oYz7/ni/jF30u1vgbCWVrxJsSbIpVMp/o/eJXfzSg="
+        },
+        "checksum": "Q1CGPlUnu0Faw2u47/1gZyhEG6E4s="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.43-r13.apk",
+        "version": "2.43-r13",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-14085",
+          "checksum": "sha1-a0yBsX7dCvBm6DPj8TXOWNRLfgc="
+        },
+        "data": {
+          "range": "bytes=14086-3078266",
+          "checksum": "sha256-+B5nvgV68oQMvFdLImb5wt0Ke1mX3SvVfEEjN5EG5dU="
+        },
+        "checksum": "Q1a0yBsX7dCvBm6DPj8TXOWNRLfgc="
+      },
+      {
+        "name": "ncurses-terminfo-base",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.6.20260815-r0.apk",
+        "version": "6.6.20260815-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10345",
+          "checksum": "sha1-QfSrArGa3wpHUhL/3OLIlWodOLA="
+        },
+        "data": {
+          "range": "bytes=10346-118136",
+          "checksum": "sha256-94VmBsGvvPAeGOI3lBlml62NN1wYMApUnj1ovcVI7Co="
+        },
+        "checksum": "Q1QfSrArGa3wpHUhL/3OLIlWodOLA="
+      },
+      {
+        "name": "ncurses",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.6.20260815-r0.apk",
+        "version": "6.6.20260815-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10496",
+          "checksum": "sha1-gn/XV1ycgCwqAncfALw5TA5CASs="
+        },
+        "data": {
+          "range": "bytes=10497-622079",
+          "checksum": "sha256-If2ejH5whFYe4d+4MU0Y5CgzWbYXohWDW0Q3JIQo43c="
+        },
+        "checksum": "Q1gn/XV1ycgCwqAncfALw5TA5CASs="
+      },
+      {
+        "name": "bash",
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.3-r12.apk",
+        "version": "5.3-r12",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7927",
+          "checksum": "sha1-MiP/OfvIiKKAeeYZwZ9TEZUMUes="
+        },
+        "data": {
+          "range": "bytes=7928-761775",
+          "checksum": "sha256-6a67wARX0cxLzVwnkqQBX1Pn8IgVa9uq95jAGW5nEeM="
+        },
+        "checksum": "Q1MiP/OfvIiKKAeeYZwZ9TEZUMUes="
+      },
+      {
+        "name": "libblkid",
+        "url": "https://packages.wolfi.dev/os/x86_64/libblkid-2.42.2-r3.apk",
+        "version": "2.42.2-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8556",
+          "checksum": "sha1-g4mMvjrH0e9Z5f3wKYDrVPUsLxk="
+        },
+        "data": {
+          "range": "bytes=8557-869136",
+          "checksum": "sha256-cdj6TpJNjDcbzBruH0yp+Ek57SH6UD3AV+YVTM3/8C4="
+        },
+        "checksum": "Q1g4mMvjrH0e9Z5f3wKYDrVPUsLxk="
+      },
+      {
+        "name": "blkid",
+        "url": "https://packages.wolfi.dev/os/x86_64/blkid-2.42.2-r3.apk",
+        "version": "2.42.2-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8568",
+          "checksum": "sha1-LopyibJeYePfY7PBazT5y8FRuYk="
+        },
+        "data": {
+          "range": "bytes=8569-280550",
+          "checksum": "sha256-P8MoEs6CRX3cHYYkiEYe69zB4w/E8ZdENXnKpPA6zhw="
+        },
+        "checksum": "Q1LopyibJeYePfY7PBazT5y8FRuYk="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.5.2-r4.apk",
+        "version": "4.5.2-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9765",
+          "checksum": "sha1-8mwy9m46Q+nYofoWKiURDdXCCBk="
+        },
+        "data": {
+          "range": "bytes=9766-107326",
+          "checksum": "sha256-CQcWRLKhYiydnvRpfxynMDvtYNe2x126F4BgtZq7+VY="
+        },
+        "checksum": "Q18mwy9m46Q+nYofoWKiURDdXCCBk="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.43-r13.apk",
+        "version": "2.43-r13",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13899",
+          "checksum": "sha1-yqugUaqNhsY3a8bibioPNCKsMck="
+        },
+        "data": {
+          "range": "bytes=13900-15515",
+          "checksum": "sha256-ocCtK3zyh3IPTW8tjbI9IDT/fKk2kP1Gfzqg6KPWrYA="
+        },
+        "checksum": "Q1yqugUaqNhsY3a8bibioPNCKsMck="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r61.apk",
+        "version": "1.37.0-r61",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10913",
+          "checksum": "sha1-Dc1coU0swhMsnFh4BnVin4Y/z6U="
+        },
+        "data": {
+          "range": "bytes=10914-430452",
+          "checksum": "sha256-Lp5skr4+yaxDhdl+G39Z7VC8YLLcwNh+fGvRe0T6bj0="
+        },
+        "checksum": "Q1Dc1coU0swhMsnFh4BnVin4Y/z6U="
+      },
+      {
+        "name": "libbrotlicommon1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.2.0-r3.apk",
+        "version": "1.2.0-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6793",
+          "checksum": "sha1-jiywS9aIP3q1TI5UwC1zp/dsVr8="
+        },
+        "data": {
+          "range": "bytes=6794-76948",
+          "checksum": "sha256-OarefY1K7DoAVQnI+gKBLCpdMFeyGlj9gEIfBGp3Fvg="
+        },
+        "checksum": "Q1jiywS9aIP3q1TI5UwC1zp/dsVr8="
+      },
+      {
+        "name": "libbrotlidec1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.2.0-r3.apk",
+        "version": "1.2.0-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6806",
+          "checksum": "sha1-G/f4liNwY7eefOjRe3Dd3U9FM7o="
+        },
+        "data": {
+          "range": "bytes=6807-38364",
+          "checksum": "sha256-U7AnPRqeMceKaariNoQB/dP2etJh98p2RzIrSMayits="
+        },
+        "checksum": "Q1G/f4liNwY7eefOjRe3Dd3U9FM7o="
+      },
+      {
+        "name": "libverto",
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r7.apk",
+        "version": "0.3.2-r7",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7019",
+          "checksum": "sha1-sDJ1BUkf//wbO4iWftq36lU0TKw="
+        },
+        "data": {
+          "range": "bytes=7020-20251",
+          "checksum": "sha256-Z1Lrte4GAbGfrMW6bu3AKImDbo/cCeXPAl63zVvzDLU="
+        },
+        "checksum": "Q1sDJ1BUkf//wbO4iWftq36lU0TKw="
+      },
+      {
+        "name": "krb5-conf",
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-conf-1.0-r9.apk",
+        "version": "1.0-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1146",
+          "checksum": "sha1-Ra+vl5lLBEyOhG8QYdPfwg9wdgg="
+        },
+        "data": {
+          "range": "bytes=1147-2879",
+          "checksum": "sha256-sdgWS1AsGdT2maS7nI53u3Yj9gq6XjsFhKRTO6Ty4jk="
+        },
+        "checksum": "Q1Ra+vl5lLBEyOhG8QYdPfwg9wdgg="
+      },
+      {
+        "name": "keyutils-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r39.apk",
+        "version": "1.6.3-r39",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8319",
+          "checksum": "sha1-EWYvd29yrhJnDZ22Zuzjm3L+k10="
+        },
+        "data": {
+          "range": "bytes=8320-18938",
+          "checksum": "sha256-hb0G2mECwi2wIXS+5hzKAsMvIUTLzhly/xGAc9MjG/s="
+        },
+        "checksum": "Q1EWYvd29yrhJnDZ22Zuzjm3L+k10="
+      },
+      {
+        "name": "libcom_err",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcom_err-1.47.4-r1.apk",
+        "version": "1.47.4-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8252",
+          "checksum": "sha1-CMcRrPrpbLziSeZwJAsj1IggRAg="
+        },
+        "data": {
+          "range": "bytes=8253-16737",
+          "checksum": "sha256-u0G4PIicoyfgySbZKrzDrrgzWhBNmqRVcMg6zQFSSS4="
+        },
+        "checksum": "Q1CMcRrPrpbLziSeZwJAsj1IggRAg="
+      },
+      {
+        "name": "libcrypto3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.6.3-r4.apk",
+        "version": "3.6.3-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11066",
+          "checksum": "sha1-q1tmKlM5V4hYJDAT4mFLNXfTWWs="
+        },
+        "data": {
+          "range": "bytes=11067-2440291",
+          "checksum": "sha256-PiuIGCXSaU+bBWb7Rt3pX07C96fH1RTr6tjAH5fG8w4="
+        },
+        "checksum": "Q1q1tmKlM5V4hYJDAT4mFLNXfTWWs="
+      },
+      {
+        "name": "libssl3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.6.3-r4.apk",
+        "version": "3.6.3-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11072",
+          "checksum": "sha1-M9icugKTo/ba2jkEhvIqVsM+I6Q="
+        },
+        "data": {
+          "range": "bytes=11073-524372",
+          "checksum": "sha256-KxEyQDoGJz5m4sfmFhkIPZQIKu4/8uy+1ADalqU/Sd8="
+        },
+        "checksum": "Q1M9icugKTo/ba2jkEhvIqVsM+I6Q="
+      },
+      {
+        "name": "krb5-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.22.2-r2.apk",
+        "version": "1.22.2-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8895",
+          "checksum": "sha1-xseCtT4lsF66PC2c5G0LLMk+aq4="
+        },
+        "data": {
+          "range": "bytes=8896-1047954",
+          "checksum": "sha256-By1IkTuSdK0eqziOaHpvntsQA25M3dL+pReOZ1lKbPo="
+        },
+        "checksum": "Q1xseCtT4lsF66PC2c5G0LLMk+aq4="
+      },
+      {
+        "name": "libunistring",
+        "url": "https://packages.wolfi.dev/os/x86_64/libunistring-1.4.2-r2.apk",
+        "version": "1.4.2-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7520",
+          "checksum": "sha1-yQVDwlBj+eVaAbOLQdnJEtSg9X8="
+        },
+        "data": {
+          "range": "bytes=7521-904686",
+          "checksum": "sha256-GI6eG0zWe5m0XvD9gtqeVflLEmYFymJ721kuHiTCrjQ="
+        },
+        "checksum": "Q1yQVDwlBj+eVaAbOLQdnJEtSg9X8="
+      },
+      {
+        "name": "libidn2",
+        "url": "https://packages.wolfi.dev/os/x86_64/libidn2-2.3.8-r8.apk",
+        "version": "2.3.8-r8",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8340",
+          "checksum": "sha1-uEc4gafn6qJPsQoKgrRTB1vaXbE="
+        },
+        "data": {
+          "range": "bytes=8341-127709",
+          "checksum": "sha256-SiZiRqAA71K/o2vmoZJXPl5tLOK26vpowh0u1DIIEDs="
+        },
+        "checksum": "Q1uEc4gafn6qJPsQoKgrRTB1vaXbE="
+      },
+      {
+        "name": "nghttp3",
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp3-1.18.0-r0.apk",
+        "version": "1.18.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6985",
+          "checksum": "sha1-F5IPxGpCQOMhv/6KeXDC/VZlhF0="
+        },
+        "data": {
+          "range": "bytes=6986-108505",
+          "checksum": "sha256-iAlEdlGPtlW0sqXgmj56DzxvsPkUX1chCVoEXPlJJkI="
+        },
+        "checksum": "Q1F5IPxGpCQOMhv/6KeXDC/VZlhF0="
+      },
+      {
+        "name": "ngtcp2",
+        "url": "https://packages.wolfi.dev/os/x86_64/ngtcp2-1.25.0-r1.apk",
+        "version": "1.25.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7106",
+          "checksum": "sha1-r2/pOwGyDrRBcQFNNfVQiTxwmTY="
+        },
+        "data": {
+          "range": "bytes=7107-233126",
+          "checksum": "sha256-5rPHzafATupYO+KFDDtNaAS6VY6hUUovvh5TWrRn9x8="
+        },
+        "checksum": "Q1r2/pOwGyDrRBcQFNNfVQiTxwmTY="
+      },
+      {
+        "name": "libpsl",
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.23.3-r0.apk",
+        "version": "0.23.3-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7874",
+          "checksum": "sha1-JX7gR0k50ZAwT6m8xnvb9taqXOo="
+        },
+        "data": {
+          "range": "bytes=7875-73564",
+          "checksum": "sha256-IMEHWLMhD0rXpPnQHsX+/VLUxFVqGF0D+bCppSnEgYA="
+        },
+        "checksum": "Q1JX7gR0k50ZAwT6m8xnvb9taqXOo="
+      },
+      {
+        "name": "libnghttp2-14",
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.70.0-r2.apk",
+        "version": "1.70.0-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7811",
+          "checksum": "sha1-oQRHF/5LZECCttiyB7bVkXopPYI="
+        },
+        "data": {
+          "range": "bytes=7812-109901",
+          "checksum": "sha256-V3N73ehpJfQwWvL71PSF24KE3IpdRb9HTZFSCgr+yeM="
+        },
+        "checksum": "Q1oQRHF/5LZECCttiyB7bVkXopPYI="
+      },
+      {
+        "name": "zlib",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.2-r4.apk",
+        "version": "1.3.2-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9127",
+          "checksum": "sha1-uur/HAJCSzF/hyt+ffNYqiqGYAs="
+        },
+        "data": {
+          "range": "bytes=9128-73248",
+          "checksum": "sha256-t35y9rhtwo05Lya7W99+zKvNIDde4vCmx+XTNgozvAc="
+        },
+        "checksum": "Q1uur/HAJCSzF/hyt+ffNYqiqGYAs="
+      },
+      {
+        "name": "gdbm",
+        "url": "https://packages.wolfi.dev/os/x86_64/gdbm-1.26-r5.apk",
+        "version": "1.26-r5",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7464",
+          "checksum": "sha1-m4CRD8lCkRLk/whYIwa2UQuA8uk="
+        },
+        "data": {
+          "range": "bytes=7465-274283",
+          "checksum": "sha256-0u2QmNUl9YQxfpb+TygxHhYAOi/40XsqJOfpEEkuGmE="
+        },
+        "checksum": "Q1m4CRD8lCkRLk/whYIwa2UQuA8uk="
+      },
+      {
+        "name": "sqlite-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/sqlite-libs-3.53.4-r0.apk",
+        "version": "3.53.4-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5297",
+          "checksum": "sha1-x8+xdfUz1lcwo4swX+n/QBhifHc="
+        },
+        "data": {
+          "range": "bytes=5298-978595",
+          "checksum": "sha256-YoBymbCMq42aqTuMRnLY3jUw1feoxwpptIrll5q34hM="
+        },
+        "checksum": "Q1x8+xdfUz1lcwo4swX+n/QBhifHc="
+      },
+      {
+        "name": "readline",
+        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.3-r2.apk",
+        "version": "8.3-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6720",
+          "checksum": "sha1-1WRlY3do45L9jnu5YAoRTSTcimY="
+        },
+        "data": {
+          "range": "bytes=6721-342785",
+          "checksum": "sha256-b8Pq+h8UH9KT10SqvwjnKyZNJ1p5qhjdXy2Yn63jtNw="
+        },
+        "checksum": "Q11WRlY3do45L9jnu5YAoRTSTcimY="
+      },
+      {
+        "name": "heimdal-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/heimdal-libs-7.8.0-r51.apk",
+        "version": "7.8.0-r51",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9136",
+          "checksum": "sha1-r9q4OvkeTlqURw1ZdYdqM2LJb+4="
+        },
+        "data": {
+          "range": "bytes=9137-1474084",
+          "checksum": "sha256-UIQDEybAlELRbwYzMxY55JzmDqYOUS2Uk2xQXMKIW8s="
+        },
+        "checksum": "Q1r9q4OvkeTlqURw1ZdYdqM2LJb+4="
+      },
+      {
+        "name": "cyrus-sasl-heimdal-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/cyrus-sasl-heimdal-libs-2.1.28-r54.apk",
+        "version": "2.1.28-r54",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10521",
+          "checksum": "sha1-pxMdknpbKHP0//I2ps885ZNaajY="
+        },
+        "data": {
+          "range": "bytes=10522-217336",
+          "checksum": "sha256-SaD3M1tquLyiTz+HEyQEct1spbdWEGEkRvTndhZQyVE="
+        },
+        "checksum": "Q1pxMdknpbKHP0//I2ps885ZNaajY="
+      },
+      {
+        "name": "libldap-2.7",
+        "url": "https://packages.wolfi.dev/os/x86_64/libldap-2.7-2.7.0-r0.apk",
+        "version": "2.7.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-14116",
+          "checksum": "sha1-XJMgJZVe8HSU6exqz2Zbhcu8aMg="
+        },
+        "data": {
+          "range": "bytes=14117-267149",
+          "checksum": "sha256-fI2nPiNuYhFL3R2YJrT5FeiLjp0gM8MkHDC4WDC9vPM="
+        },
+        "checksum": "Q1XJMgJZVe8HSU6exqz2Zbhcu8aMg="
+      },
+      {
+        "name": "libcurl-openssl4",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.21.0-r1.apk",
+        "version": "8.21.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12479",
+          "checksum": "sha1-Kj2dYTppP4NN9E6Ix8iaPQcBR+E="
+        },
+        "data": {
+          "range": "bytes=12480-578693",
+          "checksum": "sha256-ZnjNoR8Rqt69O2cUdVziPP6Hu6MdpSAwRpbu3HpMKwQ="
+        },
+        "checksum": "Q1Kj2dYTppP4NN9E6Ix8iaPQcBR+E="
+      },
+      {
+        "name": "curl",
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.21.0-r1.apk",
+        "version": "8.21.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12402",
+          "checksum": "sha1-5rcebH8VYxfqyS3Oj8NZ0mmyPKE="
+        },
+        "data": {
+          "range": "bytes=12403-236015",
+          "checksum": "sha256-QkxWQf0nX3t6G3PZoF7uf/FkG/zEePNUpG8598W11wo="
+        },
+        "checksum": "Q15rcebH8VYxfqyS3Oj8NZ0mmyPKE="
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/e2fsprogs-libs-1.47.4-r1.apk",
+        "version": "1.47.4-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8258",
+          "checksum": "sha1-1hxIEw4QVSeajx+FDtDuspATbx0="
+        },
+        "data": {
+          "range": "bytes=8259-287358",
+          "checksum": "sha256-myR9OUT2SCo+fg3sHHdzEJ3ZS06462aQke0zAS9WZao="
+        },
+        "checksum": "Q11hxIEw4QVSeajx+FDtDuspATbx0="
+      },
+      {
+        "name": "libuuid",
+        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.42.2-r3.apk",
+        "version": "2.42.2-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8563",
+          "checksum": "sha1-pms+1bXDk0H01cRFiUgbTk+X9Ic="
+        },
+        "data": {
+          "range": "bytes=8564-63098",
+          "checksum": "sha256-Y7wEE4OSx8JVo2Vo2XKK+QsS8klVZXtObABSaC7d5N8="
+        },
+        "checksum": "Q1pms+1bXDk0H01cRFiUgbTk+X9Ic="
+      },
+      {
+        "name": "e2fsprogs",
+        "url": "https://packages.wolfi.dev/os/x86_64/e2fsprogs-1.47.4-r1.apk",
+        "version": "1.47.4-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8264",
+          "checksum": "sha1-Q0787H1hQS0+/OeGVERX9ExonLg="
+        },
+        "data": {
+          "range": "bytes=8265-267133",
+          "checksum": "sha256-NQ3sNSl8cHuKOipD0agI4gYfZmqtS82x1h+Xhp27nnc="
+        },
+        "checksum": "Q1Q0787H1hQS0+/OeGVERX9ExonLg="
+      },
+      {
+        "name": "gh",
+        "url": "https://packages.wolfi.dev/os/x86_64/gh-2.97.0-r1.apk",
+        "version": "2.97.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5933",
+          "checksum": "sha1-FGpWTc3GzeOUDi/MONq88nfxeB0="
+        },
+        "data": {
+          "range": "bytes=5934-16013231",
+          "checksum": "sha256-+6X6Nws59sb24U8azAEIlmatyjsHdyrI5G0U8FGxT2o="
+        },
+        "checksum": "Q1FGpWTc3GzeOUDi/MONq88nfxeB0="
+      },
+      {
+        "name": "libpcre2-8-0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.47-r0.apk",
+        "version": "10.47-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6848",
+          "checksum": "sha1-5bkXL31L9lMVsxJdyleMiTb2Esg="
+        },
+        "data": {
+          "range": "bytes=6849-307246",
+          "checksum": "sha256-LBagnNrkJtEnWnNJIYKGEllGZqRH6y5+9I9lQ05+NIs="
+        },
+        "checksum": "Q15bkXL31L9lMVsxJdyleMiTb2Esg="
+      },
+      {
+        "name": "libexpat1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libexpat1-2.8.3-r0.apk",
+        "version": "2.8.3-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8290",
+          "checksum": "sha1-rYpLU3va57pFjMzLjqyGkCwgAnQ="
+        },
+        "data": {
+          "range": "bytes=8291-111331",
+          "checksum": "sha256-Xlpd9n5NLCqwQF1bbVZKY6Ba6LnAYhj67aa09CqnbAg="
+        },
+        "checksum": "Q1rYpLU3va57pFjMzLjqyGkCwgAnQ="
+      },
+      {
+        "name": "git",
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.55.0-r4.apk",
+        "version": "2.55.0-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8596",
+          "checksum": "sha1-m5iqPzPggZn/SxFmGCMhO07SYSY="
+        },
+        "data": {
+          "range": "bytes=8597-9774543",
+          "checksum": "sha256-UwJ6vOT1zKhqd61gt67HfislDBSi4xnYpbRDk4kXyVY="
+        },
+        "checksum": "Q1m5iqPzPggZn/SxFmGCMhO07SYSY="
+      },
+      {
+        "name": "oniguruma",
+        "url": "https://packages.wolfi.dev/os/x86_64/oniguruma-6.9.10-r4.apk",
+        "version": "6.9.10-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7542",
+          "checksum": "sha1-Dl/F1cSMSw1KYYR4nfQg5el0T70="
+        },
+        "data": {
+          "range": "bytes=7543-260384",
+          "checksum": "sha256-7/fP2cq5/cUgCjd/Crd6eq9h4Tn9u0CaWnztYuwpjaw="
+        },
+        "checksum": "Q1Dl/F1cSMSw1KYYR4nfQg5el0T70="
+      },
+      {
+        "name": "jq",
+        "url": "https://packages.wolfi.dev/os/x86_64/jq-1.8.2-r1.apk",
+        "version": "1.8.2-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8551",
+          "checksum": "sha1-M6mjaKk0DI3j3McWr+/tFxrwHJw="
+        },
+        "data": {
+          "range": "bytes=8552-249624",
+          "checksum": "sha256-OPDmbFRY23nvHQTTtlf9jyPZRmyjAvUnnpkyaEoveb0="
+        },
+        "checksum": "Q1M6mjaKk0DI3j3McWr+/tFxrwHJw="
+      },
+      {
+        "name": "libstdc++",
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9949",
+          "checksum": "sha1-0G/kziut8KEYt22cLifRa9QA+HQ="
+        },
+        "data": {
+          "range": "bytes=9950-1261924",
+          "checksum": "sha256-+PxUlxtKRnSh9H8NjtevLTb3x4S8Bl3jFaJMzHYEGlg="
+        },
+        "checksum": "Q10G/kziut8KEYt22cLifRa9QA+HQ="
+      },
+      {
+        "name": "mpdecimal",
+        "url": "https://packages.wolfi.dev/os/x86_64/mpdecimal-4.0.1-r3.apk",
+        "version": "4.0.1-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-3784",
+          "checksum": "sha1-EohWdOe6HHHuNwpodq7f2MTwLOQ="
+        },
+        "data": {
+          "range": "bytes=3785-127504",
+          "checksum": "sha256-RV3KKTtG76rqX9TYr2I//+hh890D1bOLpvZ+3Vvi9qs="
+        },
+        "checksum": "Q1EohWdOe6HHHuNwpodq7f2MTwLOQ="
+      },
+      {
+        "name": "libbz2-1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r23.apk",
+        "version": "1.0.8-r23",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8206",
+          "checksum": "sha1-f8G7w+xo1DrlIS77wzgn0TliSto="
+        },
+        "data": {
+          "range": "bytes=8207-48859",
+          "checksum": "sha256-RTIzG375JOo4rlMTuXplX0dzr20PewyC1brIL3fkmFQ="
+        },
+        "checksum": "Q1f8G7w+xo1DrlIS77wzgn0TliSto="
+      },
+      {
+        "name": "xz",
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.8.3-r1.apk",
+        "version": "5.8.3-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7092",
+          "checksum": "sha1-xMbaAqRKwa/Tx0fRXhz88d+0V3M="
+        },
+        "data": {
+          "range": "bytes=7093-388137",
+          "checksum": "sha256-Ur6ITPMaX3cot0jCgmDHBGOsx9DIjsfMrq07ciRfkgw="
+        },
+        "checksum": "Q1xMbaAqRKwa/Tx0fRXhz88d+0V3M="
+      },
+      {
+        "name": "libffi",
+        "url": "https://packages.wolfi.dev/os/x86_64/libffi-3.8.0-r0.apk",
+        "version": "3.8.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8884",
+          "checksum": "sha1-3K6PPkkaxTZGNtJpw7TqCu7SqLU="
+        },
+        "data": {
+          "range": "bytes=8885-46630",
+          "checksum": "sha256-ltapjq/kPeAASzaWS6cuACMLLmq3wANP71LdqgOHJmk="
+        },
+        "checksum": "Q13K6PPkkaxTZGNtJpw7TqCu7SqLU="
+      },
+      {
+        "name": "py3-pip-wheel",
+        "url": "https://packages.wolfi.dev/os/x86_64/py3-pip-wheel-26.2.1-r0.apk",
+        "version": "26.2.1-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12667",
+          "checksum": "sha1-gQS+ehIS8zQ88Ng2NSaEijR1clI="
+        },
+        "data": {
+          "range": "bytes=12668-1816390",
+          "checksum": "sha256-ej4LPj7g1gK7ItNg5VK29GcFzYmX4nJtzbFJ1AwsNkE="
+        },
+        "checksum": "Q1gQS+ehIS8zQ88Ng2NSaEijR1clI="
+      },
+      {
+        "name": "python-3.12-base",
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.14-r1.apk",
+        "version": "3.12.14-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11767",
+          "checksum": "sha1-Xy/Sx6FgXlcwsItoMEBO0i8jwzk="
+        },
+        "data": {
+          "range": "bytes=11768-12406387",
+          "checksum": "sha256-5+u/DeG3Kx3T0kAagko/Wqc3WqoNu6EnruYQOWhpbgI="
+        },
+        "checksum": "Q1Xy/Sx6FgXlcwsItoMEBO0i8jwzk="
+      },
+      {
+        "name": "python-3.12",
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.14-r1.apk",
+        "version": "3.12.14-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11608",
+          "checksum": "sha1-owHW26weP7ABY00mXkNY1FF1gRs="
+        },
+        "data": {
+          "range": "bytes=11609-13347",
+          "checksum": "sha256-ZUZPVTANkP9H7WHc2+f3zyw5QRpjnEgCIPyAO+sIElc="
+        },
+        "checksum": "Q1owHW26weP7ABY00mXkNY1FF1gRs="
+      }
+    ]
+  }
+}

--- a/projects/embervm/runtimes/pi/apko.yaml
+++ b/projects/embervm/runtimes/pi/apko.yaml
@@ -1,0 +1,141 @@
+# EmberVM pi runtime base image: a session-class guest that runs ONLY the pi
+# coding agent (the Qwen adapter, issue #4234) under the same shim and the same
+# frozen HTTP-over-vsock guest contract on port 1027 as ../claude.
+#
+# WHY THIS EXISTS SEPARATELY FROM ../claude, which already ships pi.
+#
+# The claude runtime carries all three CLIs, so a qwen turn pays for two it can
+# never invoke. Measured on the published image (300 MB compressed across seven
+# layers): claude 85.7 MB, codex 114.2 MB, pi 39.0 MB, wolfi base 59.7 MB, the
+# shim and guest-init the remainder. Dropping the two unusable CLI tars is a 200
+# MB cut, about 3x, and that is what makes the memMib arithmetic work: the
+# claude runtime is sized at 4096 MiB for a 262 MB Node ELF with a V8 heap on
+# top, while pi is a single Bun-compiled binary. The workload built on this
+# image runs at 256 MiB (chart piRuntimeWorkload), so a banked session snapshot
+# is 256 MiB rather than 4 GiB.
+#
+# The named consumer is the */5 synthetic probe (monolith
+# ember_public/synthetic_probe.py probe_qwen), which cold-boots a guest every
+# five minutes forever to run one trivial turn.
+#
+# THE PACKAGE SET IS DELIBERATELY IDENTICAL to ../claude/apko.yaml, and the
+# slimness comes ENTIRELY from omitting the claude and codex tars in BUILD. That
+# is a decision, not an oversight: the whole wolfi package set is 59.7 MB of the
+# 300, so trimming it buys little, while keeping it identical makes this image a
+# behavioural drop-in for a pi turn. A guest here has the same git, gh, curl and
+# jq a pi session would reach for, so the only thing that differs between the
+# two images is which CLIs exist. Diverge the package sets only with a reason
+# recorded here.
+#
+# AMD64-ONLY, matching ../claude and ../../image. pi itself ships dual-arch (its
+# payload sits at the arch-independent path pi/pi in both release tarballs), so
+# unlike the claude CLI it is not what constrains this. Every cluster node and
+# the RBE build executor are amd64, and the shared guest-init is built through
+# an amd64 platform transition, so an aarch64 variant would have no consumer and
+# no layer to carry. To add one, flip arm64 = True in BUILD and add aarch64
+# here TOGETHER with a per-arch guest-init tar.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - busybox
+    - ca-certificates-bundle
+    # pi is Bun-compiled and dynamically linked, so glibc is pinned explicitly
+    # rather than left to arrive transitively: a base that happens to pull it
+    # today would break the guest silently if that transitive edge ever changed.
+    # Same reasoning as ../claude/apko.yaml.
+    - glibc
+    # The Bash tool shells out to bash specifically, not /bin/sh. busybox alone
+    # gives an ash-flavoured sh and the tool's commands assume bash.
+    - bash
+    # Per-turn commits onto the session branch are how agent-diff produces an
+    # exact diffstat (git show <sha> --stat) with no model involvement.
+    - git
+    # Opening a PR from inside a session. gh reads GH_TOKEN/GITHUB_TOKEN, but the
+    # guest never holds one: the egress-proxy sidecar sets the Authorization
+    # header on the way out (ADR 023 phase 6b), so whatever gh sends is discarded.
+    - gh
+    # curl, because the image otherwise has NO http client at all: probing an
+    # endpoint from inside a session meant hand-writing python urllib.
+    - curl
+    # jq, because essentially every gh/API workflow pipes through it.
+    - jq
+    # Kept even though piRuntimeWorkload ships with persistence OFF (a tmpfs
+    # workspace, no volume device to probe or format). guest-init's volume path
+    # is shared with ../claude and formats a blank device on first boot, so
+    # dropping these would turn a later persistenceEnabled flip into a
+    # first-boot failure inside the guest, where it is expensive to see.
+    - e2fsprogs
+    - blkid
+    # The shim is stdlib python, matching the runtimes/python pattern.
+    - python-3.12
+
+archs:
+  - x86_64
+
+accounts:
+  groups:
+    - groupname: runtime
+      gid: 65532
+  users:
+    - username: runtime
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  HOME: /home/runtime
+  PYTHONUNBUFFERED: "1"
+  # Guests are driven headlessly over vsock. No TTY is attached, so anything that
+  # would try to render a terminal UI must not be reached.
+  TERM: dumb
+  # EMBER_CLAUDE_WORKSPACE, not an EMBER_PI_* name, because the SHIM IS SHARED:
+  # runtimes/claude/shim.py reads this exact variable (ProcessManager reads
+  # EMBER_CLAUDE_WORKSPACE, DEFAULT_WORKSPACE as the fallback) and this image
+  # ships that same file. Renaming it here would leave the shim on its default
+  # and the rename would look like it worked.
+  EMBER_CLAUDE_WORKSPACE: /workspace
+  # NOTE: egress auth is NOT here, same as ../claude. This block is OCI image
+  # config, which only the docker/crane path reads; a raw Firecracker boot starts
+  # init=ember-runtime-guest-init and never sees it. Those values live in
+  # guest-init's setDefaultEnv, which is what actually delivers them. Adding a
+  # runtime-relevant variable here alone is a silent no-op.
+
+paths:
+  - path: /home/runtime
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  # Kept despite no claude CLI in this image: guest-init seeds the trust record
+  # into $HOME/.claude.json unconditionally (volume_linux.go seedTrustRecord
+  # returns an error if the seed is missing), and the shim is shared, so the
+  # directory has to exist for the same reason the seed tar is still shipped.
+  - path: /home/runtime/.claude
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  # Mount point for the guest's ONE writable filesystem. It MUST exist in the
+  # image: the rootfs is read-only on every boot, so an init that tried to mkdir
+  # its own mount point would fail with the same EROFS that this whole
+  # arrangement exists to avoid. With persistence off this is where the tmpfs
+  # lands rather than a per-session disk.
+  - path: /session
+    type: directory
+    uid: 0
+    gid: 0
+    permissions: 0o755
+
+entrypoint:
+  # OCI entrypoint for any NON-Firecracker execution path (docker/crane). On a raw
+  # Firecracker boot the kernel ignores this and boots init=<HarnessInit>; both
+  # paths end at the same shim.
+  command: /usr/bin/python3 /usr/local/bin/ember-claude-shim

--- a/projects/embervm/runtimes/pi/package_parity_test.py
+++ b/projects/embervm/runtimes/pi/package_parity_test.py
@@ -1,0 +1,75 @@
+"""Guard: the pi runtime's wolfi package set matches the claude runtime's.
+
+The pi image exists to drop two CLI tars (claude and codex, 200 MB of the
+claude runtime's 300 MB compressed), NOT to hand-trim the wolfi base, which is
+59.7 MB of that total. Keeping the package sets identical is what makes this
+image a behavioural drop-in for a pi turn: the same git, gh, curl and jq are
+present, so the only difference between the two guests is which CLIs exist.
+
+Without this test the claim is a comment. A package added to the claude runtime
+and not here would surface as a pi turn missing a binary the claude runtime has,
+inside a guest, which is the most expensive place to find out.
+
+Divergence is allowed. It just has to be deliberate: add an entry to
+EXPECTED_DIVERGENCE with the reason, which makes the difference reviewable in
+the diff rather than discoverable in production.
+"""
+
+from pathlib import Path
+
+import yaml
+
+# Package -> why it is in one image and not the other. Empty today: the sets are
+# identical on purpose (see apko.yaml). A future entry reads like
+#   "gh": "pi's 4-tool loop never opens a PR, and gh is ~20 MB",
+EXPECTED_DIVERGENCE: dict[str, str] = {}
+
+
+def _packages(path: Path) -> set[str]:
+    config = yaml.safe_load(path.read_text())
+    return set(config["contents"]["packages"])
+
+
+def _runfile(relative: str) -> Path:
+    """Resolve a repo-relative path from the test's runfiles."""
+    here = Path(__file__).resolve().parent
+    for candidate in (here, *here.parents):
+        hit = candidate / relative
+        if hit.exists():
+            return hit
+    raise AssertionError(f"{relative} not found in runfiles under {here}")
+
+
+def test_package_sets_match_the_claude_runtime():
+    pi = _packages(_runfile("projects/embervm/runtimes/pi/apko.yaml"))
+    claude = _packages(_runfile("projects/embervm/runtimes/claude/apko.yaml"))
+
+    only_pi = pi - claude - set(EXPECTED_DIVERGENCE)
+    only_claude = claude - pi - set(EXPECTED_DIVERGENCE)
+
+    assert not only_pi, (
+        f"packages in the pi runtime but not the claude runtime: {sorted(only_pi)}. "
+        "Add them to the claude runtime too, or record the reason in "
+        "EXPECTED_DIVERGENCE."
+    )
+    assert not only_claude, (
+        f"packages in the claude runtime but not the pi runtime: {sorted(only_claude)}. "
+        "A pi session reaches for the same tools a claude session does, so add "
+        "them here too, or record the reason in EXPECTED_DIVERGENCE."
+    )
+
+
+def test_pi_runtime_is_amd64_only():
+    """An aarch64 arch here without a per-arch guest-init tar fails at PUSH time.
+
+    The claude runtime records the same constraint. It is asserted rather than
+    only commented because the failure is a missing layer blob at push, long
+    after PR CI has gone green (see the arm64 note in bazel/tools/oci).
+    """
+    config = yaml.safe_load(
+        _runfile("projects/embervm/runtimes/pi/apko.yaml").read_text()
+    )
+    assert config["archs"] == ["x86_64"], (
+        "the pi runtime is amd64-only; adding aarch64 needs a per-arch "
+        "guest-init tar and arm64 = True in BUILD, together"
+    )


### PR DESCRIPTION
Second of three. Follows #4982 (footprint trim); a monolith-side routing PR follows this one.

## The waste this targets

`agent_sessions/__init__.py:16` maps model `qwen` to family `pi`, and every family goes through the single `claude-runtime` workload at **memMib 4096**. `ember_public/synthetic_probe.py:277` runs `probe_qwen()` on the `*/5` CronWorkflow. So every five minutes, forever, one trivial turn cold-boots a 4 GiB guest carrying a 262 MB Claude ELF and a 114 MB codex binary that a pi turn can never invoke.

Layer sizes on the published `runtimes/claude` image (300 MB compressed):

| layer | MB |
|---|---|
| codex CLI | 114.2 |
| claude CLI | 85.7 |
| wolfi base | 59.7 |
| **pi CLI** | **39.0** |
| guest-init | 2.3 |
| shim + guest config | 0.16 |

## What this adds

**`projects/embervm/runtimes/pi`** — the same guest with the two unusable CLI tars dropped, about 200 MB of the 300.

The shim, trust-record seed and guest-init are the **same build artifacts**, taken from the claude runtime package rather than rebuilt, so the two images cannot drift. No shim fork was needed: `ProcessManager` already constructs its claude/codex/pi adapters lazily and only spawns the CLI a turn selects.

The wolfi package set is **deliberately identical**. It is only 59.7 MB of the total, so trimming it buys little, while keeping it identical makes the image a behavioural drop-in for a pi turn. `package_parity_test` holds that claim instead of leaving it a comment, with an `EXPECTED_DIVERGENCE` map so a future divergence has to be deliberate and reviewable.

**`piRuntimeWorkload`** — session class, **memMib 256**, floor 0, cap 2, persistence off.

## Why 256 holds, and where it stops

What lives in guest RAM is the Bun-compiled pi binary, the stdlib-python shim, and the tmpfs over `/tmp` and `/workspace`. pi's code pages are mmapped from the rootfs **block device**, so they are reclaimable page cache rather than resident, and `PI_CONTEXT_WINDOW` caps context at 30000 tokens against Qwen's 32768, so the JS heap has a ceiling rather than a frontier model's appetite. The CRD floors `memMib` at 128 (`crds/workload-crd.yaml:215`), so this is legal, not a special case.

It stops holding the moment a session hydrates a repository: with persistence off, `/workspace` **is** the tmpfs, so a checkout spends these same 256 MiB with no disk to fall back on. **This is the small-task lane** (probes, short conversational turns). A repo-attached qwen session belongs on claude-runtime. The ladder if it proves tight is values-only: 256 -> 512 -> a `persistenceEnabled` flip with a `workspaceSizeBytes`.

Persistence off also means ADR 027's `memory:true` quadrant: a bank is 256 MiB of snapshot, cheap enough that the simple path is right, and it keeps this workload clear of the placeholder-volume-drive coupling that claude-runtime carries.

## The egress trap this closes

`_noded-pod.tpl` derived `EMBERVM_NODED_EGRESS_WORKLOADS` from `claudeRuntimeWorkload.name` **alone**. A second runtime workload would have been outside the allowlist, and that does not deny loudly, it dial-times-out inside the guest, while pi reaches the in-cluster vLLM endpoint over exactly that lane. The list is now derived from all enabled runtime workloads, keeping the chart's "derived, never hand-copied" property. The `__no_workload__` sentinel path is unchanged.

Rendered: `EMBERVM_NODED_EGRESS_WORKLOADS = "claude-runtime,pi-runtime"`.

## Nothing routes here yet, on purpose

The monolith still sends every family to `claude-runtime`. embervm and monolith are separate ArgoCD apps with independent rollouts, so shipping the routing flip in this PR would let whichever synced first decide whether qwen sessions 404 on an unknown workload for a few minutes. It also means the 256 MiB sizing is proven by a real session create **before** the `*/5` probe depends on it.

## Dev

Dev enables this workload, its one session workload, because dev is where "does a guest boot and report ready in 256 MiB" gets answered on a brick with room (1gi = 768 MiB guest-schedulable after #4982). Dev has no egress lane, so it proves base build, cold boot, readiness and create/destroy, **not** a turn.

`workloads.runtimePi.rootfsPath` is set for dev regardless of the CR, because base BUILDERS are gated separately from Workload CRs; left inherited it would be unbacked in the container and mkfs would write a multi-GB image to node-4's root filesystem.

## Verification

- `ci test`: `Executed 6 out of 727 tests: 727 tests pass` (727 vs 725 on main: the two new guards registered and ran)
- The apko image built on the remote runner, 55 packages, `arch=x86_64` only
- `helm template` against prod and dev values confirms the CR, the `build-runtime-pi-rootfs` initContainer, the dev-scoped rootfs path, and the egress list above

## Rollback

`piRuntimeWorkload.enabled: false` in both deploy values files. The image and chart plumbing are inert without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CVxWW96h5c9Ybhu4bxBzr