### PR TITLE
fix(monolith): offset the qwen session synthetic from the 5-minute probe

### DIFF
--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -825,7 +825,13 @@ jobs:
     # actually routing to pi-runtime, which landed in the same session.
     - name: ember-qwen-session-synthetic
       args: ["ember-qwen-synthetic-trigger"]
-      schedule: "0 * * * *"
+      # Offset from the */5 demo probe on purpose: both endpoints share one
+      # in-flight guard in synthetic_router.py, so a trigger at :00 lands while
+      # the 5-minute probe is running and returns {"skipped": true}, which the
+      # job reports as Succeeded while recording nothing (every hourly run from
+      # arming until 2026-08-22 did exactly that; the only recorded result was
+      # an off-schedule trigger at 14:03).
+      schedule: "2 * * * *"
       concurrencyPolicy: Forbid
       activeDeadlineSeconds: 300
       # Original gate, kept for the record: "Joe arms this after watching the


### PR DESCRIPTION
Found while verifying the EmberVM flips: `/health` showed `ember_qwen` latched on a 14:03 failure although the hourly CronWorkflow reported `Succeeded` at 15:00.

Both synthetic endpoints in `ember_public/synthetic_router.py` share one `_probe_in_flight` guard, and the qwen cron fired at `:00`, the same instant as the `*/5` demo probe, so every scheduled trigger got `{"skipped": true}`: a Succeeded job that recorded nothing. The only recorded result came from an off-schedule trigger. Schedule moves to `2 * * * *`.

`ci`: Bazel 739 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP