### PR TITLE
ci: move merges onto the GitHub merge queue

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,7 +17,9 @@ things you would only learn by breaking them.
   `projects/<service>/deploy/values.yaml`, commit, push, and ArgoCD syncs within
   5 to 10 seconds.
 - **Never commit to main.** Worktree, branch, PR, rebase-merge, and this repo
-  allows rebase merges only. See the `pr-workflow` skill.
+  allows rebase merges only. Merges land through the GitHub merge queue
+  (`gh pr merge --auto --rebase` enqueues): never rebase a PR because main
+  moved, the queue does that. See the `pr-workflow` skill.
 - **`ci` is the feedback loop, not PR CI.** Run it before pushing.
 - **No em-dashes in anything you write**: site copy, CV content, docs, ADRs,
   commit messages, PR bodies, code comments. Use a comma, colon, parentheses, or

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -47,17 +47,22 @@ not land. Fetch, rebase, and push again.
 This repo allows **rebase merges only**. Squash and merge commits are disabled,
 so always `gh pr merge --rebase` (or `--auto --rebase`).
 
-**Required checks are strict: the branch must be up to date with main.** Any
-other PR merging puts every open PR into `BEHIND`, where auto-merge will not
-fire. Fix it with `gh pr update-branch <number> --rebase` and let CI re-run.
+**Merges go through the GitHub merge queue.** `gh pr merge --auto --rebase`
+("merge when ready") enqueues the PR once it is green and reviewed; the queue
+rebases it onto current main, runs `pr-checks` on the candidate (a push to a
+`gh-readonly-queue/main/pr-<n>-<sha>` branch), and merges. **Never
+`gh pr update-branch` or rebase a PR just because main moved**: the queue does
+that, and a local rebase only changes the head and restarts CI.
 
-This is deliberate, not friction to route around. It is what guarantees a PR was
-tested against **current** main, so a semantic conflict between two PRs that are
-individually green cannot break main. A GitHub merge queue would provide the
-same guarantee without the re-runs, but merge queues need an organisation-owned
-repository and this one is user-owned, so the strict check is the only mechanism
-available. If `mergeStateStatus` is `BEHIND`, update the branch. Never try to
-bypass the strict check.
+`mergeStateStatus: BEHIND` is no longer a blocker; the required check is not
+strict. The queue is what guarantees a PR was tested against **current** main,
+so a semantic conflict between two individually green PRs cannot break main.
+
+Each merge still moves main twice (the merge, then the chart write-back), and
+the queue re-tests the candidates behind it on each move. That is the queue's
+churn, not yours. A red queue run ejects the PR: re-enqueue with the same
+`gh pr merge --auto --rebase` after checking whether the failure was the flaky
+Elixir suite (#4828) or real.
 
 This rationale used to be about chart versions: the re-run let the
 missed-chart-bump guard catch two PRs claiming the same version. That reason is
@@ -73,8 +78,8 @@ walking away:
 1. Poll `gh pr view <number> --json state,mergeStateStatus` until it merges.
 2. Poll the rollout to confirm the fix is actually live.
 
-If auto-merge fails with "Pull request is in clean status", the PR is already
-green: merge directly with `gh pr merge --rebase`.
+`gh pr merge --rebase` without `--auto` also enqueues rather than merging
+directly; there is no bypass and none should be used.
 
 Use background Bash or `Monitor` for CI waits. Sleep-chained polling is blocked.
 

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -256,9 +256,20 @@ actions:
               # fresh pr-checks; this one is finished either way.
               echo "Auto-committing formatting fixes..."
               current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+              # A merge-queue candidate lives on a read-only ref, so the push
+              # below would be rejected with an opaque error. Drift here means
+              # the PR's own pr-checks run never committed it (or main moved
+              # under it); say so and fail, which ejects the PR from the queue.
+              case "${GIT_BRANCH:-$current_branch}" in
+                gh-readonly-queue/*)
+                  echo "Format drift on merge-queue candidate ${GIT_BRANCH:-$current_branch}; commit it on the PR branch and re-enqueue."
+                  git diff --stat
+                  exit 1
+                  ;;
+              esac
               git config user.name "ci-format-bot"
               git config user.email "ci-format-bot@users.noreply.github.com"
-              git remote set-url origin "https://x-access-token:${GHCR_TOKEN}@github.com/jomcgi/homelab.git"
+              git remote set-url origin "https://x-access-token:${GHCR_TOKEN}@github.com/jomcgi-org/homelab.git"
               git add -u
               git commit -m "style: auto-format"
               git push origin HEAD:"$current_branch"
@@ -389,7 +400,7 @@ actions:
           # the guarantee for every push, not just this one.
           #
           # pr-checks does exactly this for the ci-format-bot commit.
-          git remote set-url origin "https://x-access-token:${GHCR_TOKEN}@github.com/jomcgi/homelab.git"
+          git remote set-url origin "https://x-access-token:${GHCR_TOKEN}@github.com/jomcgi-org/homelab.git"
           ./bazel/helm/write-back-versions.sh .chart-version-records
 
           # ---- 3. formatting must already be correct ----------------------


### PR DESCRIPTION
Enables the GitHub merge queue now that the repo is org-owned, to end rebase churn from `strict` required checks. Ruleset already updated via API; this PR carries the CI guard for read-only queue branches and the workflow docs.

Ruleset: merge_queue (REBASE, ALLGREEN, build 5 / merge 5, 1 min wait, 60 min timeout), strict=false, OrganizationAdmin bypass so chart-version-bot's write-back push still lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JutDBVUEnncrastyE8E7kp