### PR TITLE
fix(apko): upgrade erlang to 27.3.4.16 and scope the lock sweep

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,12 +26,17 @@ repos:
         files: 'pyproject\.toml$'
         pass_filenames: false
 
+      # pass_filenames is true so a commit only re-locks the configs it actually
+      # touches. Repo-wide is still available by running the script with no
+      # arguments; it is the renovate-apko-lock-maintenance CronWorkflow's job,
+      # not something a single commit should drag along (each rewritten lock
+      # re-bakes that guest's rootfs on every brick).
       - id: update-apko-locks
         name: Update apko locks
         entry: bazel/tools/format/update-apko-locks.sh
         language: script
         files: 'apko\.yaml$'
-        pass_filenames: false
+        pass_filenames: true
 
       - id: update-atlas-sum
         name: Update Atlas migration checksums

--- a/bazel/erlang/repositories.bzl
+++ b/bazel/erlang/repositories.bzl
@@ -183,14 +183,21 @@ exports_files(["bin/protoc"], visibility = ["//visibility:public"])
 
 def _erlang_impl(_ctx):
     http_archive(
-        # OTP version MUST match the apko image's Wolfi erlang-27 (27.3.4.2)
+        # OTP version MUST match the apko image's Wolfi erlang-27 (27.3.4.16)
         # exactly: an include_erts:false release pins exact OTP app versions in
         # its .boot, so a build/runtime patch mismatch fails the pod at boot. If
         # Wolfi's erlang-27 bumps, re-pin both this and the image package together.
+        #
+        # The pin is only re-pinnable while BOTH sides still publish the version.
+        # 27.3.4.2 was dropped from the Wolfi APKINDEX (its apk still resolves on
+        # the CDN, which is why nothing broke), so `apko lock` could no longer
+        # satisfy the image's `erlang-27=27.3.4.2-r0` constraint and every lock
+        # refresh failed. Choose a version present in BOTH the Wolfi index and
+        # builds.hex.pm/builds/otp/ubuntu-22.04, not merely the newest of one.
         name = "otp_ubuntu2204_amd64",
-        urls = ["https://builds.hex.pm/builds/otp/ubuntu-22.04/OTP-27.3.4.2.tar.gz"],
-        sha256 = "32c3ee239855556350f9700cf942a0a70b60228a277f314397a709e992345dfc",
-        strip_prefix = "OTP-27.3.4.2",
+        urls = ["https://builds.hex.pm/builds/otp/ubuntu-22.04/OTP-27.3.4.16.tar.gz"],
+        sha256 = "16b455351679b5e200594a5f6b742fd0f9f8d42b0dd2b35eebbbcd2288bb44bd",
+        strip_prefix = "OTP-27.3.4.16",
         build_file_content = _OTP_BUILD,
     )
     http_archive(

--- a/bazel/tools/format/update-apko-locks.sh
+++ b/bazel/tools/format/update-apko-locks.sh
@@ -35,6 +35,23 @@ while IFS= read -r config; do
 	# would flip them all back on its next run. Strip it so both agree.
 	config="${config#./}"
 
+	# A real apko config has a top-level `contents:` block. The find below also
+	# matches Helm templates that merely BEGIN with "apko-" (the renovate
+	# apko-lock CronWorkflow and its ConfigMap), which are Kubernetes manifests
+	# apko can never resolve. Left in, they failed on every run, and because this
+	# script exits non-zero when ANY config fails, the update-apko-locks
+	# pre-commit hook rejected every commit that touched any apko.yaml anywhere
+	# in the repo.
+	#
+	# Filter on SHAPE, not on path: a path exclusion holds only until the next
+	# misnamed file lands somewhere else. Skips are logged rather than silent, so
+	# a REAL config that somehow fails this test shows up as a visible line
+	# instead of quietly never being locked again.
+	if ! grep -qE '^contents:' "$config"; then
+		echo "  Skipping (no top-level 'contents:', not an apko config): $config"
+		continue
+	fi
+
 	echo "  Updating lock for: $config"
 
 	# Do NOT pipe bazel straight into a filter. A pipeline's exit status is the
@@ -53,11 +70,25 @@ while IFS= read -r config; do
 "
 	fi
 done < <(
-	# Find all apko config files (including architecture-specific ones, excluding lock files)
-	find . \( -name "apko.yaml" -o -name "apko-*.yaml" \) \
-		-not -path "*/node_modules/*" \
-		-not -path "*/.git/*" \
-		-not -name "*.lock.json"
+	# With arguments (the pre-commit hook passes the configs being committed),
+	# lock exactly those. With none, lock everything.
+	#
+	# Scope matters more than it looks. A repo-wide refresh rewrites every lock
+	# to whatever Wolfi ships today, and each rewritten lock re-bakes that
+	# guest's multi-GB rootfs on every brick. Committing one apko.yaml should not
+	# quietly drag a fleet-wide re-bake along with it. Keeping everything current
+	# is the renovate-apko-lock-maintenance CronWorkflow's job, on its own
+	# schedule, where the resulting diff gets reviewed as its own change.
+	if [ "$#" -gt 0 ]; then
+		printf '%s\n' "$@"
+	else
+		# All apko config files (including architecture-specific ones, excluding
+		# lock files). Non-configs are filtered by shape in the loop above.
+		find . \( -name "apko.yaml" -o -name "apko-*.yaml" \) \
+			-not -path "*/node_modules/*" \
+			-not -path "*/.git/*" \
+			-not -name "*.lock.json"
+	fi
 )
 
 if [ "$failed_count" -ne 0 ]; then

--- a/projects/embervm/image/apko.lock.json
+++ b/projects/embervm/image/apko.lock.json
@@ -1,14 +1,15 @@
 {
   "version": "v1",
   "config": {
-    "name": "apko.yaml",
-    "checksum": "sha256-cxEGGLub3oIHQGJmG1LTMKAeGR0qESXbuUvyjQLhUgo="
+    "name": "projects/embervm/image/apko.yaml",
+    "checksum": "sha256-eRa9Cn1WymQZi3kxo+5QKxGxKgDU5/Hxa+HVkDwG0XY="
   },
   "contents": {
     "keyring": [
       {
         "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
-        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"
+        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "content": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA5qQUHmzqX9oa/RS3OSgL\nYTYB1mzvVmnWC0JXsAafdgRkavJ9xRhsXMKXWPKMghZw6UnkxuxQCZlB9UhaFqed\nX7SWfQ8qRgECFmdGUjoeV7P3VUkg17RU0mUKsXZZF/2mU+jCGyk5eweKcLWrk6bn\nlNNF1vBJ9EXbHdfvbQsA5GfLku5tJhqRJ4FVQAGCw+1JoSKu+o3q+6xP7z6kMfR9\ncp54FSj48rTJUibbAv+cPtZ3AnbpjdyarV7SYMfxp14Q/KR0CJYDihG3CFoU+TaM\ndr7LUrgXaYw7m7g8hA2PY1jF8aqDqVFjVu/csPKnKVQSqNHfm4C4gljwT6TDVhPe\n6xKSGKfAUNvHx2RIqSsZJCh68Af+VnfuimbHMYzGhzV4/efihpJlYsDnOXJj/PeY\nSbEIYG2yoI3AYvDFyFX2OAOtQ9d4TPs4zS4aDg4R3UseXLib46FX3ZTfIi1/W0IO\neC3AFU5mK+02jq+7swcGbgzem30dFA/B3n8NQExJjF2WlGNJxFw2WnJQqKIkIh0s\nkm5jaxJ28xYgik+bEgxy1LsilKTowdkbEPRKv36JGdap4dOEGR+LwZsM+ontF1AO\nwY6tvwtZKJWhgj7ES3BdtiC1GA2htFnP90lA7KnKbSMOxwWtSCH8spitdPdzgI8G\nSxrOb0SZs6ZFAxYYe3GlvS0CAwEAAQ==\n-----END PUBLIC KEY-----\n"
       }
     ],
     "build_repositories": [],
@@ -42,22 +43,22 @@
       },
       {
         "name": "ca-certificates-bundle",
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20260413-r0.apk",
-        "version": "20260413-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20260413-r1.apk",
+        "version": "20260413-r1",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-7872",
-          "checksum": "sha1-KyCdEL20IKE+B7DKW97GLXu2QLM="
+          "range": "bytes=0-8322",
+          "checksum": "sha1-u3xyVyewNfx7ZzTDikWdOlY9Tt8="
         },
         "data": {
-          "range": "bytes=7873-137518",
-          "checksum": "sha256-foyxNKCWc3UQM3Kq5on+Gt/2d+HlzCUl+1lqiaviWE8="
+          "range": "bytes=8323-137882",
+          "checksum": "sha256-FfsoSAq28t7qTE1H+hPbrozu3BjgGiACoDMkS37a2G0="
         },
-        "checksum": "Q1KyCdEL20IKE+B7DKW97GLXu2QLM="
+        "checksum": "Q1u3xyVyewNfx7ZzTDikWdOlY9Tt8="
       },
       {
         "name": "libgcc",
@@ -80,98 +81,98 @@
       },
       {
         "name": "glibc-locale-posix",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.43-r11.apk",
-        "version": "2.43-r11",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.43-r13.apk",
+        "version": "2.43-r13",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-13015",
-          "checksum": "sha1-npirsSp9Qt3Aa1n8CaC2i99nv8A="
+          "range": "bytes=0-13847",
+          "checksum": "sha1-CGPlUnu0Faw2u47/1gZyhEG6E4s="
         },
         "data": {
-          "range": "bytes=13016-89758",
-          "checksum": "sha256-qXzcGBEELIJays9BPEo77JB6Qr5gMKFbZteJHEuthAI="
+          "range": "bytes=13848-90588",
+          "checksum": "sha256-H7oYz7/ni/jF30u1vgbCWVrxJsSbIpVMp/o/eJXfzSg="
         },
-        "checksum": "Q1npirsSp9Qt3Aa1n8CaC2i99nv8A="
+        "checksum": "Q1CGPlUnu0Faw2u47/1gZyhEG6E4s="
       },
       {
         "name": "glibc",
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.43-r11.apk",
-        "version": "2.43-r11",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.43-r13.apk",
+        "version": "2.43-r13",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-13257",
-          "checksum": "sha1-XSTHGW6PUOUepKQvlUCPEpu+my0="
+          "range": "bytes=0-14085",
+          "checksum": "sha1-a0yBsX7dCvBm6DPj8TXOWNRLfgc="
         },
         "data": {
-          "range": "bytes=13258-3077429",
-          "checksum": "sha256-C538Z51QWuZPy/fxQGBCBbpulG8dVbn1OeaW+JsKoXQ="
+          "range": "bytes=14086-3078266",
+          "checksum": "sha256-+B5nvgV68oQMvFdLImb5wt0Ke1mX3SvVfEEjN5EG5dU="
         },
-        "checksum": "Q1XSTHGW6PUOUepKQvlUCPEpu+my0="
+        "checksum": "Q1a0yBsX7dCvBm6DPj8TXOWNRLfgc="
       },
       {
         "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-r11.apk",
-        "version": "2.43-r11",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-r13.apk",
+        "version": "2.43-r13",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-13051",
-          "checksum": "sha1-Dc94e4JF2fG8/SX4PWCAtLjItu4="
+          "range": "bytes=0-13894",
+          "checksum": "sha1-1r5jeZwjbaY6zH3ne5YLs8l/snc="
         },
         "data": {
-          "range": "bytes=13052-147283",
-          "checksum": "sha256-oI72DIuJLqlUM/LSFYKdgbxsaYUZgfThezkV95CHQPk="
+          "range": "bytes=13895-148125",
+          "checksum": "sha256-q9CKt6E5CknoVG1++3Ggasgiper58dhYbb7I6KKAZAU="
         },
-        "checksum": "Q1Dc94e4JF2fG8/SX4PWCAtLjItu4="
+        "checksum": "Q11r5jeZwjbaY6zH3ne5YLs8l/snc="
       },
       {
         "name": "libxcrypt",
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.5.2-r3.apk",
-        "version": "4.5.2-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.5.2-r4.apk",
+        "version": "4.5.2-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8536",
-          "checksum": "sha1-I0YlF5JXljMqn3nnsq4AWUw6X/8="
+          "range": "bytes=0-9765",
+          "checksum": "sha1-8mwy9m46Q+nYofoWKiURDdXCCBk="
         },
         "data": {
-          "range": "bytes=8537-106099",
-          "checksum": "sha256-mzRytDzhPafMZpD3kpn03C6x2XCNuG0nZ1F3Bjo+Jx4="
+          "range": "bytes=9766-107326",
+          "checksum": "sha256-CQcWRLKhYiydnvRpfxynMDvtYNe2x126F4BgtZq7+VY="
         },
