### PR TITLE
feat(embervm): enqueue base builds per CPU vendor so coverage converges

### DIFF
--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -755,9 +755,14 @@ defmodule Embervm.BaseBuilder do
         # under N=1 S3 retention (Joe, 2026-07-21) no predecessor ref persists in
         # the store to hydrate from, so a signature->ref history would be dead
         # weight. See docs/plans/2026-07-21-embervm-base-durability-and-cross-vendor.md.
+        #
+        # Hydrate the VENDOR-CORRECT ref (pinned_vendor_ref/3), not the scalar
+        # w.snapshot_ref: should_hydrate?/3's guard 0 already proved this instance's
+        # own vendor has a trustworthy record, so restore that ref rather than
+        # whichever vendor built last.
         state
         |> mark_hydrating(name)
-        |> spawn_hydrate(w)
+        |> spawn_hydrate(%{w | snapshot_ref: pinned_vendor_ref(state, w, node_id)})
 
       w.built_signature == signature(w) and w.snapshot_ref != nil ->
         # The SCALAR base is built, but "some vendor, somewhere" is not the same
@@ -789,11 +794,21 @@ defmodule Embervm.BaseBuilder do
   # rebuilt? True only when ALL five guards hold (fail-safe: any unmet guard falls
   # through to the ordinary build/no-op branches):
   #
-  #   0. the PINNED instance's own reported CPU vendor matches `scalar_vendor`
-  #      (the vendor apply_result/4 last stamped the scalar snapshot_ref with).
-  #      Per-vendor enqueue makes cross-vendor builds routine, so the scalar ref
-  #      can now belong to a vendor other than the one this instance runs; a
-  #      blank/unknown vendor also fails this guard (fail closed);
+  #   0. the PINNED instance resolves to a ref this control plane can vouch for,
+  #      via `pinned_vendor_ref/3`. This anchors on the DURABLE per-vendor CP
+  #      record (`w.vendor_built`), not on comparing the pinned instance's vendor
+  #      against `scalar_vendor` (the vendor `apply_result/4` last stamped the
+  #      SCALAR snapshot_ref with). Per-vendor enqueue makes cross-vendor builds
+  #      the STEADY STATE, not an edge case: `placement/3` pins a workload to ONE
+  #      instance, a repair build by definition runs on a DIFFERENT vendor from
+  #      most workloads' pin, and `apply_result/4` stamps the scalar
+  #      unconditionally while never touching `w.node_id`. A scalar comparison is
+  #      therefore false for nearly every workload in steady state, which would
+  #      disable restore-first fleet-wide rather than guard one cross-vendor
+  #      case. The per-vendor record survives exactly the failure this guard
+  #      exists to recover from (the node losing its local base): it is keyed by
+  #      vendor and does not move just because some OTHER vendor built more
+  #      recently;
   #   1. a base is recorded (snapshot_ref set) AND the spec is unchanged
   #      (built_signature == signature): we are restoring the SAME ref we would
   #      otherwise rebuild, never papering over a spec change (whose target ref is
@@ -891,24 +906,65 @@ defmodule Embervm.BaseBuilder do
     end
   end
 
+  # Defensive clause (this file's idiom): a nil or non-binary node_id would
+  # otherwise reach node_name/1 -> NodeCapacity.vendor_for/2 inside
+  # pinned_vendor_ref/3, which has no nil clause and raises FunctionClauseError,
+  # taking the GenServer down and wiping every workload's snapshot_ref with it.
+  # reconcile_desc/2's own `node_id == nil` branch is the only live caller today
+  # and already guards this, but issue #4105 was exactly this shape (a nil
+  # node_id killing the builder) via a different unguarded lookup, so this stays
+  # total rather than relying on the caller forever.
+  defp should_hydrate?(_state, _w, node_id) when not is_binary(node_id), do: false
+
   defp should_hydrate?(state, w, node_id) do
     # Regression guard: apply_result/4 sets the SCALAR snapshot_ref/scalar_vendor
     # from whichever vendor built LAST, and per-vendor enqueue (vendors_needing_build/2)
-    # makes cross-vendor builds routine rather than rare. `node_id` here is the
-    # PINNED instance (w.node_id), whose vendor can now differ from scalar_vendor.
-    # Hydrating an intel-built ref onto an amd instance would be wrong, so require
-    # the pinned instance's own vendor to match the vendor the scalar ref actually
-    # belongs to, mirroring the discipline hydrate_for_anchor/3 already applies via
-    # snapshot_refs_by_vendor. A blank/unknown vendor (no capacity fact yet) fails
-    # closed to "do not hydrate": it falls through to the ordinary build/no-op
-    # branches, which are safe.
-    pinned_vendor = Embervm.NodeCapacity.vendor_for(state.capacity_table, node_name(node_id))
-
-    pinned_vendor != "" and pinned_vendor == w.scalar_vendor and
+    # makes cross-vendor builds the steady state rather than an edge case. Anchor
+    # on the durable per-vendor record (pinned_vendor_ref/3), not the scalar: see
+    # guard 0 in the doc comment above for why the scalar comparison this guard
+    # used to make would disable restore-first fleet-wide.
+    pinned_vendor_ref(state, w, node_id) != nil and
       is_binary(w.snapshot_ref) and w.built_signature == signature(w) and
       node_reports_base_absent?(state, node_id, w.name) and
       not already_targeting?(state, node_id, w.name, signature(w)) and
       not MapSet.member?(state.hydrating, w.name)
+  end
+
+  # The ref to hydrate FOR `node_id` (a placement instance), or nil when none can
+  # be trusted. Resolves the vendor `node_id` itself runs, then looks up THAT
+  # vendor's own durable record (w.vendor_built[vendor]) rather than the scalar
+  # snapshot_ref/scalar_vendor pair, which apply_result/4 stamps from whichever
+  # vendor built LAST and so no longer identifies "the ref this instance's
+  # vendor owns" now that cross-vendor repair builds are routine. Mirrors what
+  # hydrate_for_anchor/3 already does by resolving the anchor vendor's own ref
+  # out of snapshot_refs_by_vendor/2.
+  defp pinned_vendor_ref(state, w, node_id) do
+    vendor =
+      state.capacity_table
+      |> Embervm.NodeCapacity.vendor_for(node_name(node_id))
+      |> to_string()
+      |> String.trim()
+
+    cond do
+      vendor == "" ->
+        nil
+
+      true ->
+        case Map.get(w.vendor_built, vendor) do
+          %{signature: sig, ref: ref} when is_binary(ref) and ref != "" ->
+            if sig == signature(w), do: ref, else: nil
+
+          _ ->
+            # No per-vendor record (e.g. a CP restart wiped vendor_built, or this
+            # vendor has never had a recorded build). Adopt the scalar ONLY when
+            # it demonstrably belongs to this vendor, so a restart-wiped record
+            # can still restore-first rather than falling all the way to a
+            # rebuild.
+            if w.scalar_vendor == vendor and is_binary(w.snapshot_ref),
+              do: w.snapshot_ref,
+              else: nil
+        end
+    end
   end
 
   # The node AFFIRMATIVELY reports the workload's base absent: a fact exists for
