### PR TITLE
chore(embervm): enable the KEK root in dev and make its secret ref optional

### DIFF
--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -179,6 +179,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "embervm.kekRootSecretName" . }}
                   key: {{ .Values.kekRoot.key }}
+                  # Optional on purpose: a root that has not been provisioned
+                  # yet leaves the custodian inert (every derive returns
+                  # {:error, :no_root}) rather than blocking the control plane
+                  # from starting. Encryption is its own flag.
+                  optional: true
             {{- end }}
             {{- if and .Values.runtimePython .Values.runtimePython.guestImage .Values.runtimePython.guestImage.repository }}
             # R1 zip lane (ADR embervm/002): the zip-lane runtime name -> pinned

--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -50,6 +50,14 @@ bricks:
 # Warmth GC and base retention operate on S3; separate buckets prevent
 # production GC from deleting dev artifacts. The store endpoint and bucket are
 # rendered into noded's config for S3 warmth export/restore.
+# Platform KEK root (ADR embervm/036, #4976): dev derives per-principal KEKs
+# from the embervm-kek-root item. The secretKeyRef is optional, so until the
+# item exists the custodian is inert and nothing below encrypts.
+kekRoot:
+  enabled: true
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/embervm-kek-root"
+
 noded:
   # The wildcard DaemonSet, off. See the scratchPrep note below for why this
   # matters: it selects homelab.io/firecracker=true, which all four nodes carry


### PR DESCRIPTION
Refs #4976, #4691. Rollout step 1 in dev: `kekRoot.enabled` with the `embervm-kek-root` item. The `EMBERVM_KEK_ROOT` secretKeyRef becomes `optional: true` (chart), so an unprovisioned root leaves the custodian inert (`{:error, :no_root}`) instead of blocking the control plane, which is the documented behaviour. Nothing encrypts yet; `artifactEncryption` and `store.encrypt` follow once the root is confirmed live.

Post-merge check: dev CP pod starts; if the operator rendered the Secret, the KeyService stops answering `no_root` (wrap endpoint 503 -> 404 while the encryption flag is off).

`ci`: Bazel 742 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP