### PR TITLE
fix(monolith): de-collide the moving planner plot labels

### DIFF
--- a/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
+++ b/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
@@ -11,8 +11,11 @@
     formatTaskDueDate,
     ganttDatePosition,
     ganttTimeline,
+    groupMilestonesByDate,
     mergeAgendaItems,
     moveCountdown,
+    packLaneBars,
+    packLegTags,
     progressSummary,
     sortOpenTasks,
     sumSellValues,
@@ -20,6 +23,18 @@
     titleCaseName,
   } from "./moving.js";
   import "./moving-theme.css";
+
+  // Kept in step with the matching values in moving-theme.css: the milestone
+  // row and each bar sub-row are a fixed height, and the plot reserves a fixed
+  // --pad-btm (46px) for the axis. ROW_GAP is not a CSS gap: .rows uses
+  // justify-content: space-between, so the height below reserves
+  // ROW_GAP * lanes of slack and space-between then distributes it evenly
+  // across the gaps. Only --pad-top (leg tag stagger) and the plot's total
+  // height are computed here, because those two grow with the data.
+  const MILESTONE_ROW_H = 34;
+  const BAR_ROW_H = 34;
+  const ROW_GAP = 14;
+  const PLOT_PAD_BTM = 46;
 
   let { data } = $props();
 
@@ -69,22 +84,56 @@
       }))
       .filter((collision) => collision.wording),
   );
-  const milestonePoints = $derived(
-    milestones
-      .map((milestone) => ({
-        ...milestone,
+  const milestoneGroups = $derived(groupMilestonesByDate(milestones));
+  const milestoneMarkers = $derived(
+    milestoneGroups
+      .map((group) => ({
+        ...group,
         position: ganttDatePosition(
-          milestone.occurs_on,
+          group.occursOn,
           timeline.startsOn,
           timeline.endsOn,
         ),
       }))
-      .filter((milestone) => milestone.position != null),
+      .filter((group) => group.position != null),
   );
   const legSpans = $derived(
     spans
       .filter((span) => span.kind === "move" || span.kind === "trip")
       .toSorted((left, right) => left.starts_on.localeCompare(right.starts_on)),
+  );
+  const legTagPack = $derived(
+    packLegTags(
+      legSpans
+        .map((span) => ({
+          ...span,
+          position: ganttDatePosition(
+            span.starts_on,
+            timeline.startsOn,
+            timeline.endsOn,
+          ),
+        }))
+        .filter((span) => span.position != null),
+    ),
+  );
+  const plotPadTop = $derived(
+    12 + Math.max(1, legTagPack.staggerCount) * 38 + 10,
+  );
+  const packedLanes = $derived(
+    timeline.lanes.map((lane) => {
+      const packed = packLaneBars(lane.bars);
+      return { ...lane, bars: packed.bars, subRowCount: packed.subRowCount };
+    }),
+  );
+  const plotHeight = $derived(
+    plotPadTop +
+      MILESTONE_ROW_H +
+      packedLanes.reduce(
+        (total, lane) => total + lane.subRowCount * BAR_ROW_H,
+        0,
+      ) +
+      ROW_GAP * packedLanes.length +
+      PLOT_PAD_BTM,
   );
   const currentDateLabel = new Intl.DateTimeFormat("en-GB", {
     weekday: "short",
@@ -202,6 +251,27 @@
     if (milestone.gcal_state === "synced") return "✓";
     return "○";
   }
+
+  function milestoneGroupLabel(group) {
+    const titles = group.milestones.map((item) => item.title).join(", ");
+    return group.count > 1
+      ? `${group.count} milestones, ${formatShortDate(group.occursOn)}: ${titles}`
+      : `${titles}, ${formatShortDate(group.occursOn)}, ${group.state}`;
+  }
+
+  function showMilestoneTooltip(event, group) {
+    showTooltip(
+      event,
+      group.count > 1 ? `${group.count} milestones` : group.milestones[0].title,
+      formatShortDate(group.occursOn),
+      group.milestones
+        .map(
+          (item) =>
+            `${item.title} · ${titleCaseName(item.owner)} · ${item.gcal_state}`,
+        )
+        .join("\n"),
+    );
+  }
 </script>
 
 <svelte:head>
@@ -232,30 +302,36 @@
               <strong>{countdown.headline}</strong>
               <span>{countdown.detail}</span>
             </div>
-          {:else if countdown.days > 0}
-            <h1 id="move-countdown">
-              <span class="hl"
-                >{countdown.days} {countdown.days === 1 ? "day" : "days"}</span
-              >&nbsp;to wheels&#8209;up.
-            </h1>
-          {:else if countdown.days === 0}
-            <h1 id="move-countdown">
-              <span class="hl">Wheels&#8209;up</span>&nbsp;today.
-            </h1>
           {:else}
-            <h1 id="move-countdown">
-              <span class="hl"
-                >{Math.abs(countdown.days)}
-                {Math.abs(countdown.days) === 1 ? "day" : "days"}</span
-              >&nbsp;since wheels&#8209;up.
+            <h1
+              id="move-countdown"
+              title={countdown.description}
+              aria-describedby="move-countdown-desc"
+            >
+              {#if countdown.days > 0}
+                <span class="hl"
+                  >{countdown.days}
+                  {countdown.days === 1 ? "day" : "days"}</span
+                >
+              {:else if countdown.days === 0}
+                <span class="hl">Today</span>
+              {:else}
+                <span class="hl"
+                  >{Math.abs(countdown.days)}
+                  {Math.abs(countdown.days) === 1 ? "day" : "days"}</span
+                >&nbsp;ago
+              {/if}
             </h1>
+            <span id="move-countdown-desc" class="sr-only"
+              >{countdown.description}</span
+            >
           {/if}
         </section>
 
         <section class="cell c-today" aria-labelledby="today-heading">
           <div class="ch">
             <h2 id="today-heading">Do today</h2>
-            <span class="seg-mini" role="group" aria-label="Task scope">
+            <span class="seg-mini" role="group" aria-label="Plan scope">
               <button
                 type="button"
                 aria-pressed={currentScope === "mine"}
@@ -336,15 +412,20 @@
           aria-label={`Timeline, ${formatShortDate(timeline.startsOn)} to ${formatShortDate(timeline.endsOn)}`}
           bind:this={plotCard}
         >
-          <div class="plot">
+          <div
+            class="plot"
+            style:height={`${plotHeight}px`}
+            style:--pad-top={`${plotPadTop}px`}
+          >
             <div class="plot-scale">
               {#each timeline.months.slice(1) as month (month.value)}
                 <span class="vline" style:left={`${month.position}%`}></span>
               {/each}
-              {#each legSpans as span (span.id)}
+              {#each legTagPack.tags as span (span.id)}
                 <div
                   class={`legtag ${spanHueClass(span)}`}
-                  style:left={`${ganttDatePosition(span.starts_on, timeline.startsOn, timeline.endsOn)}%`}
+                  style:left={`${span.position}%`}
+                  style:--stagger={span.stagger}
                 >
                   <b>{span.label}</b>
                   <span>{formatDateRange(span.starts_on, span.ends_on)}</span>
@@ -366,45 +447,47 @@
               <div class="row slim">
                 <span class="name">Milestones</span>
                 <div class="track">
-                  {#each milestonePoints as milestone (milestone.id)}
-                    <button
-                      type="button"
-                      class:fill={milestone.gcal_state === "synced"}
-                      class:held={milestone.gcal_state === "held"}
-                      class="dia"
-                      style:left={`${milestone.position}%`}
-                      aria-label={`${milestone.title}, ${formatShortDate(milestone.occurs_on)}, ${milestone.gcal_state}`}
-                      onpointerenter={(event) =>
-                        showTooltip(
-                          event,
-                          milestone.title,
-                          `${formatShortDate(milestone.occurs_on)} · ${titleCaseName(milestone.owner)}`,
-                          milestone.gcal_state,
-                        )}
-                      onpointerleave={() => (tooltip = null)}
-                      onfocus={(event) =>
-                        showTooltip(
-                          event,
-                          milestone.title,
-                          `${formatShortDate(milestone.occurs_on)} · ${titleCaseName(milestone.owner)}`,
-                          milestone.gcal_state,
-                        )}
-                      onblur={() => (tooltip = null)}
-                      onclick={() => openDialog(calendarDialog)}
-                    ></button>
+                  {#each milestoneMarkers as group (group.id)}
+                    <div class="dia-wrap" style:left={`${group.position}%`}>
+                      <span class="dia-marker">
+                        <button
+                          type="button"
+                          class:fill={group.state === "synced"}
+                          class:held={group.state === "held"}
+                          class="dia"
+                          aria-label={milestoneGroupLabel(group)}
+                          onpointerenter={(event) =>
+                            showMilestoneTooltip(event, group)}
+                          onpointerleave={() => (tooltip = null)}
+                          onfocus={(event) =>
+                            showMilestoneTooltip(event, group)}
+                          onblur={() => (tooltip = null)}
+                          onclick={() => openDialog(calendarDialog)}
+                        ></button>
+                        {#if group.count > 1}
+                          <span class="dia-count" aria-hidden="true"
+                            >{group.count}</span
+                          >
+                        {/if}
+                      </span>
+                      <span class="dia-date"
+                        >{formatShortDate(group.occursOn)}</span
+                      >
+                    </div>
                   {/each}
                 </div>
               </div>
-              {#each timeline.lanes as lane (lane.kind)}
+              {#each packedLanes as lane (lane.kind)}
                 <div class="row">
                   <span class="name">{lane.label}</span>
-                  <div class="track">
+                  <div class="track" style:--sub-rows={lane.subRowCount}>
                     {#each lane.bars as bar (bar.id)}
                       <button
                         type="button"
                         class="bar"
                         style:left={`${bar.position}%`}
                         style:width={`${bar.width}%`}
+                        style:--sub-row={bar.subRow}
                         aria-label={`${bar.label}, ${formatDateRange(bar.starts_on, bar.ends_on)}`}
                         onpointerenter={(event) =>
                           showTooltip(
@@ -427,7 +510,7 @@
                   </div>
                 </div>
               {/each}
-              {#if timeline.lanes.length === 0 && milestonePoints.length === 0}
+              {#if packedLanes.length === 0 && milestoneMarkers.length === 0}
                 <p class="plot-empty">No timeline dates yet.</p>
               {/if}
             </div>
@@ -559,7 +642,7 @@
               class="dot"
               aria-hidden="true"
             ></span>
-            Calendar <span class="v mono">{milestones.length} dates</span>
+            Calendar <span class="v mono">{milestoneGroups.length} dates</span>
           </button>
           <button
             class="dockbtn"

--- a/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
@@ -244,6 +244,18 @@
   color: #1a1a1a;
 }
 
+.moving .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .moving .c-agenda {
   display: none;
 }
@@ -509,7 +521,9 @@
   --pad-top: 62px;
   --pad-btm: 46px;
   position: relative;
-  height: 430px;
+  /* Height is set inline: it grows with the leg tag stagger and with the
+     number of sub-rows each bar lane needs, so nothing clips or crowds. */
+  min-height: 430px;
 }
 
 .moving .plot-scale {
@@ -527,16 +541,13 @@
 
 .moving .legtag {
   position: absolute;
-  top: 12px;
+  /* Tags that would otherwise overlap are staggered onto their own row by
+     packLegTags(); --stagger is the row index it assigned. */
+  top: calc(12px + var(--stagger, 0) * 38px);
   display: flex;
   flex-direction: column;
   gap: 3px;
-  padding-left: 12px;
   white-space: nowrap;
-}
-
-.moving .legtag:first-of-type {
-  padding-left: 0;
 }
 
 .moving .legtag b {
@@ -566,7 +577,7 @@
 .moving .today {
   position: absolute;
   z-index: 4;
-  top: 58px;
+  top: var(--pad-top);
   bottom: 40px;
   width: 2px;
   background: var(--blue);
@@ -626,21 +637,24 @@
 
 .moving .row .track {
   position: relative;
-  height: 26px;
+  /* One sub-row looks the same as the old fixed 26px track, just with room
+     for the label underneath; packLaneBars() sets --sub-rows when a lane
+     needs more than one to keep its bars from overlapping. */
+  height: calc(var(--sub-rows, 1) * 34px);
   margin-right: var(--pad-r);
 }
 
 .moving .row.slim .track {
-  height: 20px;
+  height: 34px;
 }
 
 .moving .bar {
   position: absolute;
-  top: 50%;
+  /* --sub-row is the packing slot packLaneBars() assigned this bar. */
+  top: calc(var(--sub-row, 0) * 34px + 3px);
   min-width: 13px;
   height: 13px;
   padding: 0;
-  transform: translateY(-50%);
   border: 0;
   background: var(--ink);
   box-shadow: 0 0 0 2px var(--paper);
@@ -657,9 +671,9 @@
 
 .moving .blbl {
   position: absolute;
-  top: 50%;
-  left: calc(100% + 9px);
-  transform: translateY(-50%);
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
   color: var(--ink-2);
   font-size: 11px;
   font-weight: 600;
@@ -667,13 +681,28 @@
   pointer-events: none;
 }
 
-.moving .dia {
+.moving .dia-wrap {
   position: absolute;
   top: 50%;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  transform: translate(-50%, -50%);
+}
+
+.moving .dia-marker {
+  position: relative;
+  display: inline-flex;
+}
+
+.moving .dia {
+  position: static;
   width: 10px;
   height: 10px;
   padding: 0;
-  transform: translate(-50%, -50%) rotate(45deg);
+  transform: rotate(45deg);
   border: 2px solid var(--ink);
   background: var(--paper);
   cursor: pointer;
@@ -691,7 +720,31 @@
 .moving .dia:hover,
 .moving .dia:focus-visible {
   z-index: 5;
-  transform: translate(-50%, -50%) rotate(45deg) scale(1.4);
+  transform: rotate(45deg) scale(1.4);
+}
+
+.moving .dia-count {
+  position: absolute;
+  top: -5px;
+  left: 100%;
+  margin-left: 3px;
+  padding: 0 3px;
+  border: 1.5px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-code);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1.3;
+  pointer-events: none;
+}
+
+.moving .dia-date {
+  color: var(--ink-3);
+  font-family: var(--font-code);
+  font-size: 9.5px;
+  white-space: nowrap;
+  pointer-events: none;
 }
 
 .moving .axis {
@@ -754,6 +807,7 @@
   color: var(--ink-2);
   font-size: 11.5px;
   font-style: normal;
+  white-space: pre-line;
 }
 
 .moving .c-prog {

--- a/projects/monolith/frontend/src/routes/friends/moving/moving.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving.js
@@ -87,18 +87,22 @@ export function moveCountdown(spans, now = new Date()) {
     .filter((span) => span.kind === "move" && dateStamp(span.starts_on) != null)
     .toSorted((left, right) => left.starts_on.localeCompare(right.starts_on));
 
-  if (moves.length === 0) {
+  const move = moves[0];
+
+  // starts_on is when packing begins; ends_on is the day they actually
+  // leave Canada, which is what the countdown is meant to mean. A move
+  // span with no usable ends_on falls back to the same empty shape as
+  // having no move span at all, rather than counting to NaN.
+  if (!move || dateStamp(move.ends_on) == null) {
     return {
       headline: "No move date set",
       detail: "Add a move span when the date is known.",
+      description: null,
       days: null,
     };
   }
 
-  const move = moves[0];
-  const days = Math.round(
-    (dateStamp(move.starts_on) - todayStamp(now)) / DAY_MS,
-  );
+  const days = Math.round((dateStamp(move.ends_on) - todayStamp(now)) / DAY_MS);
   let headline;
   if (days === 0) headline = "Moving day";
   else if (days === 1) headline = "1 day to go";
@@ -106,14 +110,17 @@ export function moveCountdown(spans, now = new Date()) {
   else if (days === -1) headline = "1 day since move day";
   else headline = `${Math.abs(days)} days since move day`;
 
+  const detail = formatDate(move.ends_on, {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
   return {
     headline,
-    detail: formatDate(move.starts_on, {
-      weekday: "long",
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-    }),
+    detail,
+    description: `Until you leave Canada, ${detail}`,
     days,
   };
 }
@@ -296,6 +303,108 @@ export function ganttTimeline(spans, milestones, now = new Date()) {
     lanes,
     todayPosition: ganttDatePosition(today, startsOn, endsOn),
   };
+}
+
+// Small percentage-of-track allowance so two bars that merely touch still
+// land in separate sub-rows, leaving room for the label under each.
+const BAR_OVERLAP_ALLOWANCE = 3;
+
+export function packLaneBars(bars) {
+  const list = bars ?? [];
+  const order = list
+    .map((_, index) => index)
+    .toSorted(
+      (left, right) =>
+        list[left].position - list[right].position || left - right,
+    );
+
+  const subRowEnds = [];
+  const subRowByIndex = new Array(list.length);
+
+  for (const index of order) {
+    const bar = list[index];
+    const start = bar.position;
+    const end = bar.position + bar.width;
+    let subRow = subRowEnds.findIndex((rowEnd) => start >= rowEnd);
+    if (subRow === -1) {
+      subRow = subRowEnds.length;
+      subRowEnds.push(end + BAR_OVERLAP_ALLOWANCE);
+    } else {
+      subRowEnds[subRow] = end + BAR_OVERLAP_ALLOWANCE;
+    }
+    subRowByIndex[index] = subRow;
+  }
+
+  return {
+    bars: list.map((bar, index) => ({ ...bar, subRow: subRowByIndex[index] })),
+    subRowCount: subRowEnds.length,
+  };
+}
+
+// Leg tags carry no known text width (unlike bars, which are sized by
+// date span), so overlap is approximated by how close two tags start,
+// rather than measuring pixels.
+const LEG_TAG_MIN_GAP_PERCENT = 24;
+
+export function packLegTags(tags, minGapPercent = LEG_TAG_MIN_GAP_PERCENT) {
+  const list = tags ?? [];
+  const order = list
+    .map((_, index) => index)
+    .toSorted(
+      (left, right) =>
+        list[left].position - list[right].position || left - right,
+    );
+
+  const levelEnds = [];
+  const staggerByIndex = new Array(list.length);
+
+  for (const index of order) {
+    const tag = list[index];
+    let stagger = levelEnds.findIndex(
+      (levelEnd) => tag.position >= levelEnd + minGapPercent,
+    );
+    if (stagger === -1) {
+      stagger = levelEnds.length;
+      levelEnds.push(tag.position);
+    } else {
+      levelEnds[stagger] = tag.position;
+    }
+    staggerByIndex[index] = stagger;
+  }
+
+  return {
+    tags: list.map((tag, index) => ({
+      ...tag,
+      stagger: staggerByIndex[index],
+    })),
+    staggerCount: levelEnds.length,
+  };
+}
+
+export function groupMilestonesByDate(milestones) {
+  const groups = new Map();
+  for (const milestone of milestones ?? []) {
+    if (!groups.has(milestone.occurs_on)) groups.set(milestone.occurs_on, []);
+    groups.get(milestone.occurs_on).push(milestone);
+  }
+
+  return [...groups.entries()]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([occursOn, items]) => ({
+      id: `ms-${occursOn}`,
+      occursOn,
+      milestones: items,
+      count: items.length,
+      // A shared marker can only show one fill state. Treat the group as
+      // synced only when every milestone on the date is synced, and as
+      // held if any single one is held, so a held milestone is never
+      // buried under a marker that reads as all clear.
+      state: items.some((item) => item.gcal_state === "held")
+        ? "held"
+        : items.every((item) => item.gcal_state === "synced")
+          ? "synced"
+          : "queued",
+    }));
 }
 
 export function mergeAgendaItems(milestones, spans, collisions, tasks) {

--- a/projects/monolith/frontend/src/routes/friends/moving/moving.test.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving.test.js
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   collisionWording,
   ganttDatePosition,
+  groupMilestonesByDate,
   mergeAgendaItems,
   moveCountdown,
+  packLaneBars,
+  packLegTags,
   progressSummary,
   sumSellValues,
 } from "./moving.js";
@@ -49,27 +52,230 @@ describe("collision wording", () => {
 });
 
 describe("move countdown", () => {
-  it("targets the earliest move span", () => {
+  it("targets the earliest move span, counting to its end date", () => {
     const result = moveCountdown(
       [
-        { kind: "move", starts_on: "2026-05-16" },
-        { kind: "move", starts_on: "2026-05-11" },
-        { kind: "trip", starts_on: "2026-05-02" },
+        { kind: "move", starts_on: "2026-05-16", ends_on: "2026-05-25" },
+        { kind: "move", starts_on: "2026-05-11", ends_on: "2026-05-21" },
+        { kind: "trip", starts_on: "2026-05-02", ends_on: "2026-05-05" },
       ],
       new Date(2026, 4, 1, 12),
     );
 
-    expect(result.headline).toBe("10 days to go");
-    expect(result.detail).toBe("Monday, 11 May 2026");
-    expect(result.days).toBe(10);
+    expect(result.headline).toBe("20 days to go");
+    expect(result.detail).toBe("Thursday, 21 May 2026");
+    expect(result.description).toBe(
+      "Until you leave Canada, Thursday, 21 May 2026",
+    );
+    expect(result.days).toBe(20);
+  });
+
+  it("falls back when the earliest move span has no usable end date", () => {
+    const result = moveCountdown(
+      [{ kind: "move", starts_on: "2026-05-11", ends_on: null }],
+      new Date(2026, 4, 1, 12),
+    );
+
+    expect(result).toEqual({
+      headline: "No move date set",
+      detail: "Add a move span when the date is known.",
+      description: null,
+      days: null,
+    });
   });
 
   it("states plainly when no move span exists", () => {
     expect(moveCountdown([], new Date(2026, 4, 1, 12))).toEqual({
       headline: "No move date set",
       detail: "Add a move span when the date is known.",
+      description: null,
       days: null,
     });
+  });
+});
+
+describe("lane bar packing", () => {
+  it("packs the real three-visitor collision into two sub-rows", () => {
+    // Mirrors the real data: "Pat & Veronica" (18-31 Aug) and "Catherine &
+    // Ross" (28 Aug-13 Sep) overlap and must split into sub-rows; a third,
+    // later visitor has room to reuse the first sub-row.
+    const bars = [
+      {
+        id: "span-pat-veronica",
+        label: "Pat & Veronica",
+        position: 14.05,
+        width: 10.74,
+      },
+      {
+        id: "span-catherine-ross",
+        label: "Catherine & Ross",
+        position: 22.31,
+        width: 13.23,
+      },
+      {
+        id: "span-later-visitor",
+        label: "The Chungs",
+        position: 66.12,
+        width: 5.78,
+      },
+    ];
+
+    const result = packLaneBars(bars);
+
+    expect(result.subRowCount).toBe(2);
+    const subRowById = Object.fromEntries(
+      result.bars.map((bar) => [bar.id, bar.subRow]),
+    );
+    expect(subRowById["span-pat-veronica"]).toBe(0);
+    expect(subRowById["span-catherine-ross"]).toBe(1);
+    expect(subRowById["span-later-visitor"]).toBe(0);
+  });
+
+  it("never places two overlapping bars in the same sub-row", () => {
+    const { bars, subRowCount } = packLaneBars([
+      { id: "a", position: 0, width: 20 },
+      { id: "b", position: 10, width: 20 },
+      { id: "c", position: 15, width: 5 },
+    ]);
+
+    for (let row = 0; row < subRowCount; row += 1) {
+      const inRow = bars.filter((bar) => bar.subRow === row);
+      for (let i = 0; i < inRow.length; i += 1) {
+        for (let j = i + 1; j < inRow.length; j += 1) {
+          const left = inRow[i];
+          const right = inRow[j];
+          const overlaps =
+            left.position < right.position + right.width &&
+            right.position < left.position + left.width;
+          expect(overlaps).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("breaks position ties deterministically", () => {
+    const bars = [
+      { id: "a", position: 0, width: 10 },
+      { id: "b", position: 0, width: 10 },
+    ];
+
+    expect(packLaneBars(bars)).toEqual(packLaneBars(bars));
+    const { bars: packed } = packLaneBars(bars);
+    expect(packed.find((bar) => bar.id === "a").subRow).toBe(0);
+    expect(packed.find((bar) => bar.id === "b").subRow).toBe(1);
+  });
+
+  it("gives a single bar its own sub-row", () => {
+    const { bars, subRowCount } = packLaneBars([
+      { id: "only", position: 40, width: 10 },
+    ]);
+
+    expect(subRowCount).toBe(1);
+    expect(bars).toEqual([{ id: "only", position: 40, width: 10, subRow: 0 }]);
+  });
+
+  it("handles an empty lane", () => {
+    expect(packLaneBars([])).toEqual({ bars: [], subRowCount: 0 });
+  });
+});
+
+describe("leg tag staggering", () => {
+  it("staggers the real move and trip tags, which start close together", () => {
+    // "Pack out and leave Vancouver" (1 Oct) and "Japan" (11 Oct) sit
+    // roughly 8% apart on the real four-month axis.
+    const { tags, staggerCount } = packLegTags([
+      { id: "span-move", label: "Pack out and leave Vancouver", position: 50 },
+      { id: "span-japan", label: "Japan", position: 58 },
+    ]);
+
+    expect(staggerCount).toBe(2);
+    expect(tags.find((tag) => tag.id === "span-move").stagger).toBe(0);
+    expect(tags.find((tag) => tag.id === "span-japan").stagger).toBe(1);
+  });
+
+  it("does not stagger a single tag", () => {
+    const { tags, staggerCount } = packLegTags([
+      { id: "only", label: "Only leg", position: 30 },
+    ]);
+
+    expect(staggerCount).toBe(1);
+    expect(tags[0].stagger).toBe(0);
+  });
+
+  it("handles no tags", () => {
+    expect(packLegTags([])).toEqual({ tags: [], staggerCount: 0 });
+  });
+});
+
+describe("milestone grouping by date", () => {
+  it("groups the real triple-milestone date into one marker", () => {
+    const milestones = [
+      {
+        id: "ms-lease",
+        title: "Lease ends",
+        occurs_on: "2026-10-07",
+        owner: "both",
+        gcal_state: "synced",
+      },
+      {
+        id: "ms-joe",
+        title: "Joe last day of work",
+        occurs_on: "2026-10-07",
+        owner: "joe",
+        gcal_state: "held",
+      },
+      {
+        id: "ms-anna",
+        title: "Anna last day of work",
+        occurs_on: "2026-10-07",
+        owner: "anna",
+        gcal_state: "synced",
+      },
+    ];
+
+    const groups = groupMilestonesByDate(milestones);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      occursOn: "2026-10-07",
+      count: 3,
+      state: "held",
+    });
+    expect(groups[0].milestones).toHaveLength(3);
+  });
+
+  it("marks a group synced only when every milestone on the date is synced", () => {
+    const groups = groupMilestonesByDate([
+      { id: "a", occurs_on: "2026-09-01", gcal_state: "synced" },
+      { id: "b", occurs_on: "2026-09-01", gcal_state: "synced" },
+    ]);
+
+    expect(groups[0].state).toBe("synced");
+  });
+
+  it("marks a group queued when nothing is held but not everything is synced", () => {
+    const groups = groupMilestonesByDate([
+      { id: "a", occurs_on: "2026-09-01", gcal_state: "synced" },
+      { id: "b", occurs_on: "2026-09-01", gcal_state: "queued" },
+    ]);
+
+    expect(groups[0].state).toBe("queued");
+  });
+
+  it("keeps distinct dates as separate groups, sorted", () => {
+    const groups = groupMilestonesByDate([
+      { id: "a", occurs_on: "2026-09-05", gcal_state: "synced" },
+      { id: "b", occurs_on: "2026-09-01", gcal_state: "synced" },
+    ]);
+
+    expect(groups.map((group) => group.occursOn)).toEqual([
+      "2026-09-01",
+      "2026-09-05",
+    ]);
+  });
+
+  it("handles no milestones", () => {
+    expect(groupMilestonesByDate([])).toEqual([]);
   });
 });
 


### PR DESCRIPTION
The moving planner timeline positioned every element by date with no
account of the pixel width of its text, so labels collided whenever two
dates sat closer together than their words were wide.

Three symptoms, one cause.

**Bar labels were buried.** `.blbl` was pinned at `left: calc(100% + 9px)`,
always to the right of its bar. An adjacent bar, painting later in DOM
order and carrying a `box-shadow: 0 0 0 2px var(--paper)`, covered the
previous bar's label outright, so only the last bar in a cluster kept its
name. Labels now render beneath their bar, and lanes pack into sub-rows so
a bar that would overlap drops to its own line.

**Leg tags crushed.** They were absolutely positioned at their span's start
date with `white-space: nowrap`, so two spans starting ten days apart on a
four month axis overlaid into mush. Consecutive tags now stagger
vertically. The old `.legtag:first-of-type` padding reset was a partial
hack at the same problem and is replaced rather than built on.

**Milestones were unreadable.** Markers sharing a date rendered
pixel-identical, collapsing three into one, and carried no visible label at
all, only an `aria-label` and a hover tooltip. Milestones now group by date
into one marker per day with a count badge and an always-visible date
label. A group reads as synced only when every milestone on the date is
synced, and as held if any one is held, so a held milestone is never buried
under a marker that looks all clear.

## Countdown

Re-anchored from the move span's `starts_on` to its `ends_on`, so it
measures the day you leave rather than the day packing begins. The hero
drops its trailing copy for the bare number, with the sentence moved to
hover and to an `aria-describedby` target so it is not mouse-only.

## Two things noticed while reading

- The calendar dock rendered `milestones.length` while calling them dates,
  which read wrong as soon as three milestones shared 7 October.
- The scope toggle was labelled `aria-label="Task scope"` when it
  re-scopes milestones, spans and roles as well as tasks.

## Notes

Layout maths lands in `moving.js` as pure exported functions
(`packLaneBars`, `packLegTags`, `groupMilestonesByDate`) with unit tests
covering the real data plus empty, single and tie-breaking cases, rather
than inline in the component where nothing could assert it.

Verified with `ci lint` clean and `ci test` on both
`//projects/monolith/frontend:test` and `:build_test`, run with
`--nocache_test_results` so the result is real execution rather than a
cache hit: `Executed 2 out of 2 tests: 2 tests pass`. The `build_test`
target matters here because `:test` alone does not compile Svelte
templates.

Follow-up gaps in this domain are tracked in #5007.