### PR TITLE
fix(embervm): launch the shotter guest's Chromium ELF, not the shell wrapper

### DIFF
--- a/projects/embervm/runtimes/shotter/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/shotter/guest-init/cmd/main.go
@@ -35,7 +35,20 @@ import (
 )
 
 const (
-	chromiumBinary  = "/usr/bin/chromium"
+	// The real browser ELF, deliberately NOT /usr/bin/chromium. Wolfi ships
+	// that path as a 619-byte "#!/bin/sh" wrapper which sources
+	// /etc/chromium/*.conf and calls id and stat before exec'ing this same
+	// binary. This image has no shell and no coreutils (the apko package list
+	// is chromium plus three font packages), so the kernel cannot find the
+	// shebang interpreter and exec fails with ENOENT, which Go reports as
+	// "fork/exec /usr/bin/chromium: no such file or directory": an error that
+	// reads like a missing browser when the file is present and 300 MB of
+	// Chromium sits one symlink-free directory away. Nothing is lost by
+	// skipping the wrapper. /etc/chromium is an empty directory, so it sources
+	// no flags, and chromiumArgv below passes every flag this guest needs
+	// explicitly. Adding busybox to get a shell would put one inside the
+	// browser guest to no benefit.
+	chromiumBinary  = "/usr/lib/chromium/chrome"
 	chromiumHome    = "/tmp/shotter-home"
 	chromiumProfile = "/tmp/shotter-profile"
 	cdpAddress      = "127.0.0.1"


### PR DESCRIPTION
## What broke

The shotter workload deployed with #4998 never reached Ready in production. Every base build attempt logged:

```
"msg":"ember-shotter-init: Chromium warm launch failed; readiness remains false",
"err":"start Chromium: fork/exec /usr/bin/chromium: no such file or directory"
```

guest-init behaved correctly: it left readiness false rather than snapshotting a broken browser, so noded retried the build indefinitely and `BaseBuilt` stayed false on both vendors.

## Why

`/usr/bin/chromium` is present in the image, so the constant looked right. It is a 619-byte `#!/bin/sh` wrapper:

```sh
#!/bin/sh
for f in /etc/chromium/*.conf; do [ -f "$f" ] && . "$f"; done
...
exec "/usr/lib/chromium/chrome" ${CHROMIUM_FLAGS} "$@"
```

The guest image has no shell and no coreutils. Its apko package list is `chromium`, `libfontconfig1`, `freetype`, `ttf-dejavu`, and nothing pulls in busybox or bash. Linux returns `ENOENT` when a shebang interpreter is missing, and Go reports that as a missing file, which is why the error read like an absent browser.

## The fix

Point `chromiumBinary` at `/usr/lib/chromium/chrome`, the real 300 MB ELF.

Nothing is lost by skipping the wrapper:

- `/etc/chromium` is an empty directory in the built image, so the wrapper sources no flags.
- `chromiumArgv()` already passes every flag this guest needs explicitly.
- The wrapper's `id` and `stat` calls have no binaries in this image either, so it could not have run even with `/bin/sh` present.

Adding busybox to supply a shell would put one inside the browser guest for no benefit.

## Verification

CI cannot catch this. The launch path needs a real browser, which is why `cdp.go` carries no unit test, and `ci test` was a full cache hit (`Executed 0 out of 736 tests: 736 tests pass`) because no test target depends on the constant.

The only verification is the prod base build reaching `Ready=True` with `BaseBuilt=True`. I will confirm that after the rollout and report the result.

Evidence gathered by `crane export` of the running guest digest `shotter@sha256:5975c8e9`:

| Path | Type |
|---|---|
| `usr/bin/chromium` | regular file, 619 bytes, `#!/bin/sh` |
| `usr/bin/chromium-browser` | symlink to `/usr/bin/chromium` |
| `usr/lib/chromium/chrome` | regular file, 300882728 bytes |
| `bin/sh`, `bin/busybox`, `bin/bash` | absent |
| `bin/id`, `bin/stat`, `bin/env` | absent |

Refs ADR embervm/035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)