### PR TITLE
feat(monolith): route qwen sessions to the pi-runtime workload

### DIFF
--- a/projects/monolith/agent_sessions/__init__.py
+++ b/projects/monolith/agent_sessions/__init__.py
@@ -22,3 +22,22 @@ def model_family(model: str | None) -> str:
     raise ValueError(
         f"Unknown model {model!r}; valid models: opus, sonnet, fable, luna, terra, sol, qwen"
     )
+
+
+# The EmberVM workload names a session lands on, keyed by family. These are a
+# CROSS-SERVICE CONTRACT with the embervm chart's workload CRs
+# (projects/embervm/chart/templates/workload-claude-runtime.yaml,
+# workload-pi-runtime.yaml), not a local label: the noded egress allowlist
+# (EMBERVM_NODED_EGRESS_WORKLOADS) is derived from those same workload names.
+# A name that drifts here does not fail loudly. It dial-timeouts inside the
+# guest, because the egress lane for an unrecognised workload is simply never
+# armed.
+DEFAULT_WORKLOAD = "claude-runtime"
+PI_WORKLOAD = "pi-runtime"
+
+
+def workload_for_family(family: str) -> str:
+    """Return the EmberVM workload name a session of this family creates on."""
+    if family == "pi":
+        return PI_WORKLOAD
+    return DEFAULT_WORKLOAD

--- a/projects/monolith/agent_sessions/__init__.py
+++ b/projects/monolith/agent_sessions/__init__.py
@@ -32,12 +32,17 @@ def model_family(model: str | None) -> str:
 # A name that drifts here does not fail loudly. It dial-timeouts inside the
 # guest, because the egress lane for an unrecognised workload is simply never
 # armed.
+#
+# The other half of the same contract: BOTH workload CRs must stay enabled.
+# piRuntimeWorkload.enabled defaults to FALSE in the embervm chart (prod and
+# dev values both set it true), and /api/health now depends on this lane
+# because probe_qwen runs through it. Disabling or renaming that CR makes every
+# qwen create 404, latches ember_synthetic_probe, and takes health red.
+#
+# There is deliberately no workload_for_family() helper here. The live decision
+# is transport._workload_for, which consults the env-resolved
+# transport.PI_WORKLOAD so the AGENT_PI_WORKLOAD revert lever is honoured. A
+# second mapping function reading these raw constants would look like the
+# routing mechanism while silently bypassing that lever.
 DEFAULT_WORKLOAD = "claude-runtime"
 PI_WORKLOAD = "pi-runtime"
-
-
-def workload_for_family(family: str) -> str:
-    """Return the EmberVM workload name a session of this family creates on."""
-    if family == "pi":
-        return PI_WORKLOAD
-    return DEFAULT_WORKLOAD

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -853,8 +853,10 @@ async def monolith_agent_detail(session_id: int, turn: int | None = None) -> dic
 
 
 @mcp.tool
-async def monolith_agent_session_vms(limit: int = 50, offset: int = 0) -> dict:
-    """List the EmberVM session VMs holding claude-runtime workload slots.
+async def monolith_agent_session_vms(
+    limit: int = 50, offset: int = 0, workload: str | None = None
+) -> dict:
+    """List the EmberVM session VMs holding a workload's session slots.
 
     Parked sessions count with banked toward session.maxSessions (the disk
     bucket) and no longer hold a concurrency.cap slot. Stale parked sessions
@@ -862,9 +864,17 @@ async def monolith_agent_session_vms(limit: int = 50, offset: int = 0) -> dict:
     session_cap 429. This lists the slot holders (state, timestamps, expiry)
     either way, so the stale ones can be destroyed with
     monolith-agent-session-destroy.
+
+    Args:
+        workload: Which lane to list, defaults to the claude runtime. Pass
+            "pi-runtime" to see the qwen family's lane instead. The two
+            lanes are never aggregated, since the session cap is per
+            workload.
     """
     try:
-        return await _transport.list_sessions(limit=limit, offset=offset)
+        return await _transport.list_sessions(
+            limit=limit, offset=offset, workload=workload
+        )
     except EmberVMTransportError as exc:
         return {"error": str(exc)}
 

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -1290,12 +1290,24 @@ def test_session_vms_returns_transport_payload(monkeypatch):
         "offset": 0,
     }
 
-    async def fake_list_sessions(limit=50, offset=0):
+    async def fake_list_sessions(limit=50, offset=0, workload=None):
         return payload
 
     monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
     result = asyncio.run(mcp.monolith_agent_session_vms())
     assert result == payload
+
+
+def test_session_vms_threads_workload_argument(monkeypatch):
+    calls = []
+
+    async def fake_list_sessions(limit=50, offset=0, workload=None):
+        calls.append(workload)
+        return {"items": []}
+
+    monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
+    asyncio.run(mcp.monolith_agent_session_vms(workload="pi-runtime"))
+    assert calls == ["pi-runtime"]
 
 
 def test_session_destroy_clears_matching_binding(monkeypatch, session):

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -14,7 +14,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlmodel import Session, func, select
 
-from agent_sessions import model_family, store, voice_ui
+from agent_sessions import model_family, store, transport as transport_module, voice_ui
 from agent_sessions.codex_login import codex_login_gate, watch_for_login
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.mcp import (
@@ -264,17 +264,40 @@ def _coarse_vm_map(items: list[dict]) -> dict[str, dict]:
     return vms
 
 
-async def _refresh_cp_state() -> None:
+async def _lane_sessions(workload: str) -> list:
+    """Every session the control plane reports for one workload lane."""
     items = []
     offset = 0
+    for _ in range(4):
+        page = await _transport.list_sessions(
+            limit=500, offset=offset, workload=workload
+        )
+        batch = page.get("items", [])
+        items.extend(batch)
+        offset += len(batch)
+        if not batch or offset >= int(page.get("total") or 0):
+            break
+    return items
+
+
+async def _refresh_cp_state() -> None:
+    # EVERY lane, not just the claude runtime. list_sessions is workload
+    # scoped, and since qwen sessions moved to pi-runtime a single-lane poll
+    # would leave them out of the published map entirely. The console reads an
+    # absent session_id as "off" (frontend status.js vmState), so a live qwen
+    # guest would render "vm off" and "waking vm" for its whole turn. On
+    # monolith-dev that is total, because localModelsOnly restricts the picker
+    # to qwen alone.
+    #
+    # Aggregating here does NOT contradict list_sessions defaulting to one
+    # lane: that default serves the operator tool, where the per-workload
+    # session CAP is the thing being managed. This map is keyed by session_id
+    # and wants the union.
+    lanes = list(dict.fromkeys([_transport.workload, transport_module.PI_WORKLOAD]))
+    items = []
     try:
-        for _ in range(4):
-            page = await _transport.list_sessions(limit=500, offset=offset)
-            batch = page.get("items", [])
-            items.extend(batch)
-            offset += len(batch)
-            if not batch or offset >= int(page.get("total") or 0):
-                break
+        for lane in lanes:
+            items.extend(await _lane_sessions(lane))
     except EmberVMTransportError as exc:
         # Drop the map rather than serving the last known one. A stale entry
         # renders as a confident "awake" chip for a guest that may be long

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -11,6 +11,7 @@ from sqlmodel import Session, SQLModel, create_engine
 
 from agent_sessions import api, store
 from agent_sessions import mcp
+from agent_sessions import transport
 import agent_sessions.router as agent_router
 from agent_sessions.codex_login import codex_login_gate
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
@@ -208,7 +209,7 @@ def test_list_sessions_exposes_node_identity(client, session):
 
 
 def test_list_session_vms_maps_control_plane_states(client, monkeypatch):
-    async def fake_list_sessions(limit=50, offset=0):
+    async def fake_list_sessions(limit=50, offset=0, workload=None):
         return {
             "items": [
                 {"session_id": "s-run", "state": "running", "expires_at": 99},
@@ -236,7 +237,12 @@ def test_list_session_vms_maps_control_plane_states(client, monkeypatch):
 def test_list_session_vms_follows_pagination(client, monkeypatch):
     calls = []
 
-    async def fake_list_sessions(limit=50, offset=0):
+    async def fake_list_sessions(limit=50, offset=0, workload=None):
+        # Only the claude lane is paginated here; the pi lane answers empty so
+        # this test keeps asserting pagination rather than lane fan-out (see
+        # test_refresh_cp_state_polls_every_lane for that).
+        if workload == transport.PI_WORKLOAD:
+            return {"total": 0, "items": []}
         calls.append(offset)
         if offset == 0:
             return {
@@ -257,8 +263,35 @@ def test_list_session_vms_follows_pagination(client, monkeypatch):
     assert body["vms"]["s-tail"]["state"] == "awake"
 
 
+def test_refresh_cp_state_polls_every_lane(client, monkeypatch):
+    """The VM map must cover the pi lane as well as the claude one.
+
+    list_sessions is workload scoped, so a single-lane poll leaves qwen
+    sessions out of the published map. The console reads an absent session_id
+    as "off" (frontend status.js vmState), so a live qwen guest would render
+    "vm off" for its whole turn, and on monolith-dev that is every session
+    because localModelsOnly restricts the picker to qwen.
+    """
+    lanes = []
+
+    async def fake_list_sessions(limit=50, offset=0, workload=None):
+        lanes.append(workload)
+        if workload == transport.PI_WORKLOAD:
+            return {"items": [{"session_id": "s-qwen", "state": "running"}]}
+        return {"items": [{"session_id": "s-claude", "state": "running"}]}
+
+    monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
+    asyncio.run(agent_router._refresh_cp_state())
+    body = client.get("/api/agents/vms").json()
+
+    assert sorted(lanes) == sorted([mcp._transport.workload, transport.PI_WORKLOAD])
+    # Merged, not replaced: the last lane polled must not clobber the first.
+    assert body["vms"]["s-qwen"]["state"] == "awake"
+    assert body["vms"]["s-claude"]["state"] == "awake"
+
+
 def test_list_session_vms_degrades_when_embervm_is_down(client, monkeypatch):
-    async def broken_list_sessions(limit=50, offset=0):
+    async def broken_list_sessions(limit=50, offset=0, workload=None):
         raise EmberVMTransportError("control plane unreachable")
 
     monkeypatch.setattr(mcp._transport, "list_sessions", broken_list_sessions)
@@ -271,7 +304,7 @@ def test_list_session_vms_degrades_when_embervm_is_down(client, monkeypatch):
 def test_vm_cache_refreshes_at_interval_and_stops_when_unused(monkeypatch):
     calls = []
 
-    async def fake_list_sessions(limit=50, offset=0):
+    async def fake_list_sessions(limit=50, offset=0, workload=None):
         calls.append((limit, offset))
         return {"items": [{"session_id": "s-1", "state": "running"}]}
 
@@ -293,7 +326,7 @@ def test_vm_cache_refreshes_at_interval_and_stops_when_unused(monkeypatch):
 def test_vm_stream_emits_initial_and_changed_snapshots(monkeypatch):
     state = [{"session_id": "s-1", "state": "running"}]
 
-    async def fake_list_sessions(limit=50, offset=0):
+    async def fake_list_sessions(limit=50, offset=0, workload=None):
         return {"items": state}
 
     async def exercise():
@@ -329,7 +362,7 @@ def test_refresher_survives_an_iteration_that_raises(monkeypatch):
     """
     calls = []
 
-    async def flaky_list_sessions(limit=50, offset=0):
+    async def flaky_list_sessions(limit=50, offset=0, workload=None):
         calls.append(1)
         if len(calls) == 1:
             raise ValueError("malformed page")
@@ -359,7 +392,7 @@ def test_snapshot_reclaims_a_dead_refresher(monkeypatch):
     """A finished task is not None, so `task is None` alone froze this too."""
     calls = []
 
-    async def fake_list_sessions(limit=50, offset=0):
+    async def fake_list_sessions(limit=50, offset=0, workload=None):
         calls.append(1)
         return {"items": [{"session_id": "s-1", "state": "running"}]}
 
@@ -380,7 +413,7 @@ def test_snapshot_reclaims_a_dead_refresher(monkeypatch):
 
 
 def test_vm_stream_heartbeats_when_idle(monkeypatch):
-    async def fake_list_sessions(limit=50, offset=0):
+    async def fake_list_sessions(limit=50, offset=0, workload=None):
         return {"items": []}
 
     async def exercise():

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -21,6 +21,8 @@ from typing import Awaitable, Callable, NamedTuple, Protocol
 
 import httpx
 
+import agent_sessions
+from agent_sessions import model_family
 from faas.embervm_client import (
     EmberVMTimeout,
     EmberVMTransportError,
@@ -99,6 +101,28 @@ def _status_error_detail(exc: httpx.HTTPStatusError) -> str:
 # empty default is what the guards below check: unset means the guest lane is
 # not reachable, not that it is reachable at the empty URL.
 EMBERVM_URL = os.environ.get("EMBERVM_URL", "")
+
+
+# The pi-family workload override, following the SANDBOX_WORKLOAD_PREFIX
+# precedent in the monolith chart: read once at import, from the chart's
+# agentSessions.piWorkload value. There is no security semantic here (unlike
+# an egress allowlist), so an unset OR blank value means "use the code
+# default", not "deny": this is a REVERT LEVER (set it to claude-runtime to
+# put qwen back on the old lane by a values edit, no code deploy), never a
+# deny-by-default control.
+#
+# Extracted as a function purely so the env-reading behaviour is testable
+# WITHOUT importlib.reload. Reloading this module rebinds EmberSessionGone to a
+# fresh class object while other modules (and the test file's own top-level
+# import) keep the previous one, so a later `pytest.raises(EmberSessionGone)`
+# stops matching. That failure is order dependent and reads like flakiness, so
+# do not reintroduce a reload to test this.
+def _resolve_pi_workload() -> str:
+    """Resolve the pi-family workload name from the environment."""
+    return os.environ.get("AGENT_PI_WORKLOAD", "") or agent_sessions.PI_WORKLOAD
+
+
+PI_WORKLOAD = _resolve_pi_workload()
 
 
 class EmberSessionGone(EmberVMTransportError):
@@ -258,8 +282,21 @@ class EmberVmShimTransport:
         self.workload = workload
         self.read_timeout = read_timeout
 
+    def _workload_for(self, model: str | None) -> str:
+        """Resolve the target workload for a session of this model.
+
+        model=None resolves to self.workload (the claude family default, see
+        model_family), same as every other family that is not "pi".
+        """
+        if model_family(model) == "pi":
+            return PI_WORKLOAD
+        return self.workload
+
     async def create_session(
-        self, restore_from: str | None = None, _attempt: int = 0
+        self,
+        restore_from: str | None = None,
+        model: str | None = None,
+        _attempt: int = 0,
     ) -> EmberSession:
         """Create a new session on the guest and return the session ID.
 
@@ -269,6 +306,10 @@ class EmberVmShimTransport:
                 the prior generation's guest workspace from (#4306 slice 4:
                 cross-generation continuity). None (the default) requests a
                 normal, blank create.
+            model: The model this session will run, used only to pick the
+                target workload (see _workload_for). None resolves to
+                self.workload, matching every caller that predates this
+                parameter.
 
         Returns:
             The EmberVM session identity and bearer token. lineage_id is the
@@ -289,7 +330,7 @@ class EmberVmShimTransport:
         if not EMBERVM_URL:
             raise EmberVMTransportError("EMBERVM_URL is not configured")
 
-        url = f"{EMBERVM_URL}/v1/workloads/{self.workload}/sessions"
+        url = f"{EMBERVM_URL}/v1/workloads/{self._workload_for(model)}/sessions"
         headers = auth_headers()
         timeout = httpx.Timeout(self.read_timeout, connect=SUBMIT_CONNECT_TIMEOUT)
         # A normal create posts no body at all: the CP's create route parses
@@ -329,7 +370,7 @@ class EmberVmShimTransport:
             logger.warning("embervm session creation failed: %s", exc)
             if _attempt < 3 and _retryable_from_response(exc):
                 await asyncio.sleep((2, 5, 10)[_attempt])
-                return await self.create_session(restore_from, _attempt + 1)
+                return await self.create_session(restore_from, model, _attempt + 1)
             raise EmberVMTransportError(_status_error_detail(exc)) from exc
         except httpx.TransportError as exc:
             logger.warning("embervm session creation transport error: %s", exc)
@@ -340,12 +381,18 @@ class EmberVmShimTransport:
     # is listed here and destroyed. Both calls use management auth, not a
     # session bearer token, so they act on any session in the workload.
 
-    async def list_sessions(self, limit: int = 50, offset: int = 0) -> dict:
-        """List the control plane's sessions for this workload (management auth).
+    async def list_sessions(
+        self, limit: int = 50, offset: int = 0, workload: str | None = None
+    ) -> dict:
+        """List the control plane's sessions for one workload (management auth).
 
         Args:
             limit: Maximum sessions to return (clamped 1-500 server side).
             offset: Offset into the workload's session list.
+            workload: Which lane to list; defaults to self.workload (the
+                claude runtime). The two lanes are never aggregated: the
+                session cap is per workload, so an operator managing a cap
+                wants one lane at a time.
 
         Returns:
             The control plane's paginated session listing.
@@ -356,7 +403,8 @@ class EmberVmShimTransport:
         if not EMBERVM_URL:
             raise EmberVMTransportError("EMBERVM_URL is not configured")
 
-        url = f"{EMBERVM_URL}/v1/workloads/{self.workload}/sessions"
+        target_workload = workload if workload is not None else self.workload
+        url = f"{EMBERVM_URL}/v1/workloads/{target_workload}/sessions"
         headers = auth_headers()
         # NOT self.read_timeout: that 30-minute value is sized for a turn,
         # and this listing now serves the console's fast VM-state poll. A
@@ -499,7 +547,9 @@ class EmberVmShimTransport:
         if ember is None:
             if restore_from:
                 try:
-                    ember = await self.create_session(restore_from=restore_from)
+                    ember = await self.create_session(
+                        restore_from=restore_from, model=model
+                    )
                 except EmberVMTransportError as restore_exc:
                     # Same degrade as the 410/403 arm below: the restore
                     # create was itself DENIED or timed out, so fall back to
@@ -510,7 +560,7 @@ class EmberVmShimTransport:
                         restore_from,
                         restore_exc,
                     )
-                    ember = await self.create_session()
+                    ember = await self.create_session(model=model)
                     workspace_recovery = {
                         "created": True,
                         "restored": False,
@@ -530,7 +580,7 @@ class EmberVmShimTransport:
                     await on_create(ember, cli_for_binding)
                 cli_session_id = cli_for_binding
             else:
-                ember = await self.create_session()
+                ember = await self.create_session(model=model)
                 workspace_recovery = {
                     "created": True,
                     "restored": False,
@@ -629,7 +679,9 @@ class EmberVmShimTransport:
             # is None and session_id is the only handle it ever had.
             restore_from = ember.lineage_id or ember.session_id
             try:
-                new_ember = await self.create_session(restore_from=restore_from)
+                new_ember = await self.create_session(
+                    restore_from=restore_from, model=model
+                )
             except EmberVMTransportError as restore_exc:
                 # The restore create was itself DENIED (unknown_lineage, a
                 # workload/principal mismatch, a live heir, or a concurrent
@@ -643,7 +695,7 @@ class EmberVmShimTransport:
                     restore_from,
                     restore_exc,
                 )
-                new_ember = await self.create_session()
+                new_ember = await self.create_session(model=model)
 
             cli_for_binding = cli_session_id if new_ember.restored else None
             if on_create is not None:

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -263,7 +263,7 @@ class EmberVmShimTransport:
 
     def __init__(
         self,
-        workload: str = "claude-runtime",
+        workload: str = agent_sessions.DEFAULT_WORKLOAD,
         read_timeout: float = 1800.0,
     ) -> None:
         """Initialize transport for a named EmberVM workload.

--- a/projects/monolith/agent_sessions/transport_test.py
+++ b/projects/monolith/agent_sessions/transport_test.py
@@ -121,6 +121,42 @@ def test_create_session_retryable_backoff_and_restore_payload(monkeypatch):
     assert result.session_id == "s1"
 
 
+def test_create_session_retry_keeps_qwen_on_the_pi_workload(monkeypatch):
+    """The retryable-backoff recursion must carry the model too.
+
+    This is the fifth create path and the easiest to leave unguarded: it
+    re-enters create_session positionally, so dropping the model there is
+    invisible except that the retried create lands on the 4 GiB lane. It is
+    live rather than theoretical, because a retryable create denial is exactly
+    what pi-runtime's cap of 2 produces when the */5 probe overlaps an
+    interactive qwen turn.
+    """
+    attempts = []
+
+    async def handler(request):
+        attempts.append(request)
+        if len(attempts) < 3:
+            return _error_response(request, 409, True)
+        return httpx.Response(
+            200,
+            json={"session_id": "s1", "session_token": "t1"},
+            request=request,
+        )
+
+    async def fake_sleep(seconds):
+        return None
+
+    _client(monkeypatch, handler)
+    monkeypatch.setattr(transport.asyncio, "sleep", fake_sleep)
+    asyncio.run(transport.EmberVmShimTransport().create_session(model="qwen"))
+
+    assert len(attempts) == 3
+    # EVERY attempt, not just the first: the recursion must not lose the model.
+    assert [str(request.url) for request in attempts] == [
+        "https://ember.test/v1/workloads/pi-runtime/sessions"
+    ] * 3
+
+
 @pytest.mark.parametrize("field", ["session_id", "session_token"])
 @pytest.mark.parametrize("value", [None, ""])
 def test_create_session_rejects_missing_or_empty_identity(monkeypatch, field, value):

--- a/projects/monolith/agent_sessions/transport_test.py
+++ b/projects/monolith/agent_sessions/transport_test.py
@@ -30,6 +30,10 @@ class FakeAsyncClient:
         request = httpx.Request("POST", url, **kwargs)
         return await self.handler(request)
 
+    async def get(self, url, **kwargs):
+        request = httpx.Request("GET", url, **kwargs)
+        return await self.handler(request)
+
     async def delete(self, url, **kwargs):
         request = httpx.Request("DELETE", url, **kwargs)
         return await self.handler(request)
@@ -189,6 +193,49 @@ def test_create_session_restoring_posts_restore_lineage_body(monkeypatch):
     asyncio.run(transport.EmberVmShimTransport().create_session(restore_from="s1"))
 
     assert json.loads(requests[0].content) == {"restore_lineage": "s1"}
+
+
+# -- qwen (pi family) routing: create_session targets pi-runtime -----------
+
+
+def test_create_session_qwen_targets_pi_runtime_workload(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return httpx.Response(
+            201,
+            json={"session_id": "s1", "session_token": "t1"},
+            request=request,
+        )
+
+    _client(monkeypatch, handler)
+    asyncio.run(transport.EmberVmShimTransport().create_session(model="qwen"))
+
+    assert str(requests[0].url) == "https://ember.test/v1/workloads/pi-runtime/sessions"
+
+
+@pytest.mark.parametrize("model", [None, "opus", "sonnet", "fable", "luna"])
+def test_create_session_non_pi_models_target_claude_runtime_workload(
+    monkeypatch, model
+):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return httpx.Response(
+            201,
+            json={"session_id": "s1", "session_token": "t1"},
+            request=request,
+        )
+
+    _client(monkeypatch, handler)
+    asyncio.run(transport.EmberVmShimTransport().create_session(model=model))
+
+    assert (
+        str(requests[0].url)
+        == "https://ember.test/v1/workloads/claude-runtime/sessions"
+    )
 
 
 def test_deliver_uses_ember_identity_and_cli_id_in_body(monkeypatch):
@@ -523,7 +570,7 @@ def test_deliver_recreates_reused_stale_session_once(monkeypatch):
         requests.append(request)
         return _turn_response(request, responses.pop(0))
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         nonlocal create_calls
         create_calls += 1
         seen_restore_from.append(restore_from)
@@ -562,7 +609,7 @@ def test_deliver_recreates_reused_session_on_403(monkeypatch):
         requests.append(request)
         return _turn_response(request, responses.pop(0))
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         nonlocal create_calls
         create_calls += 1
         seen_restore_from.append(restore_from)
@@ -601,7 +648,7 @@ def test_deliver_keeps_cli_session_id_when_restore_recovers_workspace(monkeypatc
         requests.append(request)
         return _turn_response(request, responses.pop(0))
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         return restored_session
 
     _client(monkeypatch, handler)
@@ -639,7 +686,7 @@ def test_deliver_falls_back_to_blank_session_when_restore_create_is_denied(
         requests.append(request)
         return _turn_response(request, responses.pop(0))
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         create_calls.append(restore_from)
         if restore_from:
             raise EmberVMTransportError("404 unknown_lineage")
@@ -675,7 +722,7 @@ def test_deliver_reused_session_403_with_failing_retry_raises_session_gone(monke
         requests.append(request)
         return _turn_response(request, responses.pop(0))
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         return fresh
 
     _client(monkeypatch, handler)
@@ -698,7 +745,7 @@ def test_deliver_does_not_retry_reused_session_on_422(monkeypatch):
         requests.append(request)
         return _turn_response(request, 422)
 
-    async def create_session():
+    async def create_session(model=None):
         nonlocal create_calls
         create_calls += 1
         return transport.EmberSession("s2", "t2", None)
@@ -723,7 +770,7 @@ def test_deliver_does_not_retry_reused_session_on_404(monkeypatch):
         requests.append(request)
         return _turn_response(request, 404)
 
-    async def create_session():
+    async def create_session(model=None):
         nonlocal create_calls
         create_calls += 1
         return transport.EmberSession("s2", "t2", None)
@@ -749,7 +796,7 @@ def test_deliver_does_not_retry_fresh_session_failure(monkeypatch):
         requests.append(request)
         return _turn_response(request, 410)
 
-    async def create_session():
+    async def create_session(model=None):
         nonlocal create_calls
         create_calls += 1
         return fresh
@@ -782,7 +829,7 @@ def test_deliver_fresh_session_retryable_then_fails(monkeypatch):
     client = transport.EmberVmShimTransport()
     fresh = transport.EmberSession("s1", "t1", None)
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         return fresh
 
     monkeypatch.setattr(client, "create_session", create_session)
@@ -804,7 +851,7 @@ def test_deliver_retryable_exhaustion(monkeypatch):
     async def fake_sleep(seconds):
         sleeps.append(seconds)
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         return transport.EmberSession("s1", "t1", None)
 
     _client(monkeypatch, handler)
@@ -827,7 +874,7 @@ def test_deliver_410_restore_heir_persisted_on_double_failure(monkeypatch):
         events.append("invoke")
         return _error_response(request, responses.pop(0), False)
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         events.append("create")
         return heir
 
@@ -854,7 +901,7 @@ def test_deliver_workspace_recovery_on_normal_create(monkeypatch):
     async def handler(request):
         return _turn_response(request)
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         return transport.EmberSession("s1", "t1", None)
 
     _client(monkeypatch, handler)
@@ -873,7 +920,7 @@ def test_deliver_workspace_recovery_on_restore_success(monkeypatch):
     async def handler(request):
         return _turn_response(request)
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         return transport.EmberSession(
             "s2", "t2", None, lineage_id="lineage-1", restored=True
         )
@@ -896,7 +943,7 @@ def test_deliver_workspace_recovery_on_restore_denial_fallback(monkeypatch):
     async def handler(request):
         return _turn_response(request)
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         if restore_from:
             raise EmberVMTransportError("restore denied")
         return transport.EmberSession("s3", "t3", None)
@@ -944,7 +991,7 @@ def test_deliver_with_no_ember_restores_and_keeps_cli_when_recovered(monkeypatch
         requests.append(request)
         return _turn_response(request)
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         create_calls.append(restore_from)
         return restored_session
 
@@ -971,7 +1018,7 @@ def test_deliver_with_no_ember_restore_denied_falls_back_to_blank(monkeypatch):
         requests.append(request)
         return _turn_response(request)
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         create_calls.append(restore_from)
         if restore_from:
             raise EmberVMTransportError("404 unknown_lineage")
@@ -1004,7 +1051,7 @@ def test_deliver_with_no_ember_and_no_restore_from_is_unchanged(monkeypatch):
         requests.append(request)
         return _turn_response(request)
 
-    async def create_session(restore_from=None):
+    async def create_session(restore_from=None, model=None):
         create_calls.append(restore_from)
         return fresh
 
@@ -1017,6 +1064,266 @@ def test_deliver_with_no_ember_and_no_restore_from_is_unchanged(monkeypatch):
     assert used == fresh
     assert json.loads(requests[0].content)["session_id"] == "cli-x"
     assert turn.result == "ok"
+
+
+# -- qwen (pi family) routing end-to-end through deliver --------------------
+# These exercise the REAL create_session (no monkeypatch on it), so the
+# create URL is the thing under test, not a fake's return value.
+
+
+def test_deliver_creates_qwen_session_on_pi_workload(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        if str(request.url).endswith("/sessions"):
+            return httpx.Response(
+                201,
+                json={"session_id": "s-pi", "session_token": "t-pi"},
+                request=request,
+            )
+        return _turn_response(request)
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    turn, used = asyncio.run(client.deliver(None, None, "hello", model="qwen"))
+
+    create_request, invoke_request = requests
+    assert (
+        str(create_request.url) == "https://ember.test/v1/workloads/pi-runtime/sessions"
+    )
+    # The workload choice must not leak into the invoke URL: it is always
+    # session-scoped regardless of which workload the session lives on.
+    assert str(invoke_request.url) == "https://ember.test/v1/sessions/s-pi/invoke"
+    assert used.session_id == "s-pi"
+    assert turn.result == "ok"
+
+
+def test_deliver_with_existing_ember_issues_no_create(monkeypatch):
+    """A live binding on claude-runtime must keep working untouched: this
+    change must not migrate an existing session to a different workload."""
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return _turn_response(request)
+
+    _client(monkeypatch, handler)
+    ember = transport.EmberSession("s1", "t1", None)
+    turn, used = asyncio.run(
+        transport.EmberVmShimTransport().deliver(ember, "cli-1", "hello", model="qwen")
+    )
+
+    assert len(requests) == 1
+    assert str(requests[0].url) == "https://ember.test/v1/sessions/s1/invoke"
+    assert used == ember
+    assert turn.result == "ok"
+
+
+def test_deliver_restore_from_passes_model_to_pi_workload(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        if str(request.url).endswith("/sessions"):
+            return httpx.Response(
+                201,
+                json={
+                    "session_id": "s-pi-2",
+                    "session_token": "t-pi-2",
+                    "lineage_id": "lineage-1",
+                    "restored": True,
+                },
+                request=request,
+            )
+        return _turn_response(request)
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    turn, used = asyncio.run(
+        client.deliver(
+            None, "cli-prior", "hello", model="qwen", restore_from="lineage-1"
+        )
+    )
+
+    create_request = requests[0]
+    assert (
+        str(create_request.url) == "https://ember.test/v1/workloads/pi-runtime/sessions"
+    )
+    assert json.loads(create_request.content) == {"restore_lineage": "lineage-1"}
+    assert used.session_id == "s-pi-2"
+    assert turn.result == "ok"
+
+
+def test_deliver_restore_denied_falls_back_to_blank_on_pi_workload(monkeypatch):
+    """A cross-workload restore is one of the CP's documented denial reasons
+    (workload/principal mismatch). The existing degrade-to-blank fallback
+    must still land on the CORRECT (pi) workload, not silently drop back to
+    claude-runtime."""
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        if str(request.url).endswith("/sessions"):
+            body = json.loads(request.content) if request.content else {}
+            if body.get("restore_lineage"):
+                return _error_response(request, 403, False)
+            return httpx.Response(
+                201,
+                json={"session_id": "s-blank", "session_token": "t-blank"},
+                request=request,
+            )
+        return _turn_response(request)
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    turn, used = asyncio.run(
+        client.deliver(
+            None, "cli-prior", "hello", model="qwen", restore_from="lineage-1"
+        )
+    )
+
+    denied_create, blank_create, _invoke = requests
+    assert (
+        str(denied_create.url) == "https://ember.test/v1/workloads/pi-runtime/sessions"
+    )
+    assert (
+        str(blank_create.url) == "https://ember.test/v1/workloads/pi-runtime/sessions"
+    )
+    assert used.session_id == "s-blank"
+    assert turn.workspace_recovery == {
+        "created": True,
+        "restored": False,
+        "degraded": "restore_denied",
+    }
+
+
+def test_deliver_session_gone_recreates_qwen_on_pi_workload(monkeypatch):
+    """The 403/410 mid-conversation recovery arm must recreate on the PI lane.
+
+    This arm is the one that fails silently if the model is not threaded: the
+    turn still succeeds, it just runs on the 4 GiB claude-runtime lane, so
+    nothing surfaces the escape. Both of its create_session calls (the restore
+    and the degrade-to-blank fallback) are covered here.
+    """
+    requests = []
+    turn_codes = [410, 200]
+
+    async def handler(request):
+        requests.append(request)
+        if str(request.url).endswith("/sessions"):
+            body = json.loads(request.content) if request.content else {}
+            if body.get("restore_lineage"):
+                return _error_response(request, 403, False)
+            return httpx.Response(
+                201,
+                json={"session_id": "s-pi-new", "session_token": "t-pi-new"},
+                request=request,
+            )
+        return _turn_response(request, turn_codes.pop(0))
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    turn, used = asyncio.run(
+        client.deliver(
+            transport.EmberSession("s1", "t1", None), "cli-1", "hello", model="qwen"
+        )
+    )
+
+    first_invoke, denied_create, blank_create, retry_invoke = requests
+    assert str(first_invoke.url) == "https://ember.test/v1/sessions/s1/invoke"
+    # Both creates on the recovery arm must target pi-runtime, not the
+    # claude-runtime default the transport instance carries.
+    assert (
+        str(denied_create.url) == "https://ember.test/v1/workloads/pi-runtime/sessions"
+    )
+    assert (
+        str(blank_create.url) == "https://ember.test/v1/workloads/pi-runtime/sessions"
+    )
+    # The lane choice must not leak into the session-scoped invoke URL.
+    assert str(retry_invoke.url) == "https://ember.test/v1/sessions/s-pi-new/invoke"
+    assert used.session_id == "s-pi-new"
+    assert turn.result == "ok"
+
+
+# -- AGENT_PI_WORKLOAD revert lever ------------------------------------------
+
+
+def test_agent_pi_workload_override_sends_qwen_to_claude_runtime(monkeypatch):
+    """The revert lever: setting the override to claude-runtime must put
+    qwen back on the old lane by a values edit, with no code deploy."""
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return httpx.Response(
+            201,
+            json={"session_id": "s1", "session_token": "t1"},
+            request=request,
+        )
+
+    _client(monkeypatch, handler)
+    monkeypatch.setattr(transport, "PI_WORKLOAD", "claude-runtime")
+    asyncio.run(transport.EmberVmShimTransport().create_session(model="qwen"))
+
+    assert (
+        str(requests[0].url)
+        == "https://ember.test/v1/workloads/claude-runtime/sessions"
+    )
+
+
+def test_agent_pi_workload_env_blank_or_unset_resolves_to_pi_runtime(monkeypatch):
+    """AGENT_PI_WORKLOAD unset OR blank both mean "use the code default": there
+    is no security semantic here, so blank is not a deny lever.
+
+    Asserted against the resolver rather than by reloading the module:
+    importlib.reload rebinds EmberSessionGone to a fresh class object, which
+    silently breaks every later pytest.raises(EmberSessionGone) in this file.
+    """
+    monkeypatch.delenv("AGENT_PI_WORKLOAD", raising=False)
+    assert transport._resolve_pi_workload() == "pi-runtime"
+
+    monkeypatch.setenv("AGENT_PI_WORKLOAD", "")
+    assert transport._resolve_pi_workload() == "pi-runtime"
+
+    # A set, non-blank value is the revert lever and IS honoured.
+    monkeypatch.setenv("AGENT_PI_WORKLOAD", "claude-runtime")
+    assert transport._resolve_pi_workload() == "claude-runtime"
+
+
+# -- list_sessions workload lane selection -----------------------------------
+
+
+def test_list_sessions_targets_named_workload(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return httpx.Response(200, json={"items": []}, request=request)
+
+    _client(monkeypatch, handler)
+    asyncio.run(transport.EmberVmShimTransport().list_sessions(workload="pi-runtime"))
+
+    assert (
+        str(requests[0].url).split("?")[0]
+        == "https://ember.test/v1/workloads/pi-runtime/sessions"
+    )
+
+
+def test_list_sessions_defaults_to_claude_runtime(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return httpx.Response(200, json={"items": []}, request=request)
+
+    _client(monkeypatch, handler)
+    asyncio.run(transport.EmberVmShimTransport().list_sessions())
+
+    assert (
+        str(requests[0].url).split("?")[0]
+        == "https://ember.test/v1/workloads/claude-runtime/sessions"
+    )
 
 
 def test_destroy_session_maps_404_to_session_gone(monkeypatch):

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -138,6 +138,14 @@ spec:
             - name: SANDBOX_WORKLOAD_PREFIX
               value: {{ .Values.sandbox.workloadPrefix | quote }}
             {{- end }}
+            {{- if .Values.agentSessions.piWorkload }}
+            # Override for the qwen (pi family) EmberVM workload name; the
+            # code default is pi-runtime. This is the REVERT LEVER: setting
+            # it to claude-runtime puts qwen back on the old lane by a
+            # values edit, with no code deploy.
+            - name: AGENT_PI_WORKLOAD
+              value: {{ .Values.agentSessions.piWorkload | quote }}
+            {{- end }}
             {{- if .Values.swarm.enabled }}
             # DBOS swarm layer (ADR agents/038, agents/053). SWARM_ENABLED is
             # the master switch the module reads: with it false the router still

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1043,10 +1043,15 @@ sandbox:
 
 agentSessions:
   # EmberVM workload the qwen (pi) family creates its guest sessions on.
-  # Empty means "use the code default" (pi-runtime). This key must exist
-  # even empty: a values file without it render-errors the template. This
-  # is the REVERT LEVER for routing qwen back to the claude-runtime lane:
-  # set it to "claude-runtime" to revert by values edit, no code deploy.
+  # Empty means "use the code default" (pi-runtime). This is the REVERT
+  # LEVER for routing qwen back to the claude-runtime lane: set it to
+  # "claude-runtime" to revert by values edit, no code deploy.
+  #
+  # A consumer values file that OMITS agentSessions renders fine, because
+  # chart defaults merge (verified against both deploy/values.yaml and
+  # dev/deploy/values.yaml). The one shape that breaks the template is an
+  # explicit null override, `agentSessions:` with no body, which gives
+  # "nil pointer evaluating interface {}.piWorkload".
   piWorkload: ""
 
 # EmberVM R4 scratch-postgres consumer (ADR embervm/001, D-R4.PR-11.1). When

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1041,6 +1041,14 @@ sandbox:
   # contract with the embervm chart. Empty falls back to the client default.
   workloadPrefix: "sandbox-"
 
+agentSessions:
+  # EmberVM workload the qwen (pi) family creates its guest sessions on.
+  # Empty means "use the code default" (pi-runtime). This key must exist
+  # even empty: a values file without it render-errors the template. This
+  # is the REVERT LEVER for routing qwen back to the claude-runtime lane:
+  # set it to "claude-runtime" to revert by values edit, no code deploy.
+  piWorkload: ""
+
 # EmberVM R4 scratch-postgres consumer (ADR embervm/001, D-R4.PR-11.1). When
 # enabled the monolith exposes SCRATCH_POSTGRES_DSN so agent run_code python runs
 # can psycopg-connect to the scale-to-zero scratch Postgres. The datastore's


### PR DESCRIPTION
Routes the pi family (`model=qwen`) off the shared `claude-runtime` workload onto the 256 MiB `pi-runtime` lane. Closes the follow-up named in `projects/embervm/deploy/values.yaml`, which stood the workload up but deliberately left the monolith-side routing for a separate change.

## Why

`claude-runtime` is sized at 4096 MiB to hold a 262 MB Node ELF with a V8 heap for the claude CLI. A qwen turn can never invoke it. `pi-runtime` runs the *same* shim on a pi-only image (200 MB of unusable CLIs dropped, roughly 3x smaller) at 256 MiB, so a banked qwen session snapshot is 256 MiB rather than 4 GiB.

## The seam

The workload name appears in exactly two URLs, both `/v1/workloads/{name}/sessions` (create and list). Invoke and destroy are session-scoped, so **existing qwen sessions on `claude-runtime` keep working untouched**: only new creates move. No migration.

All four `create_session` call sites in `deliver` thread the model. The fourth is the `403/410` mid-conversation recovery arm, and it is the one that fails silently if missed: the turn still succeeds, it just runs on the wrong lane, so nothing surfaces the escape. There is a test that drives the real `create_session` through that arm.

`list_sessions` takes an optional `workload` rather than aggregating the two lanes, because the session cap is per workload (`pi-runtime` has `cap: 2`) and an operator managing a cap wants one lane at a time.

## The risk, and why it is acceptable

`ember_public/synthetic_probe.py` `probe_qwen` calls `run_synthetic_session(model="qwen")` through this same transport every five minutes and latches `ember_synthetic_probe`, which `/api/health` 503s off. **This change moves a public health signal onto the new lane.**

So the lane was proven in production first, driven from the monolith pod with its own ServiceAccount token so it exercised the real principal:

| step | result |
|---|---|
| `POST /v1/workloads/pi-runtime/sessions` | `201` in 0.1s, `runtimes/pi@sha256:dbd2a45b...` |
| `POST /v1/sessions/{id}/invoke` | `200` in 1.8s, `result "qwen synthetic ok"`, `terminal_reason "stop"`, usage 522 in / 27 out (real llama.cpp round trip) |
| `DELETE /v1/sessions/{id}` | `202` |

`probe_qwen` accepts `terminal_reason` in `{"completed", "stop"}`, so its assertion is satisfied by the observed behaviour, and the 256 MiB sizing holds under a real session.

Egress needed nothing: the live `EMBERVM_NODED_EGRESS_WORKLOADS` is already `claude-runtime,pi-runtime` (the chart derives it from enabled workload names) and `inference.inference.svc.cluster.local:8080` is already in the sidecar allowlist.

`agentSessions.piWorkload` is the **revert lever**: set it to `claude-runtime` to put qwen back on the old lane by a values edit, no code deploy. Unset in `deploy/values.yaml` on purpose, so the code default is what ships. Verified by rendering both ways.

## Known soft edge, noted not fixed

`deliver(ember=None, restore_from=<lineage>)` for a qwen lineage created on `claude-runtime` now attempts a cross-workload restore, which the CP denies (workload/principal mismatch is one of its documented `create_denial` reasons). The existing arm already degrades to a blank session with `degraded: "restore_denied"`, so it fails soft and loses only the guest workspace of pre-existing qwen lineages, which are few. That fallback is preserved and tested.

## Verification

`ci test`: `Executed 78 out of 735 tests: 735 tests pass`, plus `1335 tests, 0 failures, 6 skipped` from the genrule suites.

Note for reviewers: an earlier run of this branch **exited 0 while reporting `734 tests pass and 1 fails remotely`**. The failure was a test-isolation defect (`importlib.reload` rebinding `EmberSessionGone` to a fresh class, silently breaking every later `pytest.raises` in the file). It is fixed by asserting on a `_resolve_pi_workload()` helper instead of reloading the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)