### PR TITLE
feat(moving): rebuild the planner page against the approved design

### DIFF
--- a/projects/monolith/frontend/src/routes/friends/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/friends/+layout.svelte
@@ -1,0 +1,18 @@
+<script>
+  let { children } = $props();
+</script>
+
+<svelte:head>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link
+    rel="preconnect"
+    href="https://fonts.gstatic.com"
+    crossorigin="anonymous"
+  />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+</svelte:head>
+
+{@render children()}

--- a/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
+++ b/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
@@ -1,13 +1,22 @@
 <script>
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
+  import { onMount } from "svelte";
   import AccessPanel from "./AccessPanel.svelte";
   import {
     collisionWording,
+    formatCad,
+    formatDateRange,
+    formatShortDate,
     formatTaskDueDate,
+    ganttDatePosition,
+    ganttTimeline,
+    mergeAgendaItems,
     moveCountdown,
     progressSummary,
     sortOpenTasks,
+    sumSellValues,
+    taskDueView,
     titleCaseName,
   } from "./moving.js";
   import "./moving-theme.css";
@@ -18,27 +27,85 @@
   let progress = $state(data.state?.progress ?? 0);
   let pendingTaskIds = $state(new Set());
   let taskError = $state("");
+  let isPhone = $state(false);
+  let mobileTab = $state("today");
+  let tasksDialog = $state();
+  let sellDialog = $state();
+  let calendarDialog = $state();
+  let rolesDialog = $state();
+  let plotCard = $state();
+  let tooltip = $state(null);
 
+  const now = new Date();
   const currentScope = $derived(data.scope === "all" ? "all" : "mine");
-  const countdown = $derived(moveCountdown(data.state?.spans ?? []));
+  const spans = $derived(data.state?.spans ?? []);
+  const milestones = $derived(data.state?.milestones ?? []);
+  const roles = $derived(data.state?.roles ?? []);
+  const rawCollisions = $derived(data.state?.collisions ?? []);
+  const viewer = $derived(data.state?.viewer ?? "");
+  const countdown = $derived(moveCountdown(spans, now));
   const openTasks = $derived(sortOpenTasks(tasks));
   const progressView = $derived(progressSummary(progress, tasks));
-  const collisions = $derived(
-    (data.state?.collisions ?? [])
-      .map((collision) =>
-        collisionWording(
-          collision,
-          data.state?.tasks ?? [],
-          data.state?.spans ?? [],
-        ),
-      )
-      .filter(Boolean),
+  const sellTasks = $derived(tasks.filter((task) => task.track === "sell"));
+  const sellTotal = $derived(sumSellValues(tasks));
+  const timeline = $derived(ganttTimeline(spans, milestones, now));
+  const agendaItems = $derived(
+    mergeAgendaItems(milestones, spans, rawCollisions, tasks),
   );
+  const todayRows = $derived(
+    openTasks.map((task) => ({ task, due: taskDueView(task.due_on, now) })),
+  );
+  const overdueRows = $derived(
+    todayRows.filter(({ due }) => due.bucket === "overdue"),
+  );
+  const weekRows = $derived(
+    todayRows.filter(({ due }) => due.bucket === "week"),
+  );
+  const collisionRows = $derived(
+    rawCollisions
+      .map((collision) => ({
+        ...collision,
+        wording: collisionWording(collision, tasks, spans),
+      }))
+      .filter((collision) => collision.wording),
+  );
+  const milestonePoints = $derived(
+    milestones
+      .map((milestone) => ({
+        ...milestone,
+        position: ganttDatePosition(
+          milestone.occurs_on,
+          timeline.startsOn,
+          timeline.endsOn,
+        ),
+      }))
+      .filter((milestone) => milestone.position != null),
+  );
+  const legSpans = $derived(
+    spans
+      .filter((span) => span.kind === "move" || span.kind === "trip")
+      .toSorted((left, right) => left.starts_on.localeCompare(right.starts_on)),
+  );
+  const currentDateLabel = new Intl.DateTimeFormat("en-GB", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  }).format(now);
 
   $effect(() => {
     tasks = data.state?.tasks ?? [];
     progress = data.state?.progress ?? 0;
     taskError = "";
+  });
+
+  onMount(() => {
+    const narrow = matchMedia("(max-width: 700px)");
+    const applyPhone = () => {
+      isPhone = narrow.matches;
+    };
+    applyPhone();
+    narrow.addEventListener("change", applyPhone);
+    return () => narrow.removeEventListener("change", applyPhone);
   });
 
   function setScope(scope) {
@@ -73,8 +140,9 @@
         `/api/moving/tasks/${encodeURIComponent(task.id)}/${action}`,
         { method: "POST" },
       );
-      if (!response.ok)
+      if (!response.ok) {
         throw new Error(`task update failed: ${response.status}`);
+      }
     } catch {
       tasks = tasks.map((item) =>
         item.id === task.id ? { ...item, done_at: task.done_at } : item,
@@ -86,6 +154,53 @@
       remaining.delete(task.id);
       pendingTaskIds = remaining;
     }
+  }
+
+  function openDialog(dialog) {
+    for (const item of [tasksDialog, sellDialog, calendarDialog, rolesDialog]) {
+      if (item?.open) item.close();
+    }
+    dialog?.showModal();
+  }
+
+  function closeFromBackdrop(event) {
+    if (event.target === event.currentTarget) event.currentTarget.close();
+  }
+
+  function showTooltip(event, title, meta, detail = "") {
+    if (!plotCard) return;
+    const stage = plotCard.getBoundingClientRect();
+    const target = event.currentTarget.getBoundingClientRect();
+    tooltip = {
+      title,
+      meta,
+      detail,
+      left: Math.min(
+        Math.max(target.left + target.width / 2 - stage.left, 100),
+        stage.width - 100,
+      ),
+      top: target.top - stage.top,
+    };
+  }
+
+  function taskHueClass(task) {
+    return `hue-${task.track ?? "none"}`;
+  }
+
+  function spanHueClass(span) {
+    return `hue-${span.kind}`;
+  }
+
+  function calendarStateClass(milestone) {
+    if (milestone.gcal_state === "held") return "warn";
+    if (milestone.gcal_state === "synced") return "ok";
+    return "idle";
+  }
+
+  function calendarStateIcon(milestone) {
+    if (milestone.gcal_state === "held") return "!";
+    if (milestone.gcal_state === "synced") return "✓";
+    return "○";
   }
 </script>
 
@@ -103,409 +218,581 @@
   </main>
 {:else}
   <main class="moving">
-    <div class="moving-grid">
-      <header class="masthead cell">
-        <div>
-          <p class="kicker">Moving planner</p>
-          <h1>Crossing</h1>
-        </div>
-        <div class="viewer">
-          <span>{titleCaseName(data.state.viewer)}</span>
-          <span>{currentScope === "mine" ? "My plan" : "All plans"}</span>
-        </div>
-      </header>
+    <div class:phone={isPhone} class="app" data-mtab={mobileTab}>
+      <div class="grid fx">
+        <header class="cell c-head">
+          <b>Crossing</b>
+          <span>{titleCaseName(viewer)}'s plan</span>
+          <time class="r" datetime={now.toISOString()}>{currentDateLabel}</time>
+        </header>
 
-      <section class="hero cell" aria-labelledby="move-countdown">
-        <p class="section-label">The crossing</p>
-        <h2 id="move-countdown">{countdown.headline}</h2>
-        <p class="countdown-detail">{countdown.detail}</p>
+        <section class="cell c-hero" aria-labelledby="move-countdown">
+          {#if countdown.days == null}
+            <div class="hero-empty" id="move-countdown">
+              <strong>{countdown.headline}</strong>
+              <span>{countdown.detail}</span>
+            </div>
+          {:else if countdown.days > 0}
+            <h1 id="move-countdown">
+              <span class="hl"
+                >{countdown.days} {countdown.days === 1 ? "day" : "days"}</span
+              >&nbsp;to wheels&#8209;up.
+            </h1>
+          {:else if countdown.days === 0}
+            <h1 id="move-countdown">
+              <span class="hl">Wheels&#8209;up</span>&nbsp;today.
+            </h1>
+          {:else}
+            <h1 id="move-countdown">
+              <span class="hl"
+                >{Math.abs(countdown.days)}
+                {Math.abs(countdown.days) === 1 ? "day" : "days"}</span
+              >&nbsp;since wheels&#8209;up.
+            </h1>
+          {/if}
+        </section>
 
-        <div class="progress-heading">
-          <span>Progress</span>
-          <strong>{progressView.label}</strong>
-        </div>
-        <div
-          class="progress-track"
-          role="progressbar"
-          aria-label="Move progress"
-          aria-valuemin="0"
-          aria-valuemax="100"
-          aria-valuenow={progressView.percent}
-        >
-          <span style:width={`${progressView.percent}%`}></span>
-        </div>
-        {#if progressView.total === 0}
-          <p class="empty-copy">No tasks yet. The first step can start here.</p>
-        {/if}
-      </section>
-
-      <section class="today cell" aria-labelledby="today-heading">
-        <div class="today-header">
-          <div>
-            <p class="section-label">Paper list</p>
-            <h2 id="today-heading">Do Today</h2>
-          </div>
-          <div class="scope-toggle" aria-label="Task scope">
-            <button
-              type="button"
-              class:active={currentScope === "mine"}
-              aria-pressed={currentScope === "mine"}
-              onclick={() => setScope("mine")}>Mine</button
+        <section class="cell c-today" aria-labelledby="today-heading">
+          <div class="ch">
+            <h2 id="today-heading">Do today</h2>
+            <span class="seg-mini" role="group" aria-label="Task scope">
+              <button
+                type="button"
+                aria-pressed={currentScope === "mine"}
+                onclick={() => setScope("mine")}>Mine</button
+              >
+              <button
+                type="button"
+                aria-pressed={currentScope === "all"}
+                onclick={() => setScope("all")}>All</button
+              >
+            </span>
+            <span class="badge"
+              >{overdueRows.length
+                ? `${overdueRows.length} late`
+                : "clear"}</span
             >
-            <button
-              type="button"
-              class:active={currentScope === "all"}
-              aria-pressed={currentScope === "all"}
-              onclick={() => setScope("all")}>All</button
-            >
           </div>
-        </div>
-
-        {#if taskError}
-          <p class="task-error" role="alert">{taskError}</p>
-        {/if}
-
-        {#if openTasks.length > 0}
-          <ul class="task-list">
-            {#each openTasks as task (task.id)}
-              <li>
-                <label>
+          <div class="cta-body">
+            {#if taskError}
+              <p class="task-error" role="alert">{taskError}</p>
+            {/if}
+            {#if overdueRows.length > 0}
+              <div class="nsec-h">Late, clear these first</div>
+              {#each overdueRows as row (row.task.id)}
+                <div class="nrow">
                   <input
+                    id={`today-${row.task.id}`}
+                    type="checkbox"
+                    checked={row.task.done_at != null}
+                    disabled={pendingTaskIds.has(row.task.id)}
+                    onchange={() => toggleTask(row.task)}
+                  />
+                  <label class="t" for={`today-${row.task.id}`}>
+                    {row.task.title}
+                    {#if row.task.owner !== viewer}
+                      <span class="w">{titleCaseName(row.task.owner)}</span>
+                    {/if}
+                  </label>
+                  <span class="due overdue">{row.due.label}</span>
+                </div>
+              {/each}
+            {/if}
+            {#if weekRows.length > 0}
+              <div class="nsec-h">Then, this week</div>
+              {#each weekRows as row (row.task.id)}
+                <div class="nrow">
+                  <input
+                    id={`today-${row.task.id}`}
+                    type="checkbox"
+                    checked={row.task.done_at != null}
+                    disabled={pendingTaskIds.has(row.task.id)}
+                    onchange={() => toggleTask(row.task)}
+                  />
+                  <label class="t" for={`today-${row.task.id}`}>
+                    {row.task.title}
+                    {#if row.task.owner !== viewer}
+                      <span class="w">{titleCaseName(row.task.owner)}</span>
+                    {/if}
+                  </label>
+                  <span class="due">{row.due.label}</span>
+                </div>
+              {/each}
+            {/if}
+            {#if overdueRows.length === 0 && weekRows.length === 0}
+              <p class="ncalm">Nothing waiting in the next seven days.</p>
+            {/if}
+            <button
+              class="allbtn"
+              type="button"
+              onclick={() => openDialog(tasksDialog)}
+              >All {openTasks.length} tasks →</button
+            >
+          </div>
+        </section>
+
+        <section
+          class="cell card-plot"
+          aria-label={`Timeline, ${formatShortDate(timeline.startsOn)} to ${formatShortDate(timeline.endsOn)}`}
+          bind:this={plotCard}
+        >
+          <div class="plot">
+            <div class="plot-scale">
+              {#each timeline.months.slice(1) as month (month.value)}
+                <span class="vline" style:left={`${month.position}%`}></span>
+              {/each}
+              {#each legSpans as span (span.id)}
+                <div
+                  class={`legtag ${spanHueClass(span)}`}
+                  style:left={`${ganttDatePosition(span.starts_on, timeline.startsOn, timeline.endsOn)}%`}
+                >
+                  <b>{span.label}</b>
+                  <span>{formatDateRange(span.starts_on, span.ends_on)}</span>
+                </div>
+              {/each}
+              <div class="baseline"></div>
+              <div class="today" style:left={`${timeline.todayPosition}%`}>
+                <i></i><span class="tlbl">Today</span>
+              </div>
+              <div class="axis">
+                {#each timeline.months as month (month.value)}
+                  <span class="m" style:left={`${month.position}%`}
+                    >{month.label}</span
+                  >
+                {/each}
+              </div>
+            </div>
+            <div class="rows">
+              <div class="row slim">
+                <span class="name">Milestones</span>
+                <div class="track">
+                  {#each milestonePoints as milestone (milestone.id)}
+                    <button
+                      type="button"
+                      class:fill={milestone.gcal_state === "synced"}
+                      class:held={milestone.gcal_state === "held"}
+                      class="dia"
+                      style:left={`${milestone.position}%`}
+                      aria-label={`${milestone.title}, ${formatShortDate(milestone.occurs_on)}, ${milestone.gcal_state}`}
+                      onpointerenter={(event) =>
+                        showTooltip(
+                          event,
+                          milestone.title,
+                          `${formatShortDate(milestone.occurs_on)} · ${titleCaseName(milestone.owner)}`,
+                          milestone.gcal_state,
+                        )}
+                      onpointerleave={() => (tooltip = null)}
+                      onfocus={(event) =>
+                        showTooltip(
+                          event,
+                          milestone.title,
+                          `${formatShortDate(milestone.occurs_on)} · ${titleCaseName(milestone.owner)}`,
+                          milestone.gcal_state,
+                        )}
+                      onblur={() => (tooltip = null)}
+                      onclick={() => openDialog(calendarDialog)}
+                    ></button>
+                  {/each}
+                </div>
+              </div>
+              {#each timeline.lanes as lane (lane.kind)}
+                <div class="row">
+                  <span class="name">{lane.label}</span>
+                  <div class="track">
+                    {#each lane.bars as bar (bar.id)}
+                      <button
+                        type="button"
+                        class="bar"
+                        style:left={`${bar.position}%`}
+                        style:width={`${bar.width}%`}
+                        aria-label={`${bar.label}, ${formatDateRange(bar.starts_on, bar.ends_on)}`}
+                        onpointerenter={(event) =>
+                          showTooltip(
+                            event,
+                            bar.label,
+                            formatDateRange(bar.starts_on, bar.ends_on),
+                          )}
+                        onpointerleave={() => (tooltip = null)}
+                        onfocus={(event) =>
+                          showTooltip(
+                            event,
+                            bar.label,
+                            formatDateRange(bar.starts_on, bar.ends_on),
+                          )}
+                        onblur={() => (tooltip = null)}
+                      >
+                        <span class="blbl">{bar.label}</span>
+                      </button>
+                    {/each}
+                  </div>
+                </div>
+              {/each}
+              {#if timeline.lanes.length === 0 && milestonePoints.length === 0}
+                <p class="plot-empty">No timeline dates yet.</p>
+              {/if}
+            </div>
+          </div>
+          {#if tooltip}
+            <div
+              class="tip shown"
+              role="status"
+              aria-live="polite"
+              style:left={`${tooltip.left}px`}
+              style:top={`${tooltip.top}px`}
+            >
+              <b>{tooltip.title}</b><span>{tooltip.meta}</span>
+              {#if tooltip.detail}<em>{tooltip.detail}</em>{/if}
+            </div>
+          {/if}
+        </section>
+
+        <section class="cell c-agenda" aria-label="The plan, as a list">
+          <div class="ch">The plan</div>
+          <div class="agenda-body">
+            {#if agendaItems.length === 0}
+              <p class="quiet-empty">No dated plan items yet.</p>
+            {:else}
+              {#each agendaItems as item, index (item.id)}
+                {#if index === 0 || agendaItems[index - 1].monthKey !== item.monthKey}
+                  <div class="amonth">{item.monthLabel}</div>
+                {/if}
+                <div
+                  class:ms={item.kind === "ms"}
+                  class:held={item.held}
+                  class:col={item.kind === "col"}
+                  class="arow"
+                >
+                  <span class="d">{formatShortDate(item.date)}</span>
+                  <span class="ic" aria-hidden="true">{item.icon}</span>
+                  <span>
+                    {#if item.kind === "col"}<b>{item.title}</b
+                      >{:else}{item.title}{/if}
+                    <span class="sub">{item.sub}</span>
+                  </span>
+                </div>
+              {/each}
+            {/if}
+          </div>
+        </section>
+
+        <section class="cell c-legsmini" aria-label="Leg dates">
+          <div class="nsec-h">Leg dates</div>
+          {#if legSpans.length === 0}
+            <p class="quiet-empty">No legs scheduled.</p>
+          {:else}
+            {#each legSpans as span (span.id)}
+              <div class="lm">
+                <span class={`sw ${spanHueClass(span)}`} aria-hidden="true"
+                ></span>
+                <span>{span.label}</span>
+                <span class="d"
+                  >{formatDateRange(span.starts_on, span.ends_on)}</span
+                >
+              </div>
+            {/each}
+          {/if}
+        </section>
+
+        <section class="cell c-prog" aria-label="Progress">
+          <div class="ch">Behind us</div>
+          <div class="prog-body">
+            <div class="prog-pct">{progressView.percent}%</div>
+            <div class="prog-right">
+              <div
+                class="prog-bar"
+                role="progressbar"
+                aria-label="Move progress"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-valuenow={progressView.percent}
+              >
+                <i style:width={`${progressView.percent}%`}></i>
+              </div>
+              <div class="prog-lbl">
+                {progressView.label} · this number only goes up
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="cell c-collide" aria-label="Collisions">
+          <div class="ch">
+            <span class="ic" aria-hidden="true">▲</span> Collisions
+            <span class="badge">{collisionRows.length}</span>
+          </div>
+          <div class="collide-body">
+            {#if collisionRows.length === 0}
+              <p class="quiet-empty">No date collisions.</p>
+            {:else}
+              {#each collisionRows as collision}
+                <div class="crow">
+                  <span class="ic" aria-hidden="true"
+                    >{collision.type === "task_span" ? "▲" : "△"}</span
+                  >
+                  <span class="d"
+                    >{formatShortDate(collision.overlaps_from)}</span
+                  >
+                  <span><b>{collision.wording}</b></span>
+                </div>
+              {/each}
+            {/if}
+          </div>
+        </section>
+
+        <nav class="c-dock" aria-label="Details">
+          <button
+            class="dockbtn"
+            type="button"
+            onclick={() => openDialog(sellDialog)}
+          >
+            To sell <span class="v mono">{formatCad(sellTotal)}</span>
+          </button>
+          <button
+            class="dockbtn"
+            type="button"
+            onclick={() => openDialog(calendarDialog)}
+          >
+            <span
+              class:ok={milestones.some(
+                (milestone) => milestone.gcal_state === "synced",
+              )}
+              class="dot"
+              aria-hidden="true"
+            ></span>
+            Calendar <span class="v mono">{milestones.length} dates</span>
+          </button>
+          <button
+            class="dockbtn"
+            type="button"
+            onclick={() => openDialog(rolesDialog)}
+          >
+            <span class:idle={roles.length === 0} class="dot" aria-hidden="true"
+            ></span>
+            Roles
+            <span class="v"
+              >{roles.length ? `${roles.length} active` : "dormant"}</span
+            >
+          </button>
+          <button
+            class="dockbtn"
+            type="button"
+            onclick={() => openDialog(tasksDialog)}
+          >
+            Tasks <span class="v mono">{openTasks.length} open</span>
+          </button>
+        </nav>
+
+        <nav class="tabbar" aria-label="Sections">
+          <button
+            type="button"
+            aria-pressed={mobileTab === "today"}
+            onclick={() => (mobileTab = "today")}>Today</button
+          >
+          <button
+            type="button"
+            aria-pressed={mobileTab === "plan"}
+            onclick={() => (mobileTab = "plan")}
+          >
+            Plan <span class="tb-n">▲ {collisionRows.length}</span>
+          </button>
+          <button
+            type="button"
+            aria-pressed={mobileTab === "more"}
+            onclick={() => (mobileTab = "more")}>More</button
+          >
+        </nav>
+      </div>
+    </div>
+
+    <dialog
+      bind:this={tasksDialog}
+      aria-labelledby="tasks-heading"
+      onclick={closeFromBackdrop}
+    >
+      <div class="dlg-head">
+        <h2 id="tasks-heading">What's left</h2>
+        <span class="sub">{openTasks.length} open</span>
+        <button
+          class="x"
+          type="button"
+          aria-label="Close"
+          onclick={() => tasksDialog.close()}>×</button
+        >
+      </div>
+      <div class="dlg-body">
+        {#if taskError}<p class="task-error" role="alert">{taskError}</p>{/if}
+        {#if tasks.length === 0}
+          <p class="prose dialog-empty">No tasks yet.</p>
+        {:else}
+          <div class="tsec">
+            <div class="th">
+              All tasks <span class="mono">{tasks.length}</span>
+            </div>
+            <ul class="tasks">
+              {#each [...tasks].sort( (left, right) => (left.due_on ?? "9999").localeCompare(right.due_on ?? "9999"), ) as task (task.id)}
+                {@const due = taskDueView(task.due_on, now)}
+                <li class:done={task.done_at != null} class="task">
+                  <input
+                    id={`task-${task.id}`}
                     type="checkbox"
                     checked={task.done_at != null}
                     disabled={pendingTaskIds.has(task.id)}
                     onchange={() => toggleTask(task)}
                   />
-                  <span class="task-copy">
-                    <strong>{task.title}</strong>
-                    <span>{formatTaskDueDate(task.due_on)}</span>
-                  </span>
-                </label>
+                  <label class="t" for={`task-${task.id}`}>
+                    <span class={`tdot ${taskHueClass(task)}`}></span>
+                    <span>{task.title}</span>
+                    {#if task.note}<span class="note">{task.note}</span>{/if}
+                  </label>
+                  <span class="who">{titleCaseName(task.owner)}</span>
+                  <span
+                    class:overdue={task.done_at == null &&
+                      due.bucket === "overdue"}
+                    class:soon={task.done_at == null && due.bucket === "week"}
+                    class="due"
+                    >{task.done_at == null
+                      ? due.label
+                      : formatTaskDueDate(task.due_on)}</span
+                  >
+                </li>
+              {/each}
+            </ul>
+          </div>
+        {/if}
+      </div>
+    </dialog>
+
+    <dialog
+      bind:this={sellDialog}
+      aria-labelledby="sell-heading"
+      onclick={closeFromBackdrop}
+    >
+      <div class="dlg-head">
+        <h2 id="sell-heading">To sell</h2>
+        <span class="sub">{formatCad(sellTotal)} total</span>
+        <button
+          class="x"
+          type="button"
+          aria-label="Close"
+          onclick={() => sellDialog.close()}>×</button
+        >
+      </div>
+      <div class="dlg-body">
+        {#if taskError}<p class="task-error" role="alert">{taskError}</p>{/if}
+        {#if sellTasks.length === 0}
+          <p class="prose dialog-empty">Nothing is marked to sell.</p>
+        {:else}
+          <div class="tsec">
+            <div class="th">
+              Sale list <span class="mono">{sellTasks.length}</span>
+            </div>
+            <ul class="tasks sell-list">
+              {#each sellTasks as task (task.id)}
+                <li class:done={task.done_at != null} class="task">
+                  <input
+                    id={`sell-${task.id}`}
+                    type="checkbox"
+                    checked={task.done_at != null}
+                    disabled={pendingTaskIds.has(task.id)}
+                    onchange={() => toggleTask(task)}
+                  />
+                  <label class="t" for={`sell-${task.id}`}>
+                    <span class="tdot hue-sell"></span><span>{task.title}</span>
+                    {#if task.note}<span class="note">{task.note}</span>{/if}
+                  </label>
+                  <span class="who">{titleCaseName(task.owner)}</span>
+                  <span class="due value">{formatCad(task.value_cad)}</span>
+                </li>
+              {/each}
+            </ul>
+          </div>
+          <div class="sell-total">
+            <span>Total</span><strong>{formatCad(sellTotal)}</strong>
+          </div>
+        {/if}
+      </div>
+    </dialog>
+
+    <dialog
+      bind:this={calendarDialog}
+      aria-labelledby="calendar-heading"
+      onclick={closeFromBackdrop}
+    >
+      <div class="dlg-head">
+        <h2 id="calendar-heading">Shared calendar</h2>
+        <span class="sub">{milestones.length} milestones</span>
+        <button
+          class="x"
+          type="button"
+          aria-label="Close"
+          onclick={() => calendarDialog.close()}>×</button
+        >
+      </div>
+      <div class="dlg-body">
+        {#if milestones.length === 0}
+          <p class="prose dialog-empty">No calendar milestones yet.</p>
+        {:else}
+          <ul class="cal">
+            {#each milestones as milestone (milestone.id)}
+              <li>
+                <span class="d">{formatShortDate(milestone.occurs_on)}</span>
+                <span>
+                  {milestone.title}
+                  <span class="cal-owner"
+                    >· {titleCaseName(milestone.owner)}</span
+                  >
+                </span>
+                <span class={`st ${calendarStateClass(milestone)}`}
+                  >{calendarStateIcon(milestone)} {milestone.gcal_state}</span
+                >
               </li>
             {/each}
           </ul>
-        {:else}
-          <div class="today-empty">
-            <strong>Nothing waiting.</strong>
-            <span>There are no unfinished tasks in this view.</span>
-          </div>
         {/if}
-      </section>
+      </div>
+    </dialog>
 
-      <section class="collisions cell" aria-labelledby="collisions-heading">
-        <p class="section-label">Heads up</p>
-        <h2 id="collisions-heading">Collisions</h2>
-        {#if collisions.length > 0}
-          <ul>
-            {#each collisions as collision}
-              <li>{collision}</li>
-            {/each}
-          </ul>
+    <dialog
+      bind:this={rolesDialog}
+      aria-labelledby="roles-heading"
+      onclick={closeFromBackdrop}
+    >
+      <div class="dlg-head">
+        <h2 id="roles-heading">Roles</h2>
+        <span class="sub"
+          >{roles.length ? `${roles.length} tracked` : "dormant"}</span
+        >
+        <button
+          class="x"
+          type="button"
+          aria-label="Close"
+          onclick={() => rolesDialog.close()}>×</button
+        >
+      </div>
+      <div class="dlg-body">
+        {#if roles.length === 0}
+          <div class="roles-note">
+            <span aria-hidden="true">○</span>
+            <span
+              ><strong>No roles are being tracked.</strong> This list can stay quiet
+              until the search starts.</span
+            >
+          </div>
         {:else}
-          <p class="empty-copy">
-            No date collisions. The plan has room to breathe.
-          </p>
+          {#each roles as role (role.id)}
+            <div class="rrow">
+              <span>
+                {role.title}<span class="loc">{role.company}</span>
+              </span>
+              <span class="watch"
+                >{role.stage ?? "watching"}{role.next_on
+                  ? ` · ${formatShortDate(role.next_on)}`
+                  : ""}</span
+              >
+            </div>
+          {/each}
         {/if}
-      </section>
-    </div>
+      </div>
+    </dialog>
   </main>
 {/if}
-
-<style>
-  .moving {
-    width: 100%;
-    height: 100dvh;
-    overflow: auto;
-    background: var(--moving-canvas);
-    color: var(--moving-ink);
-    font-family: var(--moving-font);
-  }
-
-  .access-shell {
-    display: grid;
-    min-width: 320px;
-    place-items: center;
-  }
-
-  .moving-grid {
-    display: grid;
-    grid-template-columns: minmax(330px, 0.9fr) minmax(450px, 1.35fr);
-    grid-template-rows: auto minmax(360px, 1fr) auto;
-    grid-template-areas:
-      "masthead masthead"
-      "hero today"
-      "collisions today";
-    gap: var(--moving-border);
-    width: max(100%, 784px);
-    min-height: 100%;
-    padding: var(--moving-border);
-    background: var(--moving-ink);
-  }
-
-  .cell {
-    min-width: 0;
-    padding: clamp(20px, 3vw, 48px);
-  }
-
-  .masthead {
-    grid-area: masthead;
-    display: flex;
-    align-items: end;
-    justify-content: space-between;
-    gap: 3rem;
-    background: var(--moving-accent);
-    color: var(--moving-accent-ink);
-  }
-
-  .masthead h1,
-  .masthead p {
-    margin: 0;
-  }
-
-  .masthead h1 {
-    font-size: var(--moving-size-heading);
-    font-weight: 950;
-    letter-spacing: -0.06em;
-    line-height: 0.85;
-    text-transform: uppercase;
-  }
-
-  .kicker,
-  .section-label {
-    margin: 0 0 0.65rem;
-    font-family: var(--moving-font-mono);
-    font-size: var(--moving-size-small);
-    font-weight: 800;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-  }
-
-  .viewer {
-    display: flex;
-    gap: 0.65rem;
-    align-items: center;
-    font-family: var(--moving-font-mono);
-    font-size: var(--moving-size-small);
-    font-weight: 800;
-    text-transform: uppercase;
-  }
-
-  .viewer span + span {
-    padding-left: 0.65rem;
-    border-left: 2px solid var(--moving-accent-ink);
-  }
-
-  .hero {
-    grid-area: hero;
-    display: flex;
-    flex-direction: column;
-    background: var(--moving-hero);
-  }
-
-  .hero h2 {
-    max-width: 9ch;
-    margin: 0;
-    font-size: var(--moving-size-display);
-    font-weight: 950;
-    letter-spacing: -0.075em;
-    line-height: 0.82;
-    text-transform: uppercase;
-  }
-
-  .countdown-detail {
-    margin: 1.25rem 0 3rem;
-    color: var(--moving-muted);
-    font-family: var(--moving-font-mono);
-    font-size: var(--moving-size-small);
-    font-weight: 700;
-  }
-
-  .progress-heading {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
-    margin-top: auto;
-    font-family: var(--moving-font-mono);
-    font-size: var(--moving-size-small);
-    text-transform: uppercase;
-  }
-
-  .progress-track {
-    height: 20px;
-    margin-top: 0.65rem;
-    overflow: hidden;
-    border: 3px solid var(--moving-ink);
-    background: var(--moving-paper-raised);
-  }
-
-  .progress-track span {
-    display: block;
-    height: 100%;
-    background: var(--moving-accent);
-  }
-
-  .empty-copy {
-    margin: 1rem 0 0;
-    color: var(--moving-muted);
-    font-size: var(--moving-size-body);
-    line-height: 1.45;
-  }
-
-  .today {
-    grid-area: today;
-    padding: 0;
-    background: var(--moving-paper);
-  }
-
-  .today-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    padding: clamp(20px, 3vw, 42px);
-    background: var(--moving-accent);
-    color: var(--moving-accent-ink);
-  }
-
-  .today-header h2 {
-    margin: 0;
-    font-size: var(--moving-size-heading);
-    font-weight: 950;
-    letter-spacing: -0.05em;
-    line-height: 0.9;
-    text-transform: uppercase;
-  }
-
-  .scope-toggle {
-    display: flex;
-    border: 3px solid var(--moving-accent-ink);
-  }
-
-  .scope-toggle button {
-    min-width: 60px;
-    padding: 0.65rem 0.8rem;
-    border: 0;
-    background: var(--moving-accent);
-    color: var(--moving-accent-ink);
-    font-family: var(--moving-font-mono);
-    font-size: var(--moving-size-small);
-    font-weight: 900;
-    text-transform: uppercase;
-    cursor: pointer;
-  }
-
-  .scope-toggle button + button {
-    border-left: 3px solid var(--moving-accent-ink);
-  }
-
-  .scope-toggle button.active {
-    background: var(--moving-accent-ink);
-    color: var(--moving-accent);
-  }
-
-  .scope-toggle button:focus-visible,
-  input:focus-visible {
-    outline: 3px solid var(--moving-focus);
-    outline-offset: 3px;
-  }
-
-  .task-error {
-    margin: 0;
-    padding: 0.8rem clamp(20px, 3vw, 42px);
-    background: var(--moving-danger-paper);
-    color: var(--moving-danger);
-    font-size: var(--moving-size-body);
-    font-weight: 800;
-  }
-
-  .task-list {
-    margin: 0;
-    padding: 0 clamp(20px, 3vw, 42px);
-  }
-
-  .task-list li {
-    border-bottom: 2px solid var(--moving-ink);
-  }
-
-  .task-list label {
-    display: flex;
-    gap: 1rem;
-    align-items: flex-start;
-    padding: 1.25rem 0;
-    cursor: pointer;
-  }
-
-  .task-list input {
-    flex: 0 0 auto;
-    width: 25px;
-    height: 25px;
-    margin-top: 0.1rem;
-    accent-color: var(--moving-check);
-    cursor: pointer;
-  }
-
-  .task-copy {
-    display: flex;
-    min-width: 0;
-    flex: 1;
-    justify-content: space-between;
-    gap: 1rem;
-  }
-
-  .task-copy strong {
-    font-size: var(--moving-size-body);
-    line-height: 1.3;
-  }
-
-  .task-copy span {
-    flex: 0 0 auto;
-    color: var(--moving-muted);
-    font-family: var(--moving-font-mono);
-    font-size: var(--moving-size-small);
-    line-height: 1.6;
-  }
-
-  .today-empty {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    padding: clamp(28px, 5vw, 72px) clamp(20px, 3vw, 42px);
-    font-size: var(--moving-size-body);
-  }
-
-  .today-empty strong {
-    font-size: calc(var(--moving-size-body) * 1.35);
-  }
-
-  .today-empty span {
-    color: var(--moving-muted);
-  }
-
-  .collisions {
-    grid-area: collisions;
-    background: var(--moving-collision);
-  }
-
-  .collisions h2 {
-    margin: 0;
-    font-size: calc(var(--moving-size-body) * 1.8);
-    font-weight: 950;
-    letter-spacing: -0.04em;
-    text-transform: uppercase;
-  }
-
-  .collisions ul {
-    display: grid;
-    gap: 0.85rem;
-    margin: 1.25rem 0 0;
-    padding: 0;
-  }
-
-  .collisions li {
-    padding-left: 1rem;
-    border-left: 5px solid var(--moving-ink);
-    font-size: var(--moving-size-body);
-    font-weight: 750;
-    line-height: 1.35;
-  }
-</style>

--- a/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
@@ -1,63 +1,1387 @@
-/* Crossing has its own scoped palette. Components contain layout only and
- * consume these properties, which keeps every color in this plain CSS file.
- */
 .moving {
   color-scheme: light;
-  --moving-canvas: #f05a46;
-  --moving-paper: #fff8df;
-  --moving-paper-raised: #ffffff;
-  --moving-ink: #18130f;
-  --moving-muted: #65564b;
-  --moving-accent: #ffd83d;
-  --moving-accent-ink: #18130f;
-  --moving-hero: #86cdf2;
-  --moving-collision: #89d6a4;
-  --moving-danger: #9c241f;
-  --moving-danger-paper: #ffd9ce;
-  --moving-focus: #005fcc;
-  --moving-check: #18130f;
-  --moving-border: 4px;
-  --moving-font:
-    Arial, Helvetica, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  --moving-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
-  --moving-size-small: 12px;
-  --moving-size-body: clamp(15px, 1.4vw, 19px);
-  --moving-size-heading: clamp(34px, 5vw, 72px);
-  --moving-size-display: clamp(46px, 8vw, 118px);
-}
-
-html[data-theme="dark"] .moving {
-  color-scheme: dark;
-  --moving-canvas: #161311;
-  --moving-paper: #24201c;
-  --moving-paper-raised: #302a24;
-  --moving-ink: #fff3d4;
-  --moving-muted: #d7c7aa;
-  --moving-accent: #ffd83d;
-  --moving-accent-ink: #18130f;
-  --moving-hero: #174d70;
-  --moving-collision: #174f35;
-  --moving-danger: #ff9787;
-  --moving-danger-paper: #4b211e;
-  --moving-focus: #81bdff;
-  --moving-check: #fff3d4;
+  --cream: #f3ede1;
+  --paper: #ffffff;
+  --ink: #1a1a1a;
+  --ink-2: #57534a;
+  --ink-3: #8a857a;
+  --rule: rgba(26, 26, 26, 0.14);
+  --yellow: #ffde01;
+  --blue: #6fc2ff;
+  --coral: #ff7169;
+  --green: #4ade80;
+  --font-display: "Instrument Serif", "Iowan Old Style", Georgia, serif;
+  --font-ui: "Hanken Grotesk", "Avenir Next", "Segoe UI", system-ui, sans-serif;
+  --font-code: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  --moving-canvas: var(--cream);
+  --moving-paper: var(--paper);
+  --moving-ink: var(--ink);
+  --moving-muted: var(--ink-2);
+  --moving-border: 2px;
+  --moving-font: var(--font-ui);
+  --moving-font-mono: var(--font-code);
+  --moving-size-small: 10.5px;
+  --moving-size-body: 14px;
+  --moving-size-heading: 26px;
 }
 
 @media (prefers-color-scheme: dark) {
-  html:not([data-theme="light"]) .moving {
+  .moving {
     color-scheme: dark;
-    --moving-canvas: #161311;
-    --moving-paper: #24201c;
-    --moving-paper-raised: #302a24;
-    --moving-ink: #fff3d4;
-    --moving-muted: #d7c7aa;
-    --moving-accent: #ffd83d;
-    --moving-accent-ink: #18130f;
-    --moving-hero: #174d70;
-    --moving-collision: #174f35;
-    --moving-danger: #ff9787;
-    --moving-danger-paper: #4b211e;
-    --moving-focus: #81bdff;
-    --moving-check: #fff3d4;
+    --cream: #141311;
+    --paper: #211f1c;
+    --ink: #f0ead9;
+    --ink-2: #b5af9f;
+    --ink-3: #7d786c;
+    --rule: rgba(240, 234, 217, 0.16);
+  }
+}
+
+:root[data-theme="light"] .moving {
+  color-scheme: light;
+  --cream: #f3ede1;
+  --paper: #ffffff;
+  --ink: #1a1a1a;
+  --ink-2: #57534a;
+  --ink-3: #8a857a;
+  --rule: rgba(26, 26, 26, 0.14);
+}
+
+:root[data-theme="dark"] .moving {
+  color-scheme: dark;
+  --cream: #141311;
+  --paper: #211f1c;
+  --ink: #f0ead9;
+  --ink-2: #b5af9f;
+  --ink-3: #7d786c;
+  --rule: rgba(240, 234, 217, 0.16);
+}
+
+.moving,
+.moving * {
+  box-sizing: border-box;
+}
+
+.moving {
+  min-width: 320px;
+  min-height: 100dvh;
+  margin: 0;
+  background: var(--cream);
+  color: var(--ink);
+  font-family: var(--font-ui);
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+.moving button {
+  font: inherit;
+  color: inherit;
+}
+
+.moving :focus-visible {
+  outline: 3px solid var(--blue);
+  outline-offset: -3px;
+}
+
+.moving .mono {
+  font-family: var(--font-code);
+  font-variant-numeric: tabular-nums;
+}
+
+.moving .app {
+  max-width: 1380px;
+  margin: 0 auto;
+  padding: 22px 22px 34px;
+}
+
+.moving .grid {
+  display: grid;
+  gap: 2px;
+  background: var(--ink);
+  border: 2px solid var(--ink);
+  grid-template-columns: 400px minmax(0, 1fr) 320px;
+  grid-template-areas:
+    "head head head"
+    "hero hero prog"
+    "today plot plot"
+    "today collide collide"
+    "dock dock dock";
+}
+
+.moving .cell {
+  min-width: 0;
+  background: var(--paper);
+}
+
+.moving .ch {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 16px;
+  border-bottom: 2px solid var(--ink);
+  font-family: var(--font-code);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.moving .badge {
+  margin-left: auto;
+  padding: 1px 8px;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--font-code);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.moving .c-head {
+  grid-area: head;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px 18px;
+  padding: 9px 18px;
+  color: var(--ink-2);
+  font-family: var(--font-code);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.moving .c-head b {
+  color: var(--ink);
+}
+
+.moving .c-head .r {
+  margin-left: auto;
+}
+
+.moving .seg-mini {
+  display: inline-flex;
+  border: 2px solid var(--ink);
+}
+
+.moving .seg-mini button {
+  padding: 2px 10px;
+  border: 0;
+  background: var(--paper);
+  color: var(--ink-2);
+  font-family: var(--font-code);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.moving .seg-mini button + button {
+  border-left: 2px solid var(--ink);
+}
+
+.moving .seg-mini button[aria-pressed="true"] {
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.moving .c-today .ch .seg-mini {
+  margin-left: auto;
+  border-color: #1a1a1a;
+}
+
+.moving .c-today .ch .seg-mini button {
+  border-color: #1a1a1a;
+  background: var(--yellow);
+  color: rgba(26, 26, 26, 0.6);
+}
+
+.moving .c-today .ch .seg-mini button[aria-pressed="true"] {
+  background: #1a1a1a;
+  color: var(--yellow);
+}
+
+.moving .c-today .badge {
+  margin-left: 0;
+}
+
+.moving .c-hero {
+  grid-area: hero;
+  display: flex;
+  align-items: center;
+  padding: 26px 26px 24px;
+}
+
+.moving .c-hero h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(54px, 6.2vw, 92px);
+  font-weight: 400;
+  line-height: 0.95;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
+}
+
+.moving .hero-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  color: var(--ink-2);
+  font-size: 14.5px;
+}
+
+.moving .hero-empty strong {
+  color: var(--ink);
+  font-size: 14.5px;
+  font-weight: 600;
+}
+
+.moving .hl {
+  padding: 0 0.08em;
+  background: linear-gradient(var(--yellow), var(--yellow)) no-repeat 0 62%;
+  background-size: 100% 74%;
+  color: #1a1a1a;
+}
+
+.moving .c-agenda {
+  display: none;
+}
+
+.moving .agenda-body {
+  padding: 2px 16px 12px;
+}
+
+.moving .amonth {
+  margin: 14px 0 2px;
+  padding-bottom: 4px;
+  border-bottom: 2px solid var(--ink);
+  color: var(--ink-3);
+  font-family: var(--font-code);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.moving .arow {
+  display: grid;
+  grid-template-columns: 40px 18px minmax(0, 1fr);
+  gap: 10px;
+  align-items: baseline;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--rule);
+  font-size: 13.5px;
+}
+
+.moving .arow:last-child {
+  border-bottom: 0;
+}
+
+.moving .arow .d {
+  color: var(--ink-2);
+  font-family: var(--font-code);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.moving .arow .ic {
+  font-size: 11px;
+  text-align: center;
+}
+
+.moving .arow.ms .ic {
+  color: var(--ink);
+}
+
+.moving .arow.ms.held .ic,
+.moving .arow.col .ic {
+  color: var(--coral);
+}
+
+.moving .arow.col b {
+  font-weight: 700;
+}
+
+.moving .arow .sub {
+  display: block;
+  color: var(--ink-3);
+  font-size: 11.5px;
+}
+
+.moving .c-legsmini {
+  display: none;
+  padding: 4px 16px 12px;
+}
+
+.moving .lm {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--rule);
+  font-size: 13.5px;
+}
+
+.moving .lm:last-child {
+  border-bottom: 0;
+}
+
+.moving .lm .sw {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--ink);
+  background: var(--hue);
+}
+
+.moving .lm .d {
+  color: var(--ink-2);
+  font-family: var(--font-code);
+  font-size: 11px;
+}
+
+.moving .tabbar {
+  display: none;
+}
+
+.moving .c-today {
+  grid-area: today;
+  display: flex;
+  flex-direction: column;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.moving .c-today .ch {
+  border-color: #1a1a1a;
+  background: var(--yellow);
+  color: #1a1a1a;
+}
+
+.moving .c-today .ch h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 23px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  text-transform: none;
+}
+
+.moving .c-today .badge {
+  background: #1a1a1a;
+  color: var(--yellow);
+}
+
+.moving .cta-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  padding: 2px 16px 14px;
+  overflow-y: auto;
+}
+
+.moving .nsec-h {
+  margin: 13px 0 1px;
+  color: var(--ink-3);
+  font-family: var(--font-code);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.moving .nrow {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: baseline;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.moving .nrow:last-child {
+  border-bottom: 0;
+}
+
+.moving .nrow input {
+  align-self: center;
+  width: 17px;
+  height: 17px;
+  margin: 0;
+  accent-color: var(--ink);
+  cursor: pointer;
+}
+
+.moving .nrow .t {
+  color: var(--ink);
+  font-size: 14.5px;
+  font-weight: 600;
+  line-height: 1.35;
+  cursor: pointer;
+}
+
+.moving .nrow .t .w {
+  margin-left: 6px;
+  color: var(--ink-3);
+  font-family: var(--font-code);
+  font-size: 9px;
+  font-weight: 400;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.moving .nrow .due {
+  color: var(--ink-2);
+  font-family: var(--font-code);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.moving .nrow .due.overdue {
+  padding: 0 6px;
+  border: 2px solid var(--coral);
+  background: var(--paper);
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.moving .ncalm,
+.moving .quiet-empty,
+.moving .plot-empty {
+  color: var(--ink-2);
+  font-size: 14px;
+}
+
+.moving .ncalm {
+  margin: 0;
+  padding: 13px 0 5px;
+}
+
+.moving .quiet-empty {
+  margin: 0;
+  padding: 13px 0 5px;
+}
+
+.moving .task-error {
+  margin: 8px 0 0;
+  padding: 7px 9px;
+  border: 2px solid var(--coral);
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 13.5px;
+  font-weight: 600;
+}
+
+.moving .allbtn {
+  display: block;
+  margin-top: auto;
+  padding: 10px 14px;
+  border: 2px solid var(--ink);
+  background: #1a1a1a;
+  color: var(--yellow);
+  font-family: var(--font-code);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.moving .allbtn:hover {
+  background: var(--yellow);
+  color: #1a1a1a;
+}
+
+.moving .card-plot {
+  position: relative;
+  grid-area: plot;
+}
+
+.moving .plot {
+  --gutter: 104px;
+  --pad-r: 22px;
+  --pad-top: 62px;
+  --pad-btm: 46px;
+  position: relative;
+  height: 430px;
+}
+
+.moving .plot-scale {
+  position: absolute;
+  inset: 0 var(--pad-r) 0 var(--gutter);
+}
+
+.moving .vline {
+  position: absolute;
+  top: 10px;
+  bottom: 40px;
+  width: 2px;
+  background: var(--rule);
+}
+
+.moving .legtag {
+  position: absolute;
+  top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding-left: 12px;
+  white-space: nowrap;
+}
+
+.moving .legtag:first-of-type {
+  padding-left: 0;
+}
+
+.moving .legtag b {
+  align-self: flex-start;
+  padding-bottom: 1px;
+  border-bottom: 4px solid var(--hue);
+  font-size: 12.5px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.moving .legtag span {
+  color: var(--ink-3);
+  font-family: var(--font-code);
+  font-size: 9.5px;
+}
+
+.moving .baseline {
+  position: absolute;
+  right: 0;
+  bottom: 40px;
+  left: 0;
+  height: 2px;
+  background: var(--ink);
+}
+
+.moving .today {
+  position: absolute;
+  z-index: 4;
+  top: 58px;
+  bottom: 40px;
+  width: 2px;
+  background: var(--blue);
+}
+
+.moving .today i {
+  position: absolute;
+  top: -6px;
+  left: -4px;
+  width: 10px;
+  height: 10px;
+  border: 2px solid var(--ink);
+  background: var(--blue);
+}
+
+.moving .today .tlbl {
+  position: absolute;
+  bottom: -26px;
+  left: 50%;
+  padding: 0 5px;
+  transform: translateX(-50%);
+  border: 1px solid var(--ink);
+  background: var(--blue);
+  color: #1a1a1a;
+  font-family: var(--font-code);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.moving .rows {
+  position: absolute;
+  z-index: 3;
+  inset: var(--pad-top) 0 var(--pad-btm) 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.moving .row {
+  display: grid;
+  grid-template-columns: var(--gutter) minmax(0, 1fr);
+  align-items: center;
+}
+
+.moving .row .name {
+  padding-right: 16px;
+  color: var(--ink-3);
+  font-family: var(--font-code);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-align: right;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.moving .row .track {
+  position: relative;
+  height: 26px;
+  margin-right: var(--pad-r);
+}
+
+.moving .row.slim .track {
+  height: 20px;
+}
+
+.moving .bar {
+  position: absolute;
+  top: 50%;
+  min-width: 13px;
+  height: 13px;
+  padding: 0;
+  transform: translateY(-50%);
+  border: 0;
+  background: var(--ink);
+  box-shadow: 0 0 0 2px var(--paper);
+  cursor: default;
+  transition: background 0.12s ease;
+}
+
+.moving .bar:hover,
+.moving .bar:focus-visible {
+  z-index: 5;
+  background: var(--blue);
+  box-shadow: 0 0 0 2px var(--ink);
+}
+
+.moving .blbl {
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 9px);
+  transform: translateY(-50%);
+  color: var(--ink-2);
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.moving .dia {
+  position: absolute;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  padding: 0;
+  transform: translate(-50%, -50%) rotate(45deg);
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  cursor: pointer;
+  transition: transform 0.12s ease;
+}
+
+.moving .dia.fill {
+  background: var(--ink);
+}
+
+.moving .dia.held {
+  background: var(--coral);
+}
+
+.moving .dia:hover,
+.moving .dia:focus-visible {
+  z-index: 5;
+  transform: translate(-50%, -50%) rotate(45deg) scale(1.4);
+}
+
+.moving .axis {
+  position: absolute;
+  right: 0;
+  bottom: 12px;
+  left: 0;
+  z-index: 3;
+  height: 16px;
+}
+
+.moving .axis .m {
+  position: absolute;
+  color: var(--ink-3);
+  font-family: var(--font-code);
+  font-size: 9.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.moving .plot-empty {
+  margin: auto;
+  padding-left: var(--gutter);
+}
+
+.moving .tip {
+  position: absolute;
+  z-index: 30;
+  max-width: 300px;
+  padding: 8px 12px;
+  transform: translate(-50%, calc(-100% - 12px));
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+}
+
+.moving .tip.shown {
+  opacity: 1;
+}
+
+.moving .tip b {
+  display: block;
+  font-size: 12.5px;
+  white-space: nowrap;
+}
+
+.moving .tip span {
+  display: block;
+  margin-top: 2px;
+  color: var(--ink-3);
+  font-family: var(--font-code);
+  font-size: 10.5px;
+}
+
+.moving .tip em {
+  display: block;
+  margin-top: 3px;
+  color: var(--ink-2);
+  font-size: 11.5px;
+  font-style: normal;
+}
+
+.moving .c-prog {
+  grid-area: prog;
+  display: flex;
+  flex-direction: column;
+}
+
+.moving .prog-body {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px 16px;
+}
+
+.moving .prog-pct {
+  font-family: var(--font-display);
+  font-size: 54px;
+  font-variant-numeric: tabular-nums;
+  line-height: 0.9;
+  letter-spacing: -0.02em;
+}
+
+.moving .prog-right {
+  flex: 1;
+  min-width: 0;
+}
+
+.moving .prog-bar {
+  height: 18px;
+  border: 2px solid var(--ink);
+  background: var(--paper);
+}
+
+.moving .prog-bar i {
+  display: block;
+  height: 100%;
+  border-right: 2px solid var(--ink);
+  background: var(--green);
+  transition: width 0.5s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+
+.moving .prog-lbl {
+  margin-top: 7px;
+  color: var(--ink-2);
+  font-size: 12.5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.moving .c-collide {
+  grid-area: collide;
+}
+
+.moving .c-collide .ch .ic {
+  color: var(--coral);
+  font-size: 12px;
+}
+
+.moving .collide-body {
+  padding: 2px 16px 10px;
+}
+
+.moving .crow {
+  display: grid;
+  grid-template-columns: 18px 74px minmax(0, 1fr);
+  gap: 12px;
+  align-items: baseline;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--rule);
+  font-size: 13.5px;
+}
+
+.moving .crow:last-child {
+  border-bottom: 0;
+}
+
+.moving .crow .ic {
+  color: var(--coral);
+  font-size: 11px;
+}
+
+.moving .crow .d {
+  font-family: var(--font-code);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.moving .crow b {
+  font-weight: 700;
+}
+
+.moving .c-dock {
+  grid-area: dock;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  gap: 2px;
+  background: var(--ink);
+}
+
+.moving .dockbtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  padding: 12px 16px;
+  border: 0;
+  background: var(--paper);
+  font-family: var(--font-code);
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.moving .dockbtn .v {
+  color: var(--ink-2);
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.moving .dockbtn .dot {
+  width: 8px;
+  height: 8px;
+  border: 1.5px solid var(--ink);
+  border-radius: 50%;
+}
+
+.moving .dockbtn .dot.ok {
+  background: var(--green);
+}
+
+.moving .dockbtn .dot.idle {
+  background: var(--paper);
+}
+
+.moving .dockbtn:hover {
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.moving .dockbtn:hover .v {
+  color: inherit;
+}
+
+.moving dialog {
+  width: min(680px, calc(100vw - 40px));
+  max-height: min(80dvh, 740px);
+  padding: 0;
+  transform: translateY(14px);
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  opacity: 0;
+  transition:
+    opacity 0.18s ease,
+    transform 0.2s cubic-bezier(0.2, 0.8, 0.3, 1),
+    overlay 0.2s ease allow-discrete,
+    display 0.2s ease allow-discrete;
+}
+
+.moving dialog[open] {
+  transform: none;
+  opacity: 1;
+}
+
+@starting-style {
+  .moving dialog[open] {
+    transform: translateY(14px);
+    opacity: 0;
+  }
+}
+
+.moving dialog::backdrop {
+  background: rgba(26, 26, 26, 0.5);
+}
+
+.moving .dlg-head {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 14px;
+  padding: 14px 20px 12px;
+  border-bottom: 2px solid var(--ink);
+  background: var(--paper);
+}
+
+.moving .dlg-head h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 26px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+}
+
+.moving .dlg-head .sub {
+  color: var(--ink-3);
+  font-family: var(--font-code);
+  font-size: 10.5px;
+}
+
+.moving .x {
+  width: 30px;
+  height: 30px;
+  margin-left: auto;
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.moving .x:hover {
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.moving .dlg-body {
+  max-height: calc(min(80dvh, 740px) - 66px);
+  padding: 8px 20px 20px;
+  overflow-y: auto;
+}
+
+.moving .tsec {
+  margin-top: 18px;
+}
+
+.moving .tsec > .th {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding-bottom: 5px;
+  border-bottom: 2px solid var(--ink);
+  font-family: var(--font-code);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.moving .tasks,
+.moving .cal {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.moving .task {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 9px 2px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.moving .task:last-child {
+  border-bottom: 0;
+}
+
+.moving .task input {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  accent-color: var(--ink);
+  cursor: pointer;
+}
+
+.moving .task .t {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  font-size: 13.5px;
+  cursor: pointer;
+}
+
+.moving .task .t .tdot {
+  flex: none;
+  align-self: center;
+  width: 8px;
+  height: 8px;
+  border: 1.5px solid var(--ink);
+  background: var(--hue);
+}
+
+.moving .task .t .note {
+  overflow: hidden;
+  color: var(--ink-3);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.moving .task.done .t {
+  color: var(--ink-3);
+  text-decoration: line-through;
+}
+
+.moving .task .who {
+  color: var(--ink-3);
+  font-family: var(--font-code);
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.moving .task .due {
+  min-width: 62px;
+  color: var(--ink-2);
+  font-family: var(--font-code);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.moving .task .due.overdue {
+  padding: 0 5px;
+  border: 2px solid var(--coral);
+  background: var(--paper);
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.moving .task .due.soon,
+.moving .task .due.value {
+  font-weight: 700;
+}
+
+.moving .sell-total {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 14px;
+  padding-top: 10px;
+  border-top: 2px solid var(--ink);
+  font-family: var(--font-code);
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.moving .cal {
+  margin-top: 8px;
+}
+
+.moving .cal li {
+  display: grid;
+  grid-template-columns: 86px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: baseline;
+  padding: 8px 2px;
+  border-bottom: 1px solid var(--rule);
+  font-size: 13.5px;
+}
+
+.moving .cal li:last-child {
+  border-bottom: 0;
+}
+
+.moving .cal .d {
+  color: var(--ink-2);
+  font-family: var(--font-code);
+  font-size: 11.5px;
+}
+
+.moving .cal-owner {
+  color: var(--ink-3);
+  font-size: 11.5px;
+}
+
+.moving .cal .st {
+  font-family: var(--font-code);
+  font-size: 10.5px;
+  font-weight: 700;
+}
+
+.moving .cal .st.ok {
+  color: var(--ink);
+}
+
+.moving .cal .st.warn {
+  padding: 0 5px;
+  border: 2px solid var(--coral);
+  color: var(--ink);
+}
+
+.moving .cal .st.idle {
+  color: var(--ink-3);
+}
+
+.moving .prose {
+  max-width: 58ch;
+  color: var(--ink-2);
+  font-size: 13.5px;
+}
+
+.moving .dialog-empty {
+  margin: 10px 0 0;
+}
+
+.moving .roles-note {
+  display: flex;
+  gap: 10px;
+  margin-top: 12px;
+  padding: 12px 14px;
+  border: 2px dashed var(--ink);
+  background: var(--cream);
+  color: var(--ink-2);
+  font-size: 13.5px;
+}
+
+.moving .roles-note strong {
+  color: var(--ink);
+}
+
+.moving .rrow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: baseline;
+  padding: 9px 2px;
+  border-bottom: 1px solid var(--rule);
+  font-size: 13.5px;
+}
+
+.moving .rrow:last-child {
+  border-bottom: 0;
+}
+
+.moving .rrow .loc {
+  display: block;
+  color: var(--ink-3);
+  font-size: 11.5px;
+}
+
+.moving .rrow .watch {
+  color: var(--ink-3);
+  font-family: var(--font-code);
+  font-size: 10.5px;
+  text-transform: uppercase;
+}
+
+.moving .hue-sell,
+.moving .hue-visitor {
+  --hue: var(--blue);
+}
+
+.moving .hue-admin,
+.moving .hue-trip {
+  --hue: var(--coral);
+}
+
+.moving .hue-ship,
+.moving .hue-move {
+  --hue: var(--yellow);
+}
+
+.moving .hue-people,
+.moving .hue-work {
+  --hue: var(--green);
+}
+
+.moving .hue-none {
+  --hue: var(--paper);
+}
+
+.moving.access-shell {
+  display: grid;
+  min-width: 320px;
+  place-items: center;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .moving .hl {
+    background-size: 0% 74%;
+    animation: moving-sweep 0.7s cubic-bezier(0.2, 0.8, 0.3, 1) 0.15s forwards;
+  }
+
+  .moving .fx {
+    animation: moving-rise 0.5s cubic-bezier(0.2, 0.8, 0.3, 1) both;
+  }
+
+  @keyframes moving-sweep {
+    to {
+      background-size: 100% 74%;
+    }
+  }
+
+  @keyframes moving-rise {
+    from {
+      transform: translateY(10px);
+      opacity: 0;
+    }
+  }
+}
+
+@media (max-width: 1080px) and (min-width: 701px) {
+  .moving .grid {
+    grid-template-columns: 300px minmax(0, 1fr);
+    grid-template-areas:
+      "head head"
+      "hero prog"
+      "today plot"
+      "today collide"
+      "dock dock";
+  }
+
+  .moving .card-plot {
+    overflow-x: auto;
+  }
+
+  .moving .plot {
+    min-width: 760px;
+  }
+
+  .moving .c-hero h1 {
+    font-size: clamp(38px, 5.5vw, 56px);
+  }
+}
+
+.moving .app.phone .grid {
+  display: flex;
+  flex-direction: column;
+}
+
+.moving .app.phone .card-plot,
+.moving .app.phone .c-collide {
+  display: none;
+}
+
+.moving .app.phone .c-today,
+.moving .app.phone .c-agenda,
+.moving .app.phone .c-prog,
+.moving .app.phone .c-dock,
+.moving .app.phone .c-legsmini {
+  display: none;
+}
+
+.moving .app.phone[data-mtab="today"] .c-today {
+  display: flex;
+}
+
+.moving .app.phone[data-mtab="plan"] .c-agenda {
+  display: block;
+}
+
+.moving .app.phone[data-mtab="more"] .c-prog {
+  display: flex;
+}
+
+.moving .app.phone[data-mtab="more"] .c-dock {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.moving .app.phone[data-mtab="more"] .c-legsmini {
+  display: block;
+}
+
+.moving .app.phone .c-hero {
+  padding: 12px 16px;
+}
+
+.moving .app.phone .c-hero h1 {
+  font-size: clamp(28px, 8.5vw, 36px);
+}
+
+.moving .app.phone .cta-body {
+  overflow-y: visible;
+}
+
+.moving .app.phone .prog-pct {
+  font-size: 44px;
+}
+
+.moving .app.phone .tabbar {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 2px;
+  background: var(--ink);
+}
+
+.moving .tabbar button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 12px 8px;
+  border: 0;
+  background: var(--paper);
+  font-family: var(--font-code);
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.moving .tabbar button[aria-pressed="true"] {
+  background: var(--yellow);
+  color: #1a1a1a;
+}
+
+.moving .tabbar .tb-n {
+  color: var(--coral);
+  font-size: 10px;
+}
+
+.moving .tabbar button[aria-pressed="true"] .tb-n {
+  color: #b3261e;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .moving *,
+  .moving *::before,
+  .moving *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
   }
 }

--- a/projects/monolith/frontend/src/routes/friends/moving/moving.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving.js
@@ -1,5 +1,27 @@
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+const MONTH_SHORT = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+const SPAN_KIND_LABELS = {
+  visitor: "Visitors",
+  work: "Work trips",
+  move: "The move",
+  trip: "Trips",
+};
+
 function dateParts(value) {
   const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value ?? "");
   if (!match) return null;
@@ -16,8 +38,15 @@ function dateStamp(value) {
   return Date.UTC(parts.year, parts.month - 1, parts.day);
 }
 
+function dateValue(now) {
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
 function todayStamp(now) {
-  return Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+  return dateStamp(dateValue(now));
 }
 
 function formatDate(value, options) {
@@ -29,6 +58,30 @@ function formatDate(value, options) {
   }).format(new Date(stamp));
 }
 
+export function formatShortDate(value) {
+  const parts = dateParts(value);
+  if (!parts) return "Date unknown";
+  return `${parts.day} ${MONTH_SHORT[parts.month - 1]}`;
+}
+
+export function formatDateRange(from, to) {
+  const start = dateParts(from);
+  const end = dateParts(to);
+  if (!start || !end) return "Dates unknown";
+  if (from === to) return formatShortDate(from);
+  if (start.year === end.year && start.month === end.month) {
+    return `${start.day}\u2013${end.day} ${MONTH_SHORT[start.month - 1]}`;
+  }
+  return `${formatShortDate(from)} \u2013 ${formatShortDate(to)}`;
+}
+
+export function dayDistance(from, to) {
+  const start = dateStamp(from);
+  const end = dateStamp(to);
+  if (start == null || end == null) return null;
+  return Math.round((end - start) / DAY_MS);
+}
+
 export function moveCountdown(spans, now = new Date()) {
   const moves = (spans ?? [])
     .filter((span) => span.kind === "move" && dateStamp(span.starts_on) != null)
@@ -38,6 +91,7 @@ export function moveCountdown(spans, now = new Date()) {
     return {
       headline: "No move date set",
       detail: "Add a move span when the date is known.",
+      days: null,
     };
   }
 
@@ -60,6 +114,7 @@ export function moveCountdown(spans, now = new Date()) {
       month: "long",
       year: "numeric",
     }),
+    days,
   };
 }
 
@@ -76,7 +131,7 @@ export function progressSummary(progress, tasks) {
     total,
     value,
     percent: Math.round(value * 100),
-    label: `${done} of ${total} done`,
+    label: `${done} of ${total} tasks`,
   };
 }
 
@@ -100,6 +155,28 @@ export function formatTaskDueDate(value) {
   });
 }
 
+export function taskDueView(value, now = new Date()) {
+  const distance = dayDistance(dateValue(now), value);
+  if (distance == null) {
+    return { bucket: "later", label: "No due date", days: null };
+  }
+  if (distance < 0) {
+    return {
+      bucket: "overdue",
+      label: `${Math.abs(distance)}d late`,
+      days: distance,
+    };
+  }
+  if (distance <= 7) {
+    return {
+      bucket: "week",
+      label: distance === 0 ? "today" : `in ${distance}d`,
+      days: distance,
+    };
+  }
+  return { bucket: "later", label: formatShortDate(value), days: distance };
+}
+
 function formatCollisionRange(from, to) {
   const start = dateParts(from);
   const end = dateParts(to);
@@ -117,6 +194,7 @@ function formatCollisionRange(from, to) {
 }
 
 export function collisionWording(collision, tasks, spans) {
+  if (!collision) return null;
   const tasksById = new Map((tasks ?? []).map((task) => [task.id, task]));
   const spansById = new Map((spans ?? []).map((span) => [span.id, span]));
 
@@ -138,6 +216,157 @@ export function collisionWording(collision, tasks, spans) {
   }
 
   return null;
+}
+
+export function ganttDatePosition(value, startsOn, endsOn) {
+  const valueStamp = dateStamp(value);
+  const startStamp = dateStamp(startsOn);
+  const endStamp = dateStamp(endsOn);
+  if (
+    valueStamp == null ||
+    startStamp == null ||
+    endStamp == null ||
+    endStamp <= startStamp
+  ) {
+    return null;
+  }
+  const percent = ((valueStamp - startStamp) / (endStamp - startStamp)) * 100;
+  return Math.min(100, Math.max(0, percent));
+}
+
+export function ganttTimeline(spans, milestones, now = new Date()) {
+  const today = dateValue(now);
+  const values = [
+    today,
+    ...(spans ?? []).flatMap((span) => [span.starts_on, span.ends_on]),
+    ...(milestones ?? []).map((milestone) => milestone.occurs_on),
+  ].filter((value) => dateStamp(value) != null);
+  const stamps = values.map(dateStamp);
+  const first = new Date(Math.min(...stamps));
+  const last = new Date(Math.max(...stamps));
+  const start = new Date(
+    Date.UTC(first.getUTCFullYear(), first.getUTCMonth(), 1),
+  );
+  const end = new Date(
+    Date.UTC(last.getUTCFullYear(), last.getUTCMonth() + 1, 0),
+  );
+  const startsOn = start.toISOString().slice(0, 10);
+  const endsOn = end.toISOString().slice(0, 10);
+  const months = [];
+  for (
+    let cursor = new Date(start);
+    cursor <= end;
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1)
+  ) {
+    const value = cursor.toISOString().slice(0, 10);
+    months.push({
+      value,
+      label: MONTH_SHORT[cursor.getUTCMonth()],
+      position: ganttDatePosition(value, startsOn, endsOn),
+    });
+  }
+
+  const lanes = Object.entries(SPAN_KIND_LABELS)
+    .map(([kind, label]) => ({
+      kind,
+      label,
+      bars: (spans ?? [])
+        .filter(
+          (span) =>
+            span.kind === kind &&
+            dateStamp(span.starts_on) != null &&
+            dateStamp(span.ends_on) != null,
+        )
+        .map((span) => ({
+          ...span,
+          position: ganttDatePosition(span.starts_on, startsOn, endsOn),
+          width: Math.max(
+            0.8,
+            ganttDatePosition(span.ends_on, startsOn, endsOn) -
+              ganttDatePosition(span.starts_on, startsOn, endsOn),
+          ),
+        })),
+    }))
+    .filter((lane) => lane.bars.length > 0);
+
+  return {
+    startsOn,
+    endsOn,
+    months,
+    lanes,
+    todayPosition: ganttDatePosition(today, startsOn, endsOn),
+  };
+}
+
+export function mergeAgendaItems(milestones, spans, collisions, tasks) {
+  const items = [];
+  for (const milestone of milestones ?? []) {
+    if (dateStamp(milestone.occurs_on) == null) continue;
+    items.push({
+      id: `milestone-${milestone.id}`,
+      date: milestone.occurs_on,
+      kind: "ms",
+      held: milestone.gcal_state === "held",
+      icon: "◆",
+      title: milestone.title,
+      sub: `${titleCaseName(milestone.owner)} · ${milestone.gcal_state}`,
+    });
+  }
+  for (const span of spans ?? []) {
+    if (dateStamp(span.starts_on) == null) continue;
+    items.push({
+      id: `span-${span.id}`,
+      date: span.starts_on,
+      kind: "span",
+      held: false,
+      icon: "▬",
+      title: span.label,
+      sub: formatDateRange(span.starts_on, span.ends_on),
+    });
+  }
+  for (const collision of collisions ?? []) {
+    if (dateStamp(collision.overlaps_from) == null) continue;
+    const title = collisionWording(collision, tasks, spans);
+    if (!title) continue;
+    items.push({
+      id: `collision-${collision.type}-${collision.item1_id}-${collision.item2_id}`,
+      date: collision.overlaps_from,
+      kind: "col",
+      held: false,
+      icon: collision.type === "task_span" ? "▲" : "△",
+      title,
+      sub: "Date collision",
+    });
+  }
+  return items
+    .toSorted(
+      (left, right) =>
+        left.date.localeCompare(right.date) ||
+        left.kind.localeCompare(right.kind),
+    )
+    .map((item) => ({
+      ...item,
+      monthKey: item.date.slice(0, 7),
+      monthLabel: formatDate(item.date, { month: "long", year: "numeric" }),
+    }));
+}
+
+export function sumSellValues(tasks) {
+  return (tasks ?? [])
+    .filter((task) => task.track === "sell")
+    .reduce((total, task) => {
+      const value = Number(task.value_cad);
+      return total + (Number.isFinite(value) ? value : 0);
+    }, 0);
+}
+
+export function formatCad(value) {
+  const numeric = Number(value);
+  const amount = Number.isFinite(numeric) ? numeric : 0;
+  return `C$${amount.toLocaleString("en-CA", {
+    minimumFractionDigits: Number.isInteger(amount) ? 0 : 2,
+    maximumFractionDigits: 2,
+  })}`;
 }
 
 export function titleCaseName(value) {

--- a/projects/monolith/frontend/src/routes/friends/moving/moving.test.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving.test.js
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { collisionWording, moveCountdown, progressSummary } from "./moving.js";
+import {
+  collisionWording,
+  ganttDatePosition,
+  mergeAgendaItems,
+  moveCountdown,
+  progressSummary,
+  sumSellValues,
+} from "./moving.js";
 
 const tasks = [{ id: "task-1", title: "Ship the boxes", done_at: null }];
 const spans = [
@@ -54,12 +61,14 @@ describe("move countdown", () => {
 
     expect(result.headline).toBe("10 days to go");
     expect(result.detail).toBe("Monday, 11 May 2026");
+    expect(result.days).toBe(10);
   });
 
   it("states plainly when no move span exists", () => {
     expect(moveCountdown([], new Date(2026, 4, 1, 12))).toEqual({
       headline: "No move date set",
       detail: "Add a move span when the date is known.",
+      days: null,
     });
   });
 });
@@ -71,7 +80,81 @@ describe("progress", () => {
       total: 0,
       value: 0,
       percent: 0,
-      label: "0 of 0 done",
+      label: "0 of 0 tasks",
     });
+  });
+});
+
+describe("gantt positioning", () => {
+  it("maps dates onto the timeline and clamps values outside it", () => {
+    expect(ganttDatePosition("2026-08-01", "2026-08-01", "2026-08-11")).toBe(0);
+    expect(ganttDatePosition("2026-08-06", "2026-08-01", "2026-08-11")).toBe(
+      50,
+    );
+    expect(ganttDatePosition("2027-01-01", "2026-08-01", "2026-08-11")).toBe(
+      100,
+    );
+  });
+
+  it("rejects invalid or zero-length ranges", () => {
+    expect(ganttDatePosition("bad", "2026-08-01", "2026-08-11")).toBeNull();
+    expect(
+      ganttDatePosition("2026-08-01", "2026-08-01", "2026-08-01"),
+    ).toBeNull();
+  });
+});
+
+describe("phone agenda", () => {
+  it("merges spans, milestones, and collisions in date order", () => {
+    const items = mergeAgendaItems(
+      [
+        {
+          id: "milestone-1",
+          title: "Movers booked",
+          occurs_on: "2026-09-04",
+          owner: "both",
+          gcal_state: "held",
+        },
+      ],
+      [
+        {
+          id: "span-1",
+          kind: "visitor",
+          label: "Visitors",
+          starts_on: "2026-09-02",
+          ends_on: "2026-09-05",
+        },
+      ],
+      [
+        {
+          type: "task_span",
+          item1_id: "task-1",
+          item2_id: "span-1",
+          overlaps_from: "2026-09-03",
+          overlaps_to: "2026-09-03",
+        },
+      ],
+      tasks,
+    );
+
+    expect(items.map((item) => item.kind)).toEqual(["span", "col", "ms"]);
+    expect(items[1].icon).toBe("▲");
+    expect(items[2]).toMatchObject({
+      held: true,
+      monthLabel: "September 2026",
+    });
+  });
+});
+
+describe("sell totals", () => {
+  it("adds numeric CAD values only for sell tasks", () => {
+    expect(
+      sumSellValues([
+        { track: "sell", value_cad: "125.50" },
+        { track: "sell", value_cad: 24.5 },
+        { track: "sell", value_cad: null },
+        { track: "ship", value_cad: "900" },
+      ]),
+    ).toBe(150);
   });
 });


### PR DESCRIPTION
Replaces the PR 3a page, and folds in what was deferred to PR 3b. Refs #4968.

## Why a rebuild rather than a fix

The first build was specced in prose, because the implementer could not open the design. It drifted badly: display type everywhere, invented navy and dark-green cell grounds, a full-bleed yellow masthead, and a vertical stack that scrolled instead of a grid that fits one screen. With an empty database the hero rendered its fallback string at 92px, so an empty plan read as a broken page.

This time the approved mockup's own HTML and CSS was placed in the worktree and ported directly, with the instruction that where the prose and the file disagree, the file wins.

## Corrections, all from the artifact's own CSS

- **Cells are paper on an ink ground.** `gap: 2px; background: var(--ink); border: 2px solid var(--ink)`, so the ground shows through as shared borders. No coloured cell backgrounds; navy and dark green are gone.
- **Yellow is a signal, not a ground.** It appears on the Do Today header band and pressed segmented buttons only. The artifact's comment: "A full yellow field under 8 rows of bold ink was fatiguing to read."
- **Coral is a mark**, on overdue chips and collision icons, never a ground under text.
- **The head strip is a 10.5px mono line** at `padding: 9px 18px`, not a masthead.
- **Type scale**: hero `clamp(54px, 6.2vw, 92px)` display, cell headers 11px mono, body 13.5 to 14.5px. Nothing else is display-scale.
- **Empty states are quiet**: body-size secondary text, cells keeping their shape and headers.

## What is now built

The gantt over real spans and milestones (held ones get the coral diamond), the dock with To sell, Calendar and Roles modals over real data, and the tabbed phone layout switching on the real viewport under 700px.

The artifact's mockbar is dropped. Its Joe/Anna switch existed because a mockup has no identity; the server load already resolves the viewer from the verified header. Its Desktop/Mobile switch existed because a mockup has no viewport; `matchMedia` does it, with no bezel, since a real phone is the bezel. The artifact's "Build" modal is also dropped: its schema and prompt panels document how the mockup was made and are not part of the app.

## Notes

Fonts come from a new `src/routes/friends/+layout.svelte` mirroring the public tier's Google Fonts link, so the display and mono faces load without touching the public or private layouts.

Theme tokens are scoped under `.moving`, not `:root`, so they cannot collide with the other tiers' identically-named tokens. Dark mode lives in the CSS file rather than a component `<style>` block, because the Svelte compiler silently comments out unscoped `html[data-*]` selectors while the build stays green.

## Verification

`//projects/monolith/frontend:test` and `:build_test` forced with `--nocache_test_results`: **Executed 2 out of 2 tests: 2 tests pass.** Forced deliberately: `:test` does not compile Svelte templates, and a 1,077-line page rewrite is where a template error would hide behind green unit tests.

9 vitest cases including new coverage for gantt positioning, agenda merging and sell totals. `ci lint` green. No `Chart.yaml` `version:` or `targetRevision:` touched, and `hooks.js`, the `:src_public` exclusion and `build-exclusions.test.js` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)