-        "checksum": "Q1I0YlF5JXljMqn3nnsq4AWUw6X/8="
+        "checksum": "Q18mwy9m46Q+nYofoWKiURDdXCCBk="
       },
       {
         "name": "libcrypt1",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.43-r11.apk",
-        "version": "2.43-r11",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.43-r13.apk",
+        "version": "2.43-r13",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-13067",
-          "checksum": "sha1-/MS3Zb1Y/+sboqr3bltHEFCEkqE="
+          "range": "bytes=0-13899",
+          "checksum": "sha1-yqugUaqNhsY3a8bibioPNCKsMck="
         },
         "data": {
-          "range": "bytes=13068-14685",
-          "checksum": "sha256-ePacrwddp1Us3l5Rg2i8ieOZi17FUQjiVMtw2syPQBE="
+          "range": "bytes=13900-15515",
+          "checksum": "sha256-ocCtK3zyh3IPTW8tjbI9IDT/fKk2kP1Gfzqg6KPWrYA="
         },
-        "checksum": "Q1/MS3Zb1Y/+sboqr3bltHEFCEkqE="
+        "checksum": "Q1yqugUaqNhsY3a8bibioPNCKsMck="
       },
       {
         "name": "busybox",
@@ -194,22 +195,22 @@
       },
       {
         "name": "zlib",
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.2-r3.apk",
-        "version": "1.3.2-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.2-r4.apk",
+        "version": "1.3.2-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-8782",
-          "checksum": "sha1-d+xgnhv2qmmnyUpkIEMLv/Ccfts="
+          "range": "bytes=0-9127",
+          "checksum": "sha1-uur/HAJCSzF/hyt+ffNYqiqGYAs="
         },
         "data": {
-          "range": "bytes=8783-70985",
-          "checksum": "sha256-GtMaz7tc+6/gw51/jRq2trQH8bshZpL66etBeg87OHE="
+          "range": "bytes=9128-73248",
+          "checksum": "sha256-t35y9rhtwo05Lya7W99+zKvNIDde4vCmx+XTNgozvAc="
         },
