### PR TITLE
fix(embervm): give pi-runtime a workspace volume so qwen sessions can hydrate a repo

### DIFF
--- a/projects/embervm/chart/templates/workload-pi-runtime.yaml
+++ b/projects/embervm/chart/templates/workload-pi-runtime.yaml
@@ -13,11 +13,13 @@
 # allowlist reaches the in-cluster vLLM endpoint through nothing at all and the
 # turn dies as a dial timeout with no denial logged anywhere useful.
 #
-# persistence is deliberately absent rather than set false: at 256 MiB this
-# workload uses the ADR 027 memory:true quadrant (bank a memory snapshot when
-# idle, relight on the next invoke), which is what the CRD means by no
-# persistence block. See piRuntimeWorkload in values.yaml for why the volume
-# quadrant is not worth its coupling at this size.
+# persistenceEnabled selects the quadrant (ADR 027). OFF renders no block, the
+# memory:true quadrant: an idle session banks a memory snapshot and relights.
+# ON mirrors claude-runtime: a writable volume under /session that survives
+# parking, and the ONLY place a repo checkout can live. Without it /workspace
+# is the guest tmpfs and a `git clone` of the homelab dies with "Out of
+# diskspace" while resolving deltas (#5051, every repo-attached qwen session
+# since the lane moved here on 2026-08-16). Deploy sets it true.
 apiVersion: embervm.dev/v1alpha1
 kind: Workload
 metadata:
@@ -30,6 +32,15 @@ metadata:
     {{- include "embervm.labels" . | nindent 4 }}
 spec:
   class: session
+  {{- if .Values.piRuntimeWorkload.persistenceEnabled }}
+  persistence:
+    memory: false
+    filesystem:
+      enabled: true
+      retention: 1
+      sizeBytes: {{ .Values.piRuntimeWorkload.workspaceSizeBytes }}
+      mountPath: /session
+  {{- end }}
   source:
     image:
       # Bazel-pinned from the runtime-pi guest image's .info provider, the same

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1685,7 +1685,8 @@ claudeRuntimeWorkload:
 # short conversational turns, not repo-attached work. A repo-attached qwen
 # session belongs on claude-runtime until this workload is given a volume.
 # Raising it is a values-only change; the honest ladder is 256 -> 512 -> a
-# persistenceEnabled flip with a workspaceSizeBytes, in that order.
+# persistenceEnabled flip with a workspaceSizeBytes, in that order. Deploy has
+# taken the last rung (#5051): the template wires both keys.
 piRuntimeWorkload:
   enabled: false
   name: pi-runtime
@@ -1712,6 +1713,10 @@ piRuntimeWorkload:
   # volume drive coupling (warmRestoreWithVolumeClasses plus a base epoch, which
   # MUST move together) that the claude runtime carries.
   persistenceEnabled: false
+  # 4 GiB per lineage when persistence is on: a blob:none clone of the homelab
+  # plus the working tree and pi's session files, well under claude-runtime's
+  # 10 GiB because this guest never builds.
+  workspaceSizeBytes: 4294967296
   # floor 0 for the same reason claude-runtime uses it, and more so: the floor is
   # applied PER BRICK INSTANCE, and a cold spawn to first request is ~250ms
   # against a model API leg measured in seconds. Warmth would buy a few percent

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -688,6 +688,14 @@ claudeRuntimeWorkload:
 # The follow-up that routes model=qwen here is a monolith-side change.
 piRuntimeWorkload:
   enabled: true
+  # Volume quadrant, same as claude-runtime: a repo-attached qwen session has
+  # to clone somewhere that is not the 256 MiB tmpfs. Every repo session on
+  # this lane failed at hydration with "Out of diskspace" from 2026-08-16 until
+  # this flip (#5051). 4 GiB lineage from the chart default.
+  persistenceEnabled: true
+  # 512 MiB: git index-pack over 88k objects plus the pi heap no longer shares
+  # RAM with the checkout, but 256 MiB left no headroom for the clone itself.
+  memMib: 512
 
 # SpecTrace gate for spec validation (GitHub issue #4770). Debug-gated, spec-shaped
 # trace that validates TLA+ specs against real behaviour. Deliberately OFF in production.


### PR DESCRIPTION
## Why

Every repo-attached qwen session since the lane moved to pi-runtime on 2026-08-16 (monolith sessions 200, 201, 206 to 211) failed at hydration. The guest clones the homelab over the egress lane fine, then dies with:

```
fatal: sha1 file '/workspace/src/.git/objects/pack/tmp_idx_nzzC9h' write error. Out of diskspace
```

because with no persistence block `/workspace` is the guest tmpfs inside a 256 MiB VM. The shim then 503s the invoke with `workspace does not exist: /workspace/src` (brick `embervm-noded-brick-2gi-node-1`, 06:50Z today).

The chart comment already prescribed the ladder (256 -> 512 -> a persistenceEnabled flip with a workspaceSizeBytes), but `workload-pi-runtime.yaml` never read either key, so the values flip alone would have been inert.

## What

- `workload-pi-runtime.yaml`: render the same `persistence.filesystem` block claude-runtime has, gated on `piRuntimeWorkload.persistenceEnabled`.
- chart values: `workspaceSizeBytes: 4 GiB` default, comment updated.
- deploy values: `persistenceEnabled: true`, `memMib: 512`.

Placeholder volume drives are attached to every base on armed bricks (`driver.go` `WarmRestoreWithVolume`), and the 2gi class is armed, so existing pi-runtime bases can take the real volume at restore without an epoch bump.

## Verification

- `helm template` renders the block (float `sizeBytes` form identical to claude-runtime's accepted shape).
- `ci`: `Executed 6 out of 739 tests: 739 tests pass`.
- Post-merge: Kargo promotes embervm; I will rerun the #5051 probe on `bench/null-content-fix-01` and confirm hydration lands.

Refs #5051 (cycle 0: the long probe set could not run at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WcU1F22ysoi1WhEtpGAo3