### PR TITLE
perf(embervm): let pi generate 12288 tokens so qwen's reasoning is not cut off

### DIFF
--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -398,14 +398,21 @@ PI_CONTEXT_SAFETY_TOKENS = 4096
 # so the exposure is one turn's trailing tool results, not the whole
 # conversation. This is why PI_MAX_OUTPUT_TOKENS matters for compaction but not
 # for 400-safety.
-PI_MAX_OUTPUT_TOKENS = 4096
+#
+# 12288, not 4096: qwen3.8 thinks before it answers and the reasoning counts
+# against this cap. At 4096 a hard task hit the cap mid-reasoning, pi ended
+# the turn with agent_end and no assistant text, and the shim raised
+# "pi turn produced no output" (3 of 5 graded long reps in the #5051
+# baseline). model-bench runs the same model at 16384 and passes 6/7 hard
+# tasks; 12288 keeps the compaction reserve just over half the window.
+PI_MAX_OUTPUT_TOKENS = 12288
 
 # Compaction reserve in tokens. This must exceed PI_MAX_OUTPUT_TOKENS plus
 # PI_CONTEXT_SAFETY_TOKENS so pi starts compacting while there is still room for
 # a full response at turn boundaries. pi checks compaction at agent_end and
 # before a prompt, not between tool iterations, so a run that approaches the
 # reserve mid-execution can still produce short replies.
-PI_COMPACTION_RESERVE_TOKENS = 10240
+PI_COMPACTION_RESERVE_TOKENS = 16896
 
 # Tokens to keep after compaction. pi's default keepRecentTokens (20000)
 # exceeds the usable budget after pi's default 16384 reserve (32768 - 16384 =


### PR DESCRIPTION
## Hypothesis (#5051 cycle 1, long lane)

`PI_MAX_OUTPUT_TOKENS = 4096` is the single biggest long-lane failure. In the cycle 0 baseline 3 of 5 graded long reps died the same way: llama.cpp `eval time ... / 4096 tokens`, reasoning cut off, pi ends the turn with `agent_end` and no assistant text, shim raises `pi turn produced no output`, CP answers 422. model-bench runs the same model at `max_tokens: 16384` and passes 6/7 hard tasks.

## What

- `PI_MAX_OUTPUT_TOKENS` 4096 -> 12288
- `PI_COMPACTION_RESERVE_TOKENS` 10240 -> 16896 (must stay above max output plus the 4096 safety margin; keep-recent 8000 stays below the 13104 usable after reserve)

`contextWindow` stays 30000; the llama.cpp slot is 32768.

## Decision rule

Guest-image change, so it can only be measured live. Baseline long set: 1/6 pass (worldcup 1/2, go-vsock 0/2, research 0/2 harness-blocked). After promotion: rerun the long set x2; keep iff completion improves with the fast set not regressing (p50 wall). If not, a revert PR follows with the numbers.

## Verification

- shim tests green on the relations (`31 passed` in the context/compaction subset); `ci`: `Executed 3 out of 739 tests: 739 tests pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WcU1F22ysoi1WhEtpGAo3