@@ -1432,16 +1488,50 @@ defmodule Embervm.BaseBuilder do
   #
   # Deriving from eligible_build_instances/2 is also what keeps this in step
   # with fleet_vendors/2, which counts vendors from that SAME source: a vendor
-  # that vendors_needing_build/2 returns therefore always resolves here. Ranking
-  # mirrors placement/3 and build_instance_on_node/3 so a repair build never
-  # targets an instance placement itself would reject.
+  # that vendors_needing_build/2 returns therefore always resolves here.
+  #
+  # Among that vendor's eligible instances, PREFER one whose node already
+  # reports a base for this workload (base_presence_rank/3), and fall back to
+  # build_rank/1 only to break the remaining tie. noded's AlreadyBuilt
+  # short-circuit is keyed on the RECEIVING node's own local inventory
+  # (s.bases.get(baseKey)); it only fires when the enqueue happens to land on a
+  # node that already holds a current base. Ranking on build_rank/1 alone left
+  # that to chance: on a fleet with several same-vendor bricks (three intel
+  # nodes in prod) they tie on build_rank, and Enum.max_by/2 returns the first
+  # maximal element in list order, which is state.node_ids order (dial-home
+  # registration order) and reshuffles on every noded pod roll. The live
+  # fleet's three intel bricks hold very different base inventories (11, 3, and
+  # 5 bases respectively), so an untargeted repair enqueue could land many real
+  # cold-boot bakes on whichever brick happened to register last, serialized
+  # behind that single 2Gi brick's one `building` slot. Preferring the instance
+  # that already reports the base is what keeps a repair enqueue an RPC rather
+  # than a bake, matching the PR's central claim.
   defp build_instance_of_vendor(state, w, vendor) do
     state
     |> eligible_build_instances(Map.get(w, :mem_mib) || 0)
     |> Enum.filter(fn i -> Map.get(i, :cpu_vendor) == vendor end)
     |> case do
-      [] -> nil
-      instances -> instances |> Enum.max_by(&build_rank/1) |> Map.get(:instance_id)
+      [] ->
+        nil
+
+      instances ->
+        instances
+        |> Enum.max_by(fn i -> {base_presence_rank(state, i, w.name), build_rank(i)} end)
+        |> Map.get(:instance_id)
+    end
+  end
+
+  # How strongly `instance`'s own node vouches for already holding a base for
+  # `workload`: 2 when it reports one READY, 1 when it reports one in some
+  # other state (BUILDING/FAILED; still evidence of local inventory noded may
+  # short-circuit on), 0 when it reports nothing at all. Higher is better; only
+  # a tiebreaker within one vendor's eligible instances (see
+  # build_instance_of_vendor/3).
+  defp base_presence_rank(state, instance, workload) do
+    case node_base_fact(state, instance.instance_id, workload) do
+      {:ok, %{base_state: :BASE_BUILD_STATE_READY}} -> 2
+      {:ok, _} -> 1
+      :error -> 0
     end
   end
 
@@ -1449,24 +1539,39 @@ defmodule Embervm.BaseBuilder do
   # Shared by reconcile_desc/2 and retry_workload/2 so the two scalar-guard
   # branches cannot drift. Never writes status: the workload is already servable
   # on the vendor that has a base (see the call sites).
+  #
+  # Bails when a hydrate is already in flight for this workload
+  # (state.hydrating). should_hydrate?/3's own guards 3 and 4 keep a build and a
+  # hydrate apart for the reconcile that FIRST triggers one, but the 60s
+  # WorkloadWatcher resync calls reconcile_desc/2 again while the async
+  # RestoreArtifact download is still running; by then should_hydrate?/3 is
+  # false (guard 4: already hydrating) and reconcile_desc falls through into
+  # this scalar-guard branch, which would otherwise issue a repair BuildBase for
+  # the same base key on the same node the in-flight restore is downloading
+  # onto. Deferring here is safe: the hydrate worker's completion (success or
+  # fallback-to-rebuild) re-reconciles on its own.
   defp enqueue_vendor_repairs(state, w, name) do
-    state
-    |> vendors_needing_build(w)
-    |> Enum.reduce(state, fn vendor, acc ->
-      case build_instance_of_vendor(acc, w, vendor) do
-        nil ->
-          acc
+    if MapSet.member?(state.hydrating, name) do
+      state
+    else
+      state
+      |> vendors_needing_build(w)
+      |> Enum.reduce(state, fn vendor, acc ->
+        case build_instance_of_vendor(acc, w, vendor) do
+          nil ->
+            acc
 
-        instance_id ->
-          if already_targeting?(acc, instance_id, name, signature(w)) do
-            acc
-          else
-            acc
-            |> enqueue(instance_id, name)
-            |> maybe_start_build(instance_id)
-          end
-      end
-    end)
+          instance_id ->
+            if already_targeting?(acc, instance_id, name, signature(w)) do
+              acc
+            else
+              acc
+              |> enqueue(instance_id, name)
+              |> maybe_start_build(instance_id)
+            end
+        end
+      end)
+    end
   end
 
   # Look up the capacity fact whose derived instance_id matches (the registry stamps
@@ -1930,7 +2035,7 @@ defmodule Embervm.BaseBuilder do
   defp apply_result(
          state,
          w,
-         %{signature: built_sig, cpu_vendor: vendor},
+         %{signature: built_sig, cpu_vendor: vendor, node_id: build_node_id},
          {:ok, %BuildBaseResponse{} = resp}
        ) do
     previous_ref =
@@ -1955,10 +2060,21 @@ defmodule Embervm.BaseBuilder do
     # unknown (nil); eviction is withheld until the PoolManager and SessionStore
     # report both as zero (report_base_refs/3). A ref already tracked keeps its
     # reported counts.
+    #
+    # node_id here is the INSTANCE THAT ACTUALLY BUILT this turnover
+    # (worker_meta's node_id), not w.node_id (the pinned instance). Per-vendor
+    # repair enqueue means those routinely differ: build_instance_of_vendor/3
+    # can and does target an instance other than the pin. maybe_evict_base/3
+    # later dials entry.node_id to evict the superseded base; dialing the pin
+    # instead would reach the wrong node. EvictArtifact{remote: false} is
+    # idempotent, so that call would still return success, the ref would be
+    # marked evicted and dropped from superseded_refs, and the node that
+    # actually holds the superseded base would keep it forever with no retry
+    # ever issued again for it.
     base_refs =
       if turned_over? and not Map.has_key?(w.base_refs, previous_ref) do
         Map.put(w.base_refs, previous_ref, %{
-          node_id: w.node_id,
+          node_id: build_node_id,
           primed: nil,
           sessions: nil,
           evicted: false
@@ -2012,6 +2128,15 @@ defmodule Embervm.BaseBuilder do
           # A base can finish before its node advertises the workload. Keep the
           # anchor-node export during that dial-home window; later facts replace it
           # with the per-node fan-out.
+          #
+          # w.node_id (the pin) and w.snapshot_ref (the scalar) can now disagree
+          # by vendor: a repair build's worker_meta node_id is not threaded down
+          # to this branch, and the scalar was just stamped from whichever vendor
+          # built LAST. Dialing the pin with a ref built on a different vendor
+          # produces a logged export failure, not data loss (export_reconcile's
+          # 60s sweep and the per-node fan-out above are the real durability
+          # path once any node reports); left as a dial-home-window fallback
+          # rather than reworked here.
           spawn_export(state, w.node_id, w.name, w.snapshot_ref)
 
         _ ->
@@ -2058,6 +2183,15 @@ defmodule Embervm.BaseBuilder do
   # against exporting a BUILDING/FAILED entry; requiring the node fact at all
   # means a base whose node has not yet reported is left for the next sweep
   # (never blindly re-exported without evidence it is present).
+  # Note: `w.node_id` here is the PINNED instance, and this requires the
+  # PIN's own reported ref to equal `w.snapshot_ref` (the scalar). Once a
+  # repair build lands the scalar on a vendor other than the pin's, that
+  # equality goes permanently false for this workload and the 60s export
+  # backstop goes dead on the pin's own path. This is largely compensated: the
+  # per-node fan-out in apply_result/4's export_targets branch re-exports each
+  # node's own unexported ref on every subsequent build, and per-vendor repair
+  # builds are now frequent, so a node's ref does not stay unexported for long
+  # in practice. Left as observed behaviour rather than reworked here.
   defp current_base_present_but_unexported?(state, node_ref, w) do
     is_binary(w.node_id) and is_binary(w.snapshot_ref) and
       case node_base_fact(state, node_ref, w.name) do
@@ -2947,7 +3081,24 @@ defmodule Embervm.BaseBuilder do
 
     w = %{w | backoff_ms: next_backoff, retry_timer: timer}
     state = put_in(state.workloads[w.name], w)
-    write_base_status(state, w, {:failed, message})
+
+    if w.built_signature == signature(w) and w.snapshot_ref != nil do
+      # A REPAIR build failed (e.g. the observed "guest readiness: vsockhttp:
+      # timed out waiting for guest ready at /shim/ready" on an intel brick)
+      # while the workload still genuinely serves at the current signature on
+      # the vendor that already has a base. enqueue_vendor_repairs/3 never wrote
+      # write_base_status(:building) for this build (the caller cannot observe
+      # a repair build), so it must not write the failure either: doing so
+      # would flip BaseBuilt/Ready to False for a build nobody asked for and
+      # park a servable workload there indefinitely, which is a larger version
+      # of the exact regression this PR exists to avoid. Still arm the backoff
+      # retry as normal; BaseVendorCoverage already reports the gap.
+      state
+    else
+      # No current base at all: a real build failure the caller does need to
+      # see (first build, or a rebuild with nothing old left to serve).
+      write_base_status(state, w, {:failed, message})
+    end
   end
 
   # Backoff doubles from the base on each consecutive failure. The first failure

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -760,9 +760,15 @@ defmodule Embervm.BaseBuilder do
         |> spawn_hydrate(w)
 
       w.built_signature == signature(w) and w.snapshot_ref != nil ->
-        # Desired base already built and recorded: idempotent no-op. (The watcher
-        # separately writes observedGeneration for a generation-only change.)
-        state
+        # The SCALAR base is built, but "some vendor, somewhere" is not the same
+        # as "every fleet vendor". Repair-enqueue any vendor still missing,
+        # stale, or unverified (see vendors_needing_build/2 for why unverified
+        # counts) rather than treating this as a blanket no-op. The workload is
+        # already servable on the vendor that has a base, so this deliberately
+        # does NOT write_base_status(:building): flipping the published status
+        # to building for a repair build a caller cannot observe would be a
+        # regression, and BaseVendorCoverage already reports the gap.
+        enqueue_vendor_repairs(state, w, name)
 
       already_targeting?(state, node_id, name, signature(w)) ->
         # A build for this exact signature is already queued or in flight.
@@ -780,9 +786,14 @@ defmodule Embervm.BaseBuilder do
   # -- restore-first (hydrate-on-miss, base-durability PR-2) --------------------
 
   # Should this workload's recorded base be HYDRATED (S3 restore) rather than
-  # rebuilt? True only when ALL four guards hold (fail-safe: any unmet guard falls
+  # rebuilt? True only when ALL five guards hold (fail-safe: any unmet guard falls
   # through to the ordinary build/no-op branches):
   #
+  #   0. the PINNED instance's own reported CPU vendor matches `scalar_vendor`
+  #      (the vendor apply_result/4 last stamped the scalar snapshot_ref with).
+  #      Per-vendor enqueue makes cross-vendor builds routine, so the scalar ref
+  #      can now belong to a vendor other than the one this instance runs; a
+  #      blank/unknown vendor also fails this guard (fail closed);
   #   1. a base is recorded (snapshot_ref set) AND the spec is unchanged
   #      (built_signature == signature): we are restoring the SAME ref we would
   #      otherwise rebuild, never papering over a spec change (whose target ref is
@@ -881,7 +892,20 @@ defmodule Embervm.BaseBuilder do
   end
 
   defp should_hydrate?(state, w, node_id) do
-    is_binary(w.snapshot_ref) and w.built_signature == signature(w) and
+    # Regression guard: apply_result/4 sets the SCALAR snapshot_ref/scalar_vendor
+    # from whichever vendor built LAST, and per-vendor enqueue (vendors_needing_build/2)
+    # makes cross-vendor builds routine rather than rare. `node_id` here is the
+    # PINNED instance (w.node_id), whose vendor can now differ from scalar_vendor.
+    # Hydrating an intel-built ref onto an amd instance would be wrong, so require
+    # the pinned instance's own vendor to match the vendor the scalar ref actually
+    # belongs to, mirroring the discipline hydrate_for_anchor/3 already applies via
+    # snapshot_refs_by_vendor. A blank/unknown vendor (no capacity fact yet) fails
+    # closed to "do not hydrate": it falls through to the ordinary build/no-op
+    # branches, which are safe.
+    pinned_vendor = Embervm.NodeCapacity.vendor_for(state.capacity_table, node_name(node_id))
+
+    pinned_vendor != "" and pinned_vendor == w.scalar_vendor and
+      is_binary(w.snapshot_ref) and w.built_signature == signature(w) and
       node_reports_base_absent?(state, node_id, w.name) and
       not already_targeting?(state, node_id, w.name, signature(w)) and
       not MapSet.member?(state.hydrating, w.name)
@@ -1362,6 +1386,87 @@ defmodule Embervm.BaseBuilder do
       nil -> true
       built -> Map.get(built, :signature) != signature(w)
     end
+  end
+
+  # Every fleet vendor this workload still needs a build for, sorted for a
+  # deterministic enqueue order. Deliberately covers BOTH classes
+  # `base_vendor_coverage_condition/2` reports separately:
+  #
+  #   * missing: no vendor_built record and no observed ref at all;
+  #   * unverified: an observed ref exists, but vendor_built carries nothing to
+  #     vouch for its signature.
+  #
+  # `vendor_built` is in-memory GenServer state (merge_desc/3 seeds it `%{}`)
+  # with no CRD-status rehydration, so every control-plane restart wipes
+  # attribution: verified live on 2026-08-16 after the 0.19.1 roll, 10 of 11
+  # prod workloads showed `unverified: amd`. Skipping unverified here would
+  # leave BaseVendorCoverage False forever after a restart and repair nothing,
+  # which defeats the point of enqueueing at all.
+  #
+  # A redundant enqueue is cheap, not a bake: noded's server.go returns
+  # AlreadyBuilt: true off the existing snapshotRef before either beginBuild or
+  # driveBuild run. And it terminates: start_worker/3 stamps cpu_vendor from the
+  # building node's capacity fact, apply_result/4 writes vendor_built[vendor]
+  # even for an AlreadyBuilt {:ok, %BuildBaseResponse{}}, and the next reconcile
+  # sees the record and stops enqueuing. The one bounded edge: if the capacity
+  # fact vanishes between enqueue and start_worker, vendor is "" and
+  # apply_result/4 writes no record, so the vendor is re-enqueued on the next
+  # reconcile; already_targeting?/4 keeps that from piling up and it self-clears
+  # once the node reports again.
+  defp vendors_needing_build(state, w) do
+    state |> fleet_vendors(w) |> Enum.filter(&vendor_needs_build?(w, &1)) |> Enum.sort()
+  end
+
+  # The best build-eligible INSTANCE of `vendor`, for a repair enqueue.
+  #
+  # NOT node_of_vendor/3, which is the RETENTION primitive: it scans
+  # representative_facts_by_node with no eligibility filter and without
+  # consulting state.node_ids, because addressing a vendor's store prefix does
+  # not require an instance that could host a build. Enqueueing does. Two things
+  # would break if that primitive were reused here: enqueue/3 does
+  # update_in(state.nodes[instance_id].queue, ...), which RAISES for an instance
+  # outside the placement set and would take the GenServer down; and an instance
+  # that fails build_eligible?/2 for this workload's mem_mib cannot run the build
+  # it is handed, so the build fails and the backoff retry re-enqueues it
+  # forever.
+  #
+  # Deriving from eligible_build_instances/2 is also what keeps this in step
+  # with fleet_vendors/2, which counts vendors from that SAME source: a vendor
+  # that vendors_needing_build/2 returns therefore always resolves here. Ranking
+  # mirrors placement/3 and build_instance_on_node/3 so a repair build never
+  # targets an instance placement itself would reject.
+  defp build_instance_of_vendor(state, w, vendor) do
+    state
+    |> eligible_build_instances(Map.get(w, :mem_mib) || 0)
+    |> Enum.filter(fn i -> Map.get(i, :cpu_vendor) == vendor end)
+    |> case do
+      [] -> nil
+      instances -> instances |> Enum.max_by(&build_rank/1) |> Map.get(:instance_id)
+    end
+  end
+
+  # Enqueue one repair build per vendor that lacks a current-signature base.
+  # Shared by reconcile_desc/2 and retry_workload/2 so the two scalar-guard
+  # branches cannot drift. Never writes status: the workload is already servable
+  # on the vendor that has a base (see the call sites).
+  defp enqueue_vendor_repairs(state, w, name) do
+    state
+    |> vendors_needing_build(w)
+    |> Enum.reduce(state, fn vendor, acc ->
+      case build_instance_of_vendor(acc, w, vendor) do
+        nil ->
+          acc
+
+        instance_id ->
+          if already_targeting?(acc, instance_id, name, signature(w)) do
+            acc
+          else
+            acc
+            |> enqueue(instance_id, name)
+            |> maybe_start_build(instance_id)
+          end
+      end
+    end)
   end
 
   # Look up the capacity fact whose derived instance_id matches (the registry stamps
@@ -2861,8 +2966,13 @@ defmodule Embervm.BaseBuilder do
 
         cond do
           w.built_signature == signature(w) and w.snapshot_ref != nil ->
-            # The desired base got built by some other path meanwhile; nothing to do.
-            state
+            # The desired SCALAR base got built by some other path meanwhile.
+            # That is not the same as full fleet coverage: repair-enqueue any
+            # vendor still missing, stale, or unverified, mirroring
+            # reconcile_desc's scalar-guard branch (see vendors_needing_build/2
+            # for why unverified counts). No write_base_status(:building) here
+            # either, for the same reason: the workload already serves.
+            enqueue_vendor_repairs(state, w, name)
 
           already_targeting?(state, w.node_id, name, signature(w)) ->
             # A build for the current signature is already queued or in flight

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -2817,15 +2817,30 @@ defmodule Embervm.BaseBuilderTest do
     # should_hydrate?/3 regression-guard tests below).
     assert latest(agent, "w") == before_repair
 
-    # Stated separately because it is the invariant that matters operationally:
-    # partial vendor coverage must NOT fail Ready. The workload genuinely serves
-    # on amd, so failing Ready fleet-wide would turn a degraded state into an
-    # outage. BaseVendorCoverage is the condition that carries the gap.
-    assert %{"status" => "True"} = condition(latest(agent, "w"), "Ready")
-
     mid_repair = :sys.get_state(builder).workloads["w"]
     assert mid_repair.scalar_vendor == "amd"
     assert mid_repair.snapshot_ref == "amd-base"
+
+    # The assertion above (latest(agent, "w") == before_repair) only proves the
+    # repair enqueue itself writes nothing; re-reading Ready off before_repair
+    # (captured BEFORE the repair even started) would pass unconditionally,
+    # even with the repair-enqueue feature reverted entirely. Force a REAL
+    # status write while the intel repair build is still in flight: intel
+    # joining the fleet flips BaseVendorCoverage from True to False, and the
+    # export reconcile republishes on exactly that kind of coverage change
+    # (refresh_snapshot_refs/1). This is the write that actually exercises the
+    # invariant that matters: Ready must stay True even while a status write
+    # legitimately happens during partial coverage.
+    send(builder, :export_reconcile)
+
+    assert_eventually(fn ->
+      match?(%{"status" => "False"}, condition(latest(agent, "w"), "BaseVendorCoverage"))
+    end)
+
+    mid_repair_write = latest(agent, "w")
+    assert mid_repair_write != before_repair
+    assert %{"status" => "True"} = condition(mid_repair_write, "Ready")
+    assert %{"status" => "True", "reason" => "BaseBuilt"} = condition(mid_repair_write, "BaseBuilt")
 
     send(worker, :finish)
 
@@ -2904,7 +2919,18 @@ defmodule Embervm.BaseBuilderTest do
     # vendors_needing_build/2 for why: vendor_built is in-memory-only and never
     # rehydrated, so skipping unverified would leave coverage broken forever
     # after every CP restart).
-    put_vendor_fact(table, "node-1", "intel", "w", "intel-observed", "intel")
+    #
+    # A CLASSED brick (put_brick), not a bare put_vendor_fact: put_vendor_fact
+    # writes no size_class/mem_budget_mib, so instance_build_facts/2 treats
+    # node-1/intel as a build_rank {1, 0} WILDCARD, which outranks amd's
+    # classed {0, 8192} and moves the workload's OWN pin onto node-1/intel via
+    # keep_or_replace/3 -- at which point build_instance_of_vendor/3 just
+    # returns w.node_id and the cross-instance repair path this test claims to
+    # exercise never actually runs. put_brick keeps node-1/intel classed like
+    # amd so the pin stays on node-4/amd and the repair genuinely targets a
+    # DIFFERENT instance than the one built on.
+    put_brick(table, "node-1", "intel", cpu_vendor: "intel")
+    put_base_fact(table, "node-1", "intel", "w", "intel-observed", :BASE_BUILD_STATE_READY, true)
     :ok = BaseBuilder.add_node(builder, "node-1/intel", "intel")
     :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2}))
 
@@ -3021,6 +3047,299 @@ defmodule Embervm.BaseBuilderTest do
     # RestoreArtifact.
     assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].vendor_built["intel"] end)
     assert Agent.get(calls, & &1) == 2
+  end
+
+  test "regression: should_hydrate? still restores after a cross-vendor repair build moved the scalar off the pin" do
+    # The exact steady state this PR creates (finding 1): the workload is
+    # pinned to an amd instance, but a LATER intel repair build (per-vendor
+    # enqueue is now routine) stamped the scalar snapshot_ref/scalar_vendor to
+    # "intel" without ever touching w.node_id. When the amd instance
+    # AFFIRMATIVELY reports its own base absent, should_hydrate?/3 must still
+    # fire and restore amd's OWN recorded ref (vendor_built["amd"]), not fail
+    # closed because the scalar now says "intel".
+    test_pid = self()
+    agent = start_recorder()
+    table = new_cap_table()
+    put_brick(table, "node-4", "amd", cpu_vendor: "amd")
+
+    restore_fun = fn :fake_channel, %Embervm.Node.V1.RestoreArtifactRequest{artifact: ref} ->
+      send(test_pid, {:restore_called, ref.ref})
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+    end
+
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      case Agent.get_and_update(calls, fn c -> {c, c + 1} end) do
+        0 -> {:ok, resp("amd-base")}
+        _ -> {:ok, resp("intel-base")}
+      end
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/amd", address: "amd"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 5,
+        hydrate_poll_max: 50
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "amd-base" end)
+
+    # A second fleet vendor (intel) appears and its repair build completes,
+    # stamping the SCALAR fields to intel while the pin stays on amd (both
+    # bricks are classed identically, so build_rank ties and the amd instance
+    # -- registered first -- keeps its sticky pin per keep_or_replace/3).
+    put_brick(table, "node-1", "intel", cpu_vendor: "intel")
+    :ok = BaseBuilder.add_node(builder, "node-1/intel", "intel")
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2}))
+
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].vendor_built["intel"] end)
+    workload = :sys.get_state(builder).workloads["w"]
+    assert workload.scalar_vendor == "intel"
+    assert workload.snapshot_ref == "intel-base"
+    assert workload.node_id == "node-4/amd"
+    assert workload.vendor_built["amd"].ref == "amd-base"
+
+    # amd's own instance now AFFIRMATIVELY reports its base absent (scratch
+    # loss, cold-start). A scalar comparison (pinned vendor == scalar_vendor)
+    # would read "amd" != "intel" and fail closed here, forever: this is the
+    # regression should_hydrate?/3's anchor on the per-vendor record fixes.
+    put_base_fact(table, "node-4", "amd", "w", "", :BASE_BUILD_STATE_NONE, false)
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 3}))
+
+    assert_receive {:restore_called, "amd-base"}, 1_000
+
+    # No new BuildBase was dispatched (a hydrate, not a rebuild, is what fired).
+    assert Agent.get(calls, & &1) == 2
+  end
+
+  test "repair enqueue prefers the same-vendor instance whose node already reports a base, not the highest-ranked one" do
+    # The actual prod shape: several instances of the SAME vendor (three intel
+    # bricks live). Two identically-classed intel bricks tie on build_rank/1,
+    # so the OLD tiebreak (Enum.max_by/2 keeps the first maximal element in
+    # state.node_ids order, i.e. dial-home registration order) would pick
+    # whichever brick registered first -- which reshuffles on every noded pod
+    # roll and, on the live fleet, could land a real cold-boot bake on a brick
+    # that holds none of the workload's bases while a brick that already has
+    # one sits idle. The fix ranks the instance that already reports a base
+    # for this workload first.
+    agent = start_recorder()
+    table = new_cap_table()
+    test_pid = self()
+    put_brick(table, "node-4", "amd", cpu_vendor: "amd")
+    put_brick(table, "node-1", "intel-a", cpu_vendor: "intel")
+    put_brick(table, "node-2", "intel-b", cpu_vendor: "intel")
+
+    # node-2/intel-b already reports a READY base for "w"; node-1/intel-a
+    # (registered FIRST, below) reports nothing at all.
+    put_base_fact(table, "node-2", "intel-b", "w", "intel-existing", :BASE_BUILD_STATE_READY, true)
+
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      case Agent.get_and_update(calls, fn c -> {c, c + 1} end) do
+        0 ->
+          {:ok, resp("amd-base")}
+
+        _ ->
+          send(test_pid, {:repair_building, self()})
+
+          receive do
+            :finish -> {:ok, resp("intel-existing")}
+          end
+      end
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/amd", address: "amd"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "amd-base" end)
+
+    :ok = BaseBuilder.add_node(builder, "node-1/intel-a", "intel-a")
+    :ok = BaseBuilder.add_node(builder, "node-2/intel-b", "intel-b")
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2}))
+
+    assert_receive {:repair_building, worker}, 1_000
+
+    status = BaseBuilder.status(builder)
+    assert status.nodes["node-2/intel-b"].building == "w"
+    assert status.nodes["node-1/intel-a"].building == nil
+    refute "w" in status.nodes["node-1/intel-a"].queued
+
+    send(worker, :finish)
+
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].vendor_built["intel"] end)
+    assert Agent.get(calls, & &1) == 2
+  end
+
+  test "a fleet vendor whose only instance cannot build this workload's mem need never crashes or enqueues" do
+    # build_instance_of_vendor/3's [] -> nil clause. fleet_vendors/2 and
+    # build_instance_of_vendor/3 both derive from eligible_build_instances/2
+    # with the SAME need_mib, so an ineligible-only vendor is excluded from
+    # vendors_needing_build/2 before build_instance_of_vendor/3 would ever be
+    # asked about it -- which is exactly the invariant the PR's own comment on
+    # build_instance_of_vendor/3 claims ("a vendor that vendors_needing_build/2
+    # returns therefore always resolves here"). This test is the safety net
+    # for that invariant, and the coverage the PR's rationale for not reusing
+    # node_of_vendor/3 was otherwise missing: an ineligible-only vendor must
+    # never crash the builder or leave a phantom enqueue.
+    agent = start_recorder()
+    table = new_cap_table()
+    put_brick(table, "node-4", "amd", size_class: "8gi", mem_budget: 8_192, mem_headroom: 8_000, cpu_vendor: "amd")
+    put_brick(table, "node-1", "intel", size_class: "2gi", mem_budget: 2_048, mem_headroom: 2_000, cpu_vendor: "intel")
+
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      Agent.update(calls, &(&1 + 1))
+      {:ok, resp("amd-base")}
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/amd", address: "amd"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 8_000}))
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "amd-base" end)
+
+    :ok = BaseBuilder.add_node(builder, "node-1/intel", "intel")
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 8_000, generation: 2}))
+    Process.sleep(50)
+
+    assert Process.alive?(builder)
+    assert BaseBuilder.status(builder).workloads["w"].snapshot_ref == "amd-base"
+    # Only the original amd build ever ran: intel never became eligible, so it
+    # never entered vendors_needing_build/2 and no BuildBase was dispatched.
+    assert Agent.get(calls, & &1) == 1
+    assert %{"status" => "True"} = condition(latest(agent, "w"), "BaseVendorCoverage")
+  end
+
+  test "a failed repair build does not flip BaseBuilt or Ready to False for a workload that still serves" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_brick(table, "node-4", "amd", cpu_vendor: "amd")
+    test_pid = self()
+
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      case Agent.get_and_update(calls, fn c -> {c, c + 1} end) do
+        0 ->
+          {:ok, resp("amd-base")}
+
+        _ ->
+          send(test_pid, :repair_failed)
+          # A real observed failure class (issue text): the guest never
+          # reached readiness on the repair instance.
+          {:error,
+           %GRPC.RPCError{
+             status: 4,
+             message: "guest readiness: vsockhttp: timed out waiting for guest ready at /shim/ready"
+           }}
+      end
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/amd", address: "amd"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "amd-base" end)
+    before_repair = latest(agent, "w")
+
+    put_brick(table, "node-1", "intel", cpu_vendor: "intel")
+    :ok = BaseBuilder.add_node(builder, "node-1/intel", "intel")
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2}))
+
+    assert_receive :repair_failed, 1_000
+    # Let the failed build's apply_result run.
+    Process.sleep(50)
+
+    # The workload still serves on amd, so the repair failure must not write
+    # ANY new status: not :building (never did), and now not :failed either.
+    # A build the caller never observed as :building must not be observable
+    # as failed, or a workload that genuinely serves would park at
+    # BaseBuilt=False/Ready=False indefinitely for a build nobody asked for.
+    assert latest(agent, "w") == before_repair
+    assert %{"status" => "True", "reason" => "BaseBuilt"} = condition(before_repair, "BaseBuilt")
+    assert %{"status" => "True"} = condition(before_repair, "Ready")
+
+    # The backoff retry is still armed as normal, so the repair keeps trying.
+    assert :sys.get_state(builder).workloads["w"].backoff_ms != nil
+  end
+
+  test "a repair enqueue does not fire for a workload with a hydrate already in flight" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_brick(table, "node-4", "amd", cpu_vendor: "amd")
+
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      Agent.update(calls, &(&1 + 1))
+      {:ok, resp("amd-base")}
+    end
+
+    # Accepted, but never becomes READY within this test: the hydrate worker
+    # stays in state.hydrating polling, which is exactly the in-flight window
+    # enqueue_vendor_repairs/3 must defer to.
+    restore_fun = fn :fake_channel, _req ->
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/amd", address: "amd"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 50,
+        hydrate_poll_max: 40
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "amd-base" end)
+
+    # amd's own instance affirmatively reports its base absent: should_hydrate?/3
+    # fires and marks "w" hydrating.
+    put_base_fact(table, "node-4", "amd", "w", "", :BASE_BUILD_STATE_NONE, false)
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2}))
+    assert_eventually(fn -> MapSet.member?(:sys.get_state(builder).hydrating, "w") end)
+
+    # A second fleet vendor (intel) shows up and genuinely needs a build. The
+    # 60s WorkloadWatcher resync (modeled here by a further reconcile with the
+    # SAME desc) must NOT repair-enqueue it while "w" is still hydrating: the
+    # in-flight RestoreArtifact and a fresh BuildBase must never race for the
+    # same base key.
+    put_brick(table, "node-1", "intel", cpu_vendor: "intel")
+    :ok = BaseBuilder.add_node(builder, "node-1/intel", "intel")
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 3}))
+
+    Process.sleep(80)
+
+    assert MapSet.member?(:sys.get_state(builder).hydrating, "w")
+    assert Agent.get(calls, & &1) == 1
+    refute :sys.get_state(builder).workloads["w"].vendor_built["intel"]
   end
 
   test "status carries one entry per CPU vendor the fleet reports a base on" do

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -2755,6 +2755,274 @@ defmodule Embervm.BaseBuilderTest do
     assert %{"status" => "True"} = condition(latest(agent, "w"), "BaseVendorCoverage")
   end
 
+  # -- per-vendor repair enqueue (arms coverage bookkeeping into build decisions) --
+  #
+  # PR #4993 added vendor_built/fleet_vendors/vendor_needs_build? and the
+  # BaseVendorCoverage condition, but reconcile_desc/2 and retry_workload/2 still
+  # asked only the SCALAR built_signature/snapshot_ref "is this built?", which
+  # means "some vendor, somewhere" once and for all short-circuits every later
+  # reconcile even when a second fleet vendor has nothing. These tests exercise
+  # the repair-enqueue that closes that gap.
+
+  test "reconcile repair-enqueues a vendor missing a base without flipping status to building" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_brick(table, "node-4", "amd", cpu_vendor: "amd")
+    test_pid = self()
+
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      case Agent.get_and_update(calls, fn c -> {c, c + 1} end) do
+        0 ->
+          {:ok, resp("amd-base")}
+
+        1 ->
+          send(test_pid, {:building_intel, self()})
+
+          receive do
+            :finish -> {:ok, resp("intel-base")}
+          end
+      end
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/amd", address: "amd"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "amd-base" end)
+
+    before_repair = latest(agent, "w")
+    assert %{"status" => "True", "reason" => "BaseBuilt"} = condition(before_repair, "BaseBuilt")
+    assert %{"status" => "True"} = condition(before_repair, "Ready")
+
+    # A second fleet vendor appears. Same spec (only generation moved), so the
+    # scalar guard (built_signature == signature and snapshot_ref != nil) holds;
+    # that used to be a blanket no-op.
+    put_brick(table, "node-1", "intel", cpu_vendor: "intel")
+    :ok = BaseBuilder.add_node(builder, "node-1/intel", "intel")
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2}))
+
+    assert_receive {:building_intel, worker}, 1_000
+
+    # While intel's repair build is in flight, the workload already serves on
+    # amd: no status write flips BaseBuilt to building, and the scalar fields
+    # are untouched (only the completed repair build's apply_result may move
+    # them, which is a separate, already-documented concern -- see the
+    # should_hydrate?/3 regression-guard tests below).
+    assert latest(agent, "w") == before_repair
+
+    # Stated separately because it is the invariant that matters operationally:
+    # partial vendor coverage must NOT fail Ready. The workload genuinely serves
+    # on amd, so failing Ready fleet-wide would turn a degraded state into an
+    # outage. BaseVendorCoverage is the condition that carries the gap.
+    assert %{"status" => "True"} = condition(latest(agent, "w"), "Ready")
+
+    mid_repair = :sys.get_state(builder).workloads["w"]
+    assert mid_repair.scalar_vendor == "amd"
+    assert mid_repair.snapshot_ref == "amd-base"
+
+    send(worker, :finish)
+
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].vendor_built["intel"] end)
+    intel_built = BaseBuilder.status(builder).workloads["w"].vendor_built["intel"]
+    assert intel_built.ref == "intel-base"
+  end
+
+  test "reconcile is a no-op once every fleet vendor has a current base" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_brick(table, "node-4", "amd", cpu_vendor: "amd")
+    put_brick(table, "node-1", "intel", cpu_vendor: "intel")
+
+    {:ok, builds} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      Agent.update(builds, &(&1 + 1))
+      {:ok, resp("amd-base")}
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/amd", address: "amd"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "amd-base" end)
+
+    :ok = BaseBuilder.add_node(builder, "node-1/intel", "intel")
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2}))
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].vendor_built["intel"] end)
+    assert Agent.get(builds, & &1) == 2
+
+    # Both vendors now have a current record: a further reconcile enqueues
+    # nothing, exactly the pre-existing single-vendor no-op property extended
+    # to a fully-covered fleet.
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 3}))
+    Process.sleep(50)
+
+    assert Agent.get(builds, & &1) == 2
+    assert %{"status" => "True"} = condition(latest(agent, "w"), "BaseVendorCoverage")
+  end
+
+  test "an unverified vendor (observed ref, no CP record) is repair-enqueued and converges on an already-built result" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_brick(table, "node-4", "amd", cpu_vendor: "amd")
+
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      case Agent.get_and_update(calls, fn c -> {c, c + 1} end) do
+        0 -> {:ok, resp("amd-base")}
+        _ -> {:ok, resp("intel-observed")}
+      end
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/amd", address: "amd"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "amd-base" end)
+
+    # intel already has a base ON DISK (the node observed and reported it), but
+    # the CP holds no vendor_built record for it: unverified, not missing.
+    # vendor_needs_build?/2 treats the two identically (see the comment on
+    # vendors_needing_build/2 for why: vendor_built is in-memory-only and never
+    # rehydrated, so skipping unverified would leave coverage broken forever
+    # after every CP restart).
+    put_vendor_fact(table, "node-1", "intel", "w", "intel-observed", "intel")
+    :ok = BaseBuilder.add_node(builder, "node-1/intel", "intel")
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2}))
+
+    # noded's AlreadyBuilt short-circuit still returns {:ok, %BuildBaseResponse{}}
+    # carrying the pre-existing ref (server.go answers off s.bases.get(baseKey)
+    # before beginBuild/driveBuild), which is what build_fun models by returning
+    # the SAME "intel-observed" ref. apply_result/4 writes vendor_built["intel"]
+    # from that response exactly as it would from a fresh build.
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].vendor_built["intel"] end)
+    intel_built = BaseBuilder.status(builder).workloads["w"].vendor_built["intel"]
+    assert intel_built.ref == "intel-observed"
+    assert Agent.get(calls, & &1) == 2
+    assert %{"status" => "True"} = condition(latest(agent, "w"), "BaseVendorCoverage")
+
+    # Convergence: the CP now vouches for intel too, so a further reconcile
+    # enqueues nothing more.
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 3}))
+    Process.sleep(50)
+    assert Agent.get(calls, & &1) == 2
+  end
+
+  test "retry_workload enqueues a missing vendor instead of treating the scalar guard as nothing to do" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_brick(table, "node-4", "amd", cpu_vendor: "amd")
+
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      case Agent.get_and_update(calls, fn c -> {c, c + 1} end) do
+        0 -> {:ok, resp("amd-base")}
+        _ -> {:ok, resp("intel-base")}
+      end
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/amd", address: "amd"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "amd-base" end)
+
+    put_brick(table, "node-1", "intel", cpu_vendor: "intel")
+    :ok = BaseBuilder.add_node(builder, "node-1/intel", "intel")
+
+    # Directly drive the backoff-retry path (handle_info({:retry, name}, ...)).
+    # The scalar guard holds (amd's build is current and recorded), which is
+    # exactly the condition retry_workload/2 used to treat as "the desired base
+    # got built by some other path meanwhile; nothing to do". It must now
+    # repair-enqueue intel instead of no-op'ing.
+    send(builder, {:retry, "w"})
+
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].vendor_built["intel"] end)
+    assert Agent.get(calls, & &1) == 2
+  end
+
+  test "should_hydrate? regression guard: a pinned instance whose vendor differs from scalar_vendor never hydrates the wrong ref" do
+    test_pid = self()
+    agent = start_recorder()
+    table = new_cap_table()
+    put_brick(table, "node-4", "amd", cpu_vendor: "amd")
+
+    restore_fun = fn :fake_channel, %Embervm.Node.V1.RestoreArtifactRequest{artifact: ref} ->
+      send(test_pid, {:restore_called, ref.ref})
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+    end
+
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      case Agent.get_and_update(calls, fn c -> {c, c + 1} end) do
+        0 -> {:ok, resp("amd-snap")}
+        _ -> {:ok, resp("intel-snap")}
+      end
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/amd", address: "amd"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 5,
+        hydrate_poll_max: 50
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "amd-snap" end)
+    assert :sys.get_state(builder).workloads["w"].scalar_vendor == "amd"
+
+    # The amd instance vanishes; an intel instance takes over the pin, and it
+    # AFFIRMATIVELY reports no base for "w" -- should_hydrate?/3's ordinary
+    # trigger. But apply_result/4 stamps scalar fields from whichever vendor
+    # built LAST, so the recorded scalar ref ("amd-snap") belongs to amd, not to
+    # this intel instance: hydrating it here would restore the wrong content
+    # onto the wrong vendor.
+    :ok = BaseBuilder.remove_node(builder, "node-4/amd")
+    NodeCapacity.drop(table, {"node-4", "amd"})
+    put_brick(table, "node-1", "intel", cpu_vendor: "intel")
+    put_base_fact(table, "node-1", "intel", "w", "", :BASE_BUILD_STATE_NONE, false)
+    :ok = BaseBuilder.add_node(builder, "node-1/intel", "intel")
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2}))
+
+    refute_receive {:restore_called, _}, 200
+
+    # Falls through to the scalar-guard repair path instead: intel genuinely has
+    # no base of its own, so it gets a real BuildBase, never a wrong-vendor
+    # RestoreArtifact.
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].vendor_built["intel"] end)
+    assert Agent.get(calls, & &1) == 2
+  end
+
   test "status carries one entry per CPU vendor the fleet reports a base on" do
     agent = start_recorder()
     table = new_cap_table()


### PR DESCRIPTION
The placement half of #4937. PR #4993 landed the per-vendor bookkeeping and the `BaseVendorCoverage` condition but deliberately changed no build decisions; this arms them.

## The defect

noded keys a base as `sha256(image_ref, workload_revision, cpu_vendor)`, so vendor is part of a base's identity. But `reconcile_desc/2` and `retry_workload/2` both asked "is this built?" against the scalar `snapshot_ref`, which means "some vendor, somewhere, has a base". The moment one vendor succeeded, both short-circuited permanently for a fleet where the other vendor had nothing. Every `EMBER_BASE_EPOCH` string in `deploy/values.yaml` is a manual cache-buster for that guard.

Both branches now repair-enqueue each fleet vendor lacking a current-signature base, through a shared `enqueue_vendor_repairs/3` so the two sites cannot drift.

## What is deliberately NOT changed

**`Ready` stays untouched.** A partially covered workload genuinely serves on the vendor that has a base, so failing `Ready` fleet-wide would turn a degraded state into an outage. `BaseVendorCoverage` carries the gap. There is an explicit assertion for this.

**No status write on the repair path.** Flipping `BaseBuilt` to building for a repair build the caller cannot observe would be a regression, since the workload already serves.

## The open design question from #4937, decided

`vendor_needs_build?/2` does not distinguish *unverified* (observed ref, no CP record) from *missing* (nothing at all). **This enqueues for both**, and that is the correct call rather than a shortcut:

