### PR TITLE
chore(claude): pre-approve the claude.ai jomcgi MCP connector

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,7 +42,8 @@
       "Bash(column:*)",
       "WebFetch(domain:*)",
       "Bash(bb:*)",
-      "mcp__buildbuddy"
+      "mcp__buildbuddy",
+      "mcp__claude_ai_jomcgi"
     ],
     "additionalDirectories": ["/tmp/claude-worktrees"]
   },


### PR DESCRIPTION
Adds one server-level entry to `permissions.allow` in the project `.claude/settings.json`, matching the existing `mcp__buildbuddy` shape:

```json
"mcp__buildbuddy",
"mcp__claude_ai_jomcgi"
```

Verified: `jq` parses the file, all 38 pre-existing entries are preserved, the new one is index 38 of 39.

## Why

Without it, tools from the claude.ai jomcgi connector prompt on every call. The immediate case was `monolith-monolith-agent-notify` (Discord), which a CLI session could not reach at all until the connector was attached.

## Scope note

A server-level rule is coarse by design, so this is worth stating plainly rather than discovering later. The connector is not only read tools. It also carries:

- `monolith-k8s-sync-argocd-app` — triggers an ArgoCD sync
- `monolith-monolith-agent-session-destroy` — destroys an EmberVM session VM
- `monolith-monolith-chat-set-directive` / `-revert-directive` — changes live chat directives
- `monolith-run-python` — executes code in the sandbox

All of those are now pre-approved in this repo. That is the same trade already made for `mcp__buildbuddy`, and it is reversible: replacing the entry with explicit `mcp__claude_ai_jomcgi__<tool>` names narrows it to whatever subset is wanted.

Note this does not change behaviour for a user whose own settings set `permissions.defaultMode: bypassPermissions` — it matters for sessions that do not.

## Rollback

Remove the single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CVxWW96h5c9Ybhu4bxBzr