### PR TITLE
fix(sandbox): resolve the language binary against a PATH the guest has

### DIFF
--- a/projects/firecracker/sandbox/guest-init/cmd/main.go
+++ b/projects/firecracker/sandbox/guest-init/cmd/main.go
@@ -41,6 +41,15 @@ func run(logger *slog.Logger) error {
 	// across disposable microVMs restored from the one warm-base snapshot.
 	mountTmpfsTmp(logger)
 
+	// Before ANY exec, including the warm-up below. Firecracker hands PID 1 no
+	// environment, and exec.Command resolves argv[0] against this process's
+	// PATH rather than the one in cmd.Env, so without this every language
+	// reports "executable file not found in $PATH" and the warm-up fails
+	// silently because a failed warm-up is deliberately non-fatal.
+	if err := handler.EnsureSearchPath(); err != nil {
+		return fmt.Errorf("ensure sandbox search path: %w", err)
+	}
+
 	spec, err := handler.SelectSpec()
 	if err != nil {
 		return fmt.Errorf("select sandbox language: %w", err)
@@ -121,7 +130,10 @@ func warmup(logger *slog.Logger, spec handler.Spec) {
 	cmd.Dir = "/tmp"
 	cmd.Env = spec.Environment("/tmp")
 	if out, err := cmd.CombinedOutput(); err != nil {
-		logger.Warn("language warm-up failed; guest still serves cold", "language", spec.Name, "err", err, "out", string(out))
+		// Error, not Warn: readiness still flips and the warm base still
+		// snapshots, so this log line is the ONLY signal that a guest cannot
+		// run its own toolchain. It was a Warn while all six languages failed.
+		logger.Error("language warm-up failed; guest still serves cold", "language", spec.Name, "err", err, "out", string(out))
 		return
 	}
 	logger.Info("language warm-up done", "language", spec.Name)

--- a/projects/firecracker/sandbox/guest-init/internal/handler/handler.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/handler.go
@@ -282,6 +282,14 @@ func runCommand(ctx context.Context, spec Spec, workdir string, argv []string, s
 	if len(argv) == 0 {
 		return errors.New("language spec has no command")
 	}
+	// Immediately before the exec that depends on it, not once at startup far
+	// from here. exec.CommandContext resolves argv[0] against THIS process's
+	// PATH, and a guest whose PID 1 inherits no environment resolves nothing.
+	// A no-op once PATH is set, so calling it per command costs a getenv and
+	// cannot be left behind by a refactor of main.
+	if err := EnsureSearchPath(); err != nil {
+		return fmt.Errorf("ensure sandbox search path: %w", err)
+	}
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 	cmd.Dir = workdir
 	cmd.Env = spec.Environment(workdir)

--- a/projects/firecracker/sandbox/guest-init/internal/handler/lang.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/lang.go
@@ -11,6 +11,35 @@ import (
 
 const defaultLanguageFile = "/etc/sandbox-language"
 
+// SearchPath is where every sandbox image installs its toolchain. It is both
+// the PATH handed to a snippet and the PATH guest-init must adopt for ITSELF.
+//
+// exec.Command resolves a bare argv[0] with LookPath against the CALLING
+// process's PATH, at construction time, and assigning cmd.Env afterwards does
+// not affect that lookup. Firecracker gives PID 1 no environment at all, so
+// without AdoptSearchPath the PATH below reaches only a child that is never
+// started, and every language fails with:
+//
+//	exec: "python3": executable file not found in $PATH
+const SearchPath = "/usr/bin:/bin:/usr/local/bin"
+
+// EnsureSearchPath puts SearchPath into guest-init's own environment when it
+// inherited none, so exec.Command can resolve a bare argv[0]. Call it before
+// any exec, including the warm-up, which fails the same way and is
+// deliberately non-fatal.
+//
+// Conditional on purpose. An inherited PATH is deliberate and belongs to
+// whoever set it; the fault this repairs is an EMPTY one, which is all a
+// Firecracker PID 1 ever has. It also keeps this package's exec-dependent
+// tests on their runner's real PATH rather than an image layout that only
+// exists inside a guest.
+func EnsureSearchPath() error {
+	if os.Getenv("PATH") != "" {
+		return nil
+	}
+	return os.Setenv("PATH", SearchPath)
+}
+
 // languageFile is indirect so SelectSpec can be tested without writing to /etc.
 var languageFile = defaultLanguageFile
 
@@ -152,7 +181,7 @@ func SelectSpec() (Spec, error) {
 // request commands point them at the collected, caps-enforced workdir.
 func (s Spec) Environment(workdir string) []string {
 	env := []string{
-		"PATH=/usr/bin:/bin:/usr/local/bin",
+		"PATH=" + SearchPath,
 		"HOME=" + workdir,
 		"TMPDIR=" + workdir,
 	}

--- a/projects/firecracker/sandbox/guest-init/internal/handler/lang_test.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/lang_test.go
@@ -1,12 +1,54 @@
 package handler
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 )
+
+// TestRunCommandResolvesBareArgvWithNoInheritedPath drives the real exec path
+// with the environment a Firecracker guest actually has: none.
+//
+// This crosses the seam the Environment() assertions stop short of. A correct
+// PATH in the returned slice proves nothing on its own, because exec.Command
+// resolves argv[0] against the CALLING process's PATH and never looks at
+// cmd.Env. That gap failed all six languages in production with
+// `exec: "python3": executable file not found in $PATH` while every
+// env-slice assertion in this file stayed green.
+func TestRunCommandResolvesBareArgvWithNoInheritedPath(t *testing.T) {
+	t.Setenv("PATH", "")
+	if _, err := exec.LookPath("sh"); err == nil {
+		t.Fatal("precondition failed: a bare name resolved with an empty PATH")
+	}
+
+	stdout := &capBuffer{limit: 4096}
+	stderr := &capBuffer{limit: 4096}
+	err := runCommand(context.Background(), Spec{Name: "test"}, t.TempDir(),
+		[]string{"sh", "-c", "echo resolved"}, stdout, stderr)
+	if err != nil {
+		t.Fatalf("runCommand with a bare argv[0] and no inherited PATH: %v (stderr %q)", err, stderr.buf.String())
+	}
+	if got := strings.TrimSpace(stdout.buf.String()); got != "resolved" {
+		t.Errorf("stdout = %q, want %q", got, "resolved")
+	}
+}
+
+// TestEnsureSearchPathLeavesAnInheritedPathAlone pins the conditional. An
+// inherited PATH belongs to whoever set it, and clobbering it would point this
+// package's exec-dependent tests at an image layout that exists only in a guest.
+func TestEnsureSearchPathLeavesAnInheritedPathAlone(t *testing.T) {
+	t.Setenv("PATH", "/deliberate/path")
+	if err := EnsureSearchPath(); err != nil {
+		t.Fatalf("EnsureSearchPath: %v", err)
+	}
+	if got := os.Getenv("PATH"); got != "/deliberate/path" {
+		t.Errorf("inherited PATH was overwritten: got %q", got)
+	}
+}
 
 func TestSelectSpec(t *testing.T) {
 	originalPath := languageFile


### PR DESCRIPTION
Closes #5009.

`run_code` is reachable end to end and every language fails at exec:

```
go         -> exec: "go": executable file not found in $PATH
rust       -> exec: "rustc": executable file not found in $PATH
python     -> exec: "python3": executable file not found in $PATH
javascript -> exec: "node": executable file not found in $PATH
```

Four images, four different binaries, one error shape.

## Cause

`exec.CommandContext` resolves `argv[0]` with `LookPath` against the **calling** process's PATH, at construction time. Assigning `cmd.Env` afterwards never affects that lookup. Firecracker hands PID 1 no environment (#4429), so the PATH guest-init carefully assembled reached only a child that was never started.

The apko `environment:` block already documents itself as inert for a raw Firecracker boot, noting that guest-init sets these at runtime. It did, on the wrong process.

## Fix

`EnsureSearchPath()` puts `SearchPath` into guest-init's own environment, called immediately above the exec in `runCommand` rather than once in `main`, where a refactor could leave it behind. `Environment()` now derives its PATH from the same constant so parent and child cannot drift.

It is **conditional** on PATH being empty, for two reasons: an inherited PATH is deliberate and belongs to whoever set it, and unconditionally overwriting it would point this package's existing exec-dependent tests at an in-guest image layout that does not exist on a test runner.

## Why nothing caught it

A failed warm-up is deliberately non-fatal, so readiness flipped, `/shim/ready` returned 200, and BuildBase snapshotted anyway. Six base snapshots were then read as evidence that the Go build, the rustc compile, the BEAM boot and the rest had each run. They proved only that six guests booted. That log line moves from `Warn` to `Error`, since it is the only signal a guest cannot run its own toolchain.

`lang_test.go` asserted `Environment()` contains `GOTOOLCHAIN=local` and `GOPROXY=off`. That is a claim about a `[]string`, and it passed throughout.

## Verification

The new test drives `runCommand` with PATH cleared and requires real stdout back. Falsified by deleting the fix and re-running:

```
without: FAIL  exec: "sh": executable file not found in $PATH
with:    PASS  stdout "resolved"
```

Identical error shape to production. A second test pins the conditional so it is not "simplified" into an unconditional overwrite.

`ci`: `Executed 1 out of 736 tests: 736 tests pass`.

## Deploy

No epoch bump. The workload pins its guest by digest (`ref: repository@digest`) and the base signature includes that ref, so six rebuilt images re-key and rebuild six warm bases on their own. `EMBER_BASE_EPOCH` exists for changes that do NOT move the digest, such as a new Firecracker binary under an unchanged guest.

Expect the six base rebuilds to land on the masters' scratch, the known pressure point for base rebuilds.

Not done at merge: I will run one snippet per language and paste the real stdout.