- `vendor_built` is in-memory GenServer state with no rehydration from CRD status, so **every control plane restart wipes attribution**. Verified live after the 0.19.1 roll: **10 of 11** prod workloads read `unverified: amd`, up from 5 earlier the same day. Unverified is the normal post-restart state, not an edge case.
- Skipping it would leave `BaseVendorCoverage` False forever after every restart and repair nothing, which defeats the point of enqueuing at all.
- A redundant enqueue is an RPC, not a bake: `noded/server/server.go` returns `AlreadyBuilt: true` off the existing snapshotRef *before* both `beginBuild` and `driveBuild`.
- It converges: `start_worker/3` stamps `cpu_vendor` from the building node's capacity fact, and an `AlreadyBuilt` response is still `{:ok, %BuildBaseResponse{}}`, so `apply_result/4` writes `vendor_built[vendor]` and the next reconcile stops. There is a test asserting exactly this (a second reconcile issues no further build).

So arming this bakes nothing on today's fleet and fires a handful of already-built RPCs that repair the records and flip coverage True.

## Two things found while reviewing the implementation

**The enqueue target must come from `eligible_build_instances/2`, not `node_of_vendor/3`.** The latter is the *retention* primitive: it scans `representative_facts_by_node` with no eligibility filter and never consults `state.node_ids`, because addressing a vendor's S3 prefix does not need an instance that could host a build. Enqueuing does, twice over: `enqueue/3` does `update_in(state.nodes[id].queue, ...)` which **raises for an instance outside the placement set** and would take the GenServer down, and an instance failing `build_eligible?/2` cannot run the build it is handed, so it fails and the backoff retry re-enqueues it forever. Deriving from the same source `fleet_vendors/2` uses also guarantees every vendor it returns resolves.

**`should_hydrate?/3` needed a vendor guard.** `apply_result/4` sets the scalar ref from whichever vendor built last, and this change makes cross-vendor builds routine rather than rare, so the pinned instance's vendor can now differ from the scalar's. Hydrating an intel-built ref onto an amd instance would be wrong. It now requires the two to match, mirroring what `hydrate_for_anchor/3` already does, and fails closed on a blank vendor.

## Verification

`ci test`: `1340 tests, 0 failures, 6 skipped` from the embervm control plane ExUnit suite (which runs in a genrule and so never appears in the Bazel summary), plus `Executed 2 out of 735 tests: 735 tests pass`.

New tests cover: repair-enqueue on a missing vendor without a status flip, `Ready` still True on partial coverage, full coverage staying a no-op, the unverified-converges-on-AlreadyBuilt property, `retry_workload` enqueuing instead of logging "nothing to do", and the `should_hydrate?` vendor-mismatch guard.

## Follow-up not in scope

`vendor_built` being wiped on every CP restart is worth fixing on its own terms (rehydrating attribution from `status.snapshotRefs` plus a signature check). This PR makes that survivable rather than fixing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)