### PR TITLE
feat(moving): surface the plan on desktop, honest empty states, chart polish

### DIFF
--- a/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
+++ b/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
@@ -410,12 +410,14 @@
             {#if overdueRows.length === 0 && weekRows.length === 0}
               <p class="ncalm">Nothing waiting in the next seven days.</p>
             {/if}
-            <button
-              class="allbtn"
-              type="button"
-              onclick={() => openDialog(tasksDialog)}
-              >All {openTasks.length} tasks →</button
-            >
+            {#if tasks.length > 0}
+              <button
+                class="allbtn"
+                type="button"
+                onclick={() => openDialog(tasksDialog)}
+                >All {openTasks.length} tasks →</button
+              >
+            {/if}
           </div>
         </section>
 
@@ -601,10 +603,17 @@
                 aria-valuemax="100"
                 aria-valuenow={progressView.percent}
               >
-                <i style:width={`${progressView.percent}%`}></i>
+                <i
+                  class:zero={progressView.percent === 0}
+                  style:width={`${progressView.percent}%`}
+                ></i>
               </div>
               <div class="prog-lbl">
-                {progressView.label} · this number only goes up
+                {#if progressView.total === 0}
+                  waiting on the first task
+                {:else}
+                  {progressView.label} · this number only goes up
+                {/if}
               </div>
             </div>
           </div>
@@ -640,7 +649,12 @@
             type="button"
             onclick={() => openDialog(sellDialog)}
           >
-            To sell <span class="v mono">{formatCad(sellTotal)}</span>
+            To sell
+            {#if sellTasks.length === 0}
+              <span class="v">nothing listed</span>
+            {:else}
+              <span class="v mono">{formatCad(sellTotal)}</span>
+            {/if}
           </button>
           <button
             class="dockbtn"
@@ -673,7 +687,12 @@
             type="button"
             onclick={() => openDialog(tasksDialog)}
           >
-            Tasks <span class="v mono">{openTasks.length} open</span>
+            Tasks
+            {#if tasks.length === 0}
+              <span class="v">none yet</span>
+            {:else}
+              <span class="v mono">{openTasks.length} open</span>
+            {/if}
           </button>
         </nav>
 

--- a/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
@@ -105,7 +105,8 @@
     "head head head"
     "hero hero prog"
     "today plot plot"
-    "today collide collide"
+    "agenda plot plot"
+    "agenda collide collide"
     "dock dock dock";
 }
 
@@ -257,7 +258,7 @@
 }
 
 .moving .c-agenda {
-  display: none;
+  grid-area: agenda;
 }
 
 .moving .agenda-body {
@@ -322,6 +323,7 @@
 }
 
 .moving .c-legsmini {
+  /* Rejected on desktop because chart leg tags already repeat these details. */
   display: none;
   padding: 4px 16px 12px;
 }
@@ -532,10 +534,11 @@
 }
 
 .moving .vline {
+  /* Component outlines use 2px; internal dividers use the 1px rule tier. */
   position: absolute;
   top: 10px;
   bottom: 40px;
-  width: 2px;
+  width: 1px;
   background: var(--rule);
 }
 
@@ -662,6 +665,13 @@
   transition: background 0.12s ease;
 }
 
+/* Vertical expansion stays within its sub-row; horizontal could overlap bars. */
+.moving .bar::after {
+  position: absolute;
+  content: "";
+  inset: -7px 0;
+}
+
 .moving .bar:hover,
 .moving .bar:focus-visible {
   z-index: 5;
@@ -698,7 +708,7 @@
 }
 
 .moving .dia {
-  position: static;
+  position: relative;
   width: 10px;
   height: 10px;
   padding: 0;
@@ -707,6 +717,12 @@
   background: var(--paper);
   cursor: pointer;
   transition: transform 0.12s ease;
+}
+
+.moving .dia::after {
+  position: absolute;
+  content: "";
+  inset: -8px;
 }
 
 .moving .dia.fill {
@@ -849,6 +865,10 @@
   border-right: 2px solid var(--ink);
   background: var(--green);
   transition: width 0.5s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+
+.moving .prog-bar i.zero {
+  border-right: 0;
 }
 
 .moving .prog-lbl {
@@ -1324,6 +1344,10 @@
       "today plot"
       "today collide"
       "dock dock";
+  }
+
+  .moving .c-agenda {
+    display: none;
   }
 
   .moving .card-plot {


### PR DESCRIPTION
Round two of moving planner refinements, scoped by Joe from a design audit against `.impeccable.md`: surface The plan on desktop, empty-state pass, chart micro-polish. Hero deliberately untouched.

## The plan comes to desktop

The month-grouped agenda (`.c-agenda`) was `display: none` on desktop and only existed behind the phone's Plan tab, while the left column ran two rows tall and mostly empty. The grid grows to six rows with the agenda under Do today:

```
head   head    head
hero   hero    prog
today  plot    plot
agenda plot    plot
agenda collide collide
dock   dock    dock
```

No new borders: the grid's `gap: 2px` over its ink background already draws every cell boundary, and spanning cells cover the segments that should not show. Do today now sizes to its content instead of stretching, so the All tasks button sits under the list rather than floating at the column's foot.

Deliberate exclusions, recorded in CSS comments where they live:
- **Leg dates stays phone-only.** On desktop the chart's leg tags already show each leg's label and date range; the panel would be pure duplication.
- **The 701 to 1080px layout keeps the agenda hidden** (explicitly, inside that media query, since a grid child with no matching area would auto-place into a broken implicit row). That two-column grid has no room without crushing the chart, and the phone tabs serve it below 700px.

## Honest empty states

Zero-data panels read as broken rather than early. The house pattern is the Roles button's `dormant`: words, not zeros. Now: the progress label reads `waiting on the first task` when no tasks exist (the playful `this number only goes up` line returns with the first task), the `All 0 tasks` button disappears when there are no tasks at all (an all-done `0 open` is earned and stays), To sell reads `nothing listed`, and Tasks reads `none yet`.

## Chart micro-polish

- Diamonds (~14px) and bars (13px) get invisible `::after` hit extensions toward the WCAG 2.5.8 24px minimum. Bars expand vertically only: sub-rows are 34px apart so the extension cannot cross rows, while same-sub-row neighbours can legitimately sit close enough that horizontal expansion would steal clicks from a neighbour's visible pixels.
- The progress fill drew a 2px `border-right` sliver on an empty bar at 0%; gated off via `class:zero`.
- Month gridlines drop from 2px to 1px: 2px is the component-outline tier, internal dividers are the 1px rule tier.

## Verification

- `ci lint` clean; `ci test`: `Executed 3 out of 735 tests: 735 tests pass`, and the build completing compiles the frontend via `build_test` wrapping `:build`.
- Row-height invariant held: `34px` count in the CSS is 4 before and after; the four JS plot constants untouched.
- Phone rules, tabbar, and the min-width 1600px block untouched; `.app.phone .c-agenda`'s hide still out-specifies the new base visibility.
- No chart version or `targetRevision` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)