### PR TITLE
feat(moving): UX clarity round: dark highlight, badge wording, hero context, collision rings

### DIFF
--- a/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
+++ b/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
@@ -5,6 +5,7 @@
   import AccessPanel from "./AccessPanel.svelte";
   import {
     clusterMilestoneGroups,
+    collidingSpanIds,
     collisionWording,
     formatCad,
     formatDateRange,
@@ -58,6 +59,7 @@
   const milestones = $derived(data.state?.milestones ?? []);
   const roles = $derived(data.state?.roles ?? []);
   const rawCollisions = $derived(data.state?.collisions ?? []);
+  const collidingIds = $derived(collidingSpanIds(rawCollisions));
   const viewer = $derived(data.state?.viewer ?? "");
   const countdown = $derived(moveCountdown(spans, now));
   const openTasks = $derived(sortOpenTasks(tasks));
@@ -315,11 +317,7 @@
               <span>{countdown.detail}</span>
             </div>
           {:else}
-            <h1
-              id="move-countdown"
-              title={countdown.description}
-              aria-describedby="move-countdown-desc"
-            >
+            <h1 id="move-countdown" aria-describedby="move-countdown-desc">
               {#if countdown.days > 0}
                 <span class="hl"
                   >{countdown.days}
@@ -334,9 +332,9 @@
                 >&nbsp;ago
               {/if}
             </h1>
-            <span id="move-countdown-desc" class="sr-only"
-              >{countdown.description}</span
-            >
+            <p class="hero-sub" id="move-countdown-desc">
+              {countdown.description}
+            </p>
           {/if}
         </section>
 
@@ -355,11 +353,7 @@
                 onclick={() => setScope("all")}>All</button
               >
             </span>
-            <span class="badge"
-              >{overdueRows.length
-                ? `${overdueRows.length} late`
-                : "clear"}</span
-            >
+            <span class="badge">{overdueRows.length} late</span>
           </div>
           <div class="cta-body">
             {#if taskError}
@@ -499,6 +493,7 @@
                       <button
                         type="button"
                         class="bar"
+                        class:collides={collidingIds.has(bar.id)}
                         style:left={`${bar.position}%`}
                         style:width={`${bar.width}%`}
                         style:--sub-row={bar.subRow}

--- a/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving-theme.css
@@ -10,6 +10,9 @@
   --blue: #6fc2ff;
   --coral: #ff7169;
   --green: #4ade80;
+  /* Fraction of the line box covered by the yellow highlight band. It is full
+     height in dark mode because uncovered glyph tops would be dark on dark. */
+  --hl-cover: 74%;
   --font-display: "Instrument Serif", "Iowan Old Style", Georgia, serif;
   --font-ui: "Hanken Grotesk", "Avenir Next", "Segoe UI", system-ui, sans-serif;
   --font-code: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
@@ -34,6 +37,7 @@
     --ink-2: #b5af9f;
     --ink-3: #7d786c;
     --rule: rgba(240, 234, 217, 0.16);
+    --hl-cover: 100%;
   }
 }
 
@@ -45,6 +49,7 @@
   --ink-2: #57534a;
   --ink-3: #8a857a;
   --rule: rgba(26, 26, 26, 0.14);
+  --hl-cover: 74%;
 }
 
 :root[data-theme="dark"] .moving {
@@ -55,6 +60,7 @@
   --ink-2: #b5af9f;
   --ink-3: #7d786c;
   --rule: rgba(240, 234, 217, 0.16);
+  --hl-cover: 100%;
 }
 
 .moving,
@@ -210,7 +216,9 @@
 .moving .c-hero {
   grid-area: hero;
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
   padding: 26px 26px 24px;
 }
 
@@ -238,10 +246,18 @@
   font-weight: 600;
 }
 
+.moving .hero-sub {
+  margin: 12px 0 0;
+  color: var(--ink-2);
+  font-family: var(--font-code);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+}
+
 .moving .hl {
   padding: 0 0.08em;
   background: linear-gradient(var(--yellow), var(--yellow)) no-repeat 0 62%;
-  background-size: 100% 74%;
+  background-size: 100% var(--hl-cover);
   color: #1a1a1a;
 }
 
@@ -686,6 +702,11 @@
   box-shadow: 0 0 0 2px var(--paper);
   cursor: default;
   transition: background 0.12s ease;
+}
+
+/* Coral is the collision color everywhere else, so this ring needs no legend. */
+.moving .bar.collides {
+  box-shadow: 0 0 0 2px var(--coral);
 }
 
 /* Vertical expansion stays within its sub-row; horizontal could overlap bars. */
@@ -1336,7 +1357,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .moving .hl {
-    background-size: 0% 74%;
+    background-size: 0% var(--hl-cover);
     animation: moving-sweep 0.7s cubic-bezier(0.2, 0.8, 0.3, 1) 0.15s forwards;
   }
 
@@ -1346,7 +1367,7 @@
 
   @keyframes moving-sweep {
     to {
-      background-size: 100% 74%;
+      background-size: 100% var(--hl-cover);
     }
   }
 

--- a/projects/monolith/frontend/src/routes/friends/moving/moving.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving.js
@@ -225,6 +225,19 @@ export function collisionWording(collision, tasks, spans) {
   return null;
 }
 
+export function collidingSpanIds(collisions) {
+  const ids = new Set();
+  for (const collision of collisions ?? []) {
+    if (collision.type === "span_span") {
+      ids.add(collision.item1_id);
+      ids.add(collision.item2_id);
+    } else if (collision.type === "task_span") {
+      ids.add(collision.item2_id);
+    }
+  }
+  return ids;
+}
+
 export function ganttDatePosition(value, startsOn, endsOn) {
   const valueStamp = dateStamp(value);
   const startStamp = dateStamp(startsOn);

--- a/projects/monolith/frontend/src/routes/friends/moving/moving.test.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   clusterMilestoneGroups,
+  collidingSpanIds,
   collisionWording,
   ganttDatePosition,
   groupMilestonesByDate,
@@ -17,6 +18,50 @@ const spans = [
   { id: "span-1", kind: "visitor", label: "Visitors" },
   { id: "span-2", kind: "trip", label: "Japan trip" },
 ];
+
+describe("colliding span ids", () => {
+  it("includes both spans from the Steph and Jack pack-out collision", () => {
+    const collision = {
+      type: "span_span",
+      item1_id: "span-steph-jack",
+      item2_id: "span-vancouver-pack-out",
+    };
+
+    expect(collidingSpanIds([collision])).toEqual(
+      new Set(["span-steph-jack", "span-vancouver-pack-out"]),
+    );
+  });
+
+  it("includes only the span from a task and span collision", () => {
+    const result = collidingSpanIds([
+      {
+        type: "task_span",
+        item1_id: "task-book-movers",
+        item2_id: "span-vancouver-pack-out",
+      },
+    ]);
+
+    expect(result).toEqual(new Set(["span-vancouver-pack-out"]));
+    expect(result.has("task-book-movers")).toBe(false);
+  });
+
+  it("returns an empty set for empty or null input", () => {
+    expect(collidingSpanIds([])).toEqual(new Set());
+    expect(collidingSpanIds(null)).toEqual(new Set());
+  });
+
+  it("is deterministic for the same input", () => {
+    const collisions = [
+      {
+        type: "span_span",
+        item1_id: "span-steph-jack",
+        item2_id: "span-vancouver-pack-out",
+      },
+    ];
+
+    expect(collidingSpanIds(collisions)).toEqual(collidingSpanIds(collisions));
+  });
+});
 
 describe("collision wording", () => {
   it("words a span overlap using resolved labels and its date range", () => {


### PR DESCRIPTION
UX and clarity pass on the moving planner, from Joe's dark-mode screenshot ("50 is cut off no?") plus a review against `.impeccable.md`.

## The cut-off countdown (dark-mode bug)

`.hl` draws its yellow band over 74% of the line box and forces text near-black to read on the yellow. Light mode: glyph tops above the band are ink on cream, the intended marker-pen look. Dark mode: the same tops are dark on dark, so "50 days" rendered decapitated. Coverage is now a theme token `--hl-cover` (74% light, 100% dark), quadruplicated across the four theme blocks exactly like the color tokens. The sweep animation's keyframe hardcoded `74%` too and animates with `fill-mode: forwards`; it now animates to the token, or it would have clobbered the dark override on every load.

## Status that read as a button

The Do today badge showed CLEAR (uppercase chip) directly beside the Mine/All toggle buttons: a status dressed as an action, and "ALL" adjacency made it worse. It now always uses the count language the non-empty state already used: `0 late`.

## The number now says what it counts

"50 days" until *what* lived in a `title` attribute and an sr-only span. It is now a visible mono line under the number ("Until you leave Canada, Friday 10 October 2026"); the hidden duplicates are removed and `aria-describedby` points at the visible element. The hero flexes to a column for the sub-line; the no-move-date empty branch is untouched.

## Collisions are visible where they happen

The one place an overlap is spatially legible is the Gantt, yet the collision text repeated in three panels while the colliding bars looked identical to innocent ones. New pure helper `collidingSpanIds()` (span_span marks both ids, task_span only the span, never the task) feeds a `class:collides` that draws a 2px coral ring. Coral already means collision in the agenda and the Collisions panel, so the ring needs no legend. The rule sits before `.bar:hover` at equal specificity, so hover still wins.

## Verification

- `ci lint` clean; `ci test`: `Executed 3 out of 735 tests: 735 tests pass` (frontend compiled via `build_test`).
- New vitest block covers the real span_span collision, the task_span asymmetry, empty/null input, and determinism.
- No `% 74%` literals remain; `34px` count unchanged (4=4); the four JS plot constants untouched; phone rules untouched.
- No chart version or `targetRevision` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)