### PR TITLE
chore(embervm): enable the noded bearer token in production

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -140,6 +140,14 @@ noded:
   # cause to revert.
   networkPolicy:
     enabled: true
+  # Static bearer token on noded's gRPC surface (#4693). One chart value renders
+  # the same Secret into the control plane and every brick, so enforcement and
+  # client attachment flip in this one chart version. The operator renders the
+  # 1Password item (one field, "token") into the Secret named by the chart.
+  bearerTokenSecret:
+    enabled: true
+    onepassword:
+      itemPath: "vaults/k8s-homelab/items/embervm-noded-token"
   # Warmth ownership transition guard (#4962). Every brick on the fleet writes
   # its .alive claim as of chart 0.26.0 (verified on the 2026-08-22 06:44 roll),
   # so unclaimed pre-heartbeat directories are dead and may be reaped. After


### PR DESCRIPTION
Closes #4693, step 2 of the flip checklist. Step 1 (#5070, the ingress policy) is live: six bricks Ready, stateful relight + semgrep + bazel + pages probes green through the policy, zero Hubble drops in `embervm`.

`noded.bearerTokenSecret.enabled: true` with the `embervm-noded-token` 1Password item. Renders the same `secretKeyRef` (`e-embervm-noded-token`) into the control plane and all nine brick Deployments, so enforcement and attachment flip together. The env change rolls the CP and every brick (grouped waves, ~2.5 min).

Post-merge watch: noded no longer logs the "runs open" warning, CP re-adopts every brick (registry replays), probes stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP