### PR TITLE
fix(moving): stop milestone markers overprinting and scale up on wide displays

### DIFF
--- a/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
+++ b/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
@@ -4,6 +4,7 @@
   import { onMount } from "svelte";
   import AccessPanel from "./AccessPanel.svelte";
   import {
+    clusterMilestoneGroups,
     collisionWording,
     formatCad,
     formatDateRange,
@@ -86,16 +87,18 @@
   );
   const milestoneGroups = $derived(groupMilestonesByDate(milestones));
   const milestoneMarkers = $derived(
-    milestoneGroups
-      .map((group) => ({
-        ...group,
-        position: ganttDatePosition(
-          group.occursOn,
-          timeline.startsOn,
-          timeline.endsOn,
-        ),
-      }))
-      .filter((group) => group.position != null),
+    clusterMilestoneGroups(
+      milestoneGroups
+        .map((group) => ({
+          ...group,
+          position: ganttDatePosition(
+            group.occursOn,
+            timeline.startsOn,
+            timeline.endsOn,
+          ),
+        }))
+        .filter((group) => group.position != null),
+    ),
   );
   const legSpans = $derived(
     spans
@@ -252,23 +255,32 @@
     return "○";
   }
 
+  function milestoneGroupDateLabel(group) {
+    return group.dateCount > 1
+      ? formatDateRange(group.startsOn, group.endsOn)
+      : formatShortDate(group.startsOn);
+  }
+
   function milestoneGroupLabel(group) {
     const titles = group.milestones.map((item) => item.title).join(", ");
+    const dateLabel = milestoneGroupDateLabel(group);
     return group.count > 1
-      ? `${group.count} milestones, ${formatShortDate(group.occursOn)}: ${titles}`
-      : `${titles}, ${formatShortDate(group.occursOn)}, ${group.state}`;
+      ? `${group.count} milestones, ${dateLabel}: ${titles}`
+      : `${titles}, ${dateLabel}, ${group.state}`;
   }
 
   function showMilestoneTooltip(event, group) {
     showTooltip(
       event,
       group.count > 1 ? `${group.count} milestones` : group.milestones[0].title,
-      formatShortDate(group.occursOn),
+      milestoneGroupDateLabel(group),
       group.milestones
-        .map(
-          (item) =>
-            `${item.title} · ${titleCaseName(item.owner)} · ${item.gcal_state}`,
-        )
+        .map((item) => {
+          const line = `${item.title} · ${titleCaseName(item.owner)} · ${item.gcal_state}`;
+          return group.dateCount > 1
+            ? `${formatShortDate(item.occurs_on)} · ${line}`
+            : line;
+        })
         .join("\n"),
     );
   }
@@ -471,7 +483,7 @@
                         {/if}
                       </span>
                       <span class="dia-date"
-                        >{formatShortDate(group.occursOn)}</span
+                        >{milestoneGroupDateLabel(group)}</span
                       >
                     </div>
                   {/each}

--- a/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
@@ -1339,6 +1339,34 @@
   }
 }
 
+@media (min-width: 1600px) {
+  .moving {
+    font-size: 16.5px;
+  }
+
+  .moving .app {
+    max-width: 1720px;
+  }
+
+  .moving .grid {
+    grid-template-columns: 440px minmax(0, 1fr) 360px;
+  }
+
+  .moving .dia-date,
+  .moving .axis .m,
+  .moving .legtag span {
+    font-size: 11px;
+  }
+
+  .moving .blbl {
+    font-size: 12.5px;
+  }
+
+  .moving .legtag b {
+    font-size: 14px;
+  }
+}
+
 .moving .app.phone .grid {
   display: flex;
   flex-direction: column;

--- a/projects/monolith/frontend/src/routes/friends/moving/moving.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving.js
@@ -407,6 +407,80 @@ export function groupMilestonesByDate(milestones) {
     }));
 }
 
