### PR TITLE
ci: test only affected targets on PR branches

### DIFF
--- a/bazel/tools/ci/BUILD
+++ b/bazel/tools/ci/BUILD
@@ -13,3 +13,9 @@ sh_test(
         "//:buildbuddy.yaml",
     ],
 )
+
+sh_test(
+    name = "affected_targets_test",
+    srcs = ["affected_targets_test.sh"],
+    data = ["affected-targets.sh"],
+)

--- a/bazel/tools/ci/affected-targets.sh
+++ b/bazel/tools/ci/affected-targets.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# Computes Bazel targets affected by a PR diff for faster PR feedback.
+#
+# Usage: affected-targets.sh <base-ref> [<head-ref>] [-- <bazel-query-args>...]
+#   base-ref  : git ref (e.g., origin/main)
+#   head-ref  : git ref (default HEAD)
+#   bazel-query-args : extra args passed to bazel query (after --)
+#
+# Outputs to stdout:
+#   - A single line "//..." if fallback to full test suite needed
+#   - Otherwise: one target label per line that should be tested
+#   - Nothing if no files changed or all changed files are outside packages
+#
+# Outputs to stderr:
+#   - One line prefixed "affected-targets:" explaining the decision
+#
+# Exit: 0 always (unless rdeps query fails, then fallback with exit 0)
+#
+# Algorithm:
+#   1. Collect all changed files (merge-base diff + working tree + staged changes)
+#   2. Fallback to //... if any file in the graph-mutation set changed:
+#      - BUILD files: BUILD, BUILD.bazel
+#      - Workspace files: WORKSPACE, WORKSPACE.bazel, MODULE.bazel, MODULE.bazel.lock
+#      - Config files: .bazelrc, .bazelversion, buildbuddy.yaml
+#      - Deps and locks: *.bzl, *.lock, *requirements.txt, pnpm-lock.yaml,
+#        package.json, go.mod, go.sum, mix.lock, *.apko.yaml
+#      - Tooling: anything under bazel/ directory
+#      - Deleted files: any file removed from the tree
+#   3. Otherwise map each changed file to a Bazel label: //package:relative/path
+#      (root package uses //:relative/path)
+#   4. Probe for label existence with one set() query; fallback if probe fails
+#   5. Query rdeps to find all targets that transitively depend on the labels
+#   6. Filter out external repos (@) and output sorted results
+#
+# The fallback set covers changes that invalidate a simple rdeps walk over
+# source files. Graph-shape mutations (new BUILD files, imports, deps changes,
+# toolchain changes) make the forward walk unreliable, so the full test suite
+# is needed as the gate. Deleted source files cannot be mapped to labels by
+# static inspection (the file no longer exists to find a containing package).
+#
+# Integration with buildbuddy.yaml (pr-checks action):
+#   - Queue candidates (gh-readonly-queue/* branches) run //... (full gate)
+#   - Main pushes run //... (full snapshot seed for fast PR fallbacks)
+#   - PR branches use this script to run only affected targets (fast feedback)
+#
+# Local ci test runs stay 1:1 with the full test suite by design: PRs iterate
+# fast with cheap feedback while the queue candidate is the authoritative gate.
+
+set -euo pipefail
+
+usage() {
+	cat >&2 <<EOF
+Usage: affected-targets.sh <base-ref> [<head-ref>] [-- <bazel-query-args>...]
+  base-ref  : git ref (e.g., origin/main)
+  head-ref  : git ref (default HEAD)
+  bazel-query-args : extra args passed to bazel query (after --)
+EOF
+	exit 2
+}
+
+base_ref="${1:-}"
+if [[ -z "$base_ref" ]]; then
+	usage
+fi
+
+# Parse remaining args: head-ref and optional --
+head_ref="HEAD"
+bazel_args=()
+shift
+
+if [[ $# -gt 0 && "$1" != "--" ]]; then
+	head_ref="$1"
+	shift
+fi
+
+if [[ $# -gt 0 && "$1" == "--" ]]; then
+	shift
+	bazel_args=("$@")
+fi
+
+# Get changed files relative to the merge base
+changed_files=()
+while IFS= read -r file; do
+	[[ -n "$file" ]] && changed_files+=("$file")
+done < <(git diff --name-only --diff-filter=ACMRD "$base_ref...$head_ref" 2>/dev/null || true)
+
+# Include uncommitted changes (working tree + staged)
+while IFS= read -r file; do
+	[[ -n "$file" ]] && changed_files+=("$file")
+done < <(git diff --name-only 2>/dev/null || true)
+
+while IFS= read -r file; do
+	[[ -n "$file" ]] && changed_files+=("$file")
+done < <(git diff --cached --name-only 2>/dev/null || true)
+
+# Deduplicate (but only if non-empty to avoid mapfile adding an empty element)
+if [[ ${#changed_files[@]} -gt 0 ]]; then
+	mapfile -t changed_files < <(printf '%s\n' "${changed_files[@]}" | sort -u)
+fi
+
+# If no changes, nothing to test
+if [[ ${#changed_files[@]} -eq 0 ]]; then
+	echo "affected-targets: no changes, nothing to test" >&2
+	exit 0
+fi
+
+# Check for deleted files in the diff (three-dot range and cached)
+deleted_files=()
+while IFS= read -r file; do
+	[[ -n "$file" ]] && deleted_files+=("$file")
+done < <(git diff --name-only --diff-filter=D "$base_ref...$head_ref" 2>/dev/null || true)
+
+while IFS= read -r file; do
+	[[ -n "$file" ]] && deleted_files+=("$file")
+done < <(git diff --cached --name-only --diff-filter=D 2>/dev/null || true)
+
+if [[ ${#deleted_files[@]} -gt 0 ]]; then
+	echo "affected-targets: fallback to //... because deleted file: ${deleted_files[0]}" >&2
+	echo "//..."
+	exit 0
+fi
+
+# Check each file against fallback patterns (graph-shape mutations)
+for file in "${changed_files[@]}"; do
+	# Check basename
+	basename_only="${file##*/}"
+	case "$basename_only" in
+	BUILD | BUILD.bazel | WORKSPACE | WORKSPACE.bazel | MODULE.bazel | MODULE.bazel.lock | .bazelrc | .bazelversion | buildbuddy.yaml | package.json | go.mod | go.sum | mix.lock | pnpm-lock.yaml)
+		echo "affected-targets: fallback to //... because BUILD-shaped file changed: $file" >&2
+		echo "//..."
+		exit 0
+		;;
+	esac
+
+	# Check suffixes and patterns
+	case "$file" in
+	bazel/*)
+		echo "affected-targets: fallback to //... because file under bazel/ tooling: $file" >&2
+		echo "//..."
+		exit 0
+		;;
+	*.bzl)
+		echo "affected-targets: fallback to //... because Starlark import changed: $file" >&2
+		echo "//..."
+		exit 0
+		;;
+	*requirements.txt)
+		echo "affected-targets: fallback to //... because Python deps changed: $file" >&2
+		echo "//..."
+		exit 0
+		;;
+	*.lock)
+		echo "affected-targets: fallback to //... because dependency lock changed: $file" >&2
+		echo "//..."
+		exit 0
+		;;
+	*.apko.yaml)
+		echo "affected-targets: fallback to //... because apko image config changed: $file" >&2
+		echo "//..."
+		exit 0
+		;;
+	esac
+done
+
+# Map changed files to source labels: //package:relative/path or //:relative/path for root
+source_labels=()
+outside_count=0
+
+for file in "${changed_files[@]}"; do
+	# Find the nearest enclosing package (directory with BUILD or BUILD.bazel)
+	dir="${file%/*}"
+	[[ "$dir" == "$file" ]] && dir="."
+
+	package_root=""
+	while [[ "$dir" != "" && "$dir" != "." ]]; do
+		if [[ -f "$dir/BUILD" || -f "$dir/BUILD.bazel" ]]; then
+			package_root="$dir"
+			break
+		fi
+		dir="${dir%/*}"
+	done
+
+	# Check the repo root
+	if [[ -z "$package_root" ]]; then
+		if [[ -f "BUILD" || -f "BUILD.bazel" ]]; then
+			package_root="."
+		fi
+	fi
+
+	# If no package found, the file is outside any Bazel package
+	if [[ -z "$package_root" ]]; then
+		((outside_count++)) || true
+		continue
+	fi
+
+	# Compute the label: //:relative/path for root, //package:relative/path otherwise
+	if [[ "$package_root" == "." ]]; then
+		relative_path="${file#./}"
+		label="//:$relative_path"
+	else
+		relative_path="${file#$package_root/}"
+		label="//${package_root}:$relative_path"
+	fi
+
+	source_labels+=("$label")
+done
+
+if [[ ${#source_labels[@]} -eq 0 ]]; then
+	if [[ $outside_count -gt 0 ]]; then
+		echo "affected-targets: changed files are outside every Bazel package; nothing to test ($outside_count files)" >&2
+	else
+		echo "affected-targets: no changes, nothing to test" >&2
+	fi
+	exit 0
+fi
+
+# Probe for label existence with ONE query: if any label doesn't exist in the graph,
+# the probe still succeeds with exit 0 or 3, but only existing labels appear in output.
+# stdout only: bazel's stderr (WARNING, Loading: ...) flows to OUR stderr
+# unmodified, it must never be parsed as a label.
+probe_output=$("${BAZEL:-bazel}" query "set($(printf '%s ' "${source_labels[@]}"))" --keep_going --output=label "${bazel_args[@]}") || probe_rc=$?
+probe_rc=${probe_rc:-0}
+
+# If probe exits with non-0 and non-3, treat as query failure (fallback)
+if [[ $probe_rc -ne 0 && $probe_rc -ne 3 ]]; then
+	echo "affected-targets: fallback to //... because label existence probe failed (exit $probe_rc)" >&2
+	echo "//..."
+	exit 0
+fi
+
+# Extract which labels exist (grep only the labels we queried)
+valid_labels=()
+while IFS= read -r label; do
+	[[ "$label" == //* ]] && valid_labels+=("$label")
+done < <(printf '%s\n' "$probe_output")
+
+# Check which labels were unreferenced (in input but not in output)
+unreferenced=0
+for label in "${source_labels[@]}"; do
+	found=0
+	for valid in "${valid_labels[@]}"; do
+		if [[ "$valid" == "$label" ]]; then
+			found=1
+			break
+		fi
+	done
+	if [[ $found -eq 0 ]]; then
+		((unreferenced++)) || true
+	fi
+done
+
+if [[ ${#valid_labels[@]} -eq 0 ]]; then
+	echo "affected-targets: $((outside_count + unreferenced)) files not referenced by any Bazel rule; nothing to test" >&2
+	exit 0
+fi
+
+# Query rdeps with all valid labels
+rdeps_output=$("${BAZEL:-bazel}" query "rdeps(//..., set($(printf '%s ' "${valid_labels[@]}" | xargs)))" --keep_going --output=label "${bazel_args[@]}") || rdeps_rc=$?
+rdeps_rc=${rdeps_rc:-0}
+
+# Fail CLOSED. Anything but a clean exit, or a --keep_going partial result
+# (exit 3) that still produced labels, falls back to //...: an empty list
+# here would make the PR run skip every test and report green.
+if [[ $rdeps_rc -ne 0 ]] && { [[ $rdeps_rc -ne 3 ]] || [[ -z "$rdeps_output" ]]; }; then
+	echo "affected-targets: fallback to //... because rdeps query failed (exit $rdeps_rc)" >&2
+	echo "//..."
+	exit 0
+fi
+
+if [[ -n "$rdeps_output" ]]; then
+	# Keep main-repo labels only (drops @external repos and any stray line)
+	filtered=$(printf '%s\n' "$rdeps_output" | grep "^//" | sort -u || true)
+	target_count=$(printf '%s\n' "$filtered" | grep -c . || true)
+
+	if [[ $unreferenced -gt 0 ]]; then
+		echo "affected-targets: $target_count rdeps targets ($unreferenced files unreferenced)" >&2
+	else
+		echo "affected-targets: $target_count rdeps targets" >&2
+	fi
+
+	printf '%s\n' "$filtered"
+else
+	echo "affected-targets: rdeps query returned no targets" >&2
+fi
+
+exit 0

--- a/bazel/tools/ci/affected_targets_test.sh
+++ b/bazel/tools/ci/affected_targets_test.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# Tests for affected-targets.sh
+set -euo pipefail
+
+SCRIPT=""
+for candidate in \
+	"${RUNFILES_DIR:-}/_main/bazel/tools/ci/affected-targets.sh" \
+	"${TEST_SRCDIR:-}/_main/bazel/tools/ci/affected-targets.sh" \
+	"${BASH_SOURCE[0]%/*}/affected-targets.sh"; do
+	if [[ -f "$candidate" ]]; then
+		SCRIPT="$(cd "${candidate%/*}" && pwd)/${candidate##*/}"
+		break
+	fi
+done
+if [[ -z "$SCRIPT" ]]; then
+	echo "ERROR: cannot locate affected-targets.sh" >&2
+	exit 1
+fi
+
+PASS=0
+FAIL=0
+pass() {
+	echo "PASS [$1]"
+	PASS=$((PASS + 1))
+}
+fail() {
+	echo "FAIL [$1]: $2"
+	FAIL=$((FAIL + 1))
+}
+
+# Set up temporary test environment
+TMP="${TEST_TMPDIR:-$(mktemp -d)}"
+FAKE_BAZEL="$TMP/bazel"
+WORK="$TMP/work"
+mkdir -p "$WORK"
+
+# Create a fake bazel command
+mkdir -p "$(dirname "$FAKE_BAZEL")"
+cat >"$FAKE_BAZEL" <<'EOFBAZEL'
+#!/usr/bin/env bash
+log_file="${BAZEL_LOG_FILE:-}"
+if [[ -n "$log_file" ]]; then
+	printf '%s\n' "$@" >> "$log_file"
+fi
+# Real bazel chatters on stderr; none of it may be parsed as a label.
+echo "WARNING: fake bazel noise" >&2
+echo "Loading: 0 packages loaded" >&2
+
+# Look for "query" to identify this as a bazel query
+for arg in "$@"; do
+	if [[ "$arg" =~ ^set\( ]]; then
+		# Label existence probe: extract labels from the set() call and output them
+		# Format: set(//pkg:label1 //pkg:label2 ...)
+		labels="${arg#set(}"
+		labels="${labels%)}"
+		[[ -n "$labels" ]] && printf '%s\n' $labels
+		exit "${BAZEL_SET_EXIT:-0}"
+	elif [[ "$arg" =~ ^rdeps\( ]]; then
+		# rdeps query: output fixture if provided
+		if [[ -n "${BAZEL_RDEPS_OUTPUT:-}" && -f "${BAZEL_RDEPS_OUTPUT}" ]]; then
+			cat "${BAZEL_RDEPS_OUTPUT}"
+		fi
+		exit "${BAZEL_RDEPS_EXIT:-0}"
+	fi
+done
+exit 0
+EOFBAZEL
+chmod +x "$FAKE_BAZEL"
+
+run_test() {
+	local name="$1" setup="$2"
+	local repo="$WORK/$name"
+	rm -rf "$repo"
+	mkdir -p "$repo"
+	cd "$repo"
+
+	git init -q .
+	git config user.email "t@x"
+	git config user.name "T"
+
+	$setup
+
+	local out="$TMP/$name.out" err="$TMP/$name.err" log="$TMP/$name.log"
+	rm -f "$log"
+	if BAZEL="$FAKE_BAZEL" BAZEL_LOG_FILE="$log" "$SCRIPT" "origin/main" "HEAD" >"$out" 2>"$err"; then
+		check_$name "$out" "$err" "$log"
+	else
+		check_$name "$out" "$err" "$log"
+	fi
+}
+
+# Test 1: BUILD file is fallback
+setup_build_chg() {
+	mkdir -p p
+	echo "" >p/BUILD
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+	echo "x" >p/BUILD
+}
+
+check_build_chg() {
+	[[ "$(cat "$1")" == "//..." ]] && pass "BUILD_fallback" || fail "BUILD_fallback" "$(cat "$1")"
+}
+
+# Test 2: Root package label //:file
+setup_root_label() {
+	echo "" >BUILD
+	echo "x" >tool.py
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+	echo "y" >tool.py
+}
+
+check_root_label() {
+	grep -q "^set(.*//:tool.py" "$3" && pass "root_label" || fail "root_label" "$(cat "$3")"
+}
+
+# Test 3: Deleted file is fallback
+setup_deleted() {
+	mkdir -p p
+	echo "" >p/BUILD
+	echo "x" >p/old.py
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+	rm p/old.py
+	git add p/old.py
+}
+
+check_deleted() {
+	[[ "$(cat "$1")" == "//..." ]] && pass "deleted_fallback" || fail "deleted_fallback" "$(cat "$1")"
+}
+
+# Test 4: rdeps failure fallback
+setup_rdeps_fail() {
+	mkdir -p p
+	echo "" >p/BUILD
+	echo "x" >p/f.py
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+	echo "y" >p/f.py
+}
+
+check_rdeps_fail() {
+	[[ "$(cat "$1")" == "//..." ]] && pass "rdeps_fail_fallback" || fail "rdeps_fail_fallback" "got $(cat "$1")"
+}
+
+# Fallback set: a file under bazel/, a lockfile, a .bzl
+setup_bazel_dir() {
+	mkdir -p bazel/tools p
+	echo "" >p/BUILD
+	echo "x" >bazel/tools/x.sh
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+	echo "y" >bazel/tools/x.sh
+}
+check_bazel_dir() {
+	[[ "$(cat "$1")" == "//..." ]] && pass "bazel_dir_fallback" || fail "bazel_dir_fallback" "$(cat "$1")"
+}
+setup_lockfile() {
+	mkdir -p p
+	echo "" >p/BUILD
+	echo "x" >p/requirements.lock
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+	echo "y" >p/requirements.lock
+}
+check_lockfile() {
+	[[ "$(cat "$1")" == "//..." ]] && pass "lockfile_fallback" || fail "lockfile_fallback" "$(cat "$1")"
+}
+setup_bzl() {
+	mkdir -p p
+	echo "" >p/BUILD
+	echo "x" >p/defs.bzl
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+	echo "y" >p/defs.bzl
+}
+check_bzl() {
+	[[ "$(cat "$1")" == "//..." ]] && pass "bzl_fallback" || fail "bzl_fallback" "$(cat "$1")"
+}
+
+# rdeps --keep_going exit 3 with EMPTY output must fall back, never fail open
+setup_rdeps_empty3() { setup_rdeps_fail; }
+check_rdeps_empty3() {
+	[[ "$(cat "$1")" == "//..." ]] && pass "rdeps_exit3_empty_fallback" || fail "rdeps_exit3_empty_fallback" "got '$(cat "$1")'"
+}
+
+# stderr noise from the fake bazel never leaks into stdout or the rdeps query
+setup_noise() { setup_rdeps_fail; }
+check_noise() {
+	if grep -q "WARNING" "$1" || grep -q "Loading" "$3"; then
+		fail "stderr_not_parsed" "noise leaked: stdout=$(cat "$1")"
+	else
+		pass "stderr_not_parsed"
+	fi
+}
+
+# Test 5: Single set() probe call
+setup_single_probe() {
+	mkdir -p p
+	echo "" >p/BUILD
+	touch p/a.py p/b.py
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+	echo "x" >p/a.py
+	echo "y" >p/b.py
+}
+
+check_single_probe() {
+	local cnt=$(grep -c "^set(" "$3" || true)
+	[[ $cnt -eq 1 ]] && pass "single_set_probe" || fail "single_set_probe" "got $cnt"
+}
+
+# Test 6: Args passed through (base head -- args)
+setup_args() {
+	mkdir -p p
+	echo "" >p/BUILD
+	echo "x" >p/f.py
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+	echo "y" >p/f.py
+}
+
+check_args() {
+	grep -q "\-\-config=ci" "$3" && pass "args_passthrough" || fail "args_passthrough" "args missing"
+}
+
+# Test 7: .py file to label mapping
+setup_py_map() {
+	mkdir -p p
+	cat >p/BUILD <<'EOF'
+genrule(name = "g", srcs = ["f.py"], outs = ["o.txt"], cmd = "echo")
+EOF
+	echo "x" >p/f.py
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+	echo "y" >p/f.py
+}
+
+check_py_map() {
+	grep "^set(" "$3" | grep -q "p:f.py" && pass "py_file_label" || fail "py_file_label" "label missing"
+}
+
+# Test 8: Nested packages a/BUILD a/b/BUILD
+setup_nested() {
+	mkdir -p a/b
+	echo "" >a/BUILD
+	echo "" >a/b/BUILD
+	echo "x" >a/b/nested.go
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+	echo "y" >a/b/nested.go
+}
+
+check_nested() {
+	grep "^set(" "$3" | grep -q "a/b:nested.go" && pass "nested_label" || fail "nested_label" "label missing"
+}
+
+# Test 9: File outside package
+setup_outside() {
+	mkdir -p p
+	echo "" >p/BUILD
+	echo "x" >README.md
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+	echo "y" >README.md
+}
+
+check_outside() {
+	[[ -z "$(cat "$1")" ]] && pass "file_outside_pkg" || fail "file_outside_pkg" "expected empty"
+}
+
+# Test 10: No changes
+setup_no_change() {
+	mkdir -p p
+	echo "" >p/BUILD
+	git add .
+	git commit -q -m "base"
+	git branch origin/main
+}
+
+check_no_change() {
+	[[ -z "$(cat "$1")" ]] && pass "no_changes" || fail "no_changes" "expected empty"
+}
+
+echo "--- Running affected-targets.sh tests ---"
+run_test "build_chg" "setup_build_chg"
+run_test "root_label" "setup_root_label"
+run_test "deleted" "setup_deleted"
+BAZEL_RDEPS_EXIT="1" run_test "rdeps_fail" "setup_rdeps_fail"
+run_test "single_probe" "setup_single_probe"
+
+# Special test for args: run with -- flag
+repo="$WORK/args"
+rm -rf "$repo"
+mkdir -p "$repo"
+cd "$repo"
+git init -q .
+git config user.email "t@x"
+git config user.name "T"
+setup_args
+log="$TMP/args.log"
+rm -f "$log"
+BAZEL="$FAKE_BAZEL" BAZEL_LOG_FILE="$log" "$SCRIPT" "origin/main" "HEAD" -- --config=ci --deleted_packages=bazel/tools/python >/dev/null 2>&1 || true
+grep -q "\-\-config=ci" "$log" && pass "args_passthrough" || fail "args_passthrough" "args missing"
+
+# base -- args form (no explicit head) must not take "--" as the head ref
+repo="$WORK/args2"
+rm -rf "$repo"
+mkdir -p "$repo"
+cd "$repo"
+git init -q .
+git config user.email "t@x"
+git config user.name "T"
+setup_args
+log="$TMP/args2.log"
+rm -f "$log"
+out="$TMP/args2.out"
+BAZEL="$FAKE_BAZEL" BAZEL_LOG_FILE="$log" "$SCRIPT" "origin/main" -- --config=ci >"$out" 2>/dev/null || true
+if grep -q "^--config=ci$" "$log" && ! grep -q "^--$" "$log" && [[ "$(cat "$out")" != "//..." ]]; then
+	pass "args_without_head"
+else
+	fail "args_without_head" "log=$(tr '\n' ' ' <"$log") out=$(cat "$out")"
+fi
+
+run_test "bazel_dir" "setup_bazel_dir"
+run_test "lockfile" "setup_lockfile"
+run_test "bzl" "setup_bzl"
+BAZEL_RDEPS_EXIT="3" run_test "rdeps_empty3" "setup_rdeps_empty3"
+run_test "noise" "setup_noise"
+run_test "py_map" "setup_py_map"
+run_test "nested" "setup_nested"
+run_test "outside" "setup_outside"
+run_test "no_change" "setup_no_change"
+
+echo "--- $PASS passed, $FAIL failed ---"
+[[ $FAIL -eq 0 ]]

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -171,7 +171,37 @@ actions:
           # ---- 1. tests ---------------------------------------------------
           # -future excludes future-feature BDD specs (executable specs for
           # not-yet-built features): those are intentionally red.
-          bazel test //... --config=ci --deleted_packages=bazel/tools/python --test_tag_filters=-external,-future
+          # The PR run uses affected-targets to query only affected Bazel
+          # targets, making PR feedback cheap. The queue candidate on
+          # gh-readonly-queue/* runs the full //... as the exact gate. This
+          # fallback set (BUILD files, dependency locks, bazel/ tooling,
+          # deleted files) is handled by affected-targets.sh and triggers
+          # //... when the graph shape changes.
+          #
+          # ci test locally stays 1:1 with the full run on purpose: PRs
+          # iterate fast while the queue candidate is the authoritative test.
+          if [[ "${GIT_BRANCH:-}" =~ ^gh-readonly-queue/ ]] || [ "${GIT_PR_NUMBER:-0}" = "0" ]; then
+            bazel test //... --config=ci --deleted_packages=bazel/tools/python --test_tag_filters=-external,-future
+          else
+            git fetch origin "${GIT_REPO_DEFAULT_BRANCH:-main}" --quiet
+            targets_file=$(mktemp)
+            ./bazel/tools/ci/affected-targets.sh "origin/${GIT_REPO_DEFAULT_BRANCH:-main}" HEAD -- --config=ci --deleted_packages=bazel/tools/python > "$targets_file"
+            target_count=$(grep -c . "$targets_file" || true)
+            if [ "$target_count" -eq 0 ]; then
+              echo "No Bazel targets affected by this PR; skipping bazel test (the queue candidate runs //...)"
+            else
+              echo "Running bazel test on $target_count affected targets"
+              set +e
+              bazel test --config=ci --deleted_packages=bazel/tools/python --test_tag_filters=-external,-future --target_pattern_file="$targets_file"
+              rc=$?
+              set -e
+              if [ "$rc" -eq 4 ]; then
+                echo "affected subset has no test targets; build succeeded"
+              elif [ "$rc" -ne 0 ]; then
+                exit "$rc"
+              fi
+            fi
+          fi
 
           # ---- 2. images build, and the missed-chart-bump guard -----------
           # PR branches publish nothing. `bazel build` proves the images build


### PR DESCRIPTION
PR runs test only the targets affected by the diff (rdeps over the changed source labels), with a fail-closed fallback to `//...` on graph-shape changes or any query trouble. Queue candidates, main, and local `ci test` keep the full run.

Spec'd for Sol; one correction round (fail-open on query error, root-package label, N probes, arg parsing) plus direct fixes (bazel stderr parsed as labels, exit-3-empty fail-open). 16 cases in `affected_targets_test`, runnable with or without bazel. `ci`: 742/742 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JutDBVUEnncrastyE8E7kp