### PR TITLE
fix(inference,model-bench): let a Cloudflare service token reach the LLM

### DIFF
--- a/projects/inference/deploy/templates/httproute-private.yaml
+++ b/projects/inference/deploy/templates/httproute-private.yaml
@@ -82,16 +82,70 @@ separator onto the first line of the policy, which helm lint reports as
 "invalid Yaml document separator". The same shape exists unlinted elsewhere in
 the repo, because every other chart consuming this library sets lint = False.
 
-Validates the Cloudflare Access JWT, so the only way to this route is through
-the edge rather than by reaching Envoy some other way.
+Validates the Cloudflare Access JWT when one is present.
 
-This carries NO `authorization` block and NO `audiences`, matching every other
-private-tier route (argocd, signoz, longhorn, kargo). The consequence is worth
-stating plainly: any JWT from the team issuer validates here, so the isolation
-between "this service token may call the LLM" and "this service token may call
-argocd" lives ENTIRELY in the Cloudflare Access policy, not in the cluster. Pin
-`audiences` to the /llm application's AUD tag if that ever needs to hold on its
-own.
+WRITTEN OUT RATHER THAN TAKEN FROM cf-ingress.security-policy, for the one
+field that library cannot express: `optional: true`.
+
+WHY IT IS NEEDED. Cloudflare Access injects Cf-Access-Jwt-Assertion for
+IDENTITY-based sessions. A SERVICE TOKEN request is authenticated by Access and
+forwarded WITHOUT that header, which was measured, not assumed: with the token
+the edge stopped returning its own 403 and Envoy answered
+
+    HTTP/2 401
+    www-authenticate: Bearer realm="http://private.jomcgi.dev/llm/v1/models"
+    Jwt is missing
+
+That string is Envoy's JWT filter, so the request had cleared the edge and died
+here. Every other private-tier route is a browser lane, so this is the first
+one to carry a machine caller and the first to hit it.
+
+WHAT optional CHANGES, precisely. A request with NO JWT is allowed through. A
+request WITH a JWT is still fully validated and rejected if the signature,
+issuer or expiry is wrong, and its email claim is still projected. So this is
+not "auth off", it is "auth applies to callers that have credentials of this
+kind", and the service token is a credential of a different kind that
+Cloudflare has already checked.
+
+WHAT NOW GUARDS THE ROUTE. Cloudflare Access alone, which was already true in
+substance: this policy carries no `authorization` block and no `audiences`, so
+it never decided WHO could call, only that a caller arrived through the edge.
+That last check is what is given up for tokenless callers. The residual exposure
+is something inside the cluster addressing the Envoy gateway directly with a
+private.jomcgi.dev Host header, since nothing reaches this listener from outside
+except the cloudflared tunnel.
+
+IF THIS EVER NEEDS TO HOLD ON ITS OWN, the fix is not to flip optional back: it
+is to make the caller present something verifiable. Pinning `audiences` to the
+/llm application's AUD tag
+(b61144b93ded545d30eaafecec095931d30056a596222fc2a585f1a74397a456) only helps
+once a JWT actually arrives.
 */}}
-{{ include "cf-ingress.security-policy" (dict "name" (printf "%s-private" (include "inference.fullname" .)) "team" .Values.cfIngress.team) }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "inference.fullname" . }}-private-cf-access
+  labels:
+    {{- include "inference.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "inference.fullname" . }}-private
+  jwt:
+    optional: true
+    providers:
+      - name: cloudflare-access
+        issuer: https://{{ .Values.cfIngress.team }}.cloudflareaccess.com
+        remoteJWKS:
+          # Envoy Gateway's own default, declared explicitly for the same
+          # ServerSideApply field-ownership reason the library documents.
+          cacheDuration: 300s
+          uri: https://{{ .Values.cfIngress.team }}.cloudflareaccess.com/cdn-cgi/access/certs
+        extractFrom:
+          headers:
+            - name: Cf-Access-Jwt-Assertion
+        claimToHeaders:
+          - claim: email
+            header: X-Auth-Email
 {{- end }}

--- a/projects/model-bench/bench/cli.py
+++ b/projects/model-bench/bench/cli.py
@@ -137,8 +137,23 @@ def build_parser() -> argparse.ArgumentParser:
         "--base-url",
         default=None,
         help=(
-            "OpenAI-compatible /v1 base URL (e.g. a kubectl port-forward to "
-            "in-cluster llama.cpp). Skips OpenRouter pricing and the API key."
+            "OpenAI-compatible /v1 base URL (a kubectl port-forward to in-cluster "
+            "llama.cpp, or https://private.jomcgi.dev/llm/v1 from off-cluster). "
+            "Skips OpenRouter pricing and the API key."
+        ),
+    )
+    p_run.add_argument(
+        "--header",
+        action="append",
+        default=[],
+        metavar="NAME:VALUE",
+        help=(
+            "Extra request header, repeatable. Required to reach the endpoint "
+            "through Cloudflare Access from off-cluster, which authenticates on "
+            "CF-Access-Client-Id and CF-Access-Client-Secret rather than on the "
+            "Authorization header:\n"
+            '  --header "CF-Access-Client-Id: $CF_ID" '
+            '--header "CF-Access-Client-Secret: $CF_SECRET"'
         ),
     )
     p_run.add_argument(
@@ -215,6 +230,26 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _parse_headers(raw: list[str]) -> dict[str, str]:
+    """Turn repeated --header "Name: value" into a dict.
+
+    Splits on the FIRST colon only, so a value containing one (a URL, say)
+    survives. Whitespace around both halves is stripped, because the shell form
+    people actually type has a space after the colon.
+
+    A malformed entry raises rather than being skipped: a silently dropped
+    CF-Access-Client-Secret would present as a 401 from the edge, which reads
+    like a credential problem rather than a typo in the flag.
+    """
+    headers: dict[str, str] = {}
+    for item in raw:
+        name, sep, value = item.partition(":")
+        if not sep or not name.strip():
+            raise ValueError(f"--header must be NAME:VALUE, got {item!r}")
+        headers[name.strip()] = value.strip()
+    return headers
+
+
 async def _run(args) -> None:
     """Run benchmark cells for every active (task, model) pair."""
     api_key = os.environ.get("OPENROUTER_API_KEY")
@@ -258,6 +293,9 @@ async def _run(args) -> None:
         }
         if base_url:
             client_kwargs["base_url"] = base_url
+        extra_headers = _parse_headers(getattr(args, "header", []))
+        if extra_headers:
+            client_kwargs["extra_headers"] = extra_headers
         client = OpenRouterClient(**client_kwargs)
         if not base_url:
             await client.load_prices()

--- a/projects/model-bench/bench/cli_test.py
+++ b/projects/model-bench/bench/cli_test.py
@@ -5,6 +5,7 @@ import pytest  # noqa: F401
 
 from bench.cache import HARNESS_VERSION
 from bench.cli import (
+    _parse_headers,
     _prune_stale,
     _resolve_snapshot_preset,
     _write_leaderboard_json,
@@ -60,6 +61,39 @@ def test_run_parser_accepts_base_url_and_timeout():
     assert args.base_url == "http://127.0.0.1:18080/v1"
     assert args.timeout == 900.0
     assert args.model_filter == "qwen3.8-27b"
+
+
+def test_run_parser_collects_repeated_headers():
+    """Two --header flags are needed together: Cloudflare Access checks both."""
+    p = build_parser()
+    args = p.parse_args(
+        [
+            "run",
+            "--base-url",
+            "https://private.jomcgi.dev/llm/v1",
+            "--header",
+            "CF-Access-Client-Id: abc.access",
+            "--header",
+            "CF-Access-Client-Secret: s3cret",
+        ]
+    )
+    assert _parse_headers(args.header) == {
+        "CF-Access-Client-Id": "abc.access",
+        "CF-Access-Client-Secret": "s3cret",
+    }
+
+
+def test_parse_headers_splits_on_first_colon_only():
+    """A value may contain colons; only the first separates name from value."""
+    assert _parse_headers(["X-Origin: https://example.com:8443/x"]) == {
+        "X-Origin": "https://example.com:8443/x"
+    }
+
+
+def test_parse_headers_rejects_malformed_entry():
+    """Raise rather than skip: a dropped secret reads as a 401, not as a typo."""
+    with pytest.raises(ValueError):
+        _parse_headers(["CF-Access-Client-Id"])
 
 
 def test_prune_stale_removes_only_other_versions(tmp_path, capsys):

--- a/projects/model-bench/bench/openrouter.py
+++ b/projects/model-bench/bench/openrouter.py
@@ -56,13 +56,19 @@ class OpenRouterClient:
         transport=None,
         base_url: str = "https://openrouter.ai/api/v1",
         timeout: float = 120.0,
+        extra_headers: dict[str, str] | None = None,
     ) -> None:
         self._base_url = base_url
+        # extra_headers is merged AFTER Authorization so a caller can override it,
+        # and exists because reaching a base_url through Cloudflare Access needs
+        # CF-Access-Client-Id / CF-Access-Client-Secret. Access authenticates on
+        # those two headers only; it ignores Authorization, which here carries the
+        # placeholder key the local endpoint does not check either.
         self._client = httpx.AsyncClient(
             base_url=base_url,
             transport=transport,
             timeout=httpx.Timeout(timeout),
-            headers={"Authorization": f"Bearer {api_key}"},
+            headers={"Authorization": f"Bearer {api_key}", **(extra_headers or {})},
         )
         self._prices: dict[str, tuple[float, float]] = {}
 

--- a/projects/model-bench/bench/openrouter_test.py
+++ b/projects/model-bench/bench/openrouter_test.py
@@ -97,3 +97,44 @@ def test_chat_merges_extra_body_without_overwriting_model():
     payload = json.loads(seen["json"])
     assert payload["model"] == "served-alias"
     assert payload["chat_template_kwargs"] == {"reasoning_effort": "xhigh"}
+
+
+def test_extra_headers_reach_the_wire():
+    """The Cloudflare Access pair must be ON the request, not merely accepted.
+
+    Access authenticates on these two headers and ignores Authorization, so a
+    client that swallowed them would still look correctly constructed while
+    every call came back 403 from the edge.
+    """
+    seen = {}
+
+    def handler(request):
+        seen.update(request.headers)
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            },
+        )
+
+    client = OpenRouterClient(
+        api_key="unused",
+        transport=httpx.MockTransport(handler),
+        base_url="https://private.jomcgi.dev/llm/v1",
+        extra_headers={
+            "CF-Access-Client-Id": "abc.access",
+            "CF-Access-Client-Secret": "s3cret",
+        },
+    )
+    asyncio.run(
+        client.complete(
+            model="qwen3.6-27b",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.0,
+        )
+    )
+    assert seen["cf-access-client-id"] == "abc.access"
+    assert seen["cf-access-client-secret"] == "s3cret"
+    # Authorization survives alongside them rather than being replaced.
+    assert seen["authorization"] == "Bearer unused"


### PR DESCRIPTION
Two blockers stood between the work laptop and `private.jomcgi.dev/llm/v1`. Both are fixed here.

## 1. Envoy rejected the request

Cloudflare Access injects `Cf-Access-Jwt-Assertion` for **identity-based** sessions. A **service-token** request is authenticated by Access and forwarded **without** it. Measured, not assumed: with the token the edge stopped returning its own 403 and Envoy answered

```
HTTP/2 401
www-authenticate: Bearer realm="http://private.jomcgi.dev/llm/v1/models"
Jwt is missing
```

That string is Envoy's JWT filter verbatim, so the request had cleared the edge and died at the origin. Every other private-tier route is a browser lane, so this is the first one to carry a machine caller and the first to hit it.

The SecurityPolicy is now written out in `httproute-private.yaml` rather than taken from `cf-ingress.security-policy`, for the one field that library cannot express: **`jwt.optional: true`**. Object name is unchanged, so this updates in place.

What that changes precisely: a request with **no** JWT passes. A request **with** one is still fully validated (signature, issuer, expiry) and still projects its email claim. This is not "auth off", it is "this auth applies to callers holding that kind of credential", and the service token is a different kind that Cloudflare has already checked.

What guards the route is Cloudflare Access, which was already true in substance: the policy has no `authorization` block and no `audiences`, so it never decided *who* could call, only that a caller arrived through the edge. That last check is what is given up for tokenless callers. Residual exposure is something inside the cluster addressing the Envoy gateway directly with a `private.jomcgi.dev` Host header, since nothing else reaches this listener except the cloudflared tunnel.

## 2. The harness could not authenticate even once the route allowed it

`OpenRouterClient.__init__` set `headers={"Authorization": ...}` and took nothing else, so there was no way to send `CF-Access-Client-Id` / `CF-Access-Client-Secret`, the pair Access actually checks. Adds a repeatable `--header NAME:VALUE` threaded through as `extra_headers`.

`_parse_headers` splits on the **first** colon so a value containing one survives, and **raises** on a malformed entry rather than skipping it: a silently dropped secret presents as a 401 from the edge, which reads like a credential problem rather than a typo in the flag.

## Verification

`helm lint --strict` passes, policy renders with `optional: true` under the unchanged name `inference-private-cf-access`. `ci test`: `Executed 15 out of 735 tests: 735 tests pass`.

The header test uses `MockTransport` to assert both CF headers are **on the outbound request** alongside `Authorization`, rather than merely accepted by the constructor. A test that only checked the constructor would pass against a client that swallowed them.

Usage from off-cluster:

```
bench run --base-url https://private.jomcgi.dev/llm/v1 \
  --header "CF-Access-Client-Id: $CF_ID" \
  --header "CF-Access-Client-Secret: $CF_SECRET" \
  --model qwen3.8-27b
```