### PR TITLE
fix(embervm): allow the stateful and composite activator ranges in the noded policy

### DIFF
--- a/projects/embervm/chart/chart_env_identity_test.py
+++ b/projects/embervm/chart/chart_env_identity_test.py
@@ -291,6 +291,12 @@ def test_noded_network_policy_gate_and_listener_ports():
     # the Cilium CRD caps toPorts.ports at 40 items.
     assert "endPort: 30254" in policy
     assert 'port: "30254"' not in policy
+    # noded binds the stateful and composite activator ranges by default even
+    # though the chart renders no env for them; omitting them dropped the
+    # stateful wake (2026-08-22, #4693).
+    for start, end in (("5400", 5409), ("5410", 5419)):
+        assert f'port: "{start}"' in policy
+        assert f"endPort: {end}" in policy
 
     disabled = _render(
         "noded-policy",

--- a/projects/embervm/chart/templates/noded-networkpolicy.yaml
+++ b/projects/embervm/chart/templates/noded-networkpolicy.yaml
@@ -79,9 +79,27 @@ spec:
             - port: {{ add .Values.noded.servingPortBase 2 | quote }}
               endPort: {{ add .Values.noded.servingPortBase 254 }}
               protocol: TCP
-    # Noded can optionally bind stateful and group activator listener ranges,
-    # but this chart currently renders neither EMBERVM_NODED_STATEFUL_ACTIVATOR_PORT_RANGE
-    # nor EMBERVM_NODED_GROUP_ACTIVATOR_PORT_RANGE, and exposes no corresponding
-    # containerPorts. Their zero defaults disable those listeners, so no rule is
-    # invented from servingEnvoy.statefulTcpPortRange or compositeTcpPortRange.
+    # noded binds the stateful (EMBERVM_NODED_STATEFUL_ACTIVATOR_PORT_RANGE,
+    # default 5400-5409) and composite group (EMBERVM_NODED_GROUP_ACTIVATOR_PORT_RANGE,
+    # default 5410-5419) activator ranges BY DEFAULT in noded/config/config.go,
+    # even though this chart renders neither env. The node Envoy's stateful and
+    # group tcp_proxy fallbacks dial podIP:<listenPort> on them, and the control
+    # plane's TCP activator can too. Omitting these dropped serving-envoy's wake
+    # to noded:5401 and took demo-postgres down on 2026-08-22 (#4693); the
+    # ranges are the same values servingEnvoy declares as capacity.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ .Release.Namespace | quote }}
+            {{- include "embervm.servingEnvoy.selectorLabels" . | nindent 12 }}
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ .Release.Namespace | quote }}
+            {{- include "embervm.selectorLabels" . | nindent 12 }}
+      toPorts:
+        - ports:
+            - port: {{ .Values.servingEnvoy.statefulTcpPortRange.start | quote }}
+              endPort: {{ .Values.servingEnvoy.statefulTcpPortRange.end }}
+              protocol: TCP
+            - port: {{ .Values.servingEnvoy.compositeTcpPortRange.start | quote }}
+              endPort: {{ .Values.servingEnvoy.compositeTcpPortRange.end }}
+              protocol: TCP
 {{- end }}


### PR DESCRIPTION
Refs #4693. Follows the production revert in #5077.

noded binds `5400-5409` (stateful activator) and `5410-5419` (group activator) by default; the policy omitted them on the strength of a wrong template comment, and serving-envoy's cold wake to `noded:5401` was dropped. Both ranges are now allowed from serving-envoy and the control plane via `endPort`, sourced from `servingEnvoy.statefulTcpPortRange` / `compositeTcpPortRange`, and pinned by `chart_env_identity_test`.

After this promotes: re-enable `noded.networkPolicy.enabled` in production and verify a relight from cold through the policy (not a warm VM).

`ci`: Bazel 739 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP