### PR TITLE
fix(moving): stop the agenda inflating the chart column's grid rows

### DIFF
--- a/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
@@ -261,6 +261,29 @@
   grid-area: agenda;
 }
 
+/* Desktop only: the agenda is by far the tallest cell once real data is in
+   (a season of spans and milestones renders ~1000px), and because it shares
+   grid rows with the chart column, letting it size those rows inflated the
+   chart's cell and opened a giant void between the Gantt and Collisions.
+   Instead the agenda takes whatever height the chart column defines and
+   scrolls internally for the rest; contain: size is what keeps its content
+   out of the grid's track sizing. Scoped above 1080px because the phone's
+   Plan tab sets display: block and must keep normal flow sizing. */
+@media (min-width: 1081px) {
+  .moving .c-agenda {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .moving .agenda-body {
+    flex: 1 1 0;
+    min-height: 0;
+    overflow-y: auto;
+    contain: size;
+  }
+}
+
 .moving .agenda-body {
   padding: 2px 16px 12px;
 }


### PR DESCRIPTION
Follow-up to #5038, from a screenshot of the live page with real plan data.

## What broke

The six-row grid ties the two columns together through shared rows: the agenda spans rows 4 and 5, and the chart spans rows 3 and 4. With the seeded plan the agenda renders about 1000px (my pre-merge worst-case arithmetic used half that), and the grid solver satisfied its height requirement by inflating row 4, which is also the chart's second row. The chart cell grew to match while the chart content kept its fixed JS-computed height, opening a large void between the Gantt and Collisions and pushing the dock below the fold.

## The fix

The agenda stops sizing the grid entirely. `contain: size` keeps its content out of track sizing, so the cell contributes only its header; the rows are sized by the chart column alone, and the agenda stretches to whatever height that defines (about 430px, six or so plan items) and scrolls internally for the rest. No magic heights: the cap is whatever the chart column happens to be, at any viewport and any data size. The page returns to a single-viewport dashboard.

Scoped to `min-width: 1081px` deliberately: the phone's Plan tab sets `display: block` on the same cell and needs normal flow sizing, where `contain: size` would collapse the body to zero height. Below 1081px nothing changes.

## Verification

- `ci lint` clean; `ci test`: `Executed 2 out of 735 tests: 735 tests pass`, build (and therefore the frontend compile via `build_test`) green.
- CSS-only, one file; no chart version or `targetRevision` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)