### PR TITLE
perf(embervm): give the pi guest 1024 MiB so long agentic tasks stop OOMing

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -693,9 +693,12 @@ piRuntimeWorkload:
   # this lane failed at hydration with "Out of diskspace" from 2026-08-16 until
   # this flip (#5051). 4 GiB lineage from the chart default.
   persistenceEnabled: true
-  # 512 MiB: git index-pack over 88k objects plus the pi heap no longer shares
-  # RAM with the checkout, but 256 MiB left no headroom for the clone itself.
-  memMib: 512
+  # 1024 MiB: at 512 a long agentic task (a multi-turn go or python build under
+  # projects/monolith) OOM-killed pi mid-run (exit -9), which #5067's larger
+  # token budget exposed by letting the loop run more turns before it died.
+  # The guest V8 heap plus a build subprocess plus tmpfs need more than 512 in
+  # a 2gi brick; 1024 leaves ~1 GiB for the brick daemon and its page cache.
+  memMib: 1024
 
 # SpecTrace gate for spec validation (GitHub issue #4770). Debug-gated, spec-shaped
 # trace that validates TLA+ specs against real behaviour. Deliberately OFF in production.


### PR DESCRIPTION
## Hypothesis (#5051 cycle 2, long lane)

After #5067 (maxTokens 12288) the truncation failures are gone, but go-vsock and worldcup now die with `pi exited before agent_end, exit code -9`, which the brick logs show is the OOM killer reaping pi in the 512 MiB guest. #5067 exposed a pre-existing ceiling: with truncation gone the agentic loop runs more turns and more build subprocesses (go build, python) before it runs out of memory.

## What

`piRuntimeWorkload.memMib` 512 -> 1024 in deploy values. `memMib` is a resource, not part of the base signature, so this rolls without a guest-image rebuild. 1024 fits the 2gi brick with ~1 GiB left for the daemon and page cache.

## Decision rule

Long set, 2 reps, live after promotion. Cycle 1 (12288 tokens, still 512 MiB): research 2/2 (from the #5065 diff fix), go-vsock 0/2 (429 + OOM), worldcup 0/2 (OOM). Keep iff long completion improves and the fast set does not regress. If OOM persists, the next lever is cap or a larger brick class.

## Verification

- `ci`: `Executed 4 out of 739 tests: 739 tests pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WcU1F22ysoi1WhEtpGAo3