-        "checksum": "Q1d+xgnhv2qmmnyUpkIEMLv/Ccfts="
+        "checksum": "Q1uur/HAJCSzF/hyt+ffNYqiqGYAs="
       },
       {
         "name": "libstdc++",
@@ -232,79 +233,79 @@
       },
       {
         "name": "libcrypto3",
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.6.3-r3.apk",
-        "version": "3.6.3-r3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.6.3-r4.apk",
+        "version": "3.6.3-r4",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-10990",
-          "checksum": "sha1-8czJwPp28PlmrUy6evlca3lfXlk="
+          "range": "bytes=0-11066",
+          "checksum": "sha1-q1tmKlM5V4hYJDAT4mFLNXfTWWs="
         },
         "data": {
-          "range": "bytes=10991-2439998",
-          "checksum": "sha256-Gtu+CyjMO2oH9qFjvJKo2t0zE0aDLG2dwtmDVnll8/4="
+          "range": "bytes=11067-2440291",
+          "checksum": "sha256-PiuIGCXSaU+bBWb7Rt3pX07C96fH1RTr6tjAH5fG8w4="
         },
-        "checksum": "Q18czJwPp28PlmrUy6evlca3lfXlk="
+        "checksum": "Q1q1tmKlM5V4hYJDAT4mFLNXfTWWs="
       },
       {
         "name": "ncurses-terminfo-base",
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.6.20260711-r0.apk",
-        "version": "6.6.20260711-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.6.20260815-r0.apk",
+        "version": "6.6.20260815-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-10344",
-          "checksum": "sha1-pVN+YvFtG69jaMZJt1Tqh20wICg="
+          "range": "bytes=0-10345",
+          "checksum": "sha1-QfSrArGa3wpHUhL/3OLIlWodOLA="
         },
         "data": {
-          "range": "bytes=10345-117892",
-          "checksum": "sha256-60tsu38al1Llm+/RtctrJ6trjIy+aNm+CwLwZSIN3C0="
+          "range": "bytes=10346-118136",
+          "checksum": "sha256-94VmBsGvvPAeGOI3lBlml62NN1wYMApUnj1ovcVI7Co="
         },
-        "checksum": "Q1pVN+YvFtG69jaMZJt1Tqh20wICg="
+        "checksum": "Q1QfSrArGa3wpHUhL/3OLIlWodOLA="
       },
       {
         "name": "ncurses",
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.6.20260711-r0.apk",
-        "version": "6.6.20260711-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.6.20260815-r0.apk",
+        "version": "6.6.20260815-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-10489",
-          "checksum": "sha1-oPiv8opB0FpEKDHei2gycB7Lcsk="
+          "range": "bytes=0-10496",
+          "checksum": "sha1-gn/XV1ycgCwqAncfALw5TA5CASs="
         },
         "data": {
-          "range": "bytes=10490-621030",
-          "checksum": "sha256-tq1Y6IreKkDvbO6vHEb/+oysUnBVBfw7uPrxYQ9s3oQ="
+          "range": "bytes=10497-622079",
+          "checksum": "sha256-If2ejH5whFYe4d+4MU0Y5CgzWbYXohWDW0Q3JIQo43c="
         },
-        "checksum": "Q1oPiv8opB0FpEKDHei2gycB7Lcsk="
+        "checksum": "Q1gn/XV1ycgCwqAncfALw5TA5CASs="
       },
       {
         "name": "erlang-27",
-        "url": "https://packages.wolfi.dev/os/x86_64/erlang-27-27.3.4.2-r0.apk",
-        "version": "27.3.4.2-r0",
+        "url": "https://packages.wolfi.dev/os/x86_64/erlang-27-27.3.4.16-r0.apk",
+        "version": "27.3.4.16-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-3584",
-          "checksum": "sha1-rJdBe8yrCE2eeSuWmqBVnFaho5Y="
+          "range": "bytes=0-7586",
+          "checksum": "sha1-L7QhYZS6oQ3RYSJDDYrFVIbGe+Y="
         },
         "data": {
-          "range": "bytes=3585-55274638",
-          "checksum": "sha256-nolWnrLMGP3mMiTiRKWQdzagj1wl44H42OhTEoEZnyw="
+          "range": "bytes=7587-55439421",
+          "checksum": "sha256-gHg5iJEK0/3K6a9loGBX46EdUQCc4SNc4WtCl9HRUGk="
         },
-        "checksum": "Q1rJdBe8yrCE2eeSuWmqBVnFaho5Y="
+        "checksum": "Q1L7QhYZS6oQ3RYSJDDYrFVIbGe+Y="
       }
     ]
   }

--- a/projects/embervm/image/apko.yaml
+++ b/projects/embervm/image/apko.yaml
@@ -11,10 +11,17 @@
 # run. If an arm64 node ever joins, this must become a per-arch release build (a
 # per-arch NIF), the bazel/ocaml pattern; until then, one arch is simpler.
 #
-# erlang-27 is pinned to 27.3.4.2-r0 to EXACTLY match the build OTP
+# erlang-27 is pinned to 27.3.4.16-r0 to EXACTLY match the build OTP
 # (bazel/erlang/repositories.bzl): an include_erts:false release pins exact OTP
 # app versions in its .boot script, so a build/runtime patch mismatch crash-loops
 # the pod at boot. Re-pin both together when Wolfi bumps erlang-27.
+#
+# Do not let this drift far. Wolfi drops old versions from its APKINDEX while
+# leaving the apk itself resolvable on the CDN, so a stale exact pin keeps
+# BUILDING long after `apko lock` stops being able to satisfy it. That is how
+# 27.3.4.2 got here: every lock refresh in the repo failed against this one
+# constraint while nothing visibly broke. Pick a version present in BOTH the
+# Wolfi index and builds.hex.pm/builds/otp/ubuntu-22.04.
 contents:
   repositories:
     - https://packages.wolfi.dev/os
@@ -23,7 +30,7 @@ contents:
   packages:
     - ca-certificates-bundle
     - busybox
-    - erlang-27=27.3.4.2-r0
+    - erlang-27=27.3.4.16-r0
 
 archs:
   - x86_64


### PR DESCRIPTION
The `update-apko-locks` pre-commit hook currently fails for **anyone touching any
`apko.yaml`** in the repo, for two independent reasons. Found while adding the
per-language sandbox guests (#4981), fixed separately because neither is related
to that work.

## 1. The erlang pin could no longer be resolved

Wolfi drops old versions from its APKINDEX while leaving the apk itself
resolvable on the CDN. So `projects/embervm/image` kept **building** fine (the
pinned `erlang-27-27.3.4.2-r0.apk` URL still returns HTTP 200) while `apko lock`
could no longer satisfy the `erlang-27=27.3.4.2-r0` constraint.

That is the nasty shape of this failure: a stale exact pin breaks only at
*refresh* time, silently, and stays invisible right up until the blob is finally
purged, at which point it becomes a build outage with no code change behind it.

Both sides move together to **27.3.4.16**, as that file's own comment demands: an
`include_erts: false` release pins exact OTP app versions in its `.boot` script,
so a build/runtime patch mismatch crash-loops the pod at boot. 27.3.4.16 was
chosen because it is the newest version present in **both** the Wolfi index and
`builds.hex.pm/builds/otp/ubuntu-22.04`, not merely the newest of either.

## 2. The sweep matched files that are not apko configs

`find -name "apko-*.yaml"` also matches
`projects/platform/renovate/templates/apko-lock-{script,cronworkflow}.yaml`,
which are a ConfigMap and a CronWorkflow. apko can never resolve them, and since
the script exits non-zero when ANY config fails, those two alone were enough to
reject every commit.

They are now filtered by **shape** (a top-level `contents:` block) rather than by
path, because a path exclusion holds only until the next misnamed file lands
somewhere else. Skips are logged, so a real config that somehow fails the test
shows up as a visible line instead of quietly never being locked again.

## 3. Scoping, so the fix does not trade a loud failure for a silent one

Fixing the sweep alone would make the script *succeed* and rewrite all twelve
locks. Each rewritten lock re-bakes that guest's multi-GB rootfs on every brick,
so committing one `apko.yaml` would quietly drag a fleet-wide re-bake along with
it.

The hook now passes filenames and the script locks only the configs being
committed. Repo-wide is still available by running it with no arguments, which is
the `renovate-apko-lock-maintenance` CronWorkflow's job, on its own schedule,
where the resulting diff is reviewed as its own change.

After this, the hook reports **Passed** instead of Failed.

## Verification

`ci test`: `Executed 4 out of 725 tests: 725 tests pass`.

The OTP change invalidated and re-ran the whole Elixir pipeline rather than
cache-hitting it, which is the point:

```
From Executing genrule //projects/embervm/control:release_boot_smoke:
RELEASE BOOT OK: release booted and /healthz returned 200 on the executor
healthz_status=200
```

`release_boot_smoke` is exactly the check a build/runtime OTP mismatch would
fail. `//projects/embervm/control:release_tar`, the protoc-gen-elixir genrule,
and `//bazel/erlang:mix_test_smoke` all rebuilt against the new OTP too.

Refs #4981