+// The threshold is a percentage of the track because this module cannot
+// measure rendered label width. It has to clear the widest label a cluster
+// can produce, which is a range ("7-9 Oct", about 45px) rather than a single
+// date ("16 Nov", about 34px), so 6.5 percent is roughly 52px at the desktop
+// track width.
+const MILESTONE_MIN_GAP_PERCENT = 6.5;
+
+function milestoneClusterState(milestones) {
+  if (milestones.some((item) => item.gcal_state === "held")) return "held";
+  if (milestones.every((item) => item.gcal_state === "synced")) return "synced";
+  return "queued";
+}
+
+function emitMilestoneCluster(members) {
+  const milestones = members
+    .flatMap((group) => group.milestones)
+    .toSorted((left, right) => left.occurs_on.localeCompare(right.occurs_on));
+  const dates = [...new Set(members.map((group) => group.occursOn))].toSorted(
+    (left, right) => left.localeCompare(right),
+  );
+  const startsOn = dates[0];
+  const endsOn = dates[dates.length - 1];
+  const positions = members.map((group) => group.position);
+  const minPosition = Math.min(...positions);
+  return {
+    id: `ms-${startsOn}`,
+    startsOn,
+    endsOn,
+    occursOn: startsOn,
+    dateCount: dates.length,
+    milestones,
+    count: milestones.length,
+    state: milestoneClusterState(milestones),
+    // The marker sits on the cluster's earliest date, not the midpoint of its
+    // range. The break test below compares first-member positions, so drawing
+    // the label here is what makes the minGapPercent separation it enforces
+    // also true of the labels. A midpoint would drift right by up to half a
+    // cluster's span and could close back onto its neighbour. It also keeps
+    // the diamond on a real date that lines up with the axis.
+    position: minPosition,
+  };
+}
+
+export function clusterMilestoneGroups(
+  groups,
+  minGapPercent = MILESTONE_MIN_GAP_PERCENT,
+) {
+  const list = groups ?? [];
+  if (list.length === 0) return [];
+
+  const order = list
+    .map((_, index) => index)
+    .toSorted(
+      (left, right) =>
+        list[left].position - list[right].position || left - right,
+    );
+
+  const clusters = [];
+  let current = [];
+  for (const index of order) {
+    const group = list[index];
+    if (
+      current.length > 0 &&
+      group.position - current[0].position >= minGapPercent
+    ) {
+      clusters.push(emitMilestoneCluster(current));
+      current = [];
+    }
+    current.push(group);
+  }
+  clusters.push(emitMilestoneCluster(current));
+  return clusters;
+}
+
 export function mergeAgendaItems(milestones, spans, collisions, tasks) {
   const items = [];
   for (const milestone of milestones ?? []) {

--- a/projects/monolith/frontend/src/routes/friends/moving/moving.test.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  clusterMilestoneGroups,
   collisionWording,
   ganttDatePosition,
   groupMilestonesByDate,
@@ -276,6 +277,240 @@ describe("milestone grouping by date", () => {
 
   it("handles no milestones", () => {
     expect(groupMilestonesByDate([])).toEqual([]);
+  });
+});
+
+describe("milestone clustering", () => {
+  function positionedGroup(occursOn, position, milestones) {
+    return {
+      id: `ms-${occursOn}`,
+      occursOn,
+      milestones,
+      count: milestones.length,
+      state: milestones.some((item) => item.gcal_state === "held")
+        ? "held"
+        : milestones.every((item) => item.gcal_state === "synced")
+          ? "synced"
+          : "queued",
+      position,
+    };
+  }
+
+  it("merges 7 Oct and 9 Oct markers that overprint on the real track", () => {
+    const startsOn = "2026-08-01";
+    const endsOn = "2026-11-30";
+    const seventh = ganttDatePosition("2026-10-07", startsOn, endsOn);
+    const ninth = ganttDatePosition("2026-10-09", startsOn, endsOn);
+    const groups = [
+      positionedGroup("2026-10-07", seventh, [
+        {
+          id: "ms-lease",
+          title: "Lease ends",
+          occurs_on: "2026-10-07",
+          owner: "both",
+          gcal_state: "synced",
+        },
+      ]),
+      positionedGroup("2026-10-09", ninth, [
+        {
+          id: "ms-joe",
+          title: "Joe last day of work",
+          occurs_on: "2026-10-09",
+          owner: "joe",
+          gcal_state: "held",
+        },
+        {
+          id: "ms-anna",
+          title: "Anna last day of work",
+          occurs_on: "2026-10-09",
+          owner: "anna",
+          gcal_state: "synced",
+        },
+      ]),
+    ];
+
+    const clusters = clusterMilestoneGroups(groups);
+
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].count).toBe(3);
+    expect(clusters[0].dateCount).toBe(2);
+    expect(clusters[0].startsOn).toBe("2026-10-07");
+    expect(clusters[0].endsOn).toBe("2026-10-09");
+    expect(clusters[0].occursOn).toBe("2026-10-07");
+    expect(clusters[0].id).toBe("ms-2026-10-07");
+    expect(clusters[0].position).toBe(seventh);
+    expect(clusters[0].milestones.map((item) => item.id)).toEqual([
+      "ms-lease",
+      "ms-joe",
+      "ms-anna",
+    ]);
+  });
+
+  it("keeps groups further apart than the threshold separate and sorted", () => {
+    const groups = [
+      positionedGroup("2026-11-16", 80, [
+        {
+          id: "ms-late",
+          title: "Late marker",
+          occurs_on: "2026-11-16",
+          owner: "both",
+          gcal_state: "synced",
+        },
+      ]),
+      positionedGroup("2026-09-01", 20, [
+        {
+          id: "ms-early",
+          title: "Early marker",
+          occurs_on: "2026-09-01",
+          owner: "both",
+          gcal_state: "synced",
+        },
+      ]),
+    ];
+
+    const clusters = clusterMilestoneGroups(groups);
+
+    expect(clusters).toHaveLength(2);
+    expect(clusters.map((group) => group.occursOn)).toEqual([
+      "2026-09-01",
+      "2026-11-16",
+    ]);
+    expect(clusters.map((group) => group.dateCount)).toEqual([1, 1]);
+  });
+
+  it("does not chain-merge a run of close markers into one cluster", () => {
+    const groups = [0, 4, 8, 12].map((position, index) =>
+      positionedGroup(`2026-09-0${index + 1}`, position, [
+        {
+          id: `ms-${index}`,
+          title: `Marker ${index + 1}`,
+          occurs_on: `2026-09-0${index + 1}`,
+          owner: "both",
+          gcal_state: "synced",
+        },
+      ]),
+    );
+
+    const clusters = clusterMilestoneGroups(groups);
+
+    expect(clusters).toHaveLength(2);
+    expect(clusters[0].startsOn).toBe("2026-09-01");
+    expect(clusters[0].endsOn).toBe("2026-09-02");
+    expect(clusters[1].startsOn).toBe("2026-09-03");
+    expect(clusters[1].endsOn).toBe("2026-09-04");
+    expect(clusters.map((group) => group.dateCount)).toEqual([2, 2]);
+  });
+
+  it("lets held win across a cluster, and is synced only when every milestone is", () => {
+    const heldLast = clusterMilestoneGroups([
+      positionedGroup("2026-10-07", 10, [
+        {
+          id: "ms-lease",
+          title: "Lease ends",
+          occurs_on: "2026-10-07",
+          owner: "both",
+          gcal_state: "synced",
+        },
+      ]),
+      positionedGroup("2026-10-09", 12, [
+        {
+          id: "ms-joe",
+          title: "Joe last day of work",
+          occurs_on: "2026-10-09",
+          owner: "joe",
+          gcal_state: "held",
+        },
+      ]),
+    ]);
+    expect(heldLast).toHaveLength(1);
+    expect(heldLast[0].state).toBe("held");
+
+    const allSynced = clusterMilestoneGroups([
+      positionedGroup("2026-09-01", 20, [
+        {
+          id: "ms-a",
+          title: "First",
+          occurs_on: "2026-09-01",
+          owner: "both",
+          gcal_state: "synced",
+        },
+      ]),
+      positionedGroup("2026-09-02", 22, [
+        {
+          id: "ms-b",
+          title: "Second",
+          occurs_on: "2026-09-02",
+          owner: "both",
+          gcal_state: "synced",
+        },
+      ]),
+    ]);
+    expect(allSynced).toHaveLength(1);
+    expect(allSynced[0].state).toBe("synced");
+  });
+
+  it("handles no groups", () => {
+    expect(clusterMilestoneGroups([])).toEqual([]);
+  });
+
+  it("returns the same result when called twice on the same input", () => {
+    const groups = [
+      positionedGroup("2026-10-07", 55.37, [
+        {
+          id: "ms-lease",
+          title: "Lease ends",
+          occurs_on: "2026-10-07",
+          owner: "both",
+          gcal_state: "synced",
+        },
+      ]),
+      positionedGroup("2026-10-09", 57.02, [
+        {
+          id: "ms-joe",
+          title: "Joe last day of work",
+          occurs_on: "2026-10-09",
+          owner: "joe",
+          gcal_state: "held",
+        },
+      ]),
+    ];
+
+    expect(clusterMilestoneGroups(groups)).toEqual(
+      clusterMilestoneGroups(groups),
+    );
+  });
+
+  // The whole point of clustering is that no two date labels overprint, and
+  // labels are drawn centred on the emitted position. A cluster that spanned
+  // a range and then reported its midpoint could drift back within a label's
+  // width of its neighbour, so assert the gap on the output, not the input.
+  it("always leaves a full gap between the positions it emits", () => {
+    // A wide cluster followed by a lone marker is the shape that breaks a
+    // midpoint position: 0 and 6.4 cluster, their midpoint drifts to 3.2, and
+    // the singleton at 6.6 lands 3.4 away, well inside a label's width.
+    const dense = [0, 6.4, 6.6, 13.1, 40].map((position, index) =>
+      positionedGroup(`2026-09-0${index + 1}`, position, [
+        {
+          id: `ms-${index}`,
+          title: `Marker ${index + 1}`,
+          occurs_on: `2026-09-0${index + 1}`,
+          owner: "both",
+          gcal_state: "synced",
+        },
+      ]),
+    );
+
+    const clusters = clusterMilestoneGroups(dense);
+
+    expect(clusters.length).toBeGreaterThan(1);
+    for (let index = 1; index < clusters.length; index += 1) {
+      expect(
+        clusters[index].position - clusters[index - 1].position,
+      ).toBeGreaterThanOrEqual(6.5);
+    }
+    expect(clusters.flatMap((cluster) => cluster.milestones)).toHaveLength(
+      dense.length,
+    );
   });
 });
 


### PR DESCRIPTION
Two defects on the private moving planner Gantt, both reported from a screenshot of the live page.

## Milestone markers overprinted

`groupMilestonesByDate()` keys its map on the `occurs_on` string, so it merged only milestones on the identical day. Milestones on 7 Oct and 9 Oct stayed two separate markers. At the deployed width the plot track is roughly 800px across 121 days, so two days is about 13px of separation while a `.dia-date` label ("7 Oct", 9.5px monospace, centred) is about 29px wide. The labels overlapped by ~16px and rendered as the unreadable `7 O8t9 Oct`. The `.dia-count` badge compounded it, reaching ~19px right of its own diamond and landing on the neighbour.

Grouping by date equality cannot solve a problem that is about distance on the track, so `clusterMilestoneGroups()` runs as a second, purely visual pass in track-percentage space after positions are known. `groupMilestonesByDate()` keeps its semantic job and its tests unchanged.

Two geometry details are load-bearing:

- **The marker sits on the cluster's earliest date, not the midpoint of its range.** The break test compares first-member positions, so drawing the label there is what makes the `minGapPercent` separation it enforces also true of the labels. A midpoint drifts right by up to half a cluster's span, and in the worst case (a wide cluster followed by a lone marker) closes back to `minGap/2` of its neighbour, which is where this started. It also keeps the diamond on a real date that lines up with the axis. There is a test that pins this property directly and fails under the midpoint version.
- **The gap threshold covers the widest label a cluster can produce**, which is a range like `7-9 Oct` (~45px), not a single date like `16 Nov` (~34px). Clustering introduced a label wider than the threshold was originally sized against.

Nothing is lost: the count badge, the aria-label, the tooltip, and the Calendar dialog all still enumerate every milestone individually, and multi-date tooltips now lead each line with that milestone's own date.

## Page rendered as a small island on wide displays

`.app` capped at `max-width: 1380px` with fixed pixel type throughout, so on a ~3000px viewport it used under half the screen at 9.5px chart labels. One `@media (min-width: 1600px)` raises the cap to 1720px, widens the side columns so the extra width does not all pour into the middle, and steps the chart type up one notch.

**Row heights are deliberately untouched.** The `34px` row constant is written independently in `+page.svelte` (`MILESTONE_ROW_H`, `BAR_ROW_H`, feeding the computed `plotHeight`) and in `moving-theme.css` (`calc(var(--sub-rows, 1) * 34px)`). Scaling one without the other desyncs the plot's total height from the rows drawn inside it, so the wide-viewport pass changes type sizes and the shell width only. Verified: the `34px` count in the CSS is 4 before and 4 after.

## Not in scope

`packLegTags()` still uses a width-blind 24 percent stagger gap, tracked as #5017. Widening the shell makes it strictly safer, since tag positions are percentages while label widths are fixed pixels, so a wider track buys more clearance.

## Verification

- `ci lint` clean.
- `ci test`: `Executed 5 out of 736 tests: 736 tests pass`. The frontend target was necessarily executed rather than cache-hit, since the diff changes `moving.test.js`.
- New tests cover the real 7/9 Oct overlap, the chain-merge guard, held-state precedence across a cluster, determinism, empty input, and the emitted-gap property.

Deploy note: no chart version or `targetRevision` touched, per ADR platform/009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)