### PR TITLE
test(embervm): make the recurring Elixir suite flakes deterministic

### DIFF
--- a/projects/embervm/control/test/embervm/drain_coordinator_test.exs
+++ b/projects/embervm/control/test/embervm/drain_coordinator_test.exs
@@ -86,13 +86,17 @@ defmodule Embervm.DrainCoordinatorTest do
 
     send(pid, {:node_draining, "node-4", 0})
 
-    # The three healthy classes still drain despite the session sweeper raising.
-    assert_receive {:drained, :stateful, "node-4"}
-    assert_receive {:drained, :group, "node-4"}
-    assert_receive {:drained, :serving, "node-4"}
+    # The finished op is the deterministic completion signal for the sequential
+    # fan-out. Give only that signal a scheduler budget (#4078), then inspect the
+    # messages that necessarily preceded it without further wall-clock waits.
+    assert_receive {:op, :node_drain_finished, finished}, 2_000
+    assert_received {:op, :node_drain_started, _started}
+    assert_received {:drained, :stateful, "node-4"}
+    assert_received {:drained, :group, "node-4"}
+    assert_received {:drained, :serving, "node-4"}
+    refute_received {:drained, :session, "node-4"}
 
-    # The finished op still lands, with the failed class counted as 0.
-    assert_receive {:op, :node_drain_finished, finished}
+    # The failed class is counted as 0.
     assert finished.session == 0
     # The coordinator itself did not crash.
     assert Process.alive?(pid)

--- a/projects/embervm/control/test/embervm/node_channel_test.exs
+++ b/projects/embervm/control/test/embervm/node_channel_test.exs
@@ -41,17 +41,9 @@ defmodule Embervm.NodeChannelTest do
         disconnect_fun: fn _ -> :ok end
       )
 
-    # start_link/1 links the GenServer to this test process, so it may already
-    # be torn down (by the link, concurrently with on_exit) by the time this
-    # callback runs; tolerate an already-stopped process instead of racing an
-    # alive?-then-stop check against it.
-    on_exit(fn ->
-      try do
-        GenServer.stop(pid)
-      catch
-        :exit, _ -> :ok
-      end
-    end)
+    # start_link/1 links the GenServer to this test process, so #4078 teardown
+    # uses the shared helper when the process has already exited.
+    on_exit(fn -> Embervm.TestProcess.stop_safely(pid) end)
 
     pid
   end

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -587,6 +587,15 @@ defmodule Embervm.NodeRegistryTest do
     end
   end
 
+  # #4078 expiry seam: keep the streamer alive without yielding a NodeStatus.
+  # The test can then make status silence cross :down solely by advancing its
+  # injected clock, with no asynchronous emit left to restamp last_status_at.
+  defp silent_watch do
+    fn _ch, _node_id, _emit ->
+      receive do: (:never -> {:ok, :closed})
+    end
+  end
+
   defp register_seams(opts) do
     Keyword.merge(
       [
@@ -759,6 +768,7 @@ defmodule Embervm.NodeRegistryTest do
       start_registry(
         register_seams(
           clock: clock,
+          watch_fun: silent_watch(),
           channel_remover_fun: fn key -> Agent.update(removed, &[key | &1]) end,
           age_check_ms: 60_000,
           unknown_after_ms: 5_000,
@@ -768,10 +778,9 @@ defmodule Embervm.NodeRegistryTest do
       )
 
     :ok = NodeRegistry.register(reg, %{"node" => "node-4", "pod_uid" => "uid-1", "address" => "10.0.0.1:9090"})
-    await_initial_status(reg, "node-4/uid-1")
 
     # Drive both expiry signals: registration lapses (advance past expire_after) AND
-    # the stream goes dead (advance past down_after with no fresh status).
+    # the stream goes dead (advance past down_after while silent_watch emits no status).
     advance.(100_000)
     :ok = NodeRegistry.tick(reg)
 

--- a/projects/embervm/control/test/embervm/op_log/postgres_live_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/postgres_live_test.exs
@@ -44,7 +44,8 @@ defmodule Embervm.OpLog.PostgresLiveTest do
       Embervm.TestProcess.stop_safely(server)
       {:ok, cleanup_conn} = Postgrex.start_link(Keyword.put(opts, :name, nil))
       {:ok, _} = Postgrex.query(cleanup_conn, ~s(DROP SCHEMA "#{schema}" CASCADE), [])
-      GenServer.stop(cleanup_conn)
+      # Keep every on_exit stop on the race-safe #4078 path.
+      Embervm.TestProcess.stop_safely(cleanup_conn)
     end)
 
     %{server: server}


### PR DESCRIPTION
Refs #4078 (leave open until a week passes with no `mix_test_smoke` flake on an unrelated PR).

- Expiry test: the late `updated_at` producer was the test's own `blocking_watch` emitting an initial NodeStatus after the clock advance. New `silent_watch` seam; the `refute` stays; no production change.
- Drain coordinator: one bounded wait on the deterministic `:node_drain_finished` op, then `assert_received` on what preceded it.
- Remaining `on_exit` raw stops use `stop_safely/1` (tcp_activator keeps its bounded-timeout form on purpose).

`ci`: 1357 Elixir tests 0 failures; Bazel 737 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP