### PR TITLE
fix(embervm): include files the agent created in the captured turn diff

### DIFF
--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -148,7 +148,7 @@ def _capture_turn_diff(checkout_dir, base_sha):
                 % (result.stderr or b"").decode("utf-8", "replace").strip()[:200],
             )
             return None
-        raw = result.stdout
+        raw = result.stdout + _untracked_file_diffs(checkout_dir)
         if len(raw) > MAX_TURN_DIFF_BYTES:
             _emit_turn_diff_outcome(checkout_dir, "diff", "truncated_raw")
             return {"base_sha": base_sha, "zlib_b64": None, "truncated": True}
@@ -165,6 +165,56 @@ def _capture_turn_diff(checkout_dir, base_sha):
     except Exception:
         _emit_turn_diff_outcome(checkout_dir, "diff", "diff_exception")
         return None
+
+
+# Untracked files are capped so a stray build tree or vendored download cannot
+# turn the diff into megabytes of noise; the raw cap above still applies.
+MAX_TURN_DIFF_UNTRACKED_FILES = 200
+
+
+def _untracked_file_diffs(checkout_dir):
+    """Render new, untracked files as new-file hunks, read-only.
+
+    `git diff <base>` only sees tracked paths, so a test file, a go.mod or an
+    answer.json the agent created never reached the stored diff (#5051).
+    `git add -N` would fix that but writes the index as root, which then locks
+    the CLI user out of its own checkout, so this stays read-only:
+    ls-files for the names, then one `git diff --no-index /dev/null <path>`
+    per file, whose output already carries the new-file headers git apply
+    expects. Anything odd (a name that is not a regular file, a git error)
+    is skipped, never raised.
+    """
+    try:
+        listing = subprocess.run(
+            _git_read_argv(checkout_dir, "ls-files", "--others", "--exclude-standard"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=30,
+        )
+        if listing.returncode != 0:
+            return b""
+        names = [
+            line
+            for line in listing.stdout.decode("utf-8", "replace").split("\n")
+            if line and os.path.isfile(os.path.join(checkout_dir, line))
+        ]
+        chunks = []
+        for name in names[:MAX_TURN_DIFF_UNTRACKED_FILES]:
+            # --no-index exits 1 when the files differ, which is the normal
+            # case here, so the return code is not an error signal.
+            single = subprocess.run(
+                _git_read_argv(checkout_dir, "diff", "--no-index", "/dev/null", name),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=30,
+            )
+            if single.stdout:
+                chunks.append(single.stdout)
+        return b"".join(chunks)
+    except Exception:
+        return b""
 
 
 def _turn_timing_now():

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -1513,6 +1513,38 @@ def test_turn_diff_success_logs_and_round_trips(monkeypatch, tmp_path, capsys):
     assert "checkout_dir=%s" % checkout.resolve() in captured
 
 
+def test_turn_diff_includes_untracked_files_as_new_file_hunks(tmp_path, capsys):
+    """A file the agent created must appear in the stored diff (#5051)."""
+    checkout = tmp_path / "src"
+    checkout.mkdir()
+    git = ["git", "-C", str(checkout)]
+    subprocess.run(git + ["init", "-q"], check=True)
+    subprocess.run(git + ["config", "user.email", "t@example.com"], check=True)
+    subprocess.run(git + ["config", "user.name", "t"], check=True)
+    (checkout / "tracked.txt").write_text("one\n")
+    subprocess.run(git + ["add", "tracked.txt"], check=True)
+    subprocess.run(git + ["commit", "-q", "-m", "base"], check=True)
+    base_sha = subprocess.run(
+        git + ["rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+    (checkout / "tracked.txt").write_text("one\ntwo\n")
+    (checkout / "answer.json").write_text('{"adr": "x"}\n')
+
+    result = shim._capture_turn_diff(str(checkout), base_sha)
+
+    assert result["truncated"] is False
+    raw = zlib.decompress(base64.b64decode(result["zlib_b64"])).decode()
+    assert "+two" in raw
+    assert "answer.json" in raw
+    assert "new file mode" in raw
+    assert '+{"adr": "x"}' in raw
+    # Read-only: the index must not have gained the new file.
+    status = subprocess.run(
+        git + ["status", "--porcelain"], check=True, capture_output=True, text=True
+    ).stdout
+    assert "?? answer.json" in status
+
+
 def test_turn_diff_logging_failure_does_not_change_capture(monkeypatch, tmp_path):
     checkout = tmp_path / "src"
     base_sha = "a" * 40
@@ -4616,21 +4648,19 @@ def test_turn_base_scopes_safe_directory_to_the_checkout(monkeypatch, tmp_path):
 def test_turn_diff_scopes_safe_directory_to_the_checkout(monkeypatch, tmp_path):
     checkout = tmp_path / "src"
     (checkout / ".git").mkdir(parents=True)
-    seen = {}
+    seen = []
 
     def fake_run(args, **kwargs):
-        seen["args"] = args
+        seen.append(args)
         return subprocess.CompletedProcess(args, 0, b"diff --git a/a b/a\n", b"")
 
     monkeypatch.setattr(shim.subprocess, "run", fake_run)
 
     assert shim._capture_turn_diff(str(checkout), "b" * 40) is not None
-    assert seen["args"][:3] == [
-        "git",
-        "-c",
-        "safe.directory=%s" % checkout,
-    ]
-    assert "diff" in seen["args"]
+    # Every git read (the diff and the untracked-file listing) is scoped.
+    for args in seen:
+        assert args[:3] == ["git", "-c", "safe.directory=%s" % checkout]
+    assert any("diff" in args for args in seen)
 
 
 def test_turn_base_failure_reason_includes_git_stderr(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Why

The stored turn diff is `git diff <base>`, which only sees tracked paths. A test file, a `go.mod` or an `answer.json` the agent wrote never reached the monolith, so anything grading the diff saw an empty change. In the #5051 long baseline `research-adr-writeback-01` failed twice with `answer.json` missing while the guest had written it.

## What

Read-only capture of untracked files appended to the tracked diff: `git ls-files --others --exclude-standard` for the names, then `git diff --no-index /dev/null <path>` per file (its output already carries the `new file mode` headers `git apply` expects), capped at 200 files and still under the existing raw and compressed caps. `git add -N` was rejected because it writes the index as root and locks the CLI user out of its checkout.

## Verification

- New test builds a real repo, modifies a tracked file and adds an untracked one, asserts both hunks are in the decompressed diff and that `git status` still shows `?? answer.json` (read-only).
- Existing safe-directory test now checks every git read is scoped.
- `ci`: `Executed 3 out of 739 tests: 739 tests pass`.

Refs #5051.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WcU1F22ysoi1WhEtpGAo3