### PR TITLE
feat(embervm): let a single qwen turn override the thinking level via the invoke body

### DIFF
--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -415,6 +415,24 @@ PI_MAX_OUTPUT_TOKENS = 12288
 # "high" to restore full reasoning. The value must be one of pi's
 # ThinkingLevel strings: off, minimal, low, medium, high.
 PI_DEFAULT_THINKING_LEVEL = "off"
+PI_THINKING_LEVELS = ("off", "minimal", "low", "medium", "high")
+
+
+def _resolve_thinking_level(value):
+    """Map an inbound thinking request to a valid pi ThinkingLevel.
+
+    None or an unrecognised value falls back to PI_DEFAULT_THINKING_LEVEL, so a
+    bad or missing field can never crash a turn or silently pick a wrong level.
+    A bare True means "the caller wants thinking" -> "high"; False -> "off".
+    """
+    if value is True:
+        return "high"
+    if value is False:
+        return "off"
+    if isinstance(value, str) and value in PI_THINKING_LEVELS:
+        return value
+    return PI_DEFAULT_THINKING_LEVEL
+
 
 # Compaction reserve in tokens. This must exceed PI_MAX_OUTPUT_TOKENS plus
 # PI_CONTEXT_SAFETY_TOKENS so pi starts compacting while there is still room for
@@ -2919,6 +2937,7 @@ class PiProcess:
         model=DEFAULT_PI_MODEL,
         progress_token=None,
         system_prompt=None,
+        thinking=None,
     ):
         with self.turn_lock:
             cli_ready_start = _turn_timing_now()
@@ -2999,6 +3018,13 @@ class PiProcess:
             try:
                 self._turn_timing_model_start = _turn_timing_now()
                 model_fallback_started_at = _turn_timing_now()
+                level = _resolve_thinking_level(thinking)
+                try:
+                    self._command({"type": "set_thinking_level", "level": level})
+                except Exception:
+                    # pi older than the RPC, or a transient RPC error, must never
+                    # fail the turn: the model just keeps its current level.
+                    pass
                 self._send({"type": "prompt", "message": message})
                 while True:
                     try:
@@ -3698,6 +3724,7 @@ class ProcessManager:
         branch=None,
         progress_token=None,
         system_prompt=None,
+        thinking=None,
     ):
         total_start = _turn_timing_now()
         with self._mount_lock:
@@ -3739,7 +3766,11 @@ class ProcessManager:
             prompt = {"system_prompt": system_prompt} if system_prompt else {}
             if adapter is self.pi:
                 record = adapter.turn(
-                    message, session_id, model or DEFAULT_PI_MODEL, **(extra | prompt)
+                    message,
+                    session_id,
+                    model or DEFAULT_PI_MODEL,
+                    thinking=thinking,
+                    **(extra | prompt),
                 )
             elif adapter is self.codex:
                 record = adapter.turn(
@@ -3874,6 +3905,20 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
         ):
             self._send(400, {"error": "system_prompt must be a non-empty string"})
             return
+        thinking = payload.get("thinking")
+        if thinking is not None and not (
+            thinking is True
+            or thinking is False
+            or (isinstance(thinking, str) and thinking in PI_THINKING_LEVELS)
+        ):
+            self._send(
+                400,
+                {
+                    "error": "thinking must be a bool or one of %s"
+                    % (PI_THINKING_LEVELS,)
+                },
+            )
+            return
         if "session_id" in payload:
             sid = payload.get("session_id")
             if sid is not None and (not isinstance(sid, str) or not sid.strip()):
@@ -3888,11 +3933,12 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
                 {"progress_token": progress_token.strip()} if progress_token else {}
             )
             prompt = {"system_prompt": system_prompt.strip()} if system_prompt else {}
+            thinking_override = {"thinking": thinking} if thinking is not None else {}
             record = self.manager.turn(
                 message,
                 session_id,
                 payload.get("model"),
-                **(hydration | progress | prompt),
+                **(hydration | progress | prompt | thinking_override),
             )
             if repo is not None and isinstance(record, dict):
                 if getattr(self.manager, "_hydration_error", None):

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -327,6 +327,8 @@ for line in sys.stdin:
     elif command == "set_model":
         state["model"] = {"id": request["modelId"]}
         response(command, data=state["model"])
+    elif command == "set_thinking_level":
+        response(command, data={"level": request["level"]})
     elif command == "switch_session":
         if os.environ.get("FAKE_PI_SWITCH") == "failed":
             response(command, success=False)
@@ -478,6 +480,37 @@ def test_pi_first_turn_returns_text_session_and_usage(tmp_path, monkeypatch):
     assert record["session_id"] == "pi-session"
     assert "input_tokens" in record["usage"]
     assert record["activities"] == [{"type": "bash", "command": "echo pi"}]
+    manager._close_process()
+
+
+def test_resolve_thinking_level():
+    assert shim._resolve_thinking_level(None) == shim.PI_DEFAULT_THINKING_LEVEL
+    assert shim._resolve_thinking_level(True) == "high"
+    assert shim._resolve_thinking_level(False) == "off"
+    assert shim._resolve_thinking_level("medium") == "medium"
+    assert shim._resolve_thinking_level("bogus") == shim.PI_DEFAULT_THINKING_LEVEL
+
+
+@pytest.mark.parametrize(
+    ("thinking", "expected"),
+    [("high", "high"), (None, shim.PI_DEFAULT_THINKING_LEVEL)],
+)
+def test_pi_turn_sets_thinking_level_before_prompt(
+    tmp_path, monkeypatch, thinking, expected
+):
+    manager = _pi_manager(tmp_path, monkeypatch)
+    manager.turn("hello", model="qwen", thinking=thinking)
+    requests = [
+        json.loads(line)
+        for line in (tmp_path / "pi-rpc.jsonl").read_text().splitlines()
+    ]
+    commands = [request["type"] for request in requests]
+    thinking_index = commands.index("set_thinking_level")
+    assert requests[thinking_index] == {
+        "type": "set_thinking_level",
+        "level": expected,
+    }
+    assert thinking_index < commands.index("prompt")
     manager._close_process()
 
 
@@ -2563,6 +2596,12 @@ def test_system_prompt_validation_and_forwarding():
     assert post({"message": "hello"}, manager) == [(200, {"result": "ok"})]
     assert manager.calls[0][1] == {}
 
+    manager = _Manager()
+    assert post({"message": "hello", "thinking": "high"}, manager) == [
+        (200, {"result": "ok"})
+    ]
+    assert manager.calls[0][1] == {"thinking": "high"}
+
     for token in ("", 123):
         manager = _Manager()
         responses = post({"message": "hello", "system_prompt": token}, manager)
@@ -2578,9 +2617,22 @@ def test_system_prompt_validation_and_forwarding():
         ]
         assert manager.calls == []
 
+    manager = _Manager()
+    responses = post({"message": "hello", "thinking": "bogus"}, manager)
+    assert responses == [
+        (
+            400,
+            {
+                "error": "thinking must be a bool or one of %s"
+                % (shim.PI_THINKING_LEVELS,)
+            },
+        )
+    ]
+    assert manager.calls == []
 
-def test_progress_token_forwarded_to_claude_adapter(monkeypatch):
-    """ProcessManager.turn forwards progress_token only when supplied."""
+
+def test_process_manager_forwards_adapter_specific_turn_options(monkeypatch):
+    """ProcessManager.turn forwards options only to adapters that accept them."""
     manager = _new_process_manager()
     manager._hydration_error = None
     manager._hydration_status = None
@@ -2611,6 +2663,16 @@ def test_progress_token_forwarded_to_claude_adapter(monkeypatch):
     manager.turn("msg", session_id="s1", model=None)
     assert len(calls) == 1
     assert "progress_token" not in calls[0][1]
+
+    calls.clear()
+    manager.turn("msg", session_id="s1", model="qwen", thinking="high")
+    assert len(calls) == 1
+    assert calls[0][1].get("thinking") == "high"
+
+    calls.clear()
+    manager.turn("msg", session_id="s1", model=None, thinking="high")
+    assert len(calls) == 1
+    assert "thinking" not in calls[0][1]
 
 
 def test_throttle_allows_push_after_0_2_seconds(monkeypatch):


### PR DESCRIPTION
## #5051 PR B1 (opt-in thinking, guest side)

Stacked on #5087 (default thinking off). pi exposes an RPC `set_thinking_level`, so this lets one turn override the lane default:

- `PiProcess.turn` takes an optional `thinking` and sends `set_thinking_level` before the prompt (best-effort; a missing RPC or bad value never fails the turn).
- `do_POST` reads an optional `thinking` field from the invoke body (a bool, or one of off/minimal/low/medium/high), validates it (400 on bad input), and threads it through `ProcessManager.turn` to the pi adapter only (claude/codex unaffected).
- Unknown/missing -> `PI_DEFAULT_THINKING_LEVEL` (off).

Inert until a caller sends `thinking`; the monolith `reasoning` flag that sets it is PR B2. Net effect once both land: qwen is fast by default, and a hard/long task opts into reasoning per session.

## Verification

- shim thinking tests pass; `ci`: `Executed 3 out of 739 tests: 739 tests pass`.

Base is `perf/pi-thinking-off` (#5087) so this merges after it; I will retarget to main if #5087 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WcU1F22ysoi1WhEtpGAo3