### PR TITLE
chore(embervm): keep the dev KEK root off until its 1Password item exists

### DIFF
--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -53,8 +53,11 @@ bricks:
 # Platform KEK root (ADR embervm/036, #4976): dev derives per-principal KEKs
 # from the embervm-kek-root item. The secretKeyRef is optional, so until the
 # item exists the custodian is inert and nothing below encrypts.
+# OFF until the embervm-kek-root item exists in 1Password: with it enabled
+# and no item, the OnePasswordItem stays Ready=False and ArgoCD reports the
+# app Degraded (2026-08-22). Create the item, then flip enabled: true.
 kekRoot:
-  enabled: true
+  enabled: false
   onepassword:
     itemPath: "vaults/k8s-homelab/items/embervm-kek-root"
 


### PR DESCRIPTION
Refs #4976. Values-only revert of the dev `kekRoot` enable from #5112: the `embervm-kek-root` item does not exist (operator: `failed to 'getItemID'`), so the OnePasswordItem is Ready=False and `embervm-dev` shows Degraded. The `optional: true` hardening from #5112 stays. Re-enable after the item is created (command on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP