### PR TITLE
chore(embervm): enable the noded ingress network policy in production

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -132,6 +132,14 @@ tracing:
 # ~1.5Gi/VM that is ~24Gi worst case, well within budget. This only raises the
 # runaway backstop, not any pool floor.
 noded:
+  # Ingress allow-list on every noded pod shape (#4693): gRPC from the control
+  # plane, health from kubelet and the SigNoz scraper, activator from
+  # serving-envoy and the CP, the serving DNAT range from serving-envoy. Dev has
+  # run it since 0.25.1. Flipped in production on its own, ahead of the bearer
+  # token, so a missed port shows up as a readiness or serving failure with one
+  # cause to revert.
+  networkPolicy:
+    enabled: true
   # Warmth ownership transition guard (#4962). Every brick on the fleet writes
   # its .alive claim as of chart 0.26.0 (verified on the 2026-08-22 06:44 roll),
   # so unclaimed pre-heartbeat directories are dead and may be reaped. After


### PR DESCRIPTION
Refs #4693, step 1 of the flip checklist. Values-only: `noded.networkPolicy.enabled: true` in production (dev has run it since 0.25.1). Renders two `CiliumNetworkPolicy` objects (tokenbroker + noded).

Post-merge watch: six bricks Ready, `/health` ok, synthetic probes green, no Hubble POLICY_DENIED on noded ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP