### PR TITLE
fix(embervm): keep a restored session guest ready after the volume mount hides its workspace

### DIFF
--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -3447,6 +3447,15 @@ class ProcessManager:
             with self.claude.turn_lock:
                 try:
                     ensure_workspace_volume()
+                    # The volume mount binds the volume's own (initially
+                    # empty) workspace dir over /workspace, which hides the
+                    # src dir the constructor created on the base's tmpfs.
+                    # Every adapter's ready() is isdir(workspace), so
+                    # without this a restored session answers 503 to every
+                    # readiness probe after the first and the prime fails
+                    # with "restored guest not ready" (#5051). The turn
+                    # path has always re-created it; readiness must too.
+                    _ensure_cli_dir(self.claude.workspace)
                     identity = self._workspace_identity(self.claude.workspace)
                     process = getattr(self.claude, "process", None)
                     process_dead = process is not None and process.poll() is not None

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -6,6 +6,7 @@ import datetime
 import io
 import json
 import os
+import shutil
 import signal
 import socket
 import sys
@@ -1741,6 +1742,61 @@ def test_takeover_remediation_closes_stranded_process_without_respawn(
     # Mount-only remediation (#4393): the stranded process is closed and the
     # respawn is left to the turn path's lazy spawn.
     assert manager.claude.process is None
+    assert manager.ready()
+
+
+def test_remediation_recreates_cli_workspace_hidden_by_volume_mount(
+    tmp_path, monkeypatch
+):
+    """A restored guest must stay ready once the volume mount hides src.
+
+    ensure_workspace_volume bind-mounts the volume's empty workspace dir over
+    /workspace, so the src dir the base created on tmpfs vanishes. Readiness
+    is isdir(src) for every adapter, so remediation has to put it back or the
+    prime polls 503 until its deadline (#5051).
+    """
+    manager = _new_process_manager()
+    manager.workspace = str(tmp_path)
+    manager._prewarm_clis = ()
+    manager._prewarm_complete = True
+    manager.fatal_error = None
+    manager._remediation_lock = threading.Lock()
+    manager._remediation_attempts = 0
+    manager._remediation_thread = None
+    src = tmp_path / "src"
+    src.mkdir()
+
+    class Adapter:
+        workspace = str(src)
+
+        def __init__(self):
+            self.process = None
+            self.session_id = None
+            self.turn_lock = threading.Lock()
+            self._process_workspace_identity = None
+
+        def ready(self):
+            return os.path.isdir(self.workspace)
+
+        def _close_process(self, **_kwargs):
+            self.process = None
+
+    manager.claude = Adapter()
+    manager.codex = manager.claude
+    manager.pi = manager.claude
+    manager._workspace_identity = lambda _path: (1, 1)
+
+    def fake_mount():
+        # The bind mount replaces /workspace with an empty volume dir.
+        shutil.rmtree(src)
+
+    monkeypatch.setattr(shim, "ensure_workspace_volume", fake_mount)
+    monkeypatch.setattr(shim, "_workspace_is_tmpfs", lambda: True)
+    monkeypatch.setattr(shim, "_volume_has_ext4", lambda: True)
+
+    assert manager.ready()
+    manager._remediation_thread.join(timeout=1)
+    assert src.is_dir()
     assert manager.ready()
 
 


### PR DESCRIPTION
## Why

Every session-class create on the cluster fails right now with `prime_failed: noded: restored guest not ready: vsockhttp: timed out waiting for guest ready at /shim/ready`, on both `claude-runtime` (session 215, 07:50Z) and `pi-runtime` (214, after #5061 gave it a volume). The brick log shows the same shape each time: snapshot load, `PATCH /drives/volume`, resume, `EXT4-fs (vdb): mounted`, then the shim's ready handler answering into a closed socket for the whole 60s budget.

Mechanism: the readiness probe itself kicks remediation (`_workspace_is_tmpfs() and _volume_has_ext4()`), and `ensure_workspace_volume` bind-mounts the volume's empty `workspace/` over `/workspace`. That hides the `src` dir the base created on tmpfs, and every adapter's `ready()` is `isdir(src)`, so from that moment the guest is 503 forever. The lane only ever worked when noded accepted the very first, pre-remediation 200 inside its 150 ms per-attempt cap. Fast restores passed; anything slower died. `9ab9399fe` (2026-08-05) made remediation mount-only and dropped the `_ensure_cli_dir` that came with the eager respawn; the turn path kept its own ensure, which is why a session that got past readiness always worked.

## What

- `_remediate_workspace`: re-create the CLI workspace dir right after `ensure_workspace_volume()`, same call the turn path makes.
- Test: remediation whose fake mount removes `src`; `ready()` must stay true afterwards.

## Verification

- Local pytest on the shim: the new test passes; the two remaining local failures (`test_git_proxy_helper_sets_tcp_nodelay` and a socket-count assert) fail identically on a clean main checkout on macOS.
- `ci`: `Executed 1 out of 739 tests: 739 tests pass`.
- Post-merge: the guest image and both session bases rebuild on the new digest; I will re-probe `pi-runtime` and `claude-runtime` creates with a repo once Kargo promotes.

Refs #5051 (cycle 0). Unblocks the agents lane generally, not only qwen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WcU1F22ysoi1WhEtpGAo3