### PR TITLE
feat(inference): add a one-boolean benchmark mode

### DIFF
--- a/projects/inference/deploy/templates/_helpers.tpl
+++ b/projects/inference/deploy/templates/_helpers.tpl
@@ -49,6 +49,59 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Name of the LLM Service.
+
+BENCH MODE RENAMES THIS ON PURPOSE, and the rename IS the mechanism.
+
+Every in-cluster caller reaches the LLM at the hardcoded DNS name
+`inference.inference.svc.cluster.local` (monolith chart/values.yaml
+LLAMA_CPP_URL in six places, monolith-dev, and the EmberVM egress allowlist).
+Renaming the Service makes that name NXDOMAIN, so those callers fail at DNS
+resolution, immediately and loudly, instead of hanging on a connect. The
+external route keeps working because httproute-private.yaml resolves its
+backendRef through this same helper, so both move together.
+
+WHY NOT fullnameOverride, which would be the obvious lever: the Deployment
+(deployment-llamacpp.yaml) derives its name from inference.fullname too. A
+rename there deletes and recreates the Deployment, and on a single GPU the new
+pod sits Pending on nvidia.com/gpu: 1 until ArgoCD prunes the old one. Renaming
+only the Service leaves the Deployment, and therefore the GPU claim, untouched.
+
+WHY NOT a NetworkPolicy, the other obvious lever: kubelet probes and the
+Prometheus scrape both address the POD IP rather than the Service, so they are
+unaffected by this and would have been at risk under a deny-by-default ingress
+rule. There is no probe-bearing pod under such a policy anywhere in this
+cluster to copy from, and the failure mode is a crash loop on a Recreate
+deployment whose previous engine is already torn down.
+
+The embeddings Service is deliberately NOT renamed. It is a separate CPU-only
+deployment (nGpuLayers 0) that does not contend for the GPU, and cutting it
+would break grimoire and knowledge retrieval for no benchmark benefit.
+*/}}
+{{- define "inference.serviceName" -}}
+{{- if .Values.benchMode.enabled -}}
+{{- printf "%s-bench" (include "inference.fullname" .) -}}
+{{- else -}}
+{{- include "inference.fullname" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Concurrent llama.cpp slots. ctxSize is the TOTAL KV pool divided across these,
+so lowering the count widens every remaining slot at identical VRAM: bench mode
+gives its single slot the whole 98304-token pool instead of 32768.
+
+One slot also removes batch interference from the timings, which is only
+tolerable because the Service rename above has already cut the in-cluster
+callers off. At 3 slots they would interleave and skew results; at 1 slot with
+callers still connected they would queue behind a full generation, up to about
+5.7 minutes at max_tokens 16384 and the observed 48 t/s.
+*/}}
+{{- define "inference.llamaCppParallel" -}}
+{{- if .Values.benchMode.enabled -}}1{{- else -}}{{ .Values.llamacpp.parallel }}{{- end -}}
+{{- end }}
+
+{{/*
 Embedding llama-server CLI arguments.
 */}}
 {{- define "inference.embeddingArgs" -}}
@@ -80,7 +133,7 @@ here.
 {{- define "inference.llamaCppArgs" -}}
 --n-gpu-layers {{ .Values.llamacpp.nGpuLayers | quote }} \
 --ctx-size {{ .Values.llamacpp.ctxSize | quote }} \
---parallel {{ .Values.llamacpp.parallel | quote }} \
+--parallel {{ include "inference.llamaCppParallel" . | quote }} \
 {{- if .Values.llamacpp.flashAttn }}
 --flash-attn {{ .Values.llamacpp.flashAttn | quote }} \
 {{- end }}

--- a/projects/inference/deploy/templates/httproute-private.yaml
+++ b/projects/inference/deploy/templates/httproute-private.yaml
@@ -71,7 +71,7 @@ spec:
       backendRefs:
         - group: ""
           kind: Service
-          name: {{ include "inference.fullname" . }}
+          name: {{ include "inference.serviceName" . }}
           port: {{ .Values.server.port | int }}
           weight: 1
 ---

--- a/projects/inference/deploy/templates/service.yaml
+++ b/projects/inference/deploy/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "inference.fullname" . }}
+  name: {{ include "inference.serviceName" . }}
   labels:
     {{- include "inference.labels" . | nindent 4 }}
 spec:

--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -302,6 +302,39 @@ llamacpp:
 
 runtimeClassName: nvidia
 
+# Benchmark mode. ONE BOOLEAN, flipped on to start a session and off to end it.
+#
+# Enabling it does exactly two things, both in templates/_helpers.tpl:
+#
+#   1. Renames the LLM Service to `inference-bench`, so the hardcoded DNS name
+#      every in-cluster caller uses (`inference.inference.svc.cluster.local`)
+#      stops resolving. The external route follows the rename automatically,
+#      because httproute-private.yaml takes its backendRef from the same
+#      helper. So https://private.jomcgi.dev/llm/v1 keeps working and nothing
+#      else can reach the model.
+#   2. Drops llama.cpp to a single slot, which hands that one slot the whole
+#      98304-token KV pool instead of 32768, at unchanged VRAM.
+#
+# ENABLING THIS IS A DELIBERATE OUTAGE for every in-cluster qwen consumer:
+# the monolith's Discord, summarize, chat, vision and classifier callsites,
+# monolith-dev, and EmberVM pi-runtime qwen sessions. They fail at DNS, so
+# expect fast errors and dead letters rather than hangs. Nothing pages: the
+# qwen synthetic CronWorkflow is suspended and has never run, and the composite
+# /health carries no qwen, llama or inference dependency (both verified live,
+# 2026-08-18). Embeddings are untouched, so retrieval keeps working.
+#
+# The pod rolls on each flip. strategy is Recreate on a single GPU, so qwen is
+# fully down for the model load, and the startupProbe allows up to 30 minutes.
+#
+# ctxSize is deliberately NOT raised. The largest task in projects/model-bench
+# is ~6k tokens of prompt against max_tokens 16384, so ~22k worst case, and a
+# single slot already gets 98304. Raising it to 131072 would still fit (that is
+# the VRAM footprint previously measured at 4x32k, ~1.9 GiB free) but buys
+# nothing until a long-context task exists. Measured live 2026-08-18: 21590 of
+# 24564 MiB in use, base ~18.5 GiB, KV ~1.00 GiB per 32k at q8_0.
+benchMode:
+  enabled: false
+
 # OpenAI-compatible ingress at https://private.jomcgi.dev/llm/v1, so a client
 # outside the cluster (an OpenAI SDK, curl, an IDE assistant) can call the
 # llama.cpp server. See templates/httproute-private.yaml for why this hostname


### PR DESCRIPTION
## What

`benchMode.enabled` in `projects/inference/deploy/values.yaml`. Flip on to start a session, off to end it. It does exactly two things:

1. **Renames the LLM Service to `inference-bench`.** The hardcoded DNS name every in-cluster caller uses, `inference.inference.svc.cluster.local`, stops resolving. `https://private.jomcgi.dev/llm/v1` keeps working because `httproute-private.yaml` takes its backendRef from the same helper and moves with it.
2. **Drops llama.cpp to one slot.** `ctxSize` is the total KV pool divided across slots, so the single slot gets the whole 98304 tokens instead of 32768, at unchanged VRAM.

## Why a Service rename rather than the obvious levers

**Not `fullnameOverride`.** `deployment-llamacpp.yaml:10` derives its name from `inference.fullname` too. Renaming the Deployment on a single GPU leaves the new pod Pending on `nvidia.com/gpu: 1` until ArgoCD prunes the old one. Verified by render that the Deployment name is byte-identical in both modes and the Service selector still matches the pod.

**Not a NetworkPolicy.** Kubelet probes and the Prometheus scrape address the **pod IP**, not the Service, so this leaves both intact and you keep llama.cpp's `--metrics` during the run. A deny-by-default ingress rule puts the probes at risk instead, there is no probe-bearing pod under such a policy anywhere in this cluster to copy from, and the failure mode is a crash loop on a `Recreate` deployment whose previous engine is already torn down.

DNS failure is also the better error shape: callers fail immediately rather than hanging on a connect.

## Why ctxSize is unchanged

Measured live 2026-08-18: 21590 of 24564 MiB in use, base ~18.5 GiB, KV ~1.00 GiB per 32k at q8_0, so ~6.0 GiB of KV budget. 131072 would fit with ~1.9 GiB free, landing on the footprint previously measured at 4x32k.

It buys nothing today. The largest task in `projects/model-bench/tasks/` is ~6k tokens of prompt against `max_tokens: 16384`, so ~22k worst case, and one slot already gets 98304. Worth revisiting only when a long-context task exists.

## Blast radius when enabled

A deliberate outage for in-cluster qwen consumers: the monolith's Discord, summarize, chat, vision and classifier callsites, monolith-dev, and EmberVM pi-runtime qwen sessions. Expect fast errors and dead letters, not hangs.

Nothing pages, both verified live rather than assumed:
- `ember-qwen-session-synthetic` is `suspend=true` with no `lastScheduledTime`, so it has never run.
- The composite `/health` returns 200 and contains no `qwen`, `llama` or `inference` dependency.

Embeddings are untouched (separate CPU-only deployment, `nGpuLayers: 0`), so grimoire and knowledge retrieval keep working.

The pod rolls on each flip. `strategy: Recreate` on a single GPU means qwen is fully down for the model load, and the startupProbe allows up to 30 minutes.

## Verification

Rendered both modes:

| | `false` | `true` |
|---|---|---|
| LLM Service | `inference` | `inference-bench` |
| Route backendRef | `inference` | `inference-bench` |
| LLM Deployment | `inference` | `inference` |
| `--parallel` | `"3"` | `"1"` |
| Embeddings Service | `inference-embeddings` | `inference-embeddings` |

`helm lint --strict` passes. `ci test`: `Executed 1 out of 735 tests: 735 tests pass`.

**Not auto-merged on purpose:** merging with `benchMode.enabled: false` is inert, but this is the lever for a deliberate outage, so the timing should be yours.