### PR TITLE
chore(argocd): point every Application at the jomcgi-org repo URL

### DIFF
--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -25,7 +25,7 @@ spec:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml
     # Git repo for environment-specific values.
-    - repoURL: https://github.com/jomcgi/homelab.git
+    - repoURL: https://github.com/jomcgi-org/homelab.git
       targetRevision: HEAD
       ref: values
   destination:

--- a/projects/embervm/dev/deploy/application.yaml
+++ b/projects/embervm/dev/deploy/application.yaml
@@ -33,7 +33,7 @@ spec:
         valueFiles:
           - $values/projects/embervm/dev/deploy/values.yaml
     # Git repo for environment-specific values.
-    - repoURL: https://github.com/jomcgi/homelab.git
+    - repoURL: https://github.com/jomcgi-org/homelab.git
       targetRevision: HEAD
       ref: values
   destination:

--- a/projects/inference/deploy/application.yaml
+++ b/projects/inference/deploy/application.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     path: projects/inference/deploy
     targetRevision: HEAD
     helm:

--- a/projects/mcp/context-forge-gateway/deploy/application.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/application.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     path: projects/mcp/context-forge-gateway/chart
     targetRevision: HEAD
     helm:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -15,7 +15,7 @@ spec:
         valueFiles:
           - $values/projects/monolith-public/deploy/values.yaml
     # Git repo for environment-specific values
-    - repoURL: https://github.com/jomcgi/homelab.git
+    - repoURL: https://github.com/jomcgi-org/homelab.git
       targetRevision: HEAD
       ref: values
   destination:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -35,7 +35,7 @@ spec:
         valueFiles:
           - $values/projects/monolith/deploy/values.yaml
     # Git repo for environment-specific values
-    - repoURL: https://github.com/jomcgi/homelab.git
+    - repoURL: https://github.com/jomcgi-org/homelab.git
       targetRevision: HEAD
       ref: values
   destination:

--- a/projects/monolith/dev/deploy/application.yaml
+++ b/projects/monolith/dev/deploy/application.yaml
@@ -89,7 +89,7 @@ spec:
         valueFiles:
           - $values/projects/monolith/deploy/values.yaml
           - $values/projects/monolith/dev/deploy/values.yaml
-    - repoURL: https://github.com/jomcgi/homelab.git
+    - repoURL: https://github.com/jomcgi-org/homelab.git
       targetRevision: HEAD
       ref: values
   destination:

--- a/projects/operators/oci-model-cache/deploy/application.yaml
+++ b/projects/operators/oci-model-cache/deploy/application.yaml
@@ -14,7 +14,7 @@ spec:
         valueFiles:
           - $values/projects/operators/oci-model-cache/deploy/values.yaml
     # Git repo for environment-specific values
-    - repoURL: https://github.com/jomcgi/homelab.git
+    - repoURL: https://github.com/jomcgi-org/homelab.git
       targetRevision: HEAD
       ref: values
   destination:

--- a/projects/platform/argo-workflows/application.yaml
+++ b/projects/platform/argo-workflows/application.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     path: projects/platform/argo-workflows
     targetRevision: HEAD
     helm:

--- a/projects/platform/argocd/application.yaml
+++ b/projects/platform/argocd/application.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: HEAD
     path: projects/platform/argocd
     helm:

--- a/projects/platform/atlas-operator/deploy/application.yaml
+++ b/projects/platform/atlas-operator/deploy/application.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: atlas-operator
         valueFiles:
           - $values/projects/platform/atlas-operator/deploy/values.yaml
-    - repoURL: https://github.com/jomcgi/homelab.git
+    - repoURL: https://github.com/jomcgi-org/homelab.git
       targetRevision: HEAD
       ref: values
   destination:

--- a/projects/platform/authentik/application.yaml
+++ b/projects/platform/authentik/application.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: HEAD
     path: projects/platform/authentik
     helm:

--- a/projects/platform/cert-manager/application.yaml
+++ b/projects/platform/cert-manager/application.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: HEAD
     path: projects/platform/cert-manager
     helm:

--- a/projects/platform/cilium/application.yaml
+++ b/projects/platform/cilium/application.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: HEAD
     path: projects/platform/cilium
     helm:

--- a/projects/platform/cloudflare-gateway/application.yaml
+++ b/projects/platform/cloudflare-gateway/application.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: HEAD
     path: projects/platform/cloudflare-gateway
     helm:

--- a/projects/platform/cloudnative-pg/deploy/application.yaml
+++ b/projects/platform/cloudnative-pg/deploy/application.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: cnpg
         valueFiles:
           - $values/projects/platform/cloudnative-pg/deploy/values.yaml
-    - repoURL: https://github.com/jomcgi/homelab.git
+    - repoURL: https://github.com/jomcgi-org/homelab.git
       targetRevision: HEAD
       ref: values
   destination:

--- a/projects/platform/coredns/application.yaml
+++ b/projects/platform/coredns/application.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: main
     path: projects/platform/coredns
     helm:

--- a/projects/platform/kargo/application.yaml
+++ b/projects/platform/kargo/application.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: HEAD
     path: projects/platform/kargo
     helm:

--- a/projects/platform/keda/application.yaml
+++ b/projects/platform/keda/application.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     path: projects/platform/keda
     targetRevision: HEAD
     helm:

--- a/projects/platform/kyverno/application.yaml
+++ b/projects/platform/kyverno/application.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: HEAD
     path: projects/platform/kyverno
     helm:

--- a/projects/platform/longhorn/application.yaml
+++ b/projects/platform/longhorn/application.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     path: projects/platform/longhorn
     targetRevision: HEAD
     helm:

--- a/projects/platform/nvidia-gpu-operator/application.yaml
+++ b/projects/platform/nvidia-gpu-operator/application.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     path: projects/platform/nvidia-gpu-operator
     targetRevision: HEAD
     helm:

--- a/projects/platform/opentelemetry-operator/application.yaml
+++ b/projects/platform/opentelemetry-operator/application.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: HEAD
     path: projects/platform/opentelemetry-operator
     helm:

--- a/projects/platform/priority-classes/application.yaml
+++ b/projects/platform/priority-classes/application.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: main
     path: projects/platform/priority-classes
     helm:

--- a/projects/platform/renovate/application.yaml
+++ b/projects/platform/renovate/application.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: main
     path: projects/platform/renovate
     helm:

--- a/projects/platform/seaweedfs-node4/application.yaml
+++ b/projects/platform/seaweedfs-node4/application.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     path: projects/platform/seaweedfs-node4
     targetRevision: HEAD
     helm:

--- a/projects/platform/seaweedfs-node4b/application.yaml
+++ b/projects/platform/seaweedfs-node4b/application.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     path: projects/platform/seaweedfs-node4b
     targetRevision: HEAD
     helm:

--- a/projects/platform/seaweedfs/application.yaml
+++ b/projects/platform/seaweedfs/application.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     path: projects/platform/seaweedfs
     targetRevision: HEAD
     helm:

--- a/projects/platform/signoz-addons/alerts/application.yaml
+++ b/projects/platform/signoz-addons/alerts/application.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: HEAD
     path: projects/platform/signoz-addons/alerts
     helm:

--- a/projects/platform/signoz-addons/dashboard-sidecar/application.yaml
+++ b/projects/platform/signoz-addons/dashboard-sidecar/application.yaml
@@ -15,7 +15,7 @@ spec:
         valueFiles:
           - $values/projects/platform/signoz-addons/dashboard-sidecar/values-prod.yaml
     # Git repo for environment-specific values
-    - repoURL: https://github.com/jomcgi/homelab.git
+    - repoURL: https://github.com/jomcgi-org/homelab.git
       targetRevision: HEAD
       ref: values
   destination:

--- a/projects/platform/signoz/application.yaml
+++ b/projects/platform/signoz/application.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/jomcgi/homelab.git
+    repoURL: https://github.com/jomcgi-org/homelab.git
     targetRevision: HEAD
     path: projects/platform/signoz
     helm:


### PR DESCRIPTION
The repository moved to the `jomcgi-org` organisation on 2026-08-22. The transfer dropped the ArgoCD GitHub App installation, which took every Application into `ComparisonError` for about an hour; the App was transferred and reinstalled on the org and the ArgoCD repository credential now carries the org URL and the new installation id.

ArgoCD matches credentials by URL, so the 31 Applications still naming `github.com/jomcgi/homelab.git` were fetching anonymously through GitHub's redirect. This is a mechanical rewrite of those `repoURL` lines to `github.com/jomcgi-org/homelab.git`. Go module paths, historical links and the write-back test fixtures are untouched.

Platform apps deploy on HEAD so this lands on merge; the sources resolve to the same repository either way.

`ci`: `Executed 40 out of 739 tests: 739 tests pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186v59MiisdKdMFsssE3deE