### PR TITLE
feat(inference): expose the bench Service on a LAN NodePort

### DIFF
--- a/projects/inference/deploy/templates/service.yaml
+++ b/projects/inference/deploy/templates/service.yaml
@@ -5,12 +5,44 @@ metadata:
   labels:
     {{- include "inference.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.benchMode.enabled }}
+  # NodePort ONLY while bench mode is on, so a machine on the LAN can reach the
+  # model without Cloudflare in the path. That removes the three things that
+  # make the public route awkward for a benchmark harness: the CF-Access-Client
+  # header pair, the 100s no-byte limit that 524s any non-streamed response over
+  # roughly 4800 tokens, and TLS termination at the edge.
+  #
+  # THE FIRST NodePort IN THIS CLUSTER. Everything else reaches the outside
+  # through the cloudflared tunnel, so treat this as a deliberate exception with
+  # a defined lifetime rather than a pattern to copy. It is LAN-only: the repo
+  # invariant that nothing is exposed to the internet directly still holds,
+  # because reaching this from outside would need a router port-forward that
+  # does not exist.
+  #
+  # It is also UNAUTHENTICATED. Anything on 192.168.1.0/24 can use the GPU while
+  # this is up. That is the trade being made for the duration of a session, and
+  # it is why this is welded to benchMode rather than being independently
+  # switchable: turning bench mode off closes it, and there is no way to leave
+  # it open by forgetting a second flag.
+  #
+  # Cilium runs kube-proxy-replacement, so it serves this on EVERY node, not
+  # just the one holding the pod. node-4 (192.168.1.195) is the GPU node and the
+  # shortest path; any other node IP works and simply forwards.
+  type: NodePort
+  {{- else }}
   type: ClusterIP
+  {{- end }}
   ports:
     - port: {{ .Values.server.port }}
       targetPort: http
       protocol: TCP
       name: http
+      {{- if .Values.benchMode.enabled }}
+      # Pinned rather than allocated, so the base URL on the benchmarking
+      # machine survives a re-sync. Nothing else in the cluster claims a
+      # nodePort, so the whole 30000-32767 range was free when this was chosen.
+      nodePort: {{ .Values.benchMode.nodePort | int }}
+      {{- end }}
   selector:
     {{- include "inference.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: inference

--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -342,7 +342,20 @@ benchMode:
   # move with this flag, rather than to the Service, whose name does:
   #
   #   kubectl port-forward -n inference deploy/inference 18080:8080
+  #
+  # And it puts the Service on a NodePort so a machine on the LAN can reach the
+  # model with no credentials, no Cloudflare and no timeout:
+  #
+  #   base_url = http://192.168.1.195:30800/v1     (node-4, the GPU node)
+  #   model    = qwen3.6-27b
+  #
+  # That port is UNAUTHENTICATED and open to anything on the LAN while this is
+  # true. It is welded to this one flag on purpose, so turning bench mode off
+  # closes it and there is no second switch to forget.
   enabled: true
+  # Pinned so the benchmarking machine's base URL survives a re-sync. Only read
+  # when enabled is true.
+  nodePort: 30800
 
 # OpenAI-compatible ingress at https://private.jomcgi.dev/llm/v1, so a client
 # outside the cluster (an OpenAI SDK, curl, an IDE assistant) can call the


### PR DESCRIPTION
While bench mode is on, the LLM Service becomes a NodePort on 30800 so a machine on the local network reaches the model directly:

```
base_url  http://192.168.1.195:30800/v1     # node-4, the GPU node
model     qwen3.6-27b
api_key   unused
```

No headers, no kubeconfig, no Cloudflare.

## Why

The Cloudflare route works, but it imposes three things a benchmark harness has to work around, none of which apply on the LAN:

1. **The `CF-Access-Client-Id` / `-Secret` pair** on every request, which not every client can send.
2. **The 100s no-byte limit**, which 524s any non-streamed response over roughly 4800 tokens at the observed 48 tok/s. Measured: 16384 tokens non-streamed returned `524` after 125s; the identical request with `stream: true` returned 200 after 348s.
3. **TLS at the edge**, so the whole path depends on Access being configured correctly.

A port-forward would avoid all three too, but needs a kubeconfig on the benchmarking machine and is a single TCP tunnel that dies on a network blip mid-run.

## Scope and lifetime

**First NodePort in this cluster.** Everything else reaches the outside through the cloudflared tunnel, so this is a deliberate exception with a defined lifetime, not a pattern to copy.

**LAN-only.** The invariant that nothing is exposed to the internet directly still holds: reaching this from outside needs a router port-forward that does not exist. Cilium runs `kube-proxy-replacement: true`, so it is served on every node and any node IP forwards to the pod.

**Unauthenticated on the LAN** for as long as bench mode is on. That is welded to `benchMode.enabled` rather than being independently switchable, so ending the session closes the port and there is no second flag to forget. The port is pinned rather than allocated so the base URL survives a re-sync; nothing else in the cluster claims a nodePort, so the range was entirely free.

## Verification

Rendered both ways. With `benchMode.enabled: false` the Service is byte-identical to before (`type: ClusterIP`, no `nodePort`). With it true, `type: NodePort` and `nodePort: 30800`.

NodePort is a superset of ClusterIP, so the existing `private.jomcgi.dev/llm/v1` route through this same Service keeps working. Confirmed post-merge.

`helm lint --strict` passes. `ci test`: `Executed 1 out of 735 tests: 735 tests pass`.