### PR TITLE
ci: keep the analysis cache across pr-checks runs and let the smokes cache

### DIFF
--- a/bazel/erlang/BUILD
+++ b/bazel/erlang/BUILD
@@ -69,7 +69,11 @@ filegroup(
 
 # Smoke test: proves the prebuilt ubuntu-22.04 OTP boots and runs crypto ON the
 # RBE executor (the decisive de-risk before wiring mix/elixir + apko). Built by
-# `bazel test //...`; no-remote-cache so it re-verifies the live executor.
+# `bazel test //...`. It was no-remote-cache "to re-verify the live executor",
+# which meant it, mix_test_smoke, release_boot_smoke and the claude late-resume
+# smoke re-ran on EVERY invocation (PR, queue candidate, main, write-back) with
+# unchanged inputs. The inputs are hermetic, so it caches like everything else
+# now; the executor was de-risked in 2026-07.
 genrule(
     name = "otp_smoke",
     srcs = [
@@ -78,8 +82,7 @@ genrule(
     ],
     outs = ["otp_smoke.txt"],
     cmd = "$(location otp_smoke.sh) \"$(location @otp_ubuntu2204_amd64//:Install)\" \"$@\"",
-    tags = ["no-remote-cache"],
-    tools = ["otp_smoke.sh"],
+        tools = ["otp_smoke.sh"],
 )
 
 # Proves the prebuilt OTP + precompiled Elixir compile and ExUnit-test the
@@ -118,8 +121,7 @@ genrule(
           "EMBERVM_NODE_PROTO_SRC=\"$(location //projects/embervm/proto/embervm/node/v1:node_proto)\" " +
           "EMBERVM_FAKE_NODE_SRC=\"$(location //projects/embervm/proto/embervm/node/v1/fakenode)\" " +
           "$(location mix_test.sh) \"$(location @otp_ubuntu2204_amd64//:Install)\" \"$(location @elixir_1_18_4//:bin/elixir)\" \"$(location //projects/embervm/control:mix.exs)\" \"$@\" \"$(location @hex_archive//file)\" \"$(location //projects/embervm/proto/embervm/node/v1:node_elixir_src)\" $(locations :hex_tarballs)",
-    tags = ["no-remote-cache"],
-    tools = ["mix_test.sh"],
+        tools = ["mix_test.sh"],
 )
 
 bzl_library(

--- a/bazel/erlang/BUILD
+++ b/bazel/erlang/BUILD
@@ -82,7 +82,7 @@ genrule(
     ],
     outs = ["otp_smoke.txt"],
     cmd = "$(location otp_smoke.sh) \"$(location @otp_ubuntu2204_amd64//:Install)\" \"$@\"",
-        tools = ["otp_smoke.sh"],
+    tools = ["otp_smoke.sh"],
 )
 
 # Proves the prebuilt OTP + precompiled Elixir compile and ExUnit-test the
@@ -121,7 +121,7 @@ genrule(
           "EMBERVM_NODE_PROTO_SRC=\"$(location //projects/embervm/proto/embervm/node/v1:node_proto)\" " +
           "EMBERVM_FAKE_NODE_SRC=\"$(location //projects/embervm/proto/embervm/node/v1/fakenode)\" " +
           "$(location mix_test.sh) \"$(location @otp_ubuntu2204_amd64//:Install)\" \"$(location @elixir_1_18_4//:bin/elixir)\" \"$(location //projects/embervm/control:mix.exs)\" \"$@\" \"$(location @hex_archive//file)\" \"$(location //projects/embervm/proto/embervm/node/v1:node_elixir_src)\" $(locations :hex_tarballs)",
-        tools = ["mix_test.sh"],
+    tools = ["mix_test.sh"],
 )
 
 bzl_library(

--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -72,10 +72,10 @@ multirun(
 
 # Charts only. `bazel run` has to materialise every command's runfiles on the
 # runner before any command executes, so running push_all drags all ~24 images'
-# layers out of CAS even when every action is a cache hit. Off main nothing may
-# publish anyway (push.sh.tpl takes the PR path), so PR CI runs this subset: it
-# carries the pre-merge missed-chart-bump guard at chart-sized cost, while the
-# images are proven to build with `bazel build //bazel/images:push_all`.
+# layers out of CAS even when every action is a cache hit. main's deploy runs
+# this subset through push-changed.sh after the images. PR CI no longer runs it
+# at all: the PR side of the missed-bump guard is retired (ADR platform/009)
+# and the images are proven to build with `bazel build //bazel/images:push_all`.
 multirun(
     name = "push_charts",
     commands = [

--- a/bazel/images/README.md
+++ b/bazel/images/README.md
@@ -41,8 +41,11 @@ PR branches (`pr-checks`) prove the images build and publish nothing:
 
 ```
 bazel build //bazel/images:push_all --config=ci
-bazel run //bazel/images:push_charts --config=ci --stamp
 ```
+
+(`push_charts --stamp` used to follow on PR branches. It is main-only now:
+the PR side of the guard is retired and flipping `--stamp` discarded the
+analysis cache the next run needed.)
 
 main (`deploy`) publishes through `bazel/images/push/push-changed.sh`, which
 builds the same way, reads each image's content digest from

--- a/bazel/images/generate-push-all.sh
+++ b/bazel/images/generate-push-all.sh
@@ -131,10 +131,10 @@ cat >>"$BUILD_FILE" <<'FOOTER'
 
 # Charts only. `bazel run` has to materialise every command's runfiles on the
 # runner before any command executes, so running push_all drags all ~24 images'
-# layers out of CAS even when every action is a cache hit. Off main nothing may
-# publish anyway (push.sh.tpl takes the PR path), so PR CI runs this subset: it
-# carries the pre-merge missed-chart-bump guard at chart-sized cost, while the
-# images are proven to build with `bazel build //bazel/images:push_all`.
+# layers out of CAS even when every action is a cache hit. main's deploy runs
+# this subset through push-changed.sh after the images. PR CI no longer runs it
+# at all: the PR side of the missed-bump guard is retired (ADR platform/009)
+# and the images are proven to build with `bazel build //bazel/images:push_all`.
 multirun(
     name = "push_charts",
     commands = [

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -180,10 +180,17 @@ actions:
           # before any command executes, which was 3.5 TB/week (PR #4586).
           bazel build //bazel/images:push_all --config=ci
 
-          # Charts only. Off main push.sh.tpl publishes nothing, so this exists
-          # to run bazel/helm/check-missed-bump.sh, the pre-merge guard that
-          # stops a chart whose images changed from merging un-bumped.
-          bazel run //bazel/images:push_charts --config=ci --stamp
+          # No `bazel run //bazel/images:push_charts --config=ci --stamp` here
+          # any more. On a PR branch push.sh.tpl retires the missed-bump guard
+          # (ADR platform/009: PRs carry no version) and pushes an ephemeral
+          # 0.0.0-dev chart nothing consumes, so the step proved nothing that
+          # `bazel build push_all` above does not. What it DID do was flip
+          # --stamp, which discards the whole analysis cache (see .bazelrc),
+          # and the snapshot is saved in that state: every later run re-loaded
+          # ~3000 packages / ~75k targets, about 2 of a warm run's 5.8 minutes
+          # (candidate a97c763d, 2026-08-22). main's deploy still runs
+          # push_charts through push-changed.sh, with --stamp, where the guard
+          # is the digest authority.
 
           # After the build, which is where the workspace is fattest.
           echo "DISK pr-checks after build:"; df -h /

--- a/projects/embervm/control/BUILD
+++ b/projects/embervm/control/BUILD
@@ -61,5 +61,5 @@ genrule(
     ],
     outs = ["release_boot_smoke.txt"],
     cmd = "$(location //bazel/erlang:release_boot.sh) \"$(location @otp_ubuntu2204_amd64//:Install)\" \"$(location :release_tar)\" \"$@\"",
-        tools = ["//bazel/erlang:release_boot.sh"],
+    tools = ["//bazel/erlang:release_boot.sh"],
 )

--- a/projects/embervm/control/BUILD
+++ b/projects/embervm/control/BUILD
@@ -61,6 +61,5 @@ genrule(
     ],
     outs = ["release_boot_smoke.txt"],
     cmd = "$(location //bazel/erlang:release_boot.sh) \"$(location @otp_ubuntu2204_amd64//:Install)\" \"$(location :release_tar)\" \"$@\"",
-    tags = ["no-remote-cache"],
-    tools = ["//bazel/erlang:release_boot.sh"],
+        tools = ["//bazel/erlang:release_boot.sh"],
 )

--- a/projects/embervm/runtimes/claude/BUILD
+++ b/projects/embervm/runtimes/claude/BUILD
@@ -73,8 +73,7 @@ sh_test(
     srcs = ["late_resume_smoke_test.sh"],
     args = ["$(rootpath :claude_code_patched_binary_amd64)"],
     data = [":claude_code_patched_binary_amd64"],
-    tags = ["no-remote-cache"],
-    target_compatible_with = ["@platforms//os:linux"],
+        target_compatible_with = ["@platforms//os:linux"],
 )
 
 # Workspace trust pre-seed. Remote Control server mode and the interactive paths

--- a/projects/embervm/runtimes/claude/BUILD
+++ b/projects/embervm/runtimes/claude/BUILD
@@ -73,7 +73,7 @@ sh_test(
     srcs = ["late_resume_smoke_test.sh"],
     args = ["$(rootpath :claude_code_patched_binary_amd64)"],
     data = [":claude_code_patched_binary_amd64"],
-        target_compatible_with = ["@platforms//os:linux"],
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 # Workspace trust pre-seed. Remote Control server mode and the interactive paths


### PR DESCRIPTION
Wall-time levers 1 and 3 from the merge-queue dissection: stop discarding Bazel's analysis cache between pr-checks runs (~2 min of a 5.8 min warm run), and let the four no-remote-cache smoke targets (incl. the ExUnit suite) cache on unchanged inputs.

Local `ci`: Executed 308 out of 741 tests, 741 pass; ExUnit 1384 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JutDBVUEnncrastyE8E7kp