### PR TITLE
chore(embervm): send SigV4 store credentials from production and dev

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -148,6 +148,15 @@ noded:
     enabled: true
     onepassword:
       itemPath: "vaults/k8s-homelab/items/embervm-noded-token"
+  # SigV4 credentials for the artifact store (#4708). The embervm identity in
+  # the SeaweedFS identities policy; clients sign every request once these are
+  # present, and the gateway starts checking them when s3.enableAuth flips in
+  # projects/platform/seaweedfs.
+  store:
+    credentials:
+      enabled: true
+      onepassword:
+        itemPath: "vaults/k8s-homelab/items/embervm-store"
   # Warmth ownership transition guard (#4962). Every brick on the fleet writes
   # its .alive claim as of chart 0.26.0 (verified on the 2026-08-22 06:44 roll),
   # so unclaimed pre-heartbeat directories are dead and may be reaped. After

--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -61,6 +61,12 @@ noded:
 
   store:
     bucket: embervm-dev
+    # SigV4 credentials (#4708): same identity as production, the policy grants
+    # it both buckets.
+    credentials:
+      enabled: true
+      onepassword:
+        itemPath: "vaults/k8s-homelab/items/embervm-store"
 
 # nvmeRoot lives UNDER node-4's NVMe mount so it inherits that capacity bound,
 # production's shared node-4 NVMe scratch. Scratch is shared metal; the split


### PR DESCRIPTION
Refs #4708, step 1 of the flip checklist (step 2 is the platform SeaweedFS auth flip, staged separately).

`noded.store.credentials.enabled: true` with the `embervm-store` 1Password item in both environments. Every store request is now signed with the embervm identity; SeaweedFS ignores the signature until `enableAuth` flips, so this is behaviour-neutral and proves credential delivery first (noded logs `object store configured ... signed=true`). Renders 9 brick + 1 CP credential env pairs in prod, 6 + 1 in dev.

Preflight for step 2 already done: `weed shell s3.configure` shows zero filer-stored identities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP