### PR TITLE
fix(embervm): re-place a backoff retry whose node rolled mid-backoff

### DIFF
--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -3191,10 +3191,36 @@ defmodule Embervm.BaseBuilder do
             state
 
           true ->
-            state
-            |> enqueue(w.node_id, name)
-            |> write_base_status(w, :building)
-            |> maybe_start_build(w.node_id)
+            # The pin can be stale by the time the timer fires:
+            # remove_node_from_state/2 unpins a workload (node_id -> nil) when
+            # its brick rolls but deliberately leaves an armed retry timer
+            # running (only forget_workload cancels timers), and the #4105
+            # guard above only makes the deref nil-SAFE, it does not give this
+            # branch a usable node. enqueue/3's update_in on
+            # state.nodes[stale] then raised BadMapError and took the whole
+            # builder down (#5082, observed live in embervm-dev). Re-place
+            # through placement/3 exactly like reconcile_desc/2, hold with
+            # {:pending, :no_node} when nothing is eligible (its nil-placement
+            # branch; add_node re-drives held workloads), and persist the new
+            # pin so stickiness tracks where the rebuild actually ran.
+            node_id = placement(state, w, Map.get(w, :mem_mib) || 0)
+
+            cond do
+              node_id == nil ->
+                write_base_status(state, w, {:pending, :no_node})
+
+              already_targeting?(state, node_id, name, signature(w)) ->
+                state
+
+              true ->
+                w = %{w | node_id: node_id}
+                state = put_in(state.workloads[name], w)
+
+                state
+                |> enqueue(node_id, name)
+                |> write_base_status(w, :building)
+                |> maybe_start_build(node_id)
+            end
         end
     end
   end

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -548,6 +548,75 @@ defmodule Embervm.BaseBuilderTest do
     assert Process.alive?(builder)
   end
 
+  # The sibling of the test above, for the branch that actually crashed in
+  # embervm-dev (#5082): the #4105 guard only covers already_targeting?/4, so a
+  # retry whose FIRST build failed (built_signature nil) still fell through to
+  # enqueue(w.node_id, name) with node_id nil after remove_node_from_state/2
+  # unpinned it, and update_in(state.nodes[nil].queue, ...) raised BadMapError.
+  # The old comment claimed a stale pin is unreachable through the public API;
+  # the nil pin is exactly what remove_node_from_state/2 itself produces.
+  #
+  # The fix re-places through placement/3 like reconcile_desc/2: no eligible
+  # node holds the workload at {:pending, :no_node} (the add_node re-drive test
+  # below proves recovery), and an eligible node gets the rebuild enqueued.
+  test "a retry firing after its node was removed re-places instead of crashing" do
+    agent = start_recorder()
+    {:ok, attempts} = Agent.start_link(fn -> 0 end)
+
+    # First build FAILS so the retry arms with nothing built (built_signature:
+    # nil), the exact sandbox-rust shape from embervm-dev. A long backoff keeps
+    # the real timer quiet; the test fires {:retry, "w"} by hand.
+    build_fun = fn :fake_channel, _req ->
+      n = Agent.get_and_update(attempts, fn n -> {n + 1, n + 1} end)
+
+      if n < 2 do
+        {:error, %GRPC.RPCError{status: 9, message: "no image source for imgA"}}
+      else
+        {:ok, resp("snap1")}
+      end
+    end
+
+    builder =
+      start_builder(
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        base_backoff_ms: 30_000,
+        max_backoff_ms: 60_000
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+
+    assert_eventually(fn ->
+      case latest(agent, "w") do
+        nil -> false
+        s -> match?(%{"reason" => "BuildFailed"}, condition(s, "BaseBuilt"))
+      end
+    end)
+
+    # The brick rolls mid-backoff: node leaves the placement set, workload is
+    # unpinned, timer stays armed.
+    :ok = BaseBuilder.remove_node(builder, @node.id)
+    send(builder, {:retry, "w"})
+
+    # Before the fix this crashed the GenServer (BadMapError in enqueue/3);
+    # status/1 orders this assertion after the {:retry, "w"} message. Held at
+    # {:pending, :no_node}, mirroring reconcile_desc's nil-placement branch.
+    assert Process.alive?(builder)
+
+    assert_eventually(fn ->
+      case latest(agent, "w") do
+        nil -> false
+        s -> match?(%{"reason" => "NoNodeAvailable"}, condition(s, "BaseBuilt"))
+      end
+    end)
+
+    # Recovery: the brick comes back and add_node re-drives the held workload,
+    # which now builds (attempt 2 succeeds).
+    :ok = BaseBuilder.add_node(builder, @node.id, @node.address)
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap1"}, latest(agent, "w")) end)
+    assert Agent.get(attempts, & &1) >= 2
+  end
+
   # -- forget -----------------------------------------------------------------
 
   test "forgetting a workload mid-queue drops it without building" do


### PR DESCRIPTION
Observed live in embervm-dev: `GenServer Embervm.BaseBuilder terminating, ** (BadMapError) expected a map, got: nil` at `base_builder.ex` enqueue/3 via retry_workload/2, repeating across supervisor restarts. Tracks #5082.

Root cause: a workload whose first build fails (`built_signature: nil`) arms the backoff retry timer; the brick then rolls and `remove_node_from_state/2` unpins it (`node_id -> nil`) without cancelling the timer (only forget_workload cancels timers). When the timer fires, the rebuild branch calls `enqueue(w.node_id, name)` and `update_in(state.nodes[nil].queue, ...)` raises. Each crash wipes the in-memory fleet view and re-places/rebuilds the whole fleet.

The #4105 fix made `already_targeting?/4`/`worker_signature/2` nil-safe, but its regression test only exercises the repair branch (`built_signature == signature and snapshot_ref != nil`), which returns before the crashing line. The rebuild branch stayed unguarded.

Fix: re-place through `placement/3` exactly like `reconcile_desc/2`:
- no eligible instance -> hold at `{:pending, :no_node}` (the add_node re-drive path already recovers held workloads),
- eligible instance -> persist the new pin (so stickiness tracks where the rebuild ran), enqueue, build there,
- the existing already-targeting no-op is kept against the new pin.

Validation: full ExUnit suite green on the remote Linux runner (`ci test -- //bazel/erlang:mix_test_smoke`, 1367 tests, 0 failures), including the pre-existing backoff test that exercises the healthy-pin retry path and a new regression test that reproduces the crash shape (failed first build -> remove_node -> hand-fired retry) and asserts survival, NoNodeAvailable hold, and recovery via add_node.

Closes #5082.