### PR TITLE
fix(sandbox): set GOROOT so go can compile, and put the BEAM in utf8

### DIFF
--- a/projects/firecracker/sandbox/guest-init/internal/handler/lang.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/lang.go
@@ -94,6 +94,12 @@ var languageSpecs = map[string]Spec{
 		Prepare:    prepareGo,
 		Run:        []string{"go", "run", "."},
 		Env: []string{
+			// Wolfi ships the go binary built with -trimpath, so it cannot infer
+			// its own root and exits 2 with "cannot find GOROOT directory: 'go'
+			// binary is trimmed and GOROOT is not set". Verified against the
+			// shipped image, which carries a complete root at this path:
+			// bin/go, pkg/tool/linux_amd64/compile, and src/runtime.
+			"GOROOT=/usr/lib/go",
 			"GOCACHE=/tmp/gocache",
 			"GOPATH=/tmp/gopath",
 			"GOMODCACHE=/tmp/gopath/pkg/mod",
@@ -135,7 +141,13 @@ var languageSpecs = map[string]Spec{
 		Run:        []string{"elixir", "main.exs"},
 		Env: []string{
 			"ERL_CRASH_DUMP=/dev/null",
-			"ELIXIR_ERL_OPTIONS=-noinput",
+			// +fnu sets the VM's native name encoding to utf8. Without it every
+			// run prints "the VM is running with native name encoding of latin1
+			// which may cause Elixir to malfunction as it expects utf8" to
+			// stderr, and any snippet touching a non-ASCII filename misbehaves.
+			// The usual alternative, a UTF-8 locale, is not available: the guest
+			// image ships no locale data.
+			"ELIXIR_ERL_OPTIONS=-noinput +fnu",
 		},
 		Warm:           []string{"elixir", "-e", ":ok"},
 		ExcludeOutputs: []string{"main.exs"},

--- a/projects/firecracker/sandbox/guest-init/internal/handler/lang_test.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/lang_test.go
@@ -117,9 +117,9 @@ func TestLanguageSpecs(t *testing.T) {
 		excluded   []string
 	}{
 		{name: "python", sourceFile: "main.py", run: []string{"python3", "main.py"}, extraEnv: []string{"PYTHONUNBUFFERED=1", "MPLBACKEND=Agg", "MPLCONFIGDIR=/tmp/mplconfig", "PYTHONPATH=/opt/sandbox"}, warm: []string{"python3", "-c"}, excluded: []string{"main.py"}},
-		{name: "go", sourceFile: "main.go", run: []string{"go", "run", "."}, extraEnv: []string{"GOCACHE=/tmp/gocache", "GOPATH=/tmp/gopath", "GOMODCACHE=/tmp/gopath/pkg/mod", "GOTOOLCHAIN=local", "GOPROXY=off", "GOFLAGS=-mod=mod", "CGO_ENABLED=0", "GOMAXPROCS=1"}, warm: []string{"/bin/sh", "-c"}, excluded: []string{"main.go", "go.mod", "go.sum"}},
+		{name: "go", sourceFile: "main.go", run: []string{"go", "run", "."}, extraEnv: []string{"GOROOT=/usr/lib/go", "GOCACHE=/tmp/gocache", "GOPATH=/tmp/gopath", "GOMODCACHE=/tmp/gopath/pkg/mod", "GOTOOLCHAIN=local", "GOPROXY=off", "GOFLAGS=-mod=mod", "CGO_ENABLED=0", "GOMAXPROCS=1"}, warm: []string{"/bin/sh", "-c"}, excluded: []string{"main.go", "go.mod", "go.sum"}},
 		{name: "rust", sourceFile: "main.rs", compile: []string{"rustc", "-O", "main.rs", "-o", "main"}, run: []string{"./main"}, warm: []string{"/bin/sh", "-c"}, excluded: []string{"main.rs", "main"}},
-		{name: "elixir", sourceFile: "main.exs", run: []string{"elixir", "main.exs"}, extraEnv: []string{"ERL_CRASH_DUMP=/dev/null", "ELIXIR_ERL_OPTIONS=-noinput"}, warm: []string{"elixir", "-e", ":ok"}, excluded: []string{"main.exs"}},
+		{name: "elixir", sourceFile: "main.exs", run: []string{"elixir", "main.exs"}, extraEnv: []string{"ERL_CRASH_DUMP=/dev/null", "ELIXIR_ERL_OPTIONS=-noinput +fnu"}, warm: []string{"elixir", "-e", ":ok"}, excluded: []string{"main.exs"}},
 		{name: "ocaml", sourceFile: "main.ml", run: []string{"ocaml", "main.ml"}, warm: []string{"/bin/sh", "-c"}, excluded: []string{"main.ml", "main.cmi", "main.cmo"}},
 		{name: "javascript", sourceFile: "main.js", run: []string{"node", "main.js"}, warm: []string{"node", "-e", "0"}, excluded: []string{"main.js"}},
 	}
@@ -172,6 +172,31 @@ func TestGoEnvironmentIsOffline(t *testing.T) {
 		if !contains(env, required) {
 			t.Errorf("Go environment %#v does not contain %q", env, required)
 		}
+	}
+}
+
+// TestGoEnvironmentSetsGoroot pins the variable without which the go binary
+// exits 2 before compiling anything, because Wolfi trims it and it cannot then
+// infer its own root.
+//
+// This is a data assertion and it is worth being honest about its limits: it
+// proves the string is in the slice, not that /usr/lib/go is where this image
+// actually puts the toolchain. That was established by reading the shipped
+// image (bin/go, pkg/tool/linux_amd64/compile, src/runtime/proc.go) and is
+// only ever re-proved by running go in the sandbox.
+func TestGoEnvironmentSetsGoroot(t *testing.T) {
+	env := languageSpecs["go"].Environment("/tmp/workdir")
+	if !contains(env, "GOROOT=/usr/lib/go") {
+		t.Errorf("Go environment %#v does not contain GOROOT", env)
+	}
+}
+
+// TestElixirRunsWithUtf8NameEncoding pins +fnu. The image ships no locale data,
+// so without it the BEAM starts in latin1 and warns on every run.
+func TestElixirRunsWithUtf8NameEncoding(t *testing.T) {
+	env := languageSpecs["elixir"].Environment("/tmp/workdir")
+	if !contains(env, "ELIXIR_ERL_OPTIONS=-noinput +fnu") {
+		t.Errorf("Elixir environment %#v does not request utf8 name encoding", env)
 	}
 }
 


### PR DESCRIPTION
Follow-on to #5011, which fixed the PATH fault that hid both of these.

With exec working, five of six languages ran real code:

```
rust    primes below 100000: 9592     last five: [99929, 99961, 99971, 99989, 99991]
python  3.12.14                       mean: 47.521 stdev: 30.3953
node    v24.19.0                      fib(25): 75025
elixir  1.19.5 otp: 28                multiples of 3 or 5 below 1001: 234168
ocaml   5.5.0                         gcd 462 1071 = 21    sum 1..100 = 5050
```

Go failed differently, having found and executed its binary:

```
go: cannot find GOROOT directory: 'go' binary is trimmed and GOROOT is not set
```

## GOROOT

Wolfi builds go with `-trimpath`, so the binary cannot infer its own root, and `GOROOT` was set nowhere: not in the spec `Env`, not in the apko block. It never surfaced because the exec never reached `go` at all.

`/usr/lib/go` is **read from the shipped image**, not assumed:

```
usr/lib/go/bin/go
usr/lib/go/pkg/tool/linux_amd64/compile
usr/lib/go/src/runtime/proc.go
```

Binary, tool chain and stdlib source, so a complete root rather than just where the binary happens to sit.

## Elixir encoding

Every run printed to stderr:

> the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8

The image ships no locale data, so the usual LANG fix is unavailable and `+fnu` is the right lever. Output was correct today, but that warning precedes real misbehaviour the moment a snippet touches a non-ASCII filename.

## What is deliberately NOT here

The apko `environment:` blocks are not updated to match. They describe themselves as documentation only, and the apko lock pins a **checksum of the whole file**, so mirroring two variables into them fails the build until both locks are regenerated, which re-resolves Wolfi and drags package drift into a two-variable fix. I tried it, CI rejected it:

```
Error: locking config: checksum in the lock file does not match the original config:
'projects/firecracker/sandbox/go/apko.yaml' (maybe regenerate the lock file)
```

The rationale lives in `lang.go` comments, where the values are read. `go/apko.yaml` documenting an environment without `GOROOT` is a known gap for whatever PR next has legitimate cause to regenerate that lock.

## Verification

`ci`: `Executed 1 out of 736 tests: 736 tests pass`.

`TestLanguageSpecs` pins the complete env slice with DeepEqual and rejected both additions until its expectations were updated, which is the strict-test tradeoff working as intended. Two focused tests were added alongside so a failure reads as "does not contain GOROOT" rather than a twelve-element slice diff.

Not done at merge: I will run go and elixir after the two bases rebuild and paste real stdout, plus an empty elixir stderr.