### PR TITLE
perf(embervm): group brick Deployments into sync-wave batches

### DIFF
--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -120,6 +120,29 @@ py_test(
     deps = ["@pip//pytest"],
 )
 
+py_test(
+    name = "chart_sync_wave_test",
+    srcs = ["chart_sync_wave_test.py"],
+    data = [
+        "Chart.yaml",
+        "values.yaml",
+        "@multitool//tools/helm",
+    ] + glob([
+        "templates/**/*",
+        "crds/**/*",
+    ]),
+    env = {
+        "HELM_BIN": "$(rootpath @multitool//tools/helm)",
+    },
+    deps = ["@pip//pytest"],
+)
+
+semgrep_test(
+    name = "chart_sync_wave_test_semgrep_test",
+    srcs = ["chart_sync_wave_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
 semgrep_test(
     name = "chart_env_identity_test_semgrep_test",
     srcs = ["chart_env_identity_test.py"],

--- a/projects/embervm/chart/chart_sync_wave_test.py
+++ b/projects/embervm/chart/chart_sync_wave_test.py
@@ -1,0 +1,107 @@
+"""Render-test grouped ArgoCD sync waves for brick Deployments."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+_NAME = re.compile(r"^  name: (\S+)$", re.MULTILINE)
+_WAVE = re.compile(r'^    argocd\.argoproj\.io/sync-wave: "(\d+)"$', re.MULTILINE)
+
+
+def _chart_dir() -> Path:
+    chart = Path(__file__).resolve().parent
+    if (chart / "Chart.yaml").exists():
+        return chart
+    raise RuntimeError("Could not find chart Chart.yaml")
+
+
+def _render_waves(tmp_path: Path, group_size: int) -> tuple[list[int], list[int]]:
+    classes = "\n".join(
+        f"""    - name: class-{index}
+      resources:
+        requests:
+          cpu: \"1\"
+          memory: 1Gi
+        limits:
+          memory: 1Gi"""
+        for index in range(5)
+    )
+    floors = "\n".join(
+        f"""    - node: node-{index}
+      class: class-0"""
+        for index in range(4)
+    )
+    overlay = tmp_path / f"sync-wave-group-{group_size}.yaml"
+    overlay.write_text(
+        f"""bricks:
+  enabled: true
+  syncWaveBase: 2
+  syncWaveGroupSize: {group_size}
+  classes:
+{classes}
+  nodeFloors:
+{floors}
+"""
+    )
+
+    helm_bin = os.environ.get("HELM_BIN", "helm")
+    result = subprocess.run(
+        [
+            helm_bin,
+            "template",
+            "sync-wave-test",
+            str(_chart_dir()),
+            "--values",
+            str(overlay),
+            "--show-only",
+            "templates/brick-deployment.yaml",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"helm template failed: {result.stderr}")
+
+    rendered_waves: dict[str, int] = {}
+    for document in result.stdout.split("\n---"):
+        name = _NAME.search(document)
+        wave = _WAVE.search(document)
+        if name and wave:
+            rendered_waves[name.group(1)] = int(wave.group(1))
+
+    class_waves = [
+        rendered_waves[f"sync-wave-test-embervm-noded-brick-class-{index}"]
+        for index in range(5)
+    ]
+    floor_waves = [
+        rendered_waves[f"sync-wave-test-embervm-noded-brick-class-0-node-{index}"]
+        for index in range(4)
+    ]
+    assert len(rendered_waves) == 9, "expected only five class and four floor bricks"
+    return class_waves, floor_waves
+
+
+@pytest.mark.parametrize(
+    ("group_size", "expected_classes", "expected_floors"),
+    [
+        (1, [2, 3, 4, 5, 6], [7, 8, 9, 10]),
+        (3, [2, 2, 2, 3, 3], [4, 4, 4, 5]),
+    ],
+)
+def test_brick_sync_waves_are_grouped_without_class_floor_overlap(
+    tmp_path: Path,
+    group_size: int,
+    expected_classes: list[int],
+    expected_floors: list[int],
+) -> None:
+    class_waves, floor_waves = _render_waves(tmp_path, group_size)
+
+    assert class_waves == expected_classes
+    assert floor_waves == expected_floors
+    assert min(floor_waves) > max(class_waves)

--- a/projects/embervm/chart/templates/_helpers.tpl
+++ b/projects/embervm/chart/templates/_helpers.tpl
@@ -98,6 +98,38 @@ app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
 {{- end -}}
 
 {{/*
+ArgoCD rollout wave for a size-class brick Deployment. Classes are grouped in
+list order, with at most bricks.syncWaveGroupSize Deployments sharing a wave.
+Input: (dict "ctx" $ "index" $i).
+*/}}
+{{- define "embervm.brick.classWave" -}}
+{{- $groupSize := int .ctx.Values.bricks.syncWaveGroupSize -}}
+{{- if lt $groupSize 1 -}}
+{{- fail "bricks.syncWaveGroupSize must be greater than zero" -}}
+{{- end -}}
+{{- add (int .ctx.Values.bricks.syncWaveBase) (div (int .index) $groupSize) -}}
+{{- end -}}
+
+{{/*
+ArgoCD rollout wave for a per-node floor brick Deployment. Floors start after
+all class groups, then use the same group size. The explicit empty-list guard
+keeps the integer ceiling at zero when there are no classes.
+Input: (dict "ctx" $ "index" $j).
+*/}}
+{{- define "embervm.brick.floorWave" -}}
+{{- $groupSize := int .ctx.Values.bricks.syncWaveGroupSize -}}
+{{- if lt $groupSize 1 -}}
+{{- fail "bricks.syncWaveGroupSize must be greater than zero" -}}
+{{- end -}}
+{{- $classCount := len .ctx.Values.bricks.classes -}}
+{{- $classGroupCount := 0 -}}
+{{- if gt $classCount 0 -}}
+{{- $classGroupCount = add (div (sub $classCount 1) $groupSize) 1 -}}
+{{- end -}}
+{{- add (int .ctx.Values.bricks.syncWaveBase) $classGroupCount (div (int .index) $groupSize) -}}
+{{- end -}}
+
+{{/*
 Per-node brick FLOOR labels (brick-capacity PR-3). A floor Deployment is still
 "a brick of this class" (same component + size-class labels as the class-wide
 Deployment, on purpose: it is the same kind of pod), but it MUST NOT share the

--- a/projects/embervm/chart/templates/brick-deployment.yaml
+++ b/projects/embervm/chart/templates/brick-deployment.yaml
@@ -33,16 +33,19 @@
 # unshaped node losing all four tunnel connections. With ~12 embervm merges in
 # a day that is a recurring self-inflicted outage.
 #
-# Each brick Deployment now gets its own ascending wave, so ArgoCD applies one,
-# waits for it to report Healthy (its rollout complete), and only then applies
-# the next. maxSurge:0/maxUnavailable:1 already serialised the pods WITHIN a
-# Deployment; waves serialise ACROSS them, which is the part that was missing.
+# Brick Deployments now roll in ascending wave groups. At most
+# bricks.syncWaveGroupSize Deployments share a wave, so ArgoCD bounds concurrent
+# rolls and their image pulls, waits for the whole group to report Healthy, then
+# applies the next group. maxSurge:0/maxUnavailable:1 already serialised the pods
+# WITHIN a Deployment; grouped waves bound concurrency ACROSS them, which is the
+# part that was missing.
 #
-# Waves are assigned by list position: classes take syncWaveBase + index, then
-# floors continue from syncWaveBase + len(classes) + index, so the two ranges
-# never collide and adding a class or a floor shifts only the entries after it.
-# Base defaults to 2, which leaves wave 0 for the control plane and shared infra
-# (bricks dial home to the CP, so it must be up first) and wave 1 for the
+# Waves are assigned by list position. Class i takes syncWaveBase + floor(i /
+# group size). Floors start after ceil(len(classes) / group size) class waves,
+# then floor j adds floor(j / group size), so the class and floor ranges never
+# collide. Group size defaults to 1, preserving the previous per-Deployment
+# waves. Base defaults to 2, which leaves wave 0 for the control plane and shared
+# infra (bricks dial home to the CP, so it must be up first) and wave 1 for the
 # Workload CRs, both of which keep their current waves untouched.
 #
 # This is a stopgap, NOT ADR embervm/011. That decision is OnDelete pod
@@ -61,7 +64,7 @@ kind: Deployment
 metadata:
   name: {{ include "embervm.noded.fullname" $ctx }}-brick-{{ $class.name }}
   annotations:
-    argocd.argoproj.io/sync-wave: {{ add $ctx.Values.bricks.syncWaveBase $i | quote }}
+    argocd.argoproj.io/sync-wave: {{ include "embervm.brick.classWave" (dict "ctx" $ctx "index" $i) | quote }}
   labels:
     {{- include "embervm.brick.labels" (dict "ctx" $ctx "class" $class.name) | nindent 4 }}
 spec:
@@ -130,13 +133,12 @@ spec:
 # from its class Deployment's. Reusing the class selector here would be a real
 # bug (two ReplicaSet controllers fighting over the same pods), not just style.
 #
-# Floors roll AFTER every class (wave syncWaveBase + len(classes) + index).
+# Floors roll AFTER every class group. Their waves start at syncWaveBase +
+# ceil(len(classes) / syncWaveGroupSize), then group floors by list position.
 # They are the fixed per-node capacity guarantee, so rolling them last keeps a
 # pinned brick alive on each node for as long as possible while the elastic
-# class Deployments cycle. Rolling them last also spreads them across distinct
-# waves, which matters more than it looks: the floors are pinned to different
-# nodes, so rolling them together would put a rootfs build on every node at once
-# even though no single node is over-subscribed.
+# class Deployments cycle. The group size bounds how many pinned nodes can pull
+# and build a rootfs concurrently.
 {{- range $j, $floor := .Values.bricks.nodeFloors }}
 {{- $class := $floor.class }}
 ---
@@ -145,7 +147,7 @@ kind: Deployment
 metadata:
   name: {{ include "embervm.noded.fullname" $ctx }}-brick-{{ $class }}-{{ $floor.node }}
   annotations:
-    argocd.argoproj.io/sync-wave: {{ add $ctx.Values.bricks.syncWaveBase (len $ctx.Values.bricks.classes) $j | quote }}
+    argocd.argoproj.io/sync-wave: {{ include "embervm.brick.floorWave" (dict "ctx" $ctx "index" $j) | quote }}
   labels:
     {{- include "embervm.brickFloor.labels" (dict "ctx" $ctx "class" $class "node" $floor.node) | nindent 4 }}
 spec:

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1274,20 +1274,25 @@ noded:
 # netns), which the 16Gi class covers.
 bricks:
   enabled: false
-  # First ArgoCD sync-wave handed out to a brick Deployment. Each brick then
-  # takes its own ascending wave (classes by list index, then floors continuing
-  # after them), so ArgoCD rolls the fleet ONE Deployment at a time instead of
-  # applying all of them in the same instant. Before this every brick rendered
-  # at the default wave 0 and a single chart bump stampeded the whole fleet:
-  # every replacement pod running its rootfs-builder init and pulling images at
-  # once, which saturates the shared uplink hard enough to take the wired LAN to
-  # 100% packet loss and drop the cloudflared tunnel on unshaped nodes.
+  # First ArgoCD sync-wave handed out to a brick Deployment. Brick wave groups
+  # advance in list order (classes first, then floors), so ArgoCD rolls one
+  # bounded group at a time instead of applying the whole fleet at once. Before
+  # this every brick rendered at the default wave 0 and a single chart bump
+  # stampeded the whole fleet: every replacement pod running its rootfs-builder
+  # init and pulling images at once, which saturates the shared uplink hard
+  # enough to take the wired LAN to 100% packet loss and drop the cloudflared
+  # tunnel on unshaped nodes.
   #
   # 2 keeps the existing waves intact underneath it: wave 0 is the control plane
   # and shared infra (bricks dial home to the CP, so it goes first) and wave 1 is
   # the Workload CRs. Raise it only if something new needs to land between the CP
   # and the bricks; the relative order of the bricks themselves is positional.
   syncWaveBase: 2
+  # Maximum concurrent brick Deployment rolls in one ArgoCD wave, which also
+  # bounds concurrent image pulls. Per-brick waves turned 81 seconds of actual
+  # rollout work into 13 minutes of sync time (#4897). The default 1 preserves
+  # the old behavior of assigning every brick Deployment its own wave.
+  syncWaveGroupSize: 1
   # How long a brick Deployment may take to become available before Kubernetes
   # marks it Progressing=False, which ArgoCD surfaces as Degraded.
   #

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -212,6 +212,8 @@ scratchPrep:
 # flip after this small brick verifies against the decision-log checklist.
 bricks:
   enabled: true
+  # The first grouped production roll's measured result is recorded on #4897.
+  syncWaveGroupSize: 3
   desiredReplicas:
     2gi: 1
     # Re-canary step 2 (large): the 16gi brick, added after the 2gi brick verified

--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -23,6 +23,8 @@ specTrace:
 # All other classes are explicitly zero. No autoscale in dev.
 bricks:
   enabled: true
+  # The first grouped dev roll's measured result is recorded on #4897.
+  syncWaveGroupSize: 3
   # ALL ZERO. desiredReplicas renders an UNPINNED brick per class, and nodeFloors
   # renders an ADDITIONAL pinned one: the floor does not pin the desired-replicas
   # brick, it adds a second Deployment beside it.


### PR DESCRIPTION
Refs #4897 (stays open until the grouped rollout is measured).

`bricks.syncWaveGroupSize` (default 1 renders exactly today's waves; prod and dev set 3) bounds how many brick Deployments share an ArgoCD wave. Class and floor wave ranges still never collide and floors still roll after every class. New `chart_sync_wave_test.py` pins the arithmetic for both group sizes.

After merge I will time the first grouped production roll and record the number on the issue, watching the tunnel for the uplink saturation the per-brick waves were added to prevent.

`ci`: Bazel 737 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP