### PR TITLE
feat(authentik): put the admin account in family by default

### DIFF
--- a/projects/platform/authentik/blueprints/mcp-auth.yaml
+++ b/projects/platform/authentik/blueprints/mcp-auth.yaml
@@ -31,6 +31,24 @@ entries:
       groups:
         - !Find [authentik_core.group, [name, authentik Admins]]
         - !KeyOf homelab-admin
+        # `family` is declared and owned by moving-auth.yaml, not here, and
+        # referencing it across files is deliberate rather than sloppy.
+        #
+        # user.groups and group.users are the SAME many-to-many relation, and
+        # a blueprint sets the whole list rather than appending to it. If
+        # moving-auth.yaml also declared membership (from the group's side, as
+        # `users:`), the two files would each replace what the other wrote and
+        # the membership would flap on every reconcile: present after one pass,
+        # gone after the next. That presents as intermittent 403s on
+        # friends.jomcgi.dev/moving, which is a miserable thing to debug.
+        #
+        # So akadmin's group list has exactly ONE writer, and it is this entry.
+        # Anyone adding akadmin to a future group adds it here too.
+        #
+        # Other `family` members (Anna) are added in the UI on purpose. No
+        # blueprint declares their user, so nothing in Git can fight the UI
+        # over their membership.
+        - !Find [authentik_core.group, [name, family]]
 
   # ── 3. Gate the MCP application ─────────────────────────────────────────
   # Until this exists the application has ZERO policy bindings, which in


### PR DESCRIPTION
Small follow-up to #4968. The `family` group was created with no members, so the planner was only reachable after adding `akadmin` by hand in the UI. That membership existed nowhere in Git and would not survive a rebuild.

## Why this is declared in mcp-auth.yaml rather than moving-auth.yaml

`moving-auth.yaml` owns the `family` group, so declaring membership there looks like the obvious home. It is the wrong one.

`user.groups` and `group.users` are the **same** many-to-many relation, and a blueprint sets the whole list rather than appending to it. If `moving-auth.yaml` declared membership from the group's side (`users:`) while `mcp-auth.yaml` continued to declare `akadmin`'s `groups:`, the two files would each replace what the other wrote. The membership would flap on every reconcile: present after one pass, gone after the next.

That failure mode is worse than it sounds. It presents as intermittent 403s on `friends.jomcgi.dev/moving` with nothing in the config looking wrong.

So `akadmin`'s group list keeps exactly one writer, and this is it. The cost is a cross-file `!Find` for a group another blueprint owns, which the comment explains.

## Other members stay manual, deliberately

Anna and anyone else are added in the UI. No blueprint declares their user, so nothing in Git can compete with the UI over their membership. That is the same reason there is still no enrolment flow: a self-service enrolment surface on a hostname with no Cloudflare Access in front of it is a poor trade for a group this small.

## Verification

The blueprint parses, and `helm template` renders the new reference into the `authentik-mcp-blueprints` ConfigMap. Note `projects/platform/*` deploys on `targetRevision: HEAD`, so this lands live on merge.

Confirmed against the live instance beforehand: `akadmin` currently holds `['authentik Admins', 'family', 'homelab-admin']`, so this makes the running state declarative rather than changing it.

Refs #4968

🤖 Generated with [Claude Code](https://claude.com/claude-code)