### PR TITLE
feat(monolith): arm the qwen session synthetic and wire it into health

### DIFF
--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1624,7 +1624,10 @@ claudeRuntimeWorkload:
 #
 # THE NAMED CONSUMER IS THE SYNTHETIC PROBE. The monolith maps model `qwen` to
 # family `pi` (agent_sessions/__init__.py), and ember_public's probe_qwen runs
-# one trivial turn every five minutes forever. Served on claude-runtime that is
+# one trivial turn HOURLY, from its own ember-qwen-session-synthetic
+# CronWorkflow. It is NOT part of the */5 ember-synthetic run: that one covers
+# bazel, semgrep, pages and postgres only. Read the CronWorkflow rather than
+# this comment if the cadence matters to you. Served on claude-runtime that is
 # a 4096 MiB cold boot of a guest holding a 262 MB Node ELF and a 114 MB codex
 # binary the turn can never invoke. Here it is 256 MiB.
 #

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -808,18 +808,31 @@ jobs:
 
     # The qwen session synthetic is deliberately separate from the original
     # demo probes so its hourly cadence does not turn a local-model VM test
-    # into a five-minute workload. It is suspended until Joe watches a live
-    # run return a completed turn with a non-empty result and confirms that
-    # the session is destroyed afterward. Landing a prober you have not
-    # watched succeed is how #4074 paged on its own gaps.
+    # into a five-minute workload.
+    #
+    # ARMED 2026-08-16, once the gate below was satisfied by a live run against
+    # production, driven with the monolith pod's own ServiceAccount so it went
+    # through the real principal:
+    #
+    #   POST /v1/workloads/pi-runtime/sessions   201 in 0.1s
+    #   POST /v1/sessions/{id}/invoke            200 in 1.8s
+    #        result "qwen synthetic ok", terminal_reason "stop",
+    #        usage 522 in / 27 out (a real llama.cpp round trip)
+    #   DELETE /v1/sessions/{id}                 202
+    #
+    # That is a completed turn, a non-empty result, and a destroyed session,
+    # which is exactly what the gate asked for. Arming was also gated on qwen
+    # actually routing to pi-runtime, which landed in the same session.
     - name: ember-qwen-session-synthetic
       args: ["ember-qwen-synthetic-trigger"]
       schedule: "0 * * * *"
       concurrencyPolicy: Forbid
       activeDeadlineSeconds: 300
-      # Joe arms this after watching the first green live run. That run must
-      # show a completed, non-empty qwen turn and a destroyed EmberVM session.
-      suspend: true
+      # Original gate, kept for the record: "Joe arms this after watching the
+      # first green live run. That run must show a completed, non-empty qwen
+      # turn and a destroyed EmberVM session." Landing a prober you have not
+      # watched succeed is how #4074 paged on its own gaps.
+      suspend: false
       env:
         MONOLITH_INTERNAL_URL: "http://monolith.monolith.svc.cluster.local:8000"
       resources:

--- a/projects/monolith/ember_public/health.py
+++ b/projects/monolith/ember_public/health.py
@@ -11,10 +11,22 @@ from datetime import datetime, timezone
 
 from ember_public.synthetic import read_probe
 
-# All four synthetic probes run in the one ember-synthetic CronWorkflow every
-# 5 minutes (see the jobs.cronWorkflows entry). 2.5x that cadence, so a single
-# missed or slow run never flaps the check but a dead prober still surfaces.
+# All four of the ORIGINAL synthetic probes run in the one ember-synthetic
+# CronWorkflow every 5 minutes (see the jobs.cronWorkflows entry). 2.5x that
+# cadence, so a single missed or slow run never flaps the check but a dead
+# prober still surfaces.
 EMBER_SYNTHETIC_STALENESS_S = 750.0
+
+# The qwen session synthetic is a SEPARATE CronWorkflow
+# (ember-qwen-session-synthetic) on an HOURLY schedule, deliberately not folded
+# into the 5-minute run: it cold-boots a real EmberVM guest and runs a full
+# agent turn, which is not something to do twice a minute.
+#
+# It therefore must NOT reuse EMBER_SYNTHETIC_STALENESS_S. At 750s an hourly
+# latch is stale 12.5 minutes into every hour, so the component would report
+# "prober may be dead" for roughly 80% of the time it is working perfectly.
+# Same 2.5x rule, applied to the cadence this probe actually has.
+EMBER_QWEN_STALENESS_S = 9000.0
 
 
 def synthetic_probe_health(demo: str, staleness_s: float):

--- a/projects/monolith/ember_public/health_test.py
+++ b/projects/monolith/ember_public/health_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -23,7 +23,22 @@ def test_module_registers_synthetic_postgres_health_hook():
         "ember_semgrep",
         "ember_pages",
         "ember_postgres",
+        "ember_qwen",
     }
+
+
+def test_qwen_staleness_matches_its_own_hourly_cadence():
+    """The qwen probe must NOT reuse the 5-minute probes' staleness window.
+
+    ember-qwen-session-synthetic is hourly, so at the 750s window an entirely
+    healthy hourly latch reads as stale 12.5 minutes into every hour and the
+    component reports "prober may be dead" for most of the time it is working.
+    Its window has to exceed one hour, and it is the same 2.5x rule applied to
+    the cadence this probe actually has.
+    """
+    assert health.EMBER_SYNTHETIC_STALENESS_S == 750.0
+    assert health.EMBER_QWEN_STALENESS_S > 3600.0
+    assert health.EMBER_QWEN_STALENESS_S == 9000.0
 
 
 def test_module_has_no_advisory_health_components():
@@ -70,3 +85,34 @@ def test_public_app_api_health_surfaces_synthetic_probe_failure(monkeypatch):
     body = resp.json()
     assert body["components"]["ember_postgres"]["ok"] is False
     assert "demo_postgres" not in body["components"]
+
+
+def test_hourly_qwen_latch_is_not_stale(monkeypatch):
+    """A healthy hourly qwen latch must read OK, not "prober may be dead".
+
+    This is the end-to-end form of the staleness guard: a latch written 50
+    minutes ago is entirely normal for an hourly prober, and would be marked
+    stale by the 5-minute probes' 750s window.
+    """
+    row = EmberSyntheticProbe(
+        demo="qwen",
+        ok=True,
+        detail="completed, destroyed",
+        latency_ms=1800.0,
+        checked_at=datetime.now(timezone.utc) - timedelta(minutes=50),
+    )
+
+    async def read_probe(demo):
+        return row if demo == "qwen" else None
+
+    monkeypatch.setattr(health, "read_probe", read_probe)
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    monkeypatch.setattr("core.db.get_engine", lambda: engine)
+
+    app = build_app(PUBLIC_PROFILE, [MODULE])
+    body = TestClient(app).get("/api/health").json()
+
+    assert body["components"]["ember_qwen"]["ok"] is True
+    assert "prober may be dead" not in body["components"]["ember_qwen"]["detail"]

--- a/projects/monolith/ember_public/module.py
+++ b/projects/monolith/ember_public/module.py
@@ -7,6 +7,7 @@ demos/module.py.
 
 import ember_public as _domain
 from ember_public.health import (
+    EMBER_QWEN_STALENESS_S,
     EMBER_SYNTHETIC_STALENESS_S,
     synthetic_probe_health,
 )
@@ -25,5 +26,10 @@ MODULE = _Module(
         "ember_postgres": synthetic_probe_health(
             "postgres", EMBER_SYNTHETIC_STALENESS_S
         ),
+        # The qwen session synthetic. probe_qwen has been writing this latch
+        # since it landed, but nothing read it, so a failing qwen turn was
+        # invisible to health. Registered here on its OWN staleness because its
+        # CronWorkflow is hourly, not the 5-minute one (see EMBER_QWEN_*).
+        "ember_qwen": synthetic_probe_health("qwen", EMBER_QWEN_STALENESS_S),
     },
 )


### PR DESCRIPTION
Arms `ember-qwen-session-synthetic` (Joe's call, made this session) and closes the gap that would have made arming hollow.

## The gate is satisfied

The prober carried an explicit hold: *"suspended until Joe watches a live run return a completed turn with a non-empty result and confirms that the session is destroyed afterward. Landing a prober you have not watched succeed is how #4074 paged on its own gaps."*

A live production run, driven from the monolith pod with its own ServiceAccount so it exercised the real principal:

| step | result |
|---|---|
| `POST /v1/workloads/pi-runtime/sessions` | `201` in 0.1s |
| `POST /v1/sessions/{id}/invoke` | `200` in 1.8s, `result "qwen synthetic ok"`, `terminal_reason "stop"`, usage 522 in / 27 out (real llama.cpp round trip) |
| `DELETE /v1/sessions/{id}` | `202` |

Completed turn, non-empty result, destroyed session. Routing `qwen` to `pi-runtime` landed in the same session (#5003), so the lane the prober will exercise is the one it is meant to test.

## Arming alone would have been hollow

`probe_qwen` has been writing an `ember_synthetic_probe` latch that **nothing read**. `register_health` carried only `ember_bazel`, `ember_semgrep`, `ember_pages`, `ember_postgres`. So a failing qwen turn was invisible to `/api/health` whether or not the prober ran. This registers `ember_qwen`.

## Why it needs its own staleness window

`EMBER_SYNTHETIC_STALENESS_S = 750.0` is documented in-file as 2.5x the **five minute** cadence of the `ember-synthetic` CronWorkflow. The qwen synthetic is a **separate hourly** CronWorkflow.

Registering it against 750s would mark a perfectly healthy latch stale 12.5 minutes into every hour, so the component would report `prober may be dead` for roughly 80% of the time it is working correctly, and `/api/health` would 503 for most of each hour. `EMBER_QWEN_STALENESS_S = 9000.0` is the same 2.5x rule applied to the cadence this probe actually has.

Two tests cover it: one asserting the constant exceeds an hour and is not the shared value, and an end-to-end one proving a 50-minute-old latch reads OK rather than "prober may be dead".

Note the first-run behaviour is already safe: `synthetic_probe_health` fails **open** on a missing row (`"no probe recorded yet"`), so health stays green between deploy and the first top-of-hour run.

## Comment drift

`piRuntimeWorkload` in the embervm chart claimed `probe_qwen` runs "one trivial turn every five minutes forever". It is hourly, and not part of the `*/5` run. Corrected.

The identical claim in `projects/embervm/runtimes/pi/apko.yaml` is **deliberately left alone**. I tried to fix it and the build failed:

```
Error: locking config: checksum in the lock file ... does not matches
the original config: 'projects/embervm/runtimes/pi/apko.yaml'
```

The apko lock checksums the whole file including comments, so a comment-only edit breaks the image build, and the fix would be a lock regen that refreshes Wolfi packages, moves the image digest and forces a base rebuild. Not a trade worth making for prose.

## Verification

`ci test`: `Executed 66 out of 736 tests: 736 tests pass`, no skips, no `ERROR:`, no `fails remotely`.

Rendered the CronWorkflow to confirm the flag actually lands (the template is gated on the build-time `jobs.image` pin, so a plain `helm template` renders nothing):

```
schedules:
  - "0 * * * *"
concurrencyPolicy: Forbid
suspend: false
```

Reviewer note: the first `ci test` on this branch **exited 0** while reporting `539 tests pass and 197 were skipped`. The skips were downstream of the failed apko action above. An unusual skip count is the tell; judge by comparing against a known good run, not by the exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)