### PR TITLE
fix(embervm): navigate shotter to the mapped in-cluster host

### DIFF
--- a/projects/embervm/runtimes/shotter/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/shotter/guest-init/cmd/main.go
@@ -97,7 +97,7 @@ func run(logger *slog.Logger) error {
 	}
 
 	var ready atomic.Bool
-	serveErr := startVsockServer(ctx, logger, ready.Load)
+	serveErr := startVsockServer(ctx, logger, ready.Load, proxyConfig)
 
 	if proxyConfigErr != nil {
 		// A warm failure never flips readiness (see the package doc above).
@@ -303,7 +303,7 @@ func probeCDP(ctx context.Context, client *http.Client, url string) (cdpVersion,
 	return version, nil
 }
 
-func newMux(ready func() bool, logger *slog.Logger) *http.ServeMux {
+func newMux(ready func() bool, logger *slog.Logger, config ProxyConfig) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /shim/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -347,7 +347,7 @@ func newMux(ready func() bool, logger *slog.Logger) *http.ServeMux {
 
 	// screenshotHandler (screenshot.go) drives the already warm Chromium over
 	// CDP: fresh target per invocation, navigate, wait, capture, close.
-	mux.HandleFunc("POST "+screenshotPath, screenshotHandler(logger))
+	mux.HandleFunc("POST "+screenshotPath, screenshotHandler(logger, config))
 	return mux
 }
 

--- a/projects/embervm/runtimes/shotter/guest-init/cmd/proxy_test.go
+++ b/projects/embervm/runtimes/shotter/guest-init/cmd/proxy_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -389,5 +390,19 @@ func TestBakedShotterEgressConfigParsesAndValidates(t *testing.T) {
 	}
 	if len(config.Allowlist) == 0 {
 		t.Fatal("baked config Allowlist is empty")
+	}
+
+	// Anchor the synthetic constants to the real file. screenshot.go now
+	// rewrites the navigate URL to the mapped destination, so the value below
+	// is what Chromium actually dials. A non-empty check alone would let the
+	// baked file drift away from these constants while every test that asserts
+	// an exact internal hostname stayed green, and the drift would surface only
+	// as a prod navigation to a stale service.
+	wantMapping := map[string]string{
+		publicHost:  internalService,
+		privateHost: privateInternalService,
+	}
+	if !reflect.DeepEqual(config.HostMapping, wantMapping) {
+		t.Fatalf("baked config HostMapping = %v, want %v", config.HostMapping, wantMapping)
 	}
 }

--- a/projects/embervm/runtimes/shotter/guest-init/cmd/screenshot.go
+++ b/projects/embervm/runtimes/shotter/guest-init/cmd/screenshot.go
@@ -122,7 +122,8 @@ type screenshotResponse struct {
 
 // validatedScreenshot is a screenshotRequest that has passed every check:
 // bounded dimensions, a supported wait_until, a bounded timeout, and a
-// navigate URL already downgraded to plaintext http.
+// navigate URL already rewritten to the mapped in-cluster plaintext
+// destination.
 type validatedScreenshot struct {
 	navigateURL     string
 	width, height   int
@@ -141,7 +142,7 @@ func parseScreenshotRequest(body io.Reader) (screenshotRequest, error) {
 	return req, nil
 }
 
-func validateScreenshotRequest(req screenshotRequest) (validatedScreenshot, error) {
+func validateScreenshotRequest(req screenshotRequest, config ProxyConfig) (validatedScreenshot, error) {
 	if strings.TrimSpace(req.URL) == "" {
 		return validatedScreenshot{}, fmt.Errorf("%w: url is required", errValidation)
 	}
@@ -152,7 +153,7 @@ func validateScreenshotRequest(req screenshotRequest) (validatedScreenshot, erro
 	if parsed.Host == "" {
 		return validatedScreenshot{}, fmt.Errorf("%w: url must be absolute with an explicit host", errValidation)
 	}
-	if err := rewriteToPlaintextHTTP(parsed); err != nil {
+	if err := config.rewriteToMappedInternal(parsed); err != nil {
 		return validatedScreenshot{}, err
 	}
 
@@ -199,31 +200,59 @@ func validateScreenshotRequest(req screenshotRequest) (validatedScreenshot, erro
 	}, nil
 }
 
-// rewriteToPlaintextHTTP downgrades an https URL to http in place before
-// Chromium ever sees it. This looks wrong at a glance, so the reason is
-// recorded here rather than only in the PR: the in-guest proxy (proxy.go)
-// maps a mapped public host to its internal destination by host alone and
-// always replaces the port with the internal plaintext port 3000 (ADR
-// embervm/035 section 3). An https URL makes Chromium issue a CONNECT for
-// the requested port, the proxy still maps it to the plaintext 3000
-// destination, the allowlist admits it because the destination itself is
-// allowlisted, and only then does Chromium's TLS handshake fail against a
-// plaintext server. Downgrading here refuses an unroutable request up front
-// instead of failing deep inside a TLS handshake with a confusing error.
-// This is safe because the proxy replays the request head byte for byte, so
-// the origin still sees Host: <the original host> and host-keyed routes
-// keep resolving correctly, and because the plaintext hop never leaves the
-// cluster: it is a vsock tunnel to an in-cluster service, not a public wire.
-func rewriteToPlaintextHTTP(u *url.URL) error {
+// rewriteToMappedInternal rewrites u in place to the mapped in-cluster
+// plaintext destination before Chromium ever sees the URL. Chromium's
+// built-in HSTS preload list covers the entire .dev TLD, so handing it
+// http://jomcgi.dev (or any other .dev host) makes it upgrade the URL to
+// https internally, before any network request, and issue CONNECT
+// public-host:443. The proxy correctly refuses CONNECT for a mapped host
+// (the destination is plaintext :3000 and cannot be tunnelled as TLS), and
+// the top-level navigation then fails. Rewriting scheme, host, and port
+// together here means Chromium navigates to the already-allowlisted
+// in-cluster hop and never sees a .dev hostname. The baked HostMapping is
+// the only lookup: an unmapped host is rejected, never navigated.
+func (c ProxyConfig) rewriteToMappedInternal(u *url.URL) error {
 	switch strings.ToLower(u.Scheme) {
-	case "http":
-		return nil
-	case "https":
-		u.Scheme = "http"
-		return nil
+	case "http", "https":
 	default:
 		return fmt.Errorf("%w: url scheme %q must be http or https", errValidation, u.Scheme)
 	}
+	requestedHost := u.Hostname()
+	for publicHost, mappedDestination := range c.HostMapping {
+		if strings.EqualFold(requestedHost, publicHost) {
+			u.Scheme = "http"
+			u.Host = mappedDestination
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: host %q is not a mapped destination", errValidation, requestedHost)
+}
+
+// publicizeFinalURL rewrites a CDP-reported final URL back to the public
+// https:// host when its host:port is a mapped destination, so the tool
+// never leaks internal service DNS to its caller. An off-origin redirect
+// (host does not match any mapped destination) is returned unchanged.
+func (c ProxyConfig) publicizeFinalURL(finalURL string) string {
+	parsed, err := url.Parse(finalURL)
+	if err != nil || parsed.Host == "" {
+		return finalURL
+	}
+	reported, err := parseDestination(parsed.Host, true)
+	if err != nil {
+		return finalURL
+	}
+	for publicHost, mappedDestination := range c.HostMapping {
+		mapped, err := parseDestination(mappedDestination, false)
+		if err != nil {
+			continue
+		}
+		if destinationsEqual(reported, mapped) {
+			parsed.Scheme = "https"
+			parsed.Host = publicHost
+			return parsed.String()
+		}
+	}
+	return finalURL
 }
 
 func handlerCap(navigateTimeout time.Duration) time.Duration {
@@ -236,7 +265,7 @@ func handlerCap(navigateTimeout time.Duration) time.Duration {
 
 // screenshotHandler drives the already-warm Chromium over CDP and returns a
 // PNG. It replaces the T3 stub reserved in main.go.
-func screenshotHandler(logger *slog.Logger) http.HandlerFunc {
+func screenshotHandler(logger *slog.Logger, config ProxyConfig) http.HandlerFunc {
 	cdpHTTPBase := fmt.Sprintf("http://%s:%d", cdpAddress, cdpPort)
 	return func(w http.ResponseWriter, r *http.Request) {
 		rawReq, err := parseScreenshotRequest(r.Body)
@@ -244,7 +273,7 @@ func screenshotHandler(logger *slog.Logger) http.HandlerFunc {
 			writeScreenshotError(w, logger, err)
 			return
 		}
-		validated, err := validateScreenshotRequest(rawReq)
+		validated, err := validateScreenshotRequest(rawReq, config)
 		if err != nil {
 			writeScreenshotError(w, logger, err)
 			return
@@ -258,6 +287,7 @@ func screenshotHandler(logger *slog.Logger) http.HandlerFunc {
 			writeScreenshotError(w, logger, err)
 			return
 		}
+		resp.FinalURL = config.publicizeFinalURL(resp.FinalURL)
 
 		w.Header().Set("Content-Type", screenshotContentType)
 		if err := json.NewEncoder(w).Encode(resp); err != nil {

--- a/projects/embervm/runtimes/shotter/guest-init/cmd/screenshot_test.go
+++ b/projects/embervm/runtimes/shotter/guest-init/cmd/screenshot_test.go
@@ -16,50 +16,97 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-func TestRewriteToPlaintextHTTPDowngradesHTTPS(t *testing.T) {
-	parsed, err := url.Parse("https://jomcgi.dev/agents")
-	if err != nil {
-		t.Fatalf("url.Parse: %v", err)
+func TestRewriteToMappedInternalRewritesPublicHosts(t *testing.T) {
+	config := bothMappingsProxyConfig()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "https public with query",
+			in:   "https://jomcgi.dev/x?y=1",
+			want: "http://monolith-public-frontend.monolith-public.svc.cluster.local:3000/x?y=1",
+		},
+		{
+			name: "https private path",
+			in:   "https://private.jomcgi.dev/a",
+			want: "http://monolith.monolith.svc.cluster.local:3000/a",
+		},
+		{
+			name: "mixed-case public host",
+			in:   "https://JOMCGI.DEV/",
+			want: "http://monolith-public-frontend.monolith-public.svc.cluster.local:3000/",
+		},
+		{
+			name: "http public keeps path",
+			in:   "http://jomcgi.dev/agents",
+			want: "http://monolith-public-frontend.monolith-public.svc.cluster.local:3000/agents",
+		},
 	}
-	if err := rewriteToPlaintextHTTP(parsed); err != nil {
-		t.Fatalf("rewriteToPlaintextHTTP: %v", err)
-	}
-	if got := parsed.String(); got != "http://jomcgi.dev/agents" {
-		t.Fatalf("rewritten url = %q, want http://jomcgi.dev/agents", got)
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			parsed, err := url.Parse(testCase.in)
+			if err != nil {
+				t.Fatalf("url.Parse: %v", err)
+			}
+			if err := config.rewriteToMappedInternal(parsed); err != nil {
+				t.Fatalf("rewriteToMappedInternal(%q): %v", testCase.in, err)
+			}
+			if got := parsed.String(); got != testCase.want {
+				t.Fatalf("rewritten url = %q, want %q", got, testCase.want)
+			}
+		})
 	}
 }
 
-func TestRewriteToPlaintextHTTPKeepsHTTP(t *testing.T) {
-	parsed, err := url.Parse("http://jomcgi.dev/agents")
+func TestRewriteToMappedInternalRejectsUnmappedHost(t *testing.T) {
+	parsed, err := url.Parse("https://example.com/")
 	if err != nil {
 		t.Fatalf("url.Parse: %v", err)
 	}
-	if err := rewriteToPlaintextHTTP(parsed); err != nil {
-		t.Fatalf("rewriteToPlaintextHTTP: %v", err)
+	err = bothMappingsProxyConfig().rewriteToMappedInternal(parsed)
+	if !errors.Is(err, errValidation) {
+		t.Fatalf("rewriteToMappedInternal(example.com) err = %v, want errValidation", err)
 	}
-	if got := parsed.String(); got != "http://jomcgi.dev/agents" {
-		t.Fatalf("rewritten url = %q, want http://jomcgi.dev/agents", got)
+	if !strings.Contains(err.Error(), "example.com") {
+		t.Fatalf("err = %v, want a message naming the unmapped host", err)
 	}
 }
 
-func TestRewriteToPlaintextHTTPRejectsOtherScheme(t *testing.T) {
+func TestRewriteToMappedInternalRejectsOtherScheme(t *testing.T) {
 	parsed, err := url.Parse("ftp://jomcgi.dev/agents")
 	if err != nil {
 		t.Fatalf("url.Parse: %v", err)
 	}
-	err = rewriteToPlaintextHTTP(parsed)
+	err = bothMappingsProxyConfig().rewriteToMappedInternal(parsed)
 	if !errors.Is(err, errValidation) {
-		t.Fatalf("rewriteToPlaintextHTTP(ftp) err = %v, want errValidation", err)
+		t.Fatalf("rewriteToMappedInternal(ftp) err = %v, want errValidation", err)
 	}
 }
 
-func TestValidateScreenshotRequestAppliesDefaultsAndDowngradesScheme(t *testing.T) {
-	validated, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/agents"})
+func TestRewriteToMappedInternalFailsClosedOnEmptyConfig(t *testing.T) {
+	parsed, err := url.Parse("https://jomcgi.dev/x")
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	err = (ProxyConfig{}).rewriteToMappedInternal(parsed)
+	if !errors.Is(err, errValidation) {
+		t.Fatalf("empty ProxyConfig rewrite err = %v, want errValidation", err)
+	}
+	if parsed.Host != "jomcgi.dev" || parsed.Scheme != "https" {
+		t.Fatalf("empty config mutated url to %q, want the original public url left in place", parsed.String())
+	}
+}
+
+func TestValidateScreenshotRequestAppliesDefaultsAndRewritesToMappedInternal(t *testing.T) {
+	validated, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/x?y=1"}, bothMappingsProxyConfig())
 	if err != nil {
 		t.Fatalf("validateScreenshotRequest: %v", err)
 	}
-	if validated.navigateURL != "http://jomcgi.dev/agents" {
-		t.Fatalf("navigateURL = %q, want http://jomcgi.dev/agents", validated.navigateURL)
+	wantNavigate := "http://monolith-public-frontend.monolith-public.svc.cluster.local:3000/x?y=1"
+	if validated.navigateURL != wantNavigate {
+		t.Fatalf("navigateURL = %q, want %q", validated.navigateURL, wantNavigate)
 	}
 	if validated.width != defaultWidth || validated.height != defaultHeight {
 		t.Fatalf("dimensions = %dx%d, want %dx%d default", validated.width, validated.height, defaultWidth, defaultHeight)
@@ -73,21 +120,21 @@ func TestValidateScreenshotRequestAppliesDefaultsAndDowngradesScheme(t *testing.
 }
 
 func TestValidateScreenshotRequestRejectsMissingURL(t *testing.T) {
-	_, err := validateScreenshotRequest(screenshotRequest{})
+	_, err := validateScreenshotRequest(screenshotRequest{}, bothMappingsProxyConfig())
 	if !errors.Is(err, errValidation) {
 		t.Fatalf("err = %v, want errValidation", err)
 	}
 }
 
 func TestValidateScreenshotRequestRejectsSchemelessURL(t *testing.T) {
-	_, err := validateScreenshotRequest(screenshotRequest{URL: "jomcgi.dev/agents"})
+	_, err := validateScreenshotRequest(screenshotRequest{URL: "jomcgi.dev/agents"}, bothMappingsProxyConfig())
 	if !errors.Is(err, errValidation) {
 		t.Fatalf("err = %v, want errValidation", err)
 	}
 }
 
 func TestValidateScreenshotRequestRejectsOversizedWidth(t *testing.T) {
-	_, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", Width: maxDimension + 1, Height: defaultHeight})
+	_, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", Width: maxDimension + 1, Height: defaultHeight}, bothMappingsProxyConfig())
 	if !errors.Is(err, errValidation) {
 		t.Fatalf("err = %v, want errValidation", err)
 	}
@@ -97,7 +144,7 @@ func TestValidateScreenshotRequestRejectsOversizedWidth(t *testing.T) {
 }
 
 func TestValidateScreenshotRequestRejectsOversizedHeight(t *testing.T) {
-	_, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", Width: defaultWidth, Height: maxDimension + 1})
+	_, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", Width: defaultWidth, Height: maxDimension + 1}, bothMappingsProxyConfig())
 	if !errors.Is(err, errValidation) {
 		t.Fatalf("err = %v, want errValidation", err)
 	}
@@ -107,21 +154,21 @@ func TestValidateScreenshotRequestRejectsOversizedHeight(t *testing.T) {
 }
 
 func TestValidateScreenshotRequestRejectsNegativeWidth(t *testing.T) {
-	_, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", Width: -1})
+	_, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", Width: -1}, bothMappingsProxyConfig())
 	if !errors.Is(err, errValidation) {
 		t.Fatalf("err = %v, want errValidation", err)
 	}
 }
 
 func TestValidateScreenshotRequestRejectsUnknownWaitUntil(t *testing.T) {
-	_, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", WaitUntil: "networkidle"})
+	_, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", WaitUntil: "networkidle"}, bothMappingsProxyConfig())
 	if !errors.Is(err, errValidation) {
 		t.Fatalf("err = %v, want errValidation", err)
 	}
 }
 
 func TestValidateScreenshotRequestAcceptsDOMContentLoaded(t *testing.T) {
-	validated, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", WaitUntil: "domcontentloaded"})
+	validated, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", WaitUntil: "domcontentloaded"}, bothMappingsProxyConfig())
 	if err != nil {
 		t.Fatalf("validateScreenshotRequest: %v", err)
 	}
@@ -131,13 +178,64 @@ func TestValidateScreenshotRequestAcceptsDOMContentLoaded(t *testing.T) {
 }
 
 func TestValidateScreenshotRequestRejectsTimeoutOutOfBounds(t *testing.T) {
-	_, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", TimeoutMs: maxNavigateTimeoutMs + 1})
+	_, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", TimeoutMs: maxNavigateTimeoutMs + 1}, bothMappingsProxyConfig())
 	if !errors.Is(err, errValidation) {
 		t.Fatalf("err (too large) = %v, want errValidation", err)
 	}
-	_, err = validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", TimeoutMs: 1})
+	_, err = validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/", TimeoutMs: 1}, bothMappingsProxyConfig())
 	if !errors.Is(err, errValidation) {
 		t.Fatalf("err (too small) = %v, want errValidation", err)
+	}
+}
+
+func TestValidateScreenshotRequestRejectsUnmappedHost(t *testing.T) {
+	_, err := validateScreenshotRequest(screenshotRequest{URL: "https://example.com/"}, bothMappingsProxyConfig())
+	if !errors.Is(err, errValidation) {
+		t.Fatalf("err = %v, want errValidation", err)
+	}
+}
+
+func TestValidateScreenshotRequestRejectsFTPScheme(t *testing.T) {
+	_, err := validateScreenshotRequest(screenshotRequest{URL: "ftp://jomcgi.dev/"}, bothMappingsProxyConfig())
+	if !errors.Is(err, errValidation) {
+		t.Fatalf("err = %v, want errValidation", err)
+	}
+}
+
+func TestValidateScreenshotRequestFailsClosedOnEmptyConfig(t *testing.T) {
+	_, err := validateScreenshotRequest(screenshotRequest{URL: "https://jomcgi.dev/x"}, ProxyConfig{})
+	if !errors.Is(err, errValidation) {
+		t.Fatalf("empty ProxyConfig err = %v, want errValidation", err)
+	}
+}
+
+func TestPublicizeFinalURLRewritesMappedDestination(t *testing.T) {
+	config := bothMappingsProxyConfig()
+	got := config.publicizeFinalURL("http://monolith-public-frontend.monolith-public.svc.cluster.local:3000/x")
+	if got != "https://jomcgi.dev/x" {
+		t.Fatalf("publicizeFinalURL = %q, want https://jomcgi.dev/x", got)
+	}
+	got = config.publicizeFinalURL("http://monolith.monolith.svc.cluster.local:3000/a")
+	if got != "https://private.jomcgi.dev/a" {
+		t.Fatalf("publicizeFinalURL(private) = %q, want https://private.jomcgi.dev/a", got)
+	}
+}
+
+func TestPublicizeFinalURLLeavesOffOriginUnchanged(t *testing.T) {
+	const offOrigin = "https://example.com/redirected"
+	got := bothMappingsProxyConfig().publicizeFinalURL(offOrigin)
+	if got != offOrigin {
+		t.Fatalf("publicizeFinalURL(off-origin) = %q, want unchanged %q", got, offOrigin)
+	}
+}
+
+func TestScreenshotHandlerFailsClosedOnEmptyConfig(t *testing.T) {
+	handler := screenshotHandler(discardLogger(), ProxyConfig{})
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", screenshotPath, strings.NewReader(`{"url":"https://jomcgi.dev/x"}`))
+	handler.ServeHTTP(recorder, req)
+	if recorder.Code != 400 {
+		t.Fatalf("status = %d, want 400", recorder.Code)
 	}
 }
 

--- a/projects/embervm/runtimes/shotter/guest-init/cmd/vsock_linux.go
+++ b/projects/embervm/runtimes/shotter/guest-init/cmd/vsock_linux.go
@@ -69,7 +69,7 @@ func dialVsock(ctx context.Context, cid, port uint32) (net.Conn, error) {
 	return &vsockConn{File: file}, nil
 }
 
-func startVsockServer(ctx context.Context, logger *slog.Logger, ready func() bool) <-chan error {
+func startVsockServer(ctx context.Context, logger *slog.Logger, ready func() bool, config ProxyConfig) <-chan error {
 	serveErr := make(chan error, 1)
 	ln, err := listenVsock(guestHTTPPort)
 	if err != nil {
@@ -79,7 +79,7 @@ func startVsockServer(ctx context.Context, logger *slog.Logger, ready func() boo
 		return serveErr
 	}
 	logger.Info("ember-shotter-init: vsock HTTP server listening", "port", guestHTTPPort)
-	srv := &http.Server{Handler: newMux(ready, logger)}
+	srv := &http.Server{Handler: newMux(ready, logger, config)}
 	go func() { serveErr <- srv.Serve(ln) }()
 	go func() {
 		<-ctx.Done()

--- a/projects/embervm/runtimes/shotter/guest-init/cmd/vsock_other.go
+++ b/projects/embervm/runtimes/shotter/guest-init/cmd/vsock_other.go
@@ -14,7 +14,7 @@ func dialVsock(_ context.Context, _, _ uint32) (net.Conn, error) {
 	return nil, fmt.Errorf("ember-shotter-init: AF_VSOCK unsupported on %s", runtime.GOOS)
 }
 
-func startVsockServer(_ context.Context, logger *slog.Logger, _ func() bool) <-chan error {
+func startVsockServer(_ context.Context, logger *slog.Logger, _ func() bool, _ ProxyConfig) <-chan error {
 	logger.Warn("ember-shotter-init: AF_VSOCK unsupported on this GOOS")
 	ch := make(chan error, 1)
 	close(ch)


### PR DESCRIPTION
## Problem

`screenshot_jomcgi_dev` fails for **every** input it accepts, returning a guest 502. Confirmed live, not theoretical.

The entire `.dev` TLD is on Chromium's built-in HSTS preload list. So handing Chromium `http://jomcgi.dev` makes it rewrite the URL back to `https://` internally, before any network request, and dial `CONNECT jomcgi.dev:443`. `proxy.go` then correctly refuses CONNECT for a mapped host (the destination is a plaintext `:3000` service and cannot be tunnelled as TLS), the top-level navigation fails as `errNavigationFailed`, and that maps to 502.

Prod evidence, on both reproduction attempts:

```
WARN ember-shotter-init: refusing CONNECT for a mapped host destination=jomcgi.dev:443
```

A `run_code` control probe through the identical CP endpoint returned in 15ms, which rules out the control plane, the endpoint and the network path.

## Why the previous approach could not work

`rewriteToPlaintextHTTP` rewrote the **scheme only** and left the public host in place, deferring host mapping to the proxy (ADR embervm/035 section 3). The host is precisely what triggers the HSTS upgrade, and Chromium decides before the proxy sees a byte. Both hosts this tool accepts are `.dev`, so the strategy had no working input.

## Fix

Resolve the host through the same baked `shotter-egress.json` mapping **inside the guest**, rewriting scheme, host and port together:

```
https://jomcgi.dev/foo
  -> http://monolith-public-frontend.monolith-public.svc.cluster.local:3000/foo
```

Not a `.dev` name, so no preload entry applies, so plaintext, so the existing lane carries it exactly as designed. The in-cluster plaintext hop was never broken and is already allowlisted; only the hostname needed to change.

`final_url` is mapped back to the public host so the response never leaks internal service DNS.

## What is deliberately unchanged

`proxy.go` is untouched. The mapped-host CONNECT guard **stays**: it was written for absolute-`https://` subresources and remains correct for them. It simply stops firing on the top-level navigation.

No sidecar change, no CA, no MITM, no cluster change. An earlier draft went down the TLS-termination route before it became clear the only real constraint was the hostname.

## Verification

- `ci` green: `Executed 1 out of 736 tests: 736 tests pass`.
- Tests cover both mapped hosts, mixed-case hosts, unmapped-host rejection, non-http schemes, and fail-closed behaviour on an empty config.
- The baked-config test now pins `HostMapping` to the constants the rewrite tests assert. The navigate URL is now the mapped destination, so drift would otherwise stay green in CI and surface only as a prod navigation to a stale service.

## Not proven by CI, by construction

Nothing here exercises a real navigation. `trialRender` uses `about:blank`, dev has the workload disabled (`dev/deploy/values.yaml:117`) and could not run it anyway at ~768 MiB guest-schedulable against shotter's 2048 MiB, and no target depends on the launch path. **Prod invocation is the only verifier.** I will call the tool after rollout rather than infer from readiness.

One known residual risk: any subresource hardcoded as an absolute `https://jomcgi.dev/...` URL in the markup will still hit the CONNECT guard and fail to load. Host-relative and Host-derived URLs are fine. That is a render-time question the first real capture answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)