### PR TITLE
feat(embervm): the brick silence timeout (ADR embervm/037)

### DIFF
--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -199,6 +199,12 @@ containers:
         value: {{ $ctx.Values.noded.diffBanking | quote }}
       - name: EMBERVM_NODED_DIFF_BANKING_WORKLOADS
         value: {{ $ctx.Values.noded.diffBankingWorkloads | quote }}
+      # Brick silence timeout (ADR embervm/037, #5073), seconds. Rendered only
+      # when armed: empty or 0 keeps the daemon-side gate off.
+      {{- if $ctx.Values.noded.silenceTimeoutSeconds }}
+      - name: EMBERVM_NODED_SILENCE_TIMEOUT_SECONDS
+        value: {{ $ctx.Values.noded.silenceTimeoutSeconds | quote }}
+      {{- end }}
       # Brick warmth liveness claim (#4962). The daemon parses durations with Go
       # duration syntax. Only the exact string "1" enables unclaimed reaping;
       # "0" keeps the rollout transition guard off by default.

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1113,6 +1113,13 @@ noded:
   # Relight. Keep task and park-only workloads outside the diff path.
   diffBankingWorkloads: sandbox-session
 
+  # Brick silence timeout (ADR embervm/037, #5073), in seconds. Empty or 0
+  # disables; 21600 (~6h) arms the ADR 037 bound: a brick with no dial-home or
+  # WatchNode activity past it refuses new node-local work while its live VMs
+  # keep running. Measured from last contact with Go monotonic time, so
+  # control-plane rolls never trip it.
+  silenceTimeoutSeconds: ""
+
   # Per-brick warmth ownership claim. Each brick refreshes i/<segment>/.alive
   # every intervalSeconds, and startup GC reaps a foreign claim only after
   # staleAfterSeconds. reapUnclaimed is the #4962 transition guard for warmth

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -189,6 +189,10 @@ noded:
   # this, startup GC only ever removes a claim older than staleAfterSeconds.
   warmthHeartbeat:
     reapUnclaimed: true
+  # ARMED: brick silence timeout, ~6h (ADR embervm/037, #5073). A brick with no
+  # dial-home or WatchNode contact past this bound refuses new node-local work;
+  # live VMs keep running. Rollback: set back to "".
+  silenceTimeoutSeconds: "21600"
   # WILDCARD DAEMONSET DEPRECATED (bricks-only migration). The per-node wildcard
   # noded DaemonSet is retired: node capacity is now provided entirely by the
   # size-class brick Deployments the BrickController autoscales (bricks.autoscale

--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -96,6 +96,9 @@ noded:
   # Node capacity. Dev runs one tiny brick, so use the smaller default.
   maxLiveVMs: 8
 
+  # ARMED: brick silence timeout, ~6h (ADR embervm/037, #5073). Rollback: "".
+  silenceTimeoutSeconds: "21600"
+
   # Disable warmth restore in dev. The machines are small and sessions are ephemeral.
   warmRestoreWithVolumeClasses: []
 

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -318,6 +318,15 @@ type Config struct {
 	// jittered re-POST), so a control-plane restart re-adopts it promptly and a
 	// re-pointed pod IP propagates. Default 30s. Env EMBERVM_NODED_REGISTER_INTERVAL.
 	RegisterInterval time.Duration
+	// SilenceTimeoutSeconds arms ADR embervm/037's brick silence bound: a brick
+	// with no successful control-plane contact (a 2xx dial-home POST or a
+	// WatchNode send) for longer than this refuses NEW node-local work
+	// (activator wakes and the blessing-lease self-advance in attachGeneration)
+	// with FAILED_PRECONDITION while live VMs keep running and nothing is
+	// banked or destroyed. Zero (the default) disables the gate. Contact age is
+	// measured with Go monotonic time, so NTP skew and control-plane rolls
+	// never trip it. Env EMBERVM_NODED_SILENCE_TIMEOUT_SECONDS.
+	SilenceTimeoutSeconds int
 
 	// TapPrealloc is the number of serving taps EnsureNetwork pre-creates at brick
 	// boot (ADR embervm/014 decision 4), left down until AllocateTap draws one:
@@ -607,6 +616,13 @@ func Load() (Config, error) {
 	}
 	if c.WarmthStaleAfter <= c.WarmthHeartbeatInterval {
 		return Config{}, fmt.Errorf("EMBERVM_NODED_WARMTH_STALE_AFTER must be greater than EMBERVM_NODED_WARMTH_HEARTBEAT_INTERVAL (%s <= %s)", c.WarmthStaleAfter, c.WarmthHeartbeatInterval)
+	}
+	if v := os.Getenv("EMBERVM_NODED_SILENCE_TIMEOUT_SECONDS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			return Config{}, fmt.Errorf("invalid EMBERVM_NODED_SILENCE_TIMEOUT_SECONDS %q", v)
+		}
+		c.SilenceTimeoutSeconds = n
 	}
 	if v := os.Getenv("EMBERVM_NODED_ARCHIVE_MAX_BYTES"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)

--- a/projects/embervm/noded/config/config_test.go
+++ b/projects/embervm/noded/config/config_test.go
@@ -88,6 +88,45 @@ func TestLoadCpuVendorEnvOverride(t *testing.T) {
 	}
 }
 
+func TestLoadSilenceTimeoutSeconds(t *testing.T) {
+	const key = "EMBERVM_NODED_SILENCE_TIMEOUT_SECONDS"
+	for _, tc := range []struct {
+		name    string
+		value   *string
+		want    int
+		wantErr bool
+	}{
+		{name: "unset disables", want: 0},
+		{name: "zero disables", value: stringPtr("0"), want: 0},
+		{name: "armed", value: stringPtr("21600"), want: 21600},
+		{name: "garbage", value: stringPtr("six-hours"), wantErr: true},
+		{name: "negative", value: stringPtr("-1"), wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.value == nil {
+				if err := os.Unsetenv(key); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				t.Setenv(key, *tc.value)
+			}
+			c, err := Load()
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), key) {
+					t.Fatalf("Load error = %v, want an invalid %s error", err, key)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if c.SilenceTimeoutSeconds != tc.want {
+				t.Errorf("SilenceTimeoutSeconds = %d, want %d", c.SilenceTimeoutSeconds, tc.want)
+			}
+		})
+	}
+}
+
 func TestLoadWarmRestoreWithVolumeEnv(t *testing.T) {
 	const key = "EMBERVM_NODED_WARM_RESTORE_WITH_VOLUME"
 	for _, tc := range []struct {

--- a/projects/embervm/noded/server/BUILD
+++ b/projects/embervm/noded/server/BUILD
@@ -61,6 +61,7 @@ go_test(
         "rootfs_gc_test.go",
         "server_test.go",
         "serving_test.go",
+        "silence_test.go",
         "stateful_activator_test.go",
         "stateful_test.go",
         "store_test.go",

--- a/projects/embervm/noded/server/activator.go
+++ b/projects/embervm/noded/server/activator.go
@@ -124,6 +124,14 @@ func (a *activator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ADR embervm/037: a silenced brick wakes nothing new. Splice-through above
+	// still serves an already-live VM; only the boot path stops here.
+	if err := a.server.refuseIfSilenced("activator serving wake"); err != nil {
+		a.server.logger.Warn("activator: refusing serving wake", "workload", workload, "err", err)
+		http.Error(w, status.Convert(err).Message(), http.StatusServiceUnavailable)
+		return
+	}
+
 	body, err := readActivatorBody(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)

--- a/projects/embervm/noded/server/group_activator.go
+++ b/projects/embervm/noded/server/group_activator.go
@@ -106,6 +106,14 @@ func (a *groupActivator) handle(ctx context.Context, conn net.Conn, listenPort u
 		return
 	}
 
+	// ADR embervm/037: splice-through above still serves a live entry member;
+	// a silenced brick starts no group set.
+	if err := a.server.refuseIfSilenced("group member start"); err != nil {
+		a.server.logger.Warn("group activator: refusing member start", "workload", reg.Workload, "err", err)
+		_ = conn.Close()
+		return
+	}
+
 	flight, leader, ok := a.join(reg.Workload)
 	if !ok {
 		a.server.logger.Warn("group activator: wake rejected by local limit", "workload", reg.Workload)

--- a/projects/embervm/noded/server/register.go
+++ b/projects/embervm/noded/server/register.go
@@ -198,6 +198,9 @@ func (s *Server) register(ctx context.Context, doer httpDoer, bootID string) err
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("control plane rejected registration: status %d", resp.StatusCode)
 	}
+	// A 2xx POST is control-plane contact (ADR embervm/037): refresh the
+	// silence clock. A failed or rejected POST leaves it stale.
+	s.noteContact()
 	return nil
 }
 

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -273,6 +273,14 @@ type Server struct {
 	draining            bool
 	drainDeadlineUnixMs int64
 
+	// lastContact is the instant of the last successful control-plane contact
+	// (a 2xx dial-home POST or a WatchNode send), the clock behind the ADR
+	// embervm/037 brick silence gate (see silenced/refuseIfSilenced). Stored as
+	// a time.Time carrying Go's monotonic reading so the age comparison is
+	// immune to NTP steps; zero means never contacted.
+	contactMu   sync.Mutex
+	lastContact time.Time
+
 	// activeBuilds tracks in-flight BuildBase work so a drain can finish-or-abort
 	// it inside the budget (artifact-decoupling Phase 0). Each entry's cancel tears
 	// its build context down: runBuild's deferred Release + RemoveBundle destroy the
@@ -581,6 +589,49 @@ func (s *Server) refuseIfStale(what string) error {
 		return status.Errorf(codes.FailedPrecondition, "noded: registry stale, awaiting live sync (refusing %s)", what)
 	}
 	return nil
+}
+
+// noteContact records one successful control-plane contact. time.Now embeds a
+// monotonic reading, so silenced's time.Since age check never reads the wall
+// clock and an NTP step cannot arm or disarm the gate.
+func (s *Server) noteContact() {
+	s.contactMu.Lock()
+	s.lastContact = time.Now()
+	s.contactMu.Unlock()
+}
+
+// silenced reports whether ADR embervm/037's silence bound has elapsed: no
+// control-plane contact for longer than SilenceTimeoutSeconds. A zero timeout
+// disables the gate. Never contacted (a fresh boot whose dial-home has not yet
+// succeeded) counts as silent once armed, so a booted-and-partitioned brick
+// cannot admit new work indefinitely.
+func (s *Server) silenced() bool {
+	timeout := time.Duration(s.cfg.SilenceTimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		return false
+	}
+	s.contactMu.Lock()
+	last := s.lastContact
+	s.contactMu.Unlock()
+	return last.IsZero() || time.Since(last) > timeout
+}
+
+// refuseIfSilenced rejects NEW node-local work from a silenced brick (ADR
+// embervm/037): it only refuses admission and never destroys, banks, or drains
+// anything; live VMs keep running. Mirrors refuseIfStale's shape and code.
+func (s *Server) refuseIfSilenced(what string) error {
+	if !s.silenced() {
+		return nil
+	}
+	return status.Errorf(codes.FailedPrecondition, "noded: brick silent past silence timeout, refusing %s", what)
+}
+
+// setLastContactForTest pins the contact instant so tests can age past the
+// silence bound without sleeping.
+func (s *Server) setLastContactForTest(t time.Time) {
+	s.contactMu.Lock()
+	s.lastContact = t
+	s.contactMu.Unlock()
 }
 
 // hasPrimedForWorkload reports whether the task pool already holds at least one
@@ -1742,7 +1793,13 @@ func (s *Server) WatchNode(req *nodev1.WatchNodeRequest, stream grpc.ServerStrea
 		if id := req.GetNodeId(); id != "" {
 			ns.NodeId = id
 		}
-		return stream.Send(ns)
+		if err := stream.Send(ns); err != nil {
+			return err
+		}
+		// Every successful NodeStatus send is control-plane contact (ADR
+		// embervm/037): refresh the silence clock alongside the dial-home POST.
+		s.noteContact()
+		return nil
 	}
 	if err := send(); err != nil {
 		return err

--- a/projects/embervm/noded/server/silence_test.go
+++ b/projects/embervm/noded/server/silence_test.go
@@ -1,0 +1,350 @@
+package server
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/config"
+	"github.com/jomcgi/homelab/projects/embervm/noded/volume"
+)
+
+// silenceBound is the armed ADR embervm/037 bound used across these tests. The
+// value itself is irrelevant: tests age contact with setLastContactForTest, so
+// nothing ever sleeps out the bound.
+const silenceBound = 21600
+
+// armSilence turns the silence gate on for an already-built test server.
+func armSilence(s *Server) {
+	s.cfg.SilenceTimeoutSeconds = silenceBound
+}
+
+// agedContact moves a server's last contact past the armed bound.
+func agedContact(s *Server) {
+	s.setLastContactForTest(time.Now().Add(-(silenceBound + 100) * time.Second))
+}
+
+func TestSilencedPredicate(t *testing.T) {
+	t.Run("timeout zero disables even when never contacted", func(t *testing.T) {
+		s := registerTestServer(config.Config{})
+		if s.silenced() {
+			t.Fatal("silenced() = true with the gate disabled")
+		}
+	})
+	t.Run("armed and never contacted is silent", func(t *testing.T) {
+		s := registerTestServer(config.Config{SilenceTimeoutSeconds: silenceBound})
+		if !s.silenced() {
+			t.Fatal("silenced() = false before the first contact (boot case)")
+		}
+	})
+	t.Run("fresh contact is not silent", func(t *testing.T) {
+		s := registerTestServer(config.Config{SilenceTimeoutSeconds: silenceBound})
+		s.noteContact()
+		if s.silenced() {
+			t.Fatal("silenced() = true with fresh contact")
+		}
+	})
+	t.Run("contact older than the bound is silent", func(t *testing.T) {
+		s := registerTestServer(config.Config{SilenceTimeoutSeconds: silenceBound})
+		agedContact(s)
+		if !s.silenced() {
+			t.Fatal("silenced() = false past the bound")
+		}
+	})
+}
+
+// register-2xx-refreshes-contact: only a successful dial-home POST refreshes
+// the silence clock; a rejected one leaves the brick silent.
+func TestRegister2xxRefreshesContact(t *testing.T) {
+	newSilentServer := func() *Server {
+		s := registerTestServer(config.Config{
+			Node:                  "node-4",
+			ControlPlaneURL:       "http://cp:8080",
+			SilenceTimeoutSeconds: silenceBound,
+		})
+		agedContact(s)
+		return s
+	}
+
+	ok := newSilentServer()
+	if err := ok.register(context.Background(), &fakeDoer{status: http.StatusOK}, "boot"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if ok.silenced() {
+		t.Error("a 2xx dial-home POST did not refresh the silence clock")
+	}
+
+	rejected := newSilentServer()
+	if err := rejected.register(context.Background(), &fakeDoer{status: http.StatusForbidden}, "boot"); err == nil {
+		t.Fatal("expected error on 403")
+	}
+	if !rejected.silenced() {
+		t.Error("a non-2xx dial-home POST refreshed the silence clock")
+	}
+}
+
+// watchnode-send-refreshes-contact: every successful NodeStatus send counts as
+// control-plane contact, so a streaming brick never goes silent while it talks.
+func TestWatchNodeSendRefreshesContact(t *testing.T) {
+	s := New(Options{
+		Config:    config.Config{Arch: "amd64", Node: "node-4", MaxLiveVMs: 4, SnapshotRoot: t.TempDir(), SilenceTimeoutSeconds: silenceBound},
+		Driver:    &fakeDriver{},
+		Transport: &fakeTransport{},
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	s.memHeadroom = func() uint64 { return 0 }
+	s.slotCeiling = func(configured uint64) uint64 { return configured }
+	agedContact(s)
+	if !s.silenced() {
+		t.Fatal("precondition: server should start past the bound")
+	}
+
+	lis := bufconn.Listen(1 << 20)
+	gs := grpc.NewServer()
+	nodev1.RegisterNodeServiceServer(gs, s)
+	go func() { _ = gs.Serve(lis) }()
+	t.Cleanup(gs.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial bufconn: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	client := nodev1.NewNodeServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	stream, err := client.WatchNode(ctx, &nodev1.WatchNodeRequest{NodeId: "node-4"})
+	if err != nil {
+		t.Fatalf("WatchNode: %v", err)
+	}
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("Recv initial: %v", err)
+	}
+	if s.silenced() {
+		t.Error("a successful WatchNode send did not refresh the silence clock")
+	}
+}
+
+// activator-silence-refuses-wake: a silenced brick answers the L7 activator
+// with 503 naming the gate and boots nothing; fresh contact wakes normally.
+func TestActivatorRefusesWakeWhenSilenced(t *testing.T) {
+	port, _ := activatorGuest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == defaultReadyPath {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	s, _, driver := newServingTestServer(t)
+	enableActivatorWorkload(s, "wl-serve", port)
+	armSilence(s)
+
+	rec := activatorRequest(t, s.ActivatorHandler(), "wl-serve", "/invoke", "request")
+	if rec.Code != http.StatusServiceUnavailable || !strings.Contains(rec.Body.String(), "silence") {
+		t.Fatalf("silenced wake response = %d %q, want 503 naming the silence gate", rec.Code, rec.Body.String())
+	}
+	if driver.claims != 0 {
+		t.Errorf("ClaimServing calls while silenced = %d, want 0", driver.claims)
+	}
+
+	s.noteContact()
+	rec = activatorRequest(t, s.ActivatorHandler(), "wl-serve", "/invoke", "request")
+	if rec.Code != http.StatusOK || rec.Body.String() != "ok" {
+		t.Fatalf("fresh-contact wake response = %d %q, want 200 ok", rec.Code, rec.Body.String())
+	}
+	if driver.claims != 1 {
+		t.Errorf("ClaimServing calls after contact = %d, want 1", driver.claims)
+	}
+}
+
+// stateful-activator-silence-refuses-wake: a silenced brick closes the L4 wake
+// connection without starting anything; fresh contact relights the local bundle.
+func TestStatefulActivatorRefusesWakeWhenSilenced(t *testing.T) {
+	port := statefulActivatorEchoServer(t)
+	s, _, driver := newStatefulTestServer(t)
+	listenPort := startStatefulActivator(t, s)
+	enableStatefulActivatorWorkload(s, "wl-state", listenPort, port)
+	addStatefulActivatorBundle(t, s, driver, "wl-state", "bundle-state")
+	armSilence(s)
+
+	conn := statefulActivatorConn(t, listenPort)
+	func() {
+		defer conn.Close()
+		_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+		if _, err := conn.Read(make([]byte, 1)); err == nil {
+			t.Fatal("silenced stateful activator connection stayed open")
+		}
+	}()
+	driver.mu.Lock()
+	claims, restores := driver.claims, driver.restores
+	driver.mu.Unlock()
+	if claims != 0 || restores != 0 {
+		t.Errorf("stateful wake while silenced = claims:%d restores:%d, want 0:0", claims, restores)
+	}
+
+	s.noteContact()
+	conn = statefulActivatorConn(t, listenPort)
+	statefulActivatorRoundTrip(t, conn, "relit bytes")
+	driver.mu.Lock()
+	restores = driver.restores
+	driver.mu.Unlock()
+	if restores != 1 {
+		t.Errorf("RestoreStateful calls after contact = %d, want 1", restores)
+	}
+}
+
+// group-activator-silence-refuses-start: a silenced brick starts no group set;
+// fresh contact relights the complete local set.
+func TestGroupActivatorRefusesStartWhenSilenced(t *testing.T) {
+	port := groupActivatorEchoServer(t)
+	s, _, driver, _ := newGroupMemberTestServer(t)
+	listenPort := startGroupActivator(t, s)
+	enableGroupActivatorWorkload(s, "scratch-k8s", listenPort, port)
+	addCompleteGroupActivatorSet(s, driver, port)
+	armSilence(s)
+
+	conn := groupActivatorConn(t, listenPort)
+	assertGroupActivatorClosed(t, conn)
+	driver.mu.Lock()
+	restores := driver.restores
+	driver.mu.Unlock()
+	if restores != 0 {
+		t.Errorf("RestoreGroupMember calls while silenced = %d, want 0", restores)
+	}
+
+	s.noteContact()
+	conn = groupActivatorConn(t, listenPort)
+	groupActivatorRoundTrip(t, conn, "relit group bytes")
+	driver.mu.Lock()
+	restores = driver.restores
+	driver.mu.Unlock()
+	if restores != 3 {
+		t.Errorf("RestoreGroupMember calls after contact = %d, want 3", restores)
+	}
+}
+
+// attachGeneration-silence-scoping: silence blocks ONLY the activator-origin
+// blessing-lease self-advance; the control-plane-issued blessed_generation
+// path stays open, and fresh contact restores the self-advance. A seeded lease
+// pins the gate's position: if the check ever moved BELOW ConsumeGenerationFromLease,
+// the refused call would silently consume a lease generation and the recovery
+// attach below would return the NEXT generation instead of the lease's first.
+func TestAttachGenerationSilenceScoping(t *testing.T) {
+	s, _, _ := newStatefulTestServer(t)
+	armSilence(s)
+	agedContact(s)
+	if err := s.volumes.Create("wl-state", 1<<20); err != nil {
+		t.Fatalf("create stateful volume: %v", err)
+	}
+	if err := s.volumes.ApplyBlessingLease("wl-state", volume.BlessingLease{NextGeneration: 10, LeaseEnd: 12}); err != nil {
+		t.Fatalf("seed blessing lease: %v", err)
+	}
+	before, err := s.volumes.Generation("wl-state")
+	if err != nil {
+		t.Fatalf("generation before: %v", err)
+	}
+
+	_, err = s.attachGeneration("wl-state", 0, true)
+	if status.Code(err) != codes.FailedPrecondition || !strings.Contains(status.Convert(err).Message(), "silence") {
+		t.Fatalf("silenced self-advance err = %v, want FailedPrecondition naming the silence gate", err)
+	}
+	after, err := s.volumes.Generation("wl-state")
+	if err != nil {
+		t.Fatalf("generation after refused self-advance: %v", err)
+	}
+	if after != before {
+		t.Errorf("generation advanced while silenced: %d -> %d", before, after)
+	}
+
+	blessed, err := s.attachGeneration("wl-state", 5, false)
+	if err != nil {
+		t.Fatalf("blessed_generation attach while silenced: %v", err)
+	}
+	if blessed != 5 {
+		t.Errorf("blessed_generation attach recorded %d, want 5", blessed)
+	}
+
+	s.noteContact()
+	gen, err := s.attachGeneration("wl-state", 0, true)
+	if err != nil {
+		t.Fatalf("self-advance after contact: %v", err)
+	}
+	// Exactly the seeded lease's first generation: proves the refused call
+	// consumed nothing from the lease while silenced.
+	if gen != 10 {
+		t.Errorf("self-advance after contact recorded %d, want 10 (the seeded lease's first slot)", gen)
+	}
+}
+
+// activator-silence-splices-live-vm: silence refuses NEW work but must not
+// disturb an already-live VM. If a regression moves the gate above the
+// live-splice shortcut, this fails with a 503 instead of a spliced response.
+func TestActivatorLiveVMSplicesWhileSilenced(t *testing.T) {
+	var calls int
+	port, _ := activatorGuest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path == defaultReadyPath {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write([]byte("live"))
+	}))
+	s, _, driver := newServingTestServer(t)
+	enableActivatorWorkload(s, "wl-serve", port)
+	s.servingVMs.add(&servingEntry{vmID: "already-live", workload: "wl-serve", ip: net.ParseIP("127.0.0.1"), port: port})
+	armSilence(s)
+	agedContact(s)
+
+	rec := activatorRequest(t, s.ActivatorHandler(), "wl-serve", "/invoke", "request")
+	if rec.Code != http.StatusOK || rec.Body.String() != "live" {
+		t.Fatalf("silenced splice response = %d %q, want 200 live", rec.Code, rec.Body.String())
+	}
+	if driver.claims != 0 {
+		t.Errorf("ClaimServing calls while silenced = %d, want 0", driver.claims)
+	}
+	if calls != 1 {
+		t.Errorf("guest calls = %d, want 1", calls)
+	}
+}
+
+// stateful-activator-silence-splices-live-vm: the L4 mirror of the test above.
+// A silenced brick keeps serving an already-live stateful VM and starts nothing.
+func TestStatefulActivatorLiveVMSplicesWhileSilenced(t *testing.T) {
+	port := statefulActivatorEchoServer(t)
+	s, _, driver := newStatefulTestServer(t)
+	listenPort := startStatefulActivator(t, s)
+	enableStatefulActivatorWorkload(s, "wl-state", listenPort, port)
+	s.statefulVMs.add(&statefulEntry{vmID: "already-live", workload: "wl-state", ip: net.ParseIP("127.0.0.1"), port: port})
+	armSilence(s)
+	agedContact(s)
+
+	conn := statefulActivatorConn(t, listenPort)
+	defer conn.Close()
+	statefulActivatorRoundTrip(t, conn, "live bytes")
+	driver.mu.Lock()
+	claims, restores := driver.claims, driver.restores
+	driver.mu.Unlock()
+	if claims != 0 || restores != 0 {
+		t.Errorf("stateful wake calls while silenced = claims:%d restores:%d, want 0:0", claims, restores)
+	}
+}

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -111,6 +111,12 @@ func (s *Server) attachGeneration(workload string, blessedGeneration uint64, act
 		return gen, nil
 	}
 	if activatorOrigin {
+		// ADR embervm/037: node-local self-advancement of a generation is new
+		// work and stops while the brick is silenced. The control-plane-issued
+		// blessed_generation path above is deliberately NOT gated.
+		if err := s.refuseIfSilenced(fmt.Sprintf("blessing-lease self-advance for %q", workload)); err != nil {
+			return 0, err
+		}
 		generations, err := s.volumes.ConsumeGenerationFromLease(workload, 1)
 		if err != nil {
 			s.logger.Error("noded: blessing lease read or persist failed; falling back to unblessable self-bump", "workload", workload, "err", err)
@@ -651,6 +657,9 @@ func (s *Server) recordAbortGeneration(workload string, blessedGeneration uint64
 // CHECKPOINT is left unresolved for statefulResolveTimeout, noded aborts it
 // itself (resume, discard temp) so a dead control plane cannot pin a paused VM.
 // It claims the resolve first, so it no-ops if the control plane already resolved.
+// Deliberately NOT gated by the ADR embervm/037 silence timeout: resuming an
+// already-live paused VM is recovery of live work, the same posture as the
+// activators' splice-through-while-silenced, not new work.
 func (s *Server) autoAbortCheckpoint(vmID, token string) {
 	e, ok := s.statefulVMs.claimResolve(vmID, token)
 	if !ok {

--- a/projects/embervm/noded/server/stateful_activator.go
+++ b/projects/embervm/noded/server/stateful_activator.go
@@ -143,6 +143,16 @@ func (a *statefulActivator) handle(ctx context.Context, conn net.Conn, listenPor
 		}
 	}
 
+	// ADR embervm/037: splice-through above still serves an already-live VM;
+	// a silenced brick starts nothing new. The waitForInFlight timeout path
+	// above may still forward to the configured control-plane address (that is
+	// not node-local authority; the dial fails harmlessly when partitioned).
+	if err := a.server.refuseIfSilenced("stateful activator wake"); err != nil {
+		a.server.logger.Warn("stateful activator: refusing wake", "workload", reg.Workload, "err", err)
+		_ = conn.Close()
+		return
+	}
+
 	flight, leader, ok := a.join(reg.Workload)
 	if !ok {
 		a.server.logger.Warn("stateful activator: wake rejected by local limit", "workload", reg.Workload)


### PR DESCRIPTION
Phase 4 of #5073, implementing ADR embervm/037 (merged as #5109).

Closes #5073.

## What

noded tracks last control-plane contact from its two live channels (dial-home Register 2xx at register.go, WatchNode NodeStatus sends in server.go) and refuses NEW node-local work once silence exceeds `EMBERVM_NODED_SILENCE_TIMEOUT_SECONDS`:

- L7 serving activator wake (activator.go)
- stateful L4 wake-on-connect (stateful_activator.go)
- group member start (group_activator.go)
- the blessing-lease self-advance branch of attachGeneration (stateful.go); the CP-issued blessed_generation path is deliberately NOT gated

## Semantics (per ADR 037)

- Refuse-new-work only: already-live VMs keep splicing (gates sit after every live-splice shortcut), checkpoints auto-abort as before, nothing is banked or destroyed. Fail open on warmth.
- Monotonic clock; never-contacted counts as silent when armed; composes with the registry-stale boot gate.
- Refusals are FailedPrecondition naming the gate, distinguishable from stale-registry refusal.
- Chart `noded.silenceTimeoutSeconds` defaults empty (disabled); deploy AND dev arm "21600" (6h, in the grant-expiry range so a routine CP roll never trips it).

## Validation

- Remote ci green on the scoped Go targets (`server_test`, `config_test`: 741 tests pass) after implementation and again after review fixes.
- Reviewer pass run on the full diff: two should-fix test gaps found and fixed in this diff (silenced-with-live-entry splice-through tests for both activators; lease-seeded attach-scoping test that fails if the gate ever moves below ConsumeGenerationFromLease). Two comment nits also addressed. Residual noted for the record: a direct-dial in-cluster client could still place CP-origin work on a silenced brick (bearer-token optional today, #4693 adjacent); outside this ADR's partition threat model.
- Lifecycle: 3-bdd n/a (embervm has no python BDD lane; acceptance pinned by the Go tests here).

Phase 5 STPA refresh for projects/embervm follows after this merges.