### PR TITLE
fix(sandbox): stop go ignoring its own go.mod in the temp root

### DIFF
--- a/projects/firecracker/sandbox/guest-init/internal/handler/lang.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/lang.go
@@ -108,6 +108,21 @@ var languageSpecs = map[string]Spec{
 			"GOFLAGS=-mod=mod",
 			"CGO_ENABLED=0",
 			"GOMAXPROCS=1",
+			// Overrides the base TMPDIR, which points at the workdir. Go refuses
+			// to read a go.mod that sits in os.TempDir() itself, so with the two
+			// equal it ignores the go.mod prepareGo just wrote and fails with
+			// "go.mod file not found in current directory or any parent
+			// directory". Only equality trips it: a temp root above or below the
+			// workdir is fine, which is why /tmp works and the workdir does not.
+			//
+			// Duplicate keys are not ambiguous here. os/exec dedupes cmd.Env and
+			// keeps the LAST occurrence, so this entry wins over the base one.
+			//
+			// /tmp rather than a workdir subdirectory because output collection
+			// walks the workdir: temp files written below it would come back to
+			// the caller as attachments. GOCACHE already lives on /tmp, and the
+			// tool's documented contract is that files under /tmp are lost.
+			"TMPDIR=/tmp",
 		},
 		Warm: []string{
 			"/bin/sh",

--- a/projects/firecracker/sandbox/guest-init/internal/handler/lang_test.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/lang_test.go
@@ -117,7 +117,7 @@ func TestLanguageSpecs(t *testing.T) {
 		excluded   []string
 	}{
 		{name: "python", sourceFile: "main.py", run: []string{"python3", "main.py"}, extraEnv: []string{"PYTHONUNBUFFERED=1", "MPLBACKEND=Agg", "MPLCONFIGDIR=/tmp/mplconfig", "PYTHONPATH=/opt/sandbox"}, warm: []string{"python3", "-c"}, excluded: []string{"main.py"}},
-		{name: "go", sourceFile: "main.go", run: []string{"go", "run", "."}, extraEnv: []string{"GOROOT=/usr/lib/go", "GOCACHE=/tmp/gocache", "GOPATH=/tmp/gopath", "GOMODCACHE=/tmp/gopath/pkg/mod", "GOTOOLCHAIN=local", "GOPROXY=off", "GOFLAGS=-mod=mod", "CGO_ENABLED=0", "GOMAXPROCS=1"}, warm: []string{"/bin/sh", "-c"}, excluded: []string{"main.go", "go.mod", "go.sum"}},
+		{name: "go", sourceFile: "main.go", run: []string{"go", "run", "."}, extraEnv: []string{"GOROOT=/usr/lib/go", "GOCACHE=/tmp/gocache", "GOPATH=/tmp/gopath", "GOMODCACHE=/tmp/gopath/pkg/mod", "GOTOOLCHAIN=local", "GOPROXY=off", "GOFLAGS=-mod=mod", "CGO_ENABLED=0", "GOMAXPROCS=1", "TMPDIR=/tmp"}, warm: []string{"/bin/sh", "-c"}, excluded: []string{"main.go", "go.mod", "go.sum"}},
 		{name: "rust", sourceFile: "main.rs", compile: []string{"rustc", "-O", "main.rs", "-o", "main"}, run: []string{"./main"}, warm: []string{"/bin/sh", "-c"}, excluded: []string{"main.rs", "main"}},
 		{name: "elixir", sourceFile: "main.exs", run: []string{"elixir", "main.exs"}, extraEnv: []string{"ERL_CRASH_DUMP=/dev/null", "ELIXIR_ERL_OPTIONS=-noinput +fnu"}, warm: []string{"elixir", "-e", ":ok"}, excluded: []string{"main.exs"}},
 		{name: "ocaml", sourceFile: "main.ml", run: []string{"ocaml", "main.ml"}, warm: []string{"/bin/sh", "-c"}, excluded: []string{"main.ml", "main.cmi", "main.cmo"}},
@@ -188,6 +188,28 @@ func TestGoEnvironmentSetsGoroot(t *testing.T) {
 	env := languageSpecs["go"].Environment("/tmp/workdir")
 	if !contains(env, "GOROOT=/usr/lib/go") {
 		t.Errorf("Go environment %#v does not contain GOROOT", env)
+	}
+}
+
+// TestGoTmpdirOverridesTheWorkdir pins the override that lets go read the
+// go.mod prepareGo writes. Go ignores a go.mod sitting in os.TempDir() itself,
+// and the base environment points TMPDIR at the workdir, which is that same
+// directory.
+//
+// The assertion is deliberately about ORDER, not membership. os/exec keeps the
+// last duplicate, so a TMPDIR=/tmp placed before the base entry would satisfy a
+// contains() check while leaving go reading go.mod out of the temp root and
+// failing exactly as it does in production.
+func TestGoTmpdirOverridesTheWorkdir(t *testing.T) {
+	env := languageSpecs["go"].Environment("/tmp/workdir")
+	effective := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "TMPDIR=") {
+			effective = kv
+		}
+	}
+	if effective != "TMPDIR=/tmp" {
+		t.Errorf("effective TMPDIR = %q, want %q", effective, "TMPDIR=/tmp")
 	}
 }
 


### PR DESCRIPTION
Third and final fault in the chain that kept the go sandbox from ever running code. #5011 fixed PATH, #5012 fixed GOROOT, and with both in place go compiles far enough to fail this way:

```
go: warning: ignoring go.mod in system temp root /tmp/sandbox-exec-2740208548
go: go.mod file not found in current directory or any parent directory
```

Go refuses to read a `go.mod` sitting in `os.TempDir()` itself. The base environment sets `TMPDIR` to the per-invoke workdir, which is that same directory, so the `go.mod` `prepareGo` writes is ignored on every call.

## The rule, reproduced locally

| TMPDIR | Result |
|---|---|
| the workdir itself | `ignoring go.mod in system temp root` |
| a subdirectory of the workdir | `compiled ok` |
| the tmpfs root above the workdir | `compiled ok` |

Only equality trips it, which is why this went unnoticed: nothing about the layout looks wrong.

## Why /tmp and not a subdirectory

Both work for go, but output collection walks the workdir, so temp files written below it would come back to the caller as attachments. `GOCACHE` already lives on `/tmp`, and `run_code` already documents that files under `/tmp` are lost, so this matches the contract rather than bending it.

## The test asserts order, not membership

`os/exec` keeps the **last** duplicate key, verified rather than assumed:

```
cmd.Env = []string{"TMPDIR=/first", "TMPDIR=/second"}
child sees TMPDIR = /second
```

So `contains(env, "TMPDIR=/tmp")` would pass on an environment where the override lands *before* the base entry and does nothing. The test walks the slice and asserts the effective (last) value, which is the property that actually makes go work.

`ci`: `Executed 4 out of 736 tests: 736 tests pass`.

## Verified state of the other five

Run through `run_code` after #5012 deployed:

```
rust    primes below 100000: 9592
python  3.12.14   mean: 47.521 stdev: 30.3953
node    v24.19.0  fib(25): 75025
ocaml   5.5.0     gcd 462 1071 = 21
elixir  1.19.5 otp 28, name encoding :utf8, clean stderr
```

Known and NOT fixed here: Elixir's stdout device is still latin1, so `String.upcase("café")` returns mangled bytes. `+fnu` governs filename encoding only. Filed separately.

Not done at merge: I will run go and paste real stdout.