### PR TITLE
feat(embervm): report pi activities, model calls and tool time per turn

### DIFF
--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -175,7 +175,7 @@ def _turn_timing_now():
         return None
 
 
-def _emit_turn_timing(phase, elapsed=None, path=None, status=None):
+def _emit_turn_timing(phase, elapsed=None, path=None, status=None, extra=None):
     """Best-effort timing telemetry for a single turn phase."""
     try:
         if elapsed is None:
@@ -185,7 +185,13 @@ def _emit_turn_timing(phase, elapsed=None, path=None, status=None):
             fields.append("path=%s" % path)
         if status is not None:
             fields.append("status=%s" % status)
+        extra = extra if isinstance(extra, dict) else {}
+        if "calls" in extra:
+            fields.append("calls=%s" % extra["calls"])
         fields.append("ms=%s" % max(0, int(elapsed * 1000)))
+        for key, value in extra.items():
+            if key != "calls":
+                fields.append("%s=%s" % (key, value))
         sys.stderr.write("%s\n" % " ".join(fields))
         sys.stderr.flush()
     except Exception:
@@ -1932,7 +1938,7 @@ class ClaudeProcess:
                             raise RuntimeError(str(event.get("result")))
                         record = dict(event)
                         record["voice"] = voice_summary(event.get("result", ""))
-                        record["activity"] = activity_from_events(events)
+                        record["activities"] = activity_from_events(events)
                         _emit_elapsed(
                             "model", getattr(self, "_turn_timing_model_start", None)
                         )
@@ -2479,7 +2485,7 @@ wire_api = "responses"
                             "session_id": self.session_id,
                             "usage": usage,
                             "voice": voice_summary(result_text),
-                            "activity": activity_from_events(events),
+                            "activities": activity_from_events(events),
                         }
             finally:
                 if pusher:
@@ -2904,6 +2910,16 @@ class PiProcess:
             cached_activities = []
             activities_are_stale = True
             terminal_reason = "completed"
+            num_turns = 0
+            model_ms = 0
+            tool_ms = 0
+            model_calls = 0
+            tool_calls = 0
+            tools_by_name = {}
+            model_started_at = None
+            model_fallback_started_at = None
+            tools_by_id = {}
+            tools_without_id = collections.deque()
             self._turn_done.clear()
             self._in_flight = True
             try:
@@ -2912,6 +2928,7 @@ class PiProcess:
                 pusher = None
             try:
                 self._turn_timing_model_start = _turn_timing_now()
+                model_fallback_started_at = _turn_timing_now()
                 self._send({"type": "prompt", "message": message})
                 while True:
                     try:
@@ -2932,6 +2949,96 @@ class PiProcess:
                                 "prompt failed: %s" % json.dumps(event)[:1500]
                             )
                         continue
+                    try:
+                        event_type = event.get("type")
+                        if event_type == "message_start":
+                            message_event = event.get("message", {})
+                            if (
+                                not isinstance(message_event, dict)
+                                or message_event.get("role", "assistant") == "assistant"
+                            ):
+                                model_started_at = _turn_timing_now()
+                        elif event_type == "message_end":
+                            message_event = event.get("message", {})
+                            if (
+                                isinstance(message_event, dict)
+                                and message_event.get("role") == "assistant"
+                            ):
+                                # Pi brackets model calls with assistant
+                                # message_start/message_end. Older streams without
+                                # message_start fall back to prompt send for the
+                                # first call and the previous tool_execution_end
+                                # for later calls.
+                                model_finished_at = _turn_timing_now()
+                                model_calls += 1
+                                num_turns += 1
+                                started_at = (
+                                    model_started_at
+                                    if model_started_at is not None
+                                    else model_fallback_started_at
+                                )
+                                if (
+                                    started_at is not None
+                                    and model_finished_at is not None
+                                ):
+                                    model_ms += max(
+                                        0,
+                                        int((model_finished_at - started_at) * 1000),
+                                    )
+                                model_started_at = None
+                                model_fallback_started_at = None
+                        elif event_type == "tool_execution_start":
+                            tool_calls += 1
+                            tool_started_at = _turn_timing_now()
+                            tool_name = event.get("toolName") or event.get("tool_name")
+                            if tool_name:
+                                tool_name = str(tool_name).lower()
+                                tool_usage = tools_by_name.setdefault(
+                                    tool_name, {"calls": 0, "ms": 0}
+                                )
+                                tool_usage["calls"] += 1
+                            tool_entry = (tool_started_at, tool_name)
+                            tool_id = (
+                                event.get("toolCallId")
+                                or event.get("tool_call_id")
+                                or event.get("id")
+                            )
+                            if tool_id is not None:
+                                tools_by_id[str(tool_id)] = tool_entry
+                            else:
+                                tools_without_id.append(tool_entry)
+                        elif event_type == "tool_execution_end":
+                            tool_finished_at = _turn_timing_now()
+                            tool_id = (
+                                event.get("toolCallId")
+                                or event.get("tool_call_id")
+                                or event.get("id")
+                            )
+                            if tool_id is not None:
+                                tool_entry = tools_by_id.pop(str(tool_id), None)
+                            elif tools_without_id:
+                                tool_entry = tools_without_id.popleft()
+                            else:
+                                tool_entry = None
+                            if tool_entry is not None:
+                                tool_started_at, tool_name = tool_entry
+                                elapsed_ms = 0
+                                if (
+                                    tool_started_at is not None
+                                    and tool_finished_at is not None
+                                ):
+                                    elapsed_ms = max(
+                                        0,
+                                        int(
+                                            (tool_finished_at - tool_started_at) * 1000
+                                        ),
+                                    )
+                                tool_ms += elapsed_ms
+                                if tool_name:
+                                    tools_by_name[tool_name]["ms"] += elapsed_ms
+                            model_fallback_started_at = tool_finished_at
+                    except Exception:
+                        pass
                     events.append(self._translate_activity_event(event))
                     if event.get("type") == "session":
                         candidate = event.get("id")
@@ -3012,14 +3119,41 @@ class PiProcess:
                                 "pi turn produced no output: %s" % error_detail
                             )
                         self._state()
+                        usage.update(
+                            {
+                                "model_ms": model_ms,
+                                "tool_ms": tool_ms,
+                                "model_calls": model_calls,
+                                "tool_calls": tool_calls,
+                                "tools_by_name": tools_by_name,
+                            }
+                        )
                         record = {
                             "result": result_text,
                             "terminal_reason": terminal_reason,
                             "session_id": self.session_id,
+                            "num_turns": num_turns,
                             "usage": usage,
                             "voice": voice_summary(result_text),
-                            "activity": activity_from_events(events),
+                            "activities": activity_from_events(events),
                         }
+                        _emit_turn_timing(
+                            "pi_model",
+                            model_ms / 1000.0,
+                            extra={"calls": model_calls},
+                        )
+                        tool_timing_fields = {"calls": tool_calls}
+                        for tool_name in sorted(tools_by_name):
+                            tool_usage = tools_by_name[tool_name]
+                            tool_timing_fields[tool_name] = "%s:%s" % (
+                                tool_usage["calls"],
+                                tool_usage["ms"],
+                            )
+                        _emit_turn_timing(
+                            "pi_tools",
+                            tool_ms / 1000.0,
+                            extra=tool_timing_fields,
+                        )
                         _emit_elapsed(
                             "model", getattr(self, "_turn_timing_model_start", None)
                         )

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -352,6 +352,27 @@ for line in sys.stdin:
                   "errorMessage": "provider failed: ECONNREFUSED"}]})
         elif os.environ.get("FAKE_PI_MODE") == "textless":
             emit({"type": "agent_end", "messages": []})
+        elif os.environ.get("FAKE_PI_MODE") == "telemetry":
+            emit({"type": "message_start", "message": {"role": "assistant"}})
+            emit({"type": "message_end", "message": {"role": "assistant",
+                  "content": [], "stopReason": "toolUse", "usage": {}}})
+            emit({"type": "tool_execution_start", "toolCallId": "read-1",
+                  "toolName": "read", "args": {"path": "a.txt"}})
+            emit({"type": "tool_execution_end", "toolCallId": "read-1"})
+            emit({"type": "tool_execution_start", "toolCallId": "bash-1",
+                  "toolName": "bash", "args": {"command": "echo pi"}})
+            emit({"type": "tool_execution_end", "toolCallId": "bash-1"})
+            emit({"type": "message_start", "message": {"role": "assistant"}})
+            emit({"type": "message_end", "message": {"role": "assistant",
+                  "content": [{"type": "text", "text": "Telemetry done"}],
+                  "stopReason": "stop", "usage": {"input": 5, "output": 7}}})
+            emit({"type": "agent_end", "messages": []})
+        elif os.environ.get("FAKE_PI_MODE") == "no-tools":
+            emit({"type": "message_start", "message": {"role": "assistant"}})
+            emit({"type": "message_end", "message": {"role": "assistant",
+                  "content": [{"type": "text", "text": "No tools needed"}],
+                  "stopReason": "stop", "usage": {"input": 2, "output": 3}}})
+            emit({"type": "agent_end", "messages": []})
         else:
             emit({"type": "tool_start", "toolName": "bash",
                   "args": {"command": "echo pi"}})
@@ -456,7 +477,53 @@ def test_pi_first_turn_returns_text_session_and_usage(tmp_path, monkeypatch):
     assert record["result"] == "Done <voice>Pi completed the work.</voice>"
     assert record["session_id"] == "pi-session"
     assert "input_tokens" in record["usage"]
+    assert record["activities"] == [{"type": "bash", "command": "echo pi"}]
     manager._close_process()
+
+
+def test_pi_turn_reports_model_and_tool_timing(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("FAKE_PI_MODE", "telemetry")
+    clock = [0]
+
+    def timing_now():
+        clock[0] += 1
+        return float(clock[0])
+
+    monkeypatch.setattr(shim, "_turn_timing_now", timing_now)
+    manager = _pi_manager(tmp_path, monkeypatch)
+    record = manager.turn("hello", model="qwen")
+    manager._close_process()
+
+    assert record["num_turns"] == 2
+    assert record["usage"]["model_calls"] == 2
+    assert record["usage"]["tool_calls"] == 2
+    assert record["usage"]["model_ms"] > 0
+    assert record["usage"]["tool_ms"] > 0
+    assert record["usage"]["tools_by_name"] == {
+        "read": {"calls": 1, "ms": 1000},
+        "bash": {"calls": 1, "ms": 1000},
+    }
+    assert record["activities"] == [
+        {"type": "tool_use", "name": "read", "input": {"path": "a.txt"}},
+        {"type": "bash", "command": "echo pi"},
+    ]
+    timing = capsys.readouterr().err
+    assert "phase=pi_model calls=2 ms=" in timing
+    assert "phase=pi_tools calls=2 ms=" in timing
+    assert "bash=1:1000" in timing
+    assert "read=1:1000" in timing
+
+
+def test_pi_turn_without_tools_reports_zero_tool_time(tmp_path, monkeypatch):
+    monkeypatch.setenv("FAKE_PI_MODE", "no-tools")
+    manager = _pi_manager(tmp_path, monkeypatch)
+    record = manager.turn("hello", model="qwen")
+    manager._close_process()
+
+    assert record["num_turns"] == 1
+    assert record["usage"]["tool_calls"] == 0
+    assert record["usage"]["tool_ms"] == 0
+    assert record["usage"]["tools_by_name"] == {}
 
 
 def test_pi_pushes_progress_during_turn(tmp_path, monkeypatch):
@@ -656,7 +723,7 @@ def test_codex_first_turn_returns_thread_voice_and_usage(tmp_path, monkeypatch):
             "cache_write_tokens": 0,
         },
         "voice": "Codex completed the work.",
-        "activity": [{"type": "bash", "command": "echo test"}],
+        "activities": [{"type": "bash", "command": "echo test"}],
     }
     manager._close_process()
 
@@ -791,7 +858,7 @@ def test_codex_resume_uses_positional_session_and_no_sandbox(tmp_path, monkeypat
             "cache_read_tokens": 0,
             "cache_write_tokens": 0,
         }
-        assert record["activity"] == [{"type": "bash", "command": "echo test"}]
+        assert record["activities"] == [{"type": "bash", "command": "echo test"}]
 
     assert manager.process is first_process
     calls = [
@@ -955,7 +1022,7 @@ def test_codex_turn_with_no_tool_items_has_empty_activity(tmp_path, monkeypatch)
     manager = _codex_manager(tmp_path, monkeypatch)
     record = manager.turn("no tools", model="luna")
 
-    assert record["activity"] == []
+    assert record["activities"] == []
     assert record["usage"] == {
         "input_tokens": 3,
         "output_tokens": 4,
@@ -2226,7 +2293,7 @@ def test_turn_extracts_voice_activity_and_tolerates_malformed_json(
     record = manager.turn("make changes")
     assert record["terminal_reason"] == "end_turn"
     assert record["voice"] == "Changed the files and need review."
-    assert record["activity"] == [
+    assert record["activities"] == [
         {"type": "tool_use", "name": "Read", "input": {"file_path": "a.txt"}},
         {"type": "edit", "file_path": "b.txt"},
         {"type": "write", "file_path": "c.txt"},
@@ -4405,7 +4472,7 @@ def test_codex_auth_json_is_parseable_and_inert(tmp_path, monkeypatch):
         "cache_read_tokens": 0,
         "cache_write_tokens": 0,
     }
-    assert record["activity"] == [{"type": "bash", "command": "echo test"}]
+    assert record["activities"] == [{"type": "bash", "command": "echo test"}]
     auth_path = os.path.join(str(tmp_path / "workspace"), ".codex", "auth.json")
     auth = json.loads(open(auth_path).read())
     assert auth["auth_mode"] == "chatgpt"


### PR DESCRIPTION
## Why

Two instrument gaps found while baselining #5051:

1. The claude adapter returns `"activities"`, but codex and pi returned `"activity"`, and `agent_sessions/transport.py` reads only `"activities"`. Every codex and pi turn has been arriving with no activity (live: `usage.activities == []` on every qwen turn; the compare router's "several adapters record no edit/write activities" note is this bug).
2. pi never set `num_turns`, and a pi turn's `model` phase runs 37 to 86 s while llama.cpp accounts for 10 to 20 s of it. Nothing reported where the rest went.

## What

- Rename the record key to `activities` in the codex and pi adapters (tests updated).
- pi: count assistant `message_end` events as `num_turns`; time each model call and each tool execution from the RPC event stream; carry `model_ms`, `tool_ms`, `model_calls`, `tool_calls`, `tools_by_name` in `usage`; emit `turn-timing phase=pi_model` and `phase=pi_tools` stderr lines (`_emit_turn_timing` gains an `extra` mapping). All best-effort, defaults to 0.

## Verification

- shim pytest: new tests pass; the two remaining local failures are the macOS-only socket tests that fail on a clean main checkout.
- `ci`: `Executed 3 out of 739 tests: 739 tests pass`.

Refs #5051.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WcU1F22ysoi1WhEtpGAo3