### PR TITLE
feat(embervm): deliver the platform KEK root to the key service from 1Password

### DIFF
--- a/projects/embervm/chart/chart_env_identity_test.py
+++ b/projects/embervm/chart/chart_env_identity_test.py
@@ -601,3 +601,26 @@ def test_dev_never_dials_production_control_plane(renders):
             "reach production's control plane is double-assigned by design, since "
             "adoption is additive over whatever primed_vm_ids a node reports."
         )
+
+
+def test_kek_root_renders_item_and_env_only_when_enabled():
+    chart = _chart_dir()
+    enabled = _render(
+        "kek",
+        [chart / "values.yaml"],
+        ["kekRoot.enabled=true", "kekRoot.onepassword.itemPath=vaults/x/items/y"],
+    )
+    items = [doc for kind, _, doc in _docs(enabled) if kind == "OnePasswordItem"]
+    assert any("name: kek-embervm-kek-root" in doc for doc in items)
+    control_plane = next(
+        doc
+        for kind, name, doc in _docs(enabled)
+        if kind == "Deployment" and name == "kek-embervm"
+    )
+    assert re.search(
+        r"name:\s*EMBERVM_KEK_ROOT\s+valueFrom:\s+secretKeyRef:\s+name:\s*kek-embervm-kek-root\s+key:\s*root",
+        control_plane,
+        re.S,
+    )
+    disabled = _render("kek", [chart / "values.yaml"])
+    assert "EMBERVM_KEK_ROOT" not in disabled

--- a/projects/embervm/chart/templates/_helpers.tpl
+++ b/projects/embervm/chart/templates/_helpers.tpl
@@ -241,3 +241,17 @@ path noded attaches are byte-identical.
 {{- $suffix := $digest | toString | replace ":" "-" | replace "@" "-" | replace "/" "-" -}}
 {{- printf "%s-%s.ext4" (trimSuffix ".ext4" .wl.rootfsPath) $suffix -}}
 {{- end -}}
+
+{{/*
+KEK root Secret name (ADR embervm/036). Generated from the release when the
+1Password item is named; a pre-existing Secret must be named explicitly.
+*/}}
+{{- define "embervm.kekRootSecretName" -}}
+{{- if .Values.kekRoot.name -}}
+{{- .Values.kekRoot.name -}}
+{{- else if .Values.kekRoot.onepassword.itemPath -}}
+{{- printf "%s-kek-root" (include "embervm.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- fail "kekRoot.name is required when kekRoot.enabled is true without kekRoot.onepassword.itemPath" -}}
+{{- end -}}
+{{- end -}}

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -171,6 +171,15 @@ spec:
                   name: {{ include "embervm.noded.bearerTokenSecretName" . }}
                   key: {{ .Values.noded.bearerTokenSecret.key }}
             {{- end }}
+            {{- if .Values.kekRoot.enabled }}
+            # Platform KEK root (ADR embervm/036): base64, held only in the
+            # KeyService process, never logged. Empty leaves the custodian inert.
+            - name: EMBERVM_KEK_ROOT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "embervm.kekRootSecretName" . }}
+                  key: {{ .Values.kekRoot.key }}
+            {{- end }}
             {{- if and .Values.runtimePython .Values.runtimePython.guestImage .Values.runtimePython.guestImage.repository }}
             # R1 zip lane (ADR embervm/002): the zip-lane runtime name -> pinned
             # runtime base image ref, as `runtime=ref` pairs. BaseBuilder resolves

--- a/projects/embervm/chart/templates/onepassworditem-kek-root.yaml
+++ b/projects/embervm/chart/templates/onepassworditem-kek-root.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.kekRoot.enabled .Values.kekRoot.onepassword.itemPath }}
+# The operator renders this item into a Secret of the SAME NAME with one field
+# labelled by kekRoot.key (default "root"): the base64 platform KEK root the
+# control plane's key service derives per-principal KEKs from (ADR embervm/036).
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ include "embervm.kekRootSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "embervm.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.kekRoot.onepassword.itemPath | quote }}
+{{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -205,6 +205,19 @@ node:
 auth:
   allowedServiceAccounts: []
 
+# Platform KEK root for Embervm.KeyService (ADR embervm/036, #4976). One
+# 1Password item holds the root (field "root", base64 of 32+ random bytes);
+# the control plane derives every per-principal KEK from it in memory and
+# never persists a derived key. Disabled here: the service starts inert and
+# every derive/wrap returns {:error, :no_root}. Set onepassword.itemPath to
+# render the OnePasswordItem and the env; name defaults to <fullname>-kek-root.
+kekRoot:
+  enabled: false
+  name: ""
+  key: root
+  onepassword:
+    itemPath: ""
+
 # Fair dispatcher tuning (Task 11). The pool floor/cap and invocation policy are
 # per-Workload in the CR; these are the cross-workload enforcement knobs.
 dispatcher:


### PR DESCRIPTION
Refs #4976 (PR 2 of ADR embervm/036). Chart-only: `kekRoot.enabled` + `kekRoot.onepassword.itemPath` render an `OnePasswordItem` and `EMBERVM_KEK_ROOT` on the control plane, same shape as the noded bearer token. Default off; render test pins both states. No environment enables it yet (a values PR follows once the `embervm-kek-root` item is confirmed).

`ci`: Bazel 739 pass (same diff, re-based after a local mishap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP