### PR TITLE
chore(embervm): reap unclaimed pre-heartbeat warmth in production

### DIFF
--- a/projects/embervm/chart/chart_env_identity_test.py
+++ b/projects/embervm/chart/chart_env_identity_test.py
@@ -463,14 +463,23 @@ def test_noded_bucket_path_configuration(renders):
     )
 
 
-def test_brick_renders_default_warmth_heartbeat_env(renders):
-    """Brick Deployments claim warmth with safe transition defaults."""
+def test_brick_renders_default_warmth_heartbeat_env():
+    """Brick Deployments claim warmth with safe transition defaults.
+
+    Rendered from the chart defaults, not production: production flipped
+    reapUnclaimed on once every brick heartbeated (#4962), and the default
+    is what a fresh environment inherits.
+    """
+    chart = _chart_dir()
+    rendered = _render("warmth", [chart / "values.yaml"], ["bricks.enabled=true"])
     brick_deployments = [
         doc
-        for kind, _, doc in _docs(renders["prod"])
+        for kind, _, doc in _docs(rendered)
         if kind == "Deployment" and "app.kubernetes.io/component: noded-brick" in doc
     ]
-    assert brick_deployments, "production rendered no brick Deployment; test is inert"
+    assert brick_deployments, (
+        "default render produced no brick Deployment; test is inert"
+    )
 
     expected = {
         "EMBERVM_NODED_WARMTH_HEARTBEAT_INTERVAL": "30s",

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -132,6 +132,12 @@ tracing:
 # ~1.5Gi/VM that is ~24Gi worst case, well within budget. This only raises the
 # runaway backstop, not any pool floor.
 noded:
+  # Warmth ownership transition guard (#4962). Every brick on the fleet writes
+  # its .alive claim as of chart 0.26.0 (verified on the 2026-08-22 06:44 roll),
+  # so unclaimed pre-heartbeat directories are dead and may be reaped. After
+  # this, startup GC only ever removes a claim older than staleAfterSeconds.
+  warmthHeartbeat:
+    reapUnclaimed: true
   # WILDCARD DAEMONSET DEPRECATED (bricks-only migration). The per-node wildcard
   # noded DaemonSet is retired: node capacity is now provided entirely by the
   # size-class brick Deployments the BrickController autoscales (bricks.autoscale


### PR DESCRIPTION
Closes #4962. Values-only flip of the transition guard shipped in #5054, after verifying on the 0.26.0 roll that every brick heartbeats (log evidence on the issue). Renders all six bricks with `EMBERVM_NODED_REAP_UNCLAIMED_WARMTH="1"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP