### PR TITLE
fix(embervm): make brick warmth ownership a checked liveness claim

### DIFF
--- a/projects/embervm/chart/chart_env_identity_test.py
+++ b/projects/embervm/chart/chart_env_identity_test.py
@@ -402,6 +402,32 @@ def test_noded_bucket_path_configuration(renders):
     )
 
 
+def test_brick_renders_default_warmth_heartbeat_env(renders):
+    """Brick Deployments claim warmth with safe transition defaults."""
+    brick_deployments = [
+        doc
+        for kind, _, doc in _docs(renders["prod"])
+        if kind == "Deployment" and "app.kubernetes.io/component: noded-brick" in doc
+    ]
+    assert brick_deployments, "production rendered no brick Deployment; test is inert"
+
+    expected = {
+        "EMBERVM_NODED_WARMTH_HEARTBEAT_INTERVAL": "30s",
+        "EMBERVM_NODED_WARMTH_STALE_AFTER": "600s",
+        "EMBERVM_NODED_REAP_UNCLAIMED_WARMTH": "0",
+    }
+    for deployment in brick_deployments:
+        for name, value in expected.items():
+            rendered_env = re.search(
+                rf"name:\s*{name}\s+value:\s*\"([^\"]+)\"", deployment
+            )
+            assert rendered_env, f"brick Deployment is missing {name}"
+            assert rendered_env.group(1) == value, (
+                f"brick Deployment renders {name}={rendered_env.group(1)!r}, "
+                f"want {value!r}"
+            )
+
+
 def test_dev_hostpaths_are_under_production_scratch_never_beside_it(renders):
     """Dev's hostPaths must be UNDER production's, not siblings of it.
 

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -199,6 +199,15 @@ containers:
         value: {{ $ctx.Values.noded.diffBanking | quote }}
       - name: EMBERVM_NODED_DIFF_BANKING_WORKLOADS
         value: {{ $ctx.Values.noded.diffBankingWorkloads | quote }}
+      # Brick warmth liveness claim (#4962). The daemon parses durations with Go
+      # duration syntax. Only the exact string "1" enables unclaimed reaping;
+      # "0" keeps the rollout transition guard off by default.
+      - name: EMBERVM_NODED_WARMTH_HEARTBEAT_INTERVAL
+        value: "{{ $ctx.Values.noded.warmthHeartbeat.intervalSeconds }}s"
+      - name: EMBERVM_NODED_WARMTH_STALE_AFTER
+        value: "{{ $ctx.Values.noded.warmthHeartbeat.staleAfterSeconds }}s"
+      - name: EMBERVM_NODED_REAP_UNCLAIMED_WARMTH
+        value: {{ ternary "1" "0" $ctx.Values.noded.warmthHeartbeat.reapUnclaimed | quote }}
       - name: EMBERVM_NODED_DAEMON_RESERVE_MIB
         value: {{ $ctx.Values.bricks.daemonReserveMib | default 512 | quote }}
       # Serving tap pre-provisioning (ADR embervm/014 decision 4). Zero (default)

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1093,6 +1093,18 @@ noded:
   # Relight. Keep task and park-only workloads outside the diff path.
   diffBankingWorkloads: sandbox-session
 
+  # Per-brick warmth ownership claim. Each brick refreshes i/<segment>/.alive
+  # every intervalSeconds, and startup GC reaps a foreign claim only after
+  # staleAfterSeconds. reapUnclaimed is the #4962 transition guard for warmth
+  # written before heartbeat support. Keep it false until every fleet brick
+  # heartbeats, then flip it in the follow-up values PR. The 2026-08-15 incident
+  # showed that path ownership alone lets one restarting brick reap a live
+  # sibling's only relight path.
+  warmthHeartbeat:
+    intervalSeconds: 30
+    staleAfterSeconds: 600
+    reapUnclaimed: false
+
   # Serving tap pre-provisioning (ADR embervm/014 decision 4): the number of serving
   # taps EnsureNetwork pre-creates at brick boot, left down until AllocateTap draws
   # one, so instance boot skips netlink create/attach work. Zero (the default)

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -62,14 +62,41 @@ func run(logger *slog.Logger) error {
 		"node", cfg.Node, "arch", cfg.Arch,
 		"maxLiveVMs", cfg.MaxLiveVMs, "registryCache", cfg.RegistryCachePath)
 
-	// Startup GC of orphan per-instance (brick) warmth: reap SnapshotRoot/i/<seg>
-	// dirs left by evicted/rolled-out co-located bricks whose pod UID is not ours.
-	// Fail-soft (warmth is regenerable) and narrow: bases/ and the VolumeRoot are
-	// never touched, and this is a no-op on the legacy DaemonSet (flat warmth).
-	if removed := config.PruneStaleInstanceWarmth(cfg, func(segment string, err error) {
+	// Claim our own per-instance warmth before inspecting any sibling. A brick
+	// that cannot publish its claim must not boot, because another brick could
+	// otherwise correctly conclude that its warmth is stale or unclaimed.
+	bootTime := time.Now()
+	if err := config.WriteInstanceHeartbeat(cfg, bootTime); err != nil {
+		return fmt.Errorf("write startup instance warmth heartbeat: %w", err)
+	}
+	// Startup GC is fail-soft and narrow: it reaps only foreign stale claims (or
+	// unclaimed warmth when the transition guard is explicitly enabled), never
+	// bases/, the VolumeRoot, fresh siblings, or this brick's own segment.
+	pruned := config.PruneStaleInstanceWarmth(cfg, bootTime, func(segment string, err error) {
 		logger.Warn("startup GC: could not remove stale instance warmth", "segment", segment, "err", err)
-	}); len(removed) > 0 {
-		logger.Info("startup GC: reaped stale instance warmth", "count", len(removed), "segments", removed)
+	})
+	for _, segment := range pruned.SkippedLive {
+		logger.Debug("startup GC: skipped live instance warmth", "segment", segment)
+	}
+	logger.Info("startup GC: checked instance warmth",
+		"removedCount", len(pruned.Removed), "removedSegments", pruned.Removed,
+		"skippedLiveCount", len(pruned.SkippedLive),
+		"skippedUnclaimedCount", len(pruned.SkippedUnclaimed))
+	if cfg.SnapshotRoot != "" && cfg.SizeClass != "" && cfg.PodUID != "" {
+		go func() {
+			ticker := time.NewTicker(cfg.WarmthHeartbeatInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case now := <-ticker.C:
+					if err := config.WriteInstanceHeartbeat(cfg, now); err != nil {
+						logger.Warn("could not refresh instance warmth heartbeat", "err", err)
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
 	}
 	// Unconditional so every brick can restore a placeholder-bearing base hydrated from S3.
 	if _, err := driver.EnsurePlaceholderVolume(cfg.SnapshotRoot); err != nil {

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -154,6 +154,19 @@ type Config struct {
 	// this is empty, so a Config built directly (tests) without deriving it keeps
 	// the flat layout.
 	WarmthRoot string
+	// WarmthHeartbeatInterval controls how often a brick refreshes the .alive
+	// claim in its per-instance warmth directory. Default 30s. Env
+	// EMBERVM_NODED_WARMTH_HEARTBEAT_INTERVAL.
+	WarmthHeartbeatInterval time.Duration
+	// WarmthStaleAfter is the minimum age of a foreign brick's .alive claim
+	// before startup GC may reap its warmth. It must be greater than
+	// WarmthHeartbeatInterval. Default 600s. Env
+	// EMBERVM_NODED_WARMTH_STALE_AFTER.
+	WarmthStaleAfter time.Duration
+	// ReapUnclaimedWarmth permits startup GC to remove foreign warmth that has
+	// no .alive claim. Only the exact env value "1" enables this transition
+	// guard; every other value is false. Env EMBERVM_NODED_REAP_UNCLAIMED_WARMTH.
+	ReapUnclaimedWarmth bool
 	// BinPath is the firecracker binary (baked into the image at /opt/fc).
 	BinPath string
 	// KernelImagePath is the guest kernel (baked at /opt/fc), shared by every VM.
@@ -411,24 +424,27 @@ func Load() (Config, error) {
 		MaxLiveVMs:       atoiDefault("EMBERVM_NODED_MAX_LIVE_VMS", 8),
 		DaemonReserveMib: atoiDefault("EMBERVM_NODED_DAEMON_RESERVE_MIB", 512),
 		// Default 512 MiB memory reject floor; zero means use this fallback.
-		MemRejectFloorMib:   atoiDefault("EMBERVM_NODED_MEM_REJECT_FLOOR_MIB", 512),
-		AdmissionModel:      getenvDefault("EMBERVM_NODED_ADMISSION_MODEL", "observed"),
-		VMOverheadMib:       atoiDefault("EMBERVM_NODED_VM_OVERHEAD_MIB", 0),
-		SnapshotRoot:        os.Getenv("EMBERVM_NODED_SNAPSHOT_ROOT"),
-		BinPath:             getenvDefault("EMBERVM_NODED_FIRECRACKER_BIN", "/opt/fc/firecracker"),
-		KernelImagePath:     getenvDefault("EMBERVM_NODED_KERNEL_IMAGE", "/opt/fc/vmlinux.container"),
-		KernelBootArgs:      os.Getenv("EMBERVM_NODED_KERNEL_BOOT_ARGS"),
-		HarnessInit:         getenvDefault("EMBERVM_NODED_HARNESS_INIT", "/usr/local/bin/fc-shim-init"),
-		CanonicalVsockDir:   getenvDefault("EMBERVM_NODED_CANONICAL_VSOCK_DIR", "/disks/nvme-02/embervm-noded-vsock"),
-		GuestOomScoreAdj:    atoiDefault("EMBERVM_NODED_GUEST_OOM_SCORE_ADJ", 1000),
-		BootReadyTimeout:    60 * time.Second,
-		RestoreReadyTimeout: 2 * time.Second,
-		DrainTimeout:        110 * time.Second,
-		EgressSidecarAddr:   getenvDefault("EMBERVM_NODED_EGRESS_SIDECAR_ADDR", "127.0.0.1:8888"),
-		EgressEnabled:       boolDefault("EMBERVM_NODED_EGRESS_ENABLED", false),
-		EgressWorkloads:     csvDefault("EMBERVM_NODED_EGRESS_WORKLOADS"),
-		ArchiveFetchTimeout: 60 * time.Second,
-		ArchiveMaxBytes:     512 << 20,
+		MemRejectFloorMib:       atoiDefault("EMBERVM_NODED_MEM_REJECT_FLOOR_MIB", 512),
+		AdmissionModel:          getenvDefault("EMBERVM_NODED_ADMISSION_MODEL", "observed"),
+		VMOverheadMib:           atoiDefault("EMBERVM_NODED_VM_OVERHEAD_MIB", 0),
+		SnapshotRoot:            os.Getenv("EMBERVM_NODED_SNAPSHOT_ROOT"),
+		WarmthHeartbeatInterval: 30 * time.Second,
+		WarmthStaleAfter:        600 * time.Second,
+		ReapUnclaimedWarmth:     os.Getenv("EMBERVM_NODED_REAP_UNCLAIMED_WARMTH") == "1",
+		BinPath:                 getenvDefault("EMBERVM_NODED_FIRECRACKER_BIN", "/opt/fc/firecracker"),
+		KernelImagePath:         getenvDefault("EMBERVM_NODED_KERNEL_IMAGE", "/opt/fc/vmlinux.container"),
+		KernelBootArgs:          os.Getenv("EMBERVM_NODED_KERNEL_BOOT_ARGS"),
+		HarnessInit:             getenvDefault("EMBERVM_NODED_HARNESS_INIT", "/usr/local/bin/fc-shim-init"),
+		CanonicalVsockDir:       getenvDefault("EMBERVM_NODED_CANONICAL_VSOCK_DIR", "/disks/nvme-02/embervm-noded-vsock"),
+		GuestOomScoreAdj:        atoiDefault("EMBERVM_NODED_GUEST_OOM_SCORE_ADJ", 1000),
+		BootReadyTimeout:        60 * time.Second,
+		RestoreReadyTimeout:     2 * time.Second,
+		DrainTimeout:            110 * time.Second,
+		EgressSidecarAddr:       getenvDefault("EMBERVM_NODED_EGRESS_SIDECAR_ADDR", "127.0.0.1:8888"),
+		EgressEnabled:           boolDefault("EMBERVM_NODED_EGRESS_ENABLED", false),
+		EgressWorkloads:         csvDefault("EMBERVM_NODED_EGRESS_WORKLOADS"),
+		ArchiveFetchTimeout:     60 * time.Second,
+		ArchiveMaxBytes:         512 << 20,
 
 		PodIP: os.Getenv("EMBERVM_NODED_POD_IP"),
 		// Dial-home registration (R0 PR-2): the daemon advertises its identity to
@@ -554,6 +570,18 @@ func Load() (Config, error) {
 	if err := parseDuration("EMBERVM_NODED_REGISTER_INTERVAL", &c.RegisterInterval); err != nil {
 		return Config{}, err
 	}
+	if err := parseDuration("EMBERVM_NODED_WARMTH_HEARTBEAT_INTERVAL", &c.WarmthHeartbeatInterval); err != nil {
+		return Config{}, err
+	}
+	if err := parseDuration("EMBERVM_NODED_WARMTH_STALE_AFTER", &c.WarmthStaleAfter); err != nil {
+		return Config{}, err
+	}
+	if c.WarmthHeartbeatInterval <= 0 {
+		return Config{}, fmt.Errorf("EMBERVM_NODED_WARMTH_HEARTBEAT_INTERVAL must be greater than zero, got %s", c.WarmthHeartbeatInterval)
+	}
+	if c.WarmthStaleAfter <= c.WarmthHeartbeatInterval {
+		return Config{}, fmt.Errorf("EMBERVM_NODED_WARMTH_STALE_AFTER must be greater than EMBERVM_NODED_WARMTH_HEARTBEAT_INTERVAL (%s <= %s)", c.WarmthStaleAfter, c.WarmthHeartbeatInterval)
+	}
 	if v := os.Getenv("EMBERVM_NODED_ARCHIVE_MAX_BYTES"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
@@ -598,11 +626,61 @@ func parsePortRange(raw string) ([2]uint32, error) {
 	return [2]uint32{uint32(lo), uint32(hi)}, nil
 }
 
-// PruneStaleInstanceWarmth removes per-instance (brick) warmth directories under
-// SnapshotRoot/i/ that do NOT belong to this daemon's own pod UID, reclaiming the
-// regenerable snapshot state left behind by evicted or rolled-out co-located
-// bricks (nothing GCs dead-instance warmth today, so orphan dirs accumulate).
-// It is deliberately narrow and fail-soft:
+// InstanceWarmthPruneResult reports the outcome of a startup warmth GC pass.
+type InstanceWarmthPruneResult struct {
+	Removed          []string
+	SkippedLive      []string
+	SkippedUnclaimed []string
+}
+
+// WriteInstanceHeartbeat atomically writes this brick's ownership claim at
+// SnapshotRoot/i/<ownSegment>/.alive. The file contains the full pod UID and the
+// supplied RFC3339 timestamp, while its mtime is the liveness authority used by
+// PruneStaleInstanceWarmth. It is a no-op for a non-brick configuration.
+func WriteInstanceHeartbeat(c Config, now time.Time) error {
+	if c.SnapshotRoot == "" || c.SizeClass == "" || c.PodUID == "" {
+		return nil
+	}
+
+	segmentDir := filepath.Join(c.SnapshotRoot, InstanceWarmthSubdir, instanceSegment(c.PodUID))
+	if err := os.MkdirAll(segmentDir, 0o750); err != nil {
+		return fmt.Errorf("create instance warmth directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(segmentDir, ".alive.tmp-")
+	if err != nil {
+		return fmt.Errorf("create temporary instance heartbeat: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	contents := c.PodUID + "\n" + now.UTC().Format(time.RFC3339) + "\n"
+	if _, err := tmp.WriteString(contents); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temporary instance heartbeat: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary instance heartbeat: %w", err)
+	}
+	alivePath := filepath.Join(segmentDir, ".alive")
+	if err := os.Rename(tmpPath, alivePath); err != nil {
+		return fmt.Errorf("publish instance heartbeat: %w", err)
+	}
+	// Rename preserves the temporary file's mtime rather than setting it to now.
+	// Pin the published file to the caller's clock so pruning and tests use the
+	// same liveness instant.
+	if err := os.Chtimes(alivePath, now, now); err != nil {
+		return fmt.Errorf("set instance heartbeat mtime: %w", err)
+	}
+	return nil
+}
+
+// PruneStaleInstanceWarmth removes only foreign per-instance warmth directories
+// under SnapshotRoot/i/ whose .alive claim is older than WarmthStaleAfter. A
+// fresh claim is a live sibling and is never touched. A directory with no claim
+// is skipped unless ReapUnclaimedWarmth is enabled, which is the guarded
+// transition path for warmth created by pre-heartbeat daemons.
+//
+// The sweep is deliberately narrow and fail-soft:
 //
 //   - It ONLY touches SnapshotRoot/i/<segment> entries. It never removes bases/
 //     (node-shared rootfs snapshots), the VolumeRoot (durable data, a separate
@@ -611,14 +689,16 @@ func parsePortRange(raw string) ([2]uint32, error) {
 //     both set): the legacy DaemonSet's warmth is flat at SnapshotRoot with no
 //     i/ subtree to sweep, so there is nothing (and nothing safe) to prune.
 //   - A missing i/ directory, an unreadable entry, or a failed removal is logged
-//     via removeErr (if non-nil) and skipped, never fatal: warmth is regenerable,
-//     so a boot must not block on a GC hiccup.
+//     via removeErr (if non-nil) and skipped, never fatal: a GC hiccup must not
+//     block boot, and preserving extra warmth is the safe failure mode.
 //
-// It returns the list of segments it removed (for logging/tests). removeErr, when
-// non-nil, is called once per entry that could not be removed.
-func PruneStaleInstanceWarmth(c Config, removeErr func(segment string, err error)) []string {
+// It returns removed, live, and unclaimed segment lists for logging and tests.
+// removeErr, when non-nil, is called once per entry that could not be inspected
+// or removed.
+func PruneStaleInstanceWarmth(c Config, now time.Time, removeErr func(segment string, err error)) InstanceWarmthPruneResult {
+	var result InstanceWarmthPruneResult
 	if c.SnapshotRoot == "" || c.SizeClass == "" || c.PodUID == "" {
-		return nil
+		return result
 	}
 	instancesDir := filepath.Join(c.SnapshotRoot, InstanceWarmthSubdir)
 	entries, err := os.ReadDir(instancesDir)
@@ -629,23 +709,39 @@ func PruneStaleInstanceWarmth(c Config, removeErr func(segment string, err error
 		if !os.IsNotExist(err) && removeErr != nil {
 			removeErr("", err)
 		}
-		return nil
+		return result
 	}
 	ownSegment := instanceSegment(c.PodUID)
-	var removed []string
 	for _, e := range entries {
 		if e.Name() == ownSegment {
 			continue // never reap our own live warmth
 		}
-		if err := os.RemoveAll(filepath.Join(instancesDir, e.Name())); err != nil {
+		segmentPath := filepath.Join(instancesDir, e.Name())
+		aliveInfo, err := os.Stat(filepath.Join(segmentPath, ".alive"))
+		if err != nil {
+			if !os.IsNotExist(err) {
+				if removeErr != nil {
+					removeErr(e.Name(), fmt.Errorf("inspect heartbeat: %w", err))
+				}
+				continue
+			}
+			if !c.ReapUnclaimedWarmth {
+				result.SkippedUnclaimed = append(result.SkippedUnclaimed, e.Name())
+				continue
+			}
+		} else if now.Sub(aliveInfo.ModTime()) <= c.WarmthStaleAfter {
+			result.SkippedLive = append(result.SkippedLive, e.Name())
+			continue
+		}
+		if err := os.RemoveAll(segmentPath); err != nil {
 			if removeErr != nil {
 				removeErr(e.Name(), err)
 			}
 			continue
 		}
-		removed = append(removed, e.Name())
+		result.Removed = append(result.Removed, e.Name())
 	}
-	return removed
+	return result
 }
 
 // InstanceWarmthSubdir is the single-letter parent directory under SnapshotRoot

--- a/projects/embervm/noded/config/config_test.go
+++ b/projects/embervm/noded/config/config_test.go
@@ -264,6 +264,8 @@ func TestLoadDefaults(t *testing.T) {
 		"EMBERVM_NODED_MAX_LIVE_VMS", "EMBERVM_NODED_IMAGES", "EMBERVM_NODED_IMAGES_FILE",
 		"EMBERVM_NODED_BOOT_READY_TIMEOUT", "EMBERVM_NODED_RESTORE_READY_TIMEOUT",
 		"EMBERVM_NODED_DRAIN_TIMEOUT", "EMBERVM_NODED_DIFF_BANKING", "EMBERVM_NODED_DIFF_BANKING_WORKLOADS",
+		"EMBERVM_NODED_WARMTH_HEARTBEAT_INTERVAL", "EMBERVM_NODED_WARMTH_STALE_AFTER",
+		"EMBERVM_NODED_REAP_UNCLAIMED_WARMTH",
 	} {
 		t.Setenv(k, "")
 	}
@@ -283,6 +285,15 @@ func TestLoadDefaults(t *testing.T) {
 	}
 	if c.DiffBanking {
 		t.Error("DiffBanking should default false")
+	}
+	if c.WarmthHeartbeatInterval != 30*time.Second {
+		t.Errorf("WarmthHeartbeatInterval = %s, want 30s", c.WarmthHeartbeatInterval)
+	}
+	if c.WarmthStaleAfter != 10*time.Minute {
+		t.Errorf("WarmthStaleAfter = %s, want 10m", c.WarmthStaleAfter)
+	}
+	if c.ReapUnclaimedWarmth {
+		t.Error("ReapUnclaimedWarmth should default false")
 	}
 	if c.BinPath != "/opt/fc/firecracker" {
 		t.Errorf("BinPath = %q, want /opt/fc/firecracker", c.BinPath)
@@ -569,42 +580,125 @@ func TestWorstCaseSocketPathUnderSunLen(t *testing.T) {
 	t.Logf("worst-case brick socket path is %d bytes: %q", len(worst), worst)
 }
 
-// TestPruneStaleInstanceWarmth proves the startup GC reaps orphan per-instance
-// warmth (other pods' i/<seg> dirs) while never touching our own segment, bases/,
-// or anything outside i/; and that it is a no-op for the legacy DaemonSet.
+// TestPruneStaleInstanceWarmth proves startup GC uses checked liveness claims,
+// never a foreign path pattern alone, to decide which brick warmth to reap.
 func TestPruneStaleInstanceWarmth(t *testing.T) {
 	const ownUID = "a1b2c3d4-e5f6-4788-9abc-def012345678"
 	ownSeg := instanceSegment(ownUID)
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
 
-	t.Run("brick reaps other segments, keeps own and bases", func(t *testing.T) {
+	setup := func(t *testing.T) (string, Config) {
+		t.Helper()
 		root := t.TempDir()
-		instancesDir := filepath.Join(root, InstanceWarmthSubdir)
-		mkdir := func(p string) {
-			if err := os.MkdirAll(p, 0o750); err != nil {
-				t.Fatal(err)
-			}
+		c := Config{
+			SnapshotRoot:     root,
+			SizeClass:        "8gi",
+			PodUID:           ownUID,
+			WarmthStaleAfter: 10 * time.Minute,
 		}
-		mkdir(filepath.Join(instancesDir, ownSeg))
-		mkdir(filepath.Join(instancesDir, "deadbeef0000")) // orphan
-		mkdir(filepath.Join(instancesDir, "cafef00d1111")) // orphan
-		basesDir := filepath.Join(root, "bases", "somekey")
-		mkdir(basesDir)
+		return root, c
+	}
+	mkdirSegment := func(t *testing.T, root, segment string) string {
+		t.Helper()
+		path := filepath.Join(root, InstanceWarmthSubdir, segment)
+		if err := os.MkdirAll(path, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	writeAlive := func(t *testing.T, segmentPath string, heartbeat time.Time) {
+		t.Helper()
+		path := filepath.Join(segmentPath, ".alive")
+		if err := os.WriteFile(path, []byte("foreign-pod-uid\n"+heartbeat.Format(time.RFC3339)+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, heartbeat, heartbeat); err != nil {
+			t.Fatal(err)
+		}
+	}
 
-		c := Config{SnapshotRoot: root, SizeClass: "8gi", PodUID: ownUID}
-		removed := PruneStaleInstanceWarmth(c, func(seg string, err error) {
+	t.Run("fresh sibling is live", func(t *testing.T) {
+		root, c := setup(t)
+		segment := "49c0376d0900"
+		segmentPath := mkdirSegment(t, root, segment)
+		writeAlive(t, segmentPath, now.Add(-time.Minute))
+
+		result := PruneStaleInstanceWarmth(c, now, func(seg string, err error) {
 			t.Errorf("unexpected removeErr(%q, %v)", seg, err)
 		})
-		if len(removed) != 2 {
-			t.Errorf("removed = %v, want 2 orphans", removed)
+		if len(result.SkippedLive) != 1 || result.SkippedLive[0] != segment {
+			t.Errorf("SkippedLive = %v, want [%s]", result.SkippedLive, segment)
 		}
-		if _, err := os.Stat(filepath.Join(instancesDir, ownSeg)); err != nil {
+		if len(result.Removed) != 0 {
+			t.Errorf("Removed = %v, want none", result.Removed)
+		}
+		if _, err := os.Stat(segmentPath); err != nil {
+			t.Errorf("fresh sibling warmth must survive: %v", err)
+		}
+	})
+
+	t.Run("stale sibling is removed", func(t *testing.T) {
+		root, c := setup(t)
+		segment := "deadbeef0000"
+		segmentPath := mkdirSegment(t, root, segment)
+		writeAlive(t, segmentPath, now.Add(-11*time.Minute))
+
+		result := PruneStaleInstanceWarmth(c, now, nil)
+		if len(result.Removed) != 1 || result.Removed[0] != segment {
+			t.Errorf("Removed = %v, want [%s]", result.Removed, segment)
+		}
+		if _, err := os.Stat(segmentPath); !os.IsNotExist(err) {
+			t.Errorf("stale sibling warmth should be gone, stat err = %v", err)
+		}
+	})
+
+	t.Run("unclaimed sibling is skipped by default", func(t *testing.T) {
+		root, c := setup(t)
+		segment := "cafef00d1111"
+		segmentPath := mkdirSegment(t, root, segment)
+
+		result := PruneStaleInstanceWarmth(c, now, nil)
+		if len(result.SkippedUnclaimed) != 1 || result.SkippedUnclaimed[0] != segment {
+			t.Errorf("SkippedUnclaimed = %v, want [%s]", result.SkippedUnclaimed, segment)
+		}
+		if _, err := os.Stat(segmentPath); err != nil {
+			t.Errorf("unclaimed warmth must survive while guard is off: %v", err)
+		}
+	})
+
+	t.Run("unclaimed sibling is removed when enabled", func(t *testing.T) {
+		root, c := setup(t)
+		c.ReapUnclaimedWarmth = true
+		segment := "cafef00d1111"
+		segmentPath := mkdirSegment(t, root, segment)
+
+		result := PruneStaleInstanceWarmth(c, now, nil)
+		if len(result.Removed) != 1 || result.Removed[0] != segment {
+			t.Errorf("Removed = %v, want [%s]", result.Removed, segment)
+		}
+		if _, err := os.Stat(segmentPath); !os.IsNotExist(err) {
+			t.Errorf("enabled guard should reap unclaimed warmth, stat err = %v", err)
+		}
+	})
+
+	t.Run("own stale claim and shared bases are never touched", func(t *testing.T) {
+		root, c := setup(t)
+		ownPath := mkdirSegment(t, root, ownSeg)
+		writeAlive(t, ownPath, now.Add(-24*time.Hour))
+		basesDir := filepath.Join(root, "bases", "somekey")
+		if err := os.MkdirAll(basesDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+
+		result := PruneStaleInstanceWarmth(c, now, nil)
+		if len(result.Removed) != 0 {
+			t.Errorf("Removed = %v, want none", result.Removed)
+		}
+		if _, err := os.Stat(ownPath); err != nil {
 			t.Errorf("own segment must survive GC: %v", err)
 		}
 		if _, err := os.Stat(basesDir); err != nil {
-			t.Errorf("bases/ must NEVER be touched by GC: %v", err)
-		}
-		if _, err := os.Stat(filepath.Join(instancesDir, "deadbeef0000")); !os.IsNotExist(err) {
-			t.Errorf("orphan segment should be gone, stat err = %v", err)
+			t.Errorf("bases/ must never be touched by GC: %v", err)
 		}
 	})
 
@@ -615,8 +709,8 @@ func TestPruneStaleInstanceWarmth(t *testing.T) {
 			t.Fatal(err)
 		}
 		c := Config{SnapshotRoot: root, SizeClass: "", PodUID: ownUID}
-		if removed := PruneStaleInstanceWarmth(c, nil); removed != nil {
-			t.Errorf("legacy DS GC removed %v, want nil", removed)
+		if result := PruneStaleInstanceWarmth(c, now, nil); len(result.Removed) != 0 {
+			t.Errorf("legacy DS GC removed %v, want none", result.Removed)
 		}
 		if _, err := os.Stat(filepath.Join(root, InstanceWarmthSubdir, "deadbeef0000")); err != nil {
 			t.Errorf("non-brick must not touch i/: %v", err)
@@ -624,12 +718,87 @@ func TestPruneStaleInstanceWarmth(t *testing.T) {
 	})
 
 	t.Run("missing i/ dir is not an error", func(t *testing.T) {
-		root := t.TempDir()
-		c := Config{SnapshotRoot: root, SizeClass: "8gi", PodUID: ownUID}
-		if removed := PruneStaleInstanceWarmth(c, func(seg string, err error) {
+		_, c := setup(t)
+		result := PruneStaleInstanceWarmth(c, now, func(seg string, err error) {
 			t.Errorf("unexpected removeErr(%q, %v) for missing dir", seg, err)
-		}); removed != nil {
-			t.Errorf("removed = %v, want nil for missing i/", removed)
+		})
+		if len(result.Removed) != 0 || len(result.SkippedLive) != 0 || len(result.SkippedUnclaimed) != 0 {
+			t.Errorf("result = %+v, want empty for missing i/", result)
 		}
 	})
+}
+
+func TestWriteInstanceHeartbeat(t *testing.T) {
+	root := t.TempDir()
+	c := Config{
+		SnapshotRoot: root,
+		SizeClass:    "8gi",
+		PodUID:       "a1b2c3d4-e5f6-4788-9abc-def012345678",
+	}
+	first := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	second := first.Add(30 * time.Second)
+	path := filepath.Join(root, InstanceWarmthSubdir, instanceSegment(c.PodUID), ".alive")
+
+	if err := WriteInstanceHeartbeat(c, first); err != nil {
+		t.Fatal(err)
+	}
+	firstInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("heartbeat was not created: %v", err)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantContents := c.PodUID + "\n" + first.Format(time.RFC3339) + "\n"
+	if string(contents) != wantContents {
+		t.Errorf("heartbeat contents = %q, want %q", contents, wantContents)
+	}
+
+	if err := WriteInstanceHeartbeat(c, second); err != nil {
+		t.Fatal(err)
+	}
+	secondInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !secondInfo.ModTime().After(firstInfo.ModTime()) {
+		t.Errorf("second mtime = %s, want after %s", secondInfo.ModTime(), firstInfo.ModTime())
+	}
+}
+
+func TestLoadRejectsWarmthStaleAfterAtOrBelowHeartbeatInterval(t *testing.T) {
+	t.Setenv("EMBERVM_NODED_WARMTH_HEARTBEAT_INTERVAL", "30s")
+	t.Setenv("EMBERVM_NODED_WARMTH_STALE_AFTER", "30s")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load should reject warmth staleAfter <= heartbeat interval")
+	}
+}
+
+func TestLoadWarmthHeartbeatConfig(t *testing.T) {
+	t.Setenv("EMBERVM_NODED_WARMTH_HEARTBEAT_INTERVAL", "45s")
+	t.Setenv("EMBERVM_NODED_WARMTH_STALE_AFTER", "15m")
+	t.Setenv("EMBERVM_NODED_REAP_UNCLAIMED_WARMTH", "1")
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.WarmthHeartbeatInterval != 45*time.Second {
+		t.Errorf("WarmthHeartbeatInterval = %s, want 45s", c.WarmthHeartbeatInterval)
+	}
+	if c.WarmthStaleAfter != 15*time.Minute {
+		t.Errorf("WarmthStaleAfter = %s, want 15m", c.WarmthStaleAfter)
+	}
+	if !c.ReapUnclaimedWarmth {
+		t.Error("ReapUnclaimedWarmth = false, want true for exact value 1")
+	}
+
+	t.Setenv("EMBERVM_NODED_REAP_UNCLAIMED_WARMTH", "true")
+	c, err = Load()
+	if err != nil {
+		t.Fatalf("Load with non-1 transition guard: %v", err)
+	}
+	if c.ReapUnclaimedWarmth {
+		t.Error("ReapUnclaimedWarmth = true for value true, want exact-value-1 parsing")
+	}
 }


### PR DESCRIPTION
Refs #4962 (stays open for the `reapUnclaimed` flip once every brick heartbeats).

A brick writes `i/<segment>/.alive` before its startup prune and refreshes it every 30s; the prune reaps only foreign claims older than 600s, counts fresh claims as live siblings, and leaves unclaimed (pre-heartbeat) segments alone unless `noded.warmthHeartbeat.reapUnclaimed` is on (default off, the transition guard). A brick that cannot write its own claim does not boot.

`ci`: Bazel 735 pass (config tests cover live/stale/unclaimed/own-segment and the interval-vs-staleAfter guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP