### PR TITLE
perf(embervm): default the pi lane to thinking off so short qwen turns skip the reasoning trace

### DIFF
--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -407,6 +407,15 @@ PI_CONTEXT_SAFETY_TOKENS = 4096
 # tasks; 12288 keeps the compaction reserve just over half the window.
 PI_MAX_OUTPUT_TOKENS = 12288
 
+# Thinking level for the pi lane. "off" makes pi send
+# chat_template_kwargs.enable_thinking=false to the qwen server, which for a
+# short task cuts generation from a full reasoning trace to a direct answer
+# (measured 32 -> 4 tokens on a trivial prompt, #5051). This is the SMALL-TASK
+# lane (chart comment), so thinking off is the intended default; flip to
+# "high" to restore full reasoning. The value must be one of pi's
+# ThinkingLevel strings: off, minimal, low, medium, high.
+PI_DEFAULT_THINKING_LEVEL = "off"
+
 # Compaction reserve in tokens. This must exceed PI_MAX_OUTPUT_TOKENS plus
 # PI_CONTEXT_SAFETY_TOKENS so pi starts compacting while there is still room for
 # a full response at turn boundaries. pi checks compaction at agent_end and
@@ -2690,12 +2699,14 @@ class PiProcess:
                     "compat": {
                         "supportsDeveloperRole": False,
                         "supportsReasoningEffort": False,
+                        "thinkingFormat": "qwen-chat-template",
                     },
                     "models": [
                         {
                             "id": PI_MODELS[DEFAULT_PI_MODEL],
                             "contextWindow": PI_CONTEXT_WINDOW,
                             "maxTokens": PI_MAX_OUTPUT_TOKENS,
+                            "reasoning": True,
                         }
                     ],
                 }
@@ -2705,12 +2716,13 @@ class PiProcess:
             json.dump(config, stream)
 
     def _write_settings_json(self, pi_home):
-        """Write pi's settings.json with compaction configuration.
+        """Write pi's settings.json with managed lane configuration.
 
         pi may persist unrelated keys in settings.json, so this method reads
-        any existing file, merges the compaction block, and writes back. If
-        the file is missing, unreadable, or contains invalid JSON, fall back
-        to writing just the compaction block without crashing the spawn.
+        any existing file, merges the compaction and thinking defaults, and
+        writes back. If the file is missing, unreadable, or contains invalid
+        JSON, fall back to writing just those defaults without crashing the
+        spawn.
         """
         agent_dir = os.path.join(pi_home, "agent")
         _ensure_cli_dir(agent_dir)
@@ -2733,6 +2745,7 @@ class PiProcess:
             "reserveTokens": PI_COMPACTION_RESERVE_TOKENS,
             "keepRecentTokens": PI_COMPACTION_KEEP_RECENT_TOKENS,
         }
+        existing_settings["defaultThinkingLevel"] = PI_DEFAULT_THINKING_LEVEL
 
         try:
             with open(settings_path, "w") as stream:

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -4318,10 +4318,13 @@ def test_pi_models_json_declares_correct_context_window(tmp_path, monkeypatch):
 
     models_path = tmp_path / "workspace" / ".pi" / "agent" / "models.json"
     models = json.loads(models_path.read_text())
-    model_dict = models["providers"]["openai-completions"]["models"][0]
+    provider = models["providers"]["openai-completions"]
+    model_dict = provider["models"][0]
 
+    assert provider["compat"]["thinkingFormat"] == "qwen-chat-template"
     assert model_dict["contextWindow"] == shim.PI_CONTEXT_WINDOW
     assert model_dict["maxTokens"] == shim.PI_MAX_OUTPUT_TOKENS
+    assert model_dict["reasoning"] is True
 
     manager._close_process()
 
@@ -4354,6 +4357,17 @@ def test_pi_settings_json_compaction_reserve_exceeds_max_output(tmp_path, monkey
     ), "Compaction reserve too small: full response may not fit when compaction fires"
 
 
+def test_pi_default_thinking_level_is_valid():
+    """The configured default must be one of pi's ThinkingLevel strings."""
+    assert shim.PI_DEFAULT_THINKING_LEVEL in {
+        "off",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+    }
+
+
 def test_pi_settings_json_keep_recent_smaller_than_usable_window(tmp_path, monkeypatch):
     """keepRecentTokens must be less than the usable window after compaction."""
     usable_after_reserve = shim.PI_CONTEXT_WINDOW - shim.PI_COMPACTION_RESERVE_TOKENS
@@ -4377,6 +4391,7 @@ def test_pi_settings_json_is_written_with_compaction_block(tmp_path, monkeypatch
         settings["compaction"]["keepRecentTokens"]
         == shim.PI_COMPACTION_KEEP_RECENT_TOKENS
     )
+    assert settings["defaultThinkingLevel"] == shim.PI_DEFAULT_THINKING_LEVEL
 
     manager._close_process()
 
@@ -4414,6 +4429,7 @@ def test_pi_settings_json_corrupt_file_does_not_break_spawn(tmp_path, monkeypatc
 
     settings = json.loads(settings_path.read_text())
     assert "compaction" in settings, "Corrupt file was not replaced with fresh content"
+    assert settings["defaultThinkingLevel"] == shim.PI_DEFAULT_THINKING_LEVEL
 
     manager._close_process()
 


### PR DESCRIPTION
## Cycle 3 (#5051, fast lane)

qwen generation dominates the fast-task wall, and most of those tokens are the reasoning trace. pi (earendil-works/pi v0.83.0) only sends `chat_template_kwargs.enable_thinking` when `compat.thinkingFormat: "qwen-chat-template"` and the model is `reasoning: true`; the value then follows `settings.json` `defaultThinkingLevel`. The shim set none of these, so the server defaulted to thinking on.

Proven directly against the live llama.cpp endpoint: `chat_template_kwargs: {enable_thinking: false}` cuts a trivial answer from **32 to 4** completion tokens, correct, no reasoning block. `reasoning_effort` is ignored by llama.cpp for this model (matching pi's `supportsReasoningEffort: false`).

## What

- models.json: `compat.thinkingFormat: "qwen-chat-template"`, model `reasoning: true`.
- settings.json: `defaultThinkingLevel` = new `PI_DEFAULT_THINKING_LEVEL` constant (`"off"`; flip to `"high"` to restore full reasoning).

This is the small-task lane by design (qwen only ever runs on pi-runtime, the lean pi-only image; the all-CLIs claude-runtime lane runs claude/codex, untouched). It is a shim change on the clean guest-image rollout path, not a base-admission change.

## Decision + follow-up

Ship as the default-off state, measure the fast set (2 reps) after rollout, keep iff correctness holds and p50 wall improves. A per-turn opt-in follows: pi exposes an RPC `set_thinking_level`, so a `reasoning` flag plumbed monolith -> invoke -> shim gives fast-by-default with thinking on demand for hard/long tasks (which also unblocks the long lane).

## Verification

- `ci`: `Executed 3 out of 739 tests: 739 tests pass`.
- Post-rollout I will re-run the fast set on the live lane and post before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WcU1F22ysoi1WhEtpGAo3