### PR TITLE
fix(embervm): unnest the brick controller env from the serving lane and arm dev's warmth GC

### DIFF
--- a/projects/embervm/chart/chart_env_identity_test.py
+++ b/projects/embervm/chart/chart_env_identity_test.py
@@ -175,6 +175,33 @@ def test_renders_are_non_empty(renders):
     )
 
 
+def test_dev_brick_controller_and_warmth_gc_envs_render(renders):
+    def control_plane_env(rendered: str) -> dict[str, str]:
+        deployments = [
+            doc
+            for kind, _, doc in _docs(rendered)
+            if kind == "Deployment"
+            and re.search(r"^\s+- name: control-plane\s*$", doc, re.M)
+        ]
+        assert len(deployments) == 1, (
+            f"expected one control-plane Deployment, found {len(deployments)}"
+        )
+        return dict(
+            re.findall(
+                r'^\s+- name: (EMBERVM_[A-Z0-9_]+)\s*\n\s+value: "([^"]*)"\s*$',
+                deployments[0],
+                re.M,
+            )
+        )
+
+    prod_env = control_plane_env(renders["prod"])
+    dev_env = control_plane_env(renders["dev"])
+
+    assert "EMBERVM_BRICK_AUTOSCALE_MODE" in prod_env
+    assert dev_env.get("EMBERVM_BRICK_AUTOSCALE_MODE") == "observe"
+    assert dev_env.get("EMBERVM_WARMTH_S3_GC_EXPECTED_NODES") == "node-4"
+
+
 def test_noded_bearer_secret_flips_control_plane_and_bricks_together():
     chart = _chart_dir()
     enabled = _render(

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -296,6 +296,9 @@ spec:
               value: "{{ .Values.servingEnvoy.compositeTcpPortRange.start }}-{{ .Values.servingEnvoy.compositeTcpPortRange.end }}"
             - name: EMBERVM_MAX_GROUP_SIZE
               value: {{ .Values.servingEnvoy.maxGroupSize | quote }}
+            {{- end }}
+            {{- end }}
+            {{- /* #4948: Brick controller config is independent of servingEnvoy and xDS. */}}
             {{- if .Values.bricks.enabled }}
             # Brick capacity (PR-3): the per-size-class DESIRED replica counts the
             # Embervm.BrickController reconciles the brick Deployments to, as a JSON
@@ -327,6 +330,8 @@ spec:
             - name: EMBERVM_BRICK_AUTOSCALE_MODE
               value: {{ $auto.mode | default "off" | quote }}
             {{- end }}
+            {{- if .Values.xds.enabled }}
+            {{- if .Values.servingEnvoy.enabled }}
             # The R5 composite (group) TCP activator port range: the values-declared
             # range the activator physically binds on the pod (Task 7), so the node
             # Envoy's group tcp_proxy fallback dials podIP:<listenPort>. Same range as

--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -213,12 +213,16 @@ baseRetention:
 warmthRetention:
   sweepEnabled: "1"
 
-# S3-direct warmth GC stays disabled here, and not for symmetry: arming it also
-# needs warmthS3Gc.expectedNodes naming dev's fleet, because an empty fleet
-# contract makes every sweep abort on the freshness check, dry run included.
-# Arming the flag alone would render config that silently never acts.
+# #4952: S3-direct warmth GC is armed against dev's own embervm-dev bucket.
+# expectedNodes names dev's entire one-node fleet so the freshness contract can
+# pass. The per-sweep caps are a quarter of production for a quarter of the
+# fleet. Rollback is setting enabled back to "".
 warmthS3Gc:
-  enabled: ""
+  enabled: "1"
+  expectedNodes:
+    - node-4
+  maxPrefixes: "50"
+  maxBytes: "26843545600" # 25 GiB
 
 # Tracing: reuse production endpoint (if available).
 tracing:


### PR DESCRIPTION
Closes #4948, #4952. #4949's remaining half (stateful in dev) is recorded on that issue as a scope fork.

- The brick controller env block now renders under its own `bricks.enabled` guard instead of inside `servingEnvoy.enabled`. Production's `helm template` output is byte-identical before and after (verified by diff against `origin/main`'s chart); dev now renders `EMBERVM_BRICK_AUTOSCALE_MODE=observe`.
- Dev arms `warmthS3Gc` with `expectedNodes: [node-4]` and caps at a quarter of production, against the `embervm-dev` bucket.

Post-merge verification on the issues: dev BrickController observe-mode log noise, and a dry-run GC manifest actually landing in `embervm-dev`.

`ci`: Bazel 739 pass (new render assertions included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP