### PR TITLE
revert(embervm): pi guest back to 512 MiB, 1024 broke session create

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -693,12 +693,12 @@ piRuntimeWorkload:
   # this lane failed at hydration with "Out of diskspace" from 2026-08-16 until
   # this flip (#5051). 4 GiB lineage from the chart default.
   persistenceEnabled: true
-  # 1024 MiB: at 512 a long agentic task (a multi-turn go or python build under
-  # projects/monolith) OOM-killed pi mid-run (exit -9), which #5067's larger
-  # token budget exposed by letting the loop run more turns before it died.
-  # The guest V8 heap plus a build subprocess plus tmpfs need more than 512 in
-  # a 2gi brick; 1024 leaves ~1 GiB for the brick daemon and its page cache.
-  memMib: 1024
+  # 512 MiB. 1024 was tried (#5068) to stop long-task OOM but every pi-runtime
+  # session create then hung 180s at the control-plane GenServer and 500ed
+  # (#5051): the memMib bump rebuilt the base but broke create cluster-wide,
+  # so it was reverted. The OOM ceiling is real; the fix is a larger brick
+  # class or a cap change, not memMib on the 2gi brick.
+  memMib: 512
 
 # SpecTrace gate for spec validation (GitHub issue #4770). Debug-gated, spec-shaped
 # trace that validates TLA+ specs against real behaviour. Deliberately OFF in production.


### PR DESCRIPTION
## Why

#5068 raised `piRuntimeWorkload.memMib` 512 -> 1024 to stop long-task OOM. On the live lane the result was worse: every pi-runtime session create hung for 180s at the control-plane `SessionManager` GenServer and returned 500, so the whole qwen lane went down (all 6 cycle-2 long reps failed at create, and a trivial no-repo probe fails the same way). The memMib change did rebuild the base at the new size (it is in the base signature), but create never reached a brick.

Revert to restore the lane. The OOM ceiling from cycle 1 is real and stays an open long-lane item; the fix is a larger brick class or a `cap`/pacing change, not a memMib bump on the 2gi brick.

## Verification

- `ci test`: green.
- After promotion I will confirm a pi-runtime create succeeds again on the live lane.

Refs #5051 cycle 2 (revert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WcU1F22ysoi1WhEtpGAo3