### PR TITLE
fix(site): live hardware line, neutral storage labels, roadmap state, one source for restore numbers

### DIFF
--- a/projects/monolith/frontend/src/lib/public/agentstory/AgentScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/agentstory/AgentScrollStory.svelte
@@ -10,6 +10,7 @@
     easeInOut,
     sub,
   } from "./timeline.js";
+  import { sessionRestoreMs } from "$lib/public/fcstory/metrics.js";
 
   let scrollerEl,
     heroEl,
@@ -143,7 +144,7 @@
     if (beat === "pre") setPill("off", "off");
     else if (beat === "wake")
       setPill(
-        w < 0.45 ? "restoring" : "awake · 2.5 ms",
+        w < 0.45 ? "restoring" : `awake · ${sessionRestoreMs} ms`,
         w < 0.45 ? "asleep" : "run",
       );
     else if (beat === "hydrate") setPill("awake · turn running", "run");
@@ -365,7 +366,7 @@
                   did last night's chart bump deploy?
                 </div>
                 <div class="ci evt" data-at="0.14">
-                  <b>vm awake · 2.5 ms</b>
+                  <b>vm awake · {sessionRestoreMs} ms</b>
                 </div>
                 <div class="ci evt" data-at="0.30">
                   clone jomcgi/homelab · <b>full history</b>
@@ -389,7 +390,7 @@
                   add a regression test for that fix
                 </div>
                 <div class="ci evt frost" data-at="0.905">
-                  restored on <b>brick-3</b> · --resume
+                  restored on <b>new node</b> · --resume
                 </div>
                 <div class="ci msg bot" data-at="0.935">
                   Picking up where we left off.
@@ -549,7 +550,7 @@
                   width="208"
                   height="20"
                 /><text class="swap-t" id="t-fake" x="428" y="298"
-                  >Bearer ember-guest…dummy…</text
+                  >Bearer &lt;placeholder&gt;</text
                 ><line
                   class="strike"
                   id="s-fake"
@@ -609,8 +610,7 @@
                   width="470"
                   height="92"
                   rx="10"
-                /><text class="llabel frost" x="212" y="412"
-                  >seaweedfs s3 · bucket embervm</text
+                /><text class="llabel frost" x="212" y="412">object store</text
                 ><g id="g-s3base"
                   ><rect
                     class="box paper frost-b"
@@ -642,7 +642,7 @@
                   width="164"
                   height="92"
                   rx="10"
-                /><text class="llabel" x="712" y="410">brick-3</text><rect
+                /><text class="llabel" x="712" y="410">new node</text><rect
                   class="box paper ember-b"
                   x="712"
                   y="418"
@@ -666,7 +666,7 @@
                 id="p-load"
                 d="M300,264 C315,235 370,215 440,192"
               /><text class="elabel el-ember" id="l-load" x="204" y="210"
-                >load · 2.5 ms</text
+                >load · {sessionRestoreMs} ms</text
               ><path
                 class="epath ep-amber"
                 id="p-patch"
@@ -725,13 +725,13 @@
     </p>
     <ol>
       <li>
-        01 · wake: vm awake · 2.5 ms, one shared base snapshot, volume patched
-        while paused
+        01 · wake: vm awake · {sessionRestoreMs} ms, one shared base snapshot, volume
+        patched while paused
       </li>
       <li>02 · hydrate: clone jomcgi/homelab through the egress sidecar</li>
       <li>03 · creds: real credentials stay outside the vm</li>
       <li>04 · park: idle 20 s, vm destroyed, disk kept</li>
-      <li>05 · resume: workspace in s3, restored on brick-3</li>
+      <li>05 · resume: workspace in s3, restored on new node</li>
     </ol>
   </div>
   <main class="doc">
@@ -739,7 +739,9 @@
     <dl class="tiers-mini">
       <div>
         <dt class="ram">guest ram</dt>
-        <dd>disposable · rebuilt in <b>2.5 ms</b> · never snapshotted</dd>
+        <dd>
+          disposable · rebuilt in <b>{sessionRestoreMs} ms</b> · never snapshotted
+        </dd>
       </div>
       <div>
         <dt class="disk">node scratch</dt>
@@ -748,7 +750,7 @@
         </dd>
       </div>
       <div>
-        <dt class="s3">seaweedfs s3</dt>
+        <dt class="s3">durable storage</dt>
         <dd>
           retired workspaces · <b>survives the machine</b> · deleted after 7 days
         </dd>

--- a/projects/monolith/frontend/src/lib/public/agentstory/timeline.js
+++ b/projects/monolith/frontend/src/lib/public/agentstory/timeline.js
@@ -78,15 +78,15 @@ export const CALLS = {
       a: 0.04,
       b: 0.32,
       cls: "w-frost",
-      text: "PUT s3://embervm/session-workspace/<lineage>",
+      text: "PUT workspace snapshot to object store",
     },
     {
       a: 0.42,
       b: 0.66,
       cls: "w-frost",
-      text: "GET s3://embervm/session-workspace/<lineage>  → brick-3",
+      text: "GET workspace snapshot → new node",
     },
-    { a: 0.68, b: 0.82, cls: "w-ember", text: "PUT /snapshot/load  (brick-3)" },
+    { a: 0.68, b: 0.82, cls: "w-ember", text: "PUT /snapshot/load (new node)" },
     {
       a: 0.84,
       b: 0.96,

--- a/projects/monolith/frontend/src/lib/public/fcstory/metrics.js
+++ b/projects/monolith/frontend/src/lib/public/fcstory/metrics.js
@@ -63,3 +63,14 @@ export const agentFirstModelCallMs = 140;
 export const semgrepRestoreMs = 22;
 export const semgrepScanSec = 0.72;
 export const semgrepColdStartSec = 6.7;
+
+// ---- Restore time figures for UI display (measured, baked by hand) ----
+
+// Agent session base-snapshot restore from disk: the time from dispatch to
+// the guest listening on vsock after a warm restore (not including dispatch
+// latency or the full request path). Used in agent session pages.
+export const sessionRestoreMs = 2.5;
+
+// Serving-class best wake from disk: the fastest measured wake of a serving
+// workload snapshot to answering queries. Used in ember landing and copy.
+export const servingWakeMs = 78;

--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -226,7 +226,7 @@
 </div>
 
 <!-- ═══ Project stack ═══ -->
-<HomepageRack />
+<HomepageRack {stats} />
 
 <!-- ═══ Footer ═══ -->
 <Footer />

--- a/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
+++ b/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
@@ -13,6 +13,25 @@
     apps.find((a) => a.slug === slug),
   );
   const featuredApps = apps.filter((a) => a.featured);
+
+  let { stats } = $props();
+
+  // Format the hardware eyebrow from live stats when available, or show
+  // static fallback if stats are unavailable.
+  function buildEyebrow(statsData) {
+    if (!statsData?.cluster) return "HOMELAB";
+    const c = statsData.cluster;
+    const g = statsData.gpu;
+    const parts = [];
+    if (c.nodes != null) parts.push(`${c.nodes} nodes`);
+    if (c.cpu_capacity_cores != null)
+      parts.push(`${c.cpu_capacity_cores} CPUs`);
+    if (c.memory_capacity_gb != null) parts.push(`${c.memory_capacity_gb} GB`);
+    if (g != null) parts.push("one RTX 4090");
+    return parts.length > 0 ? parts.join(" · ") : "HOMELAB";
+  }
+
+  const eyebrow = buildEyebrow(stats);
 </script>
 
 <section
@@ -21,7 +40,7 @@
   aria-label="Homelab hardware and systems"
 >
   <p class="rack-eyebrow">
-    4 nodes &middot; 52 CPUs &middot; 112 GB &middot; one RTX 4090
+    {eyebrow}
   </p>
   <h2>HOMELAB</h2>
 

--- a/projects/monolith/frontend/src/routes/public/cv/cv-data.js
+++ b/projects/monolith/frontend/src/routes/public/cv/cv-data.js
@@ -32,7 +32,7 @@ export const tagline =
   "Senior Platform Engineer @ Semgrep · AWS / EKS · Kubernetes · eBPF";
 
 export const summary =
-  "Mostly I build infrastructure and abstractions so that other engineers don't have to think about it: Kubernetes, eBPF, and the layers under them. Caremad about developer and user experience.";
+  "Mostly I build infrastructure and abstractions so that other engineers don't have to think about it: Kubernetes, eBPF, and the layers under them. Care mad about developer and user experience.";
 
 export const jobs = [
   // Current role stays deliberately scope-level: what the job is, not a

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -10,6 +10,7 @@
   // and the wake action stays on /ember/postgres where its Turnstile gate
   // and rate limits live.
   import { onMount } from "svelte";
+  import { servingWakeMs } from "$lib/public/fcstory/metrics.js";
   import "$lib/public/ember/ember.css";
   import "./landing.css";
 
@@ -59,7 +60,7 @@
 
   // Headline numbers count up from zero on load; skipped under reduced
   // motion (which also keeps visual-regression captures deterministic).
-  let bestWake = $state(78);
+  let bestWake = $state(servingWakeMs);
   let vmRestore = $state(22);
 
   onMount(() => {
@@ -72,7 +73,7 @@
       const tick = (t) => {
         const p = Math.min(1, (t - t0) / dur);
         const ease = 1 - Math.pow(1 - p, 3);
-        bestWake = Math.round(78 * ease);
+        bestWake = Math.round(servingWakeMs * ease);
         vmRestore = Math.round(22 * ease);
         if (p < 1) requestAnimationFrame(tick);
       };
@@ -143,14 +144,14 @@
       desc: "Ember becomes a standalone artifact somebody else could run: no dependency on the rest of this cluster.",
     },
     {
-      done: false,
+      done: true,
       name: "transport auth",
-      desc: "Every control channel authenticates: a bearer token on the control-plane-to-daemon lane first, mTLS with per-node identity as the upgrade path.",
+      desc: "The control-plane-to-daemon lane authenticates with a bearer token behind an ingress policy, enabled in production; per-node mTLS stays the upgrade path.",
     },
     {
-      done: false,
+      done: true,
       name: "encryption at rest",
-      desc: "Each principal's snapshots and workspaces get their own envelope keys, platform-managed or held in the customer's own KMS, and a restore must prove principal, lineage, node, and lease before a key is released.",
+      desc: "Each principal's snapshots and workspaces use envelope encryption with capability-gated restore.",
     },
   ];
 </script>
@@ -159,7 +160,7 @@
   <title>Ember · a workload orchestrator on Firecracker microVMs</title>
   <meta
     name="description"
-    content="A workload orchestrator that runs untrusted code in hardware-isolated Firecracker microVMs. Services sleep as snapshots and wake on demand, disk to answering queries in 78 ms. Includes a live Postgres you can wake yourself."
+    content="A workload orchestrator that runs untrusted code in hardware-isolated Firecracker microVMs. Services sleep as snapshots and wake on demand, disk to answering queries in {servingWakeMs} ms. Includes a live Postgres you can wake yourself."
   />
 </svelte:head>
 

--- a/projects/monolith/frontend/src/routes/public/ember/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/agents/+page.svelte
@@ -1,12 +1,13 @@
 <script>
   import AgentScrollStory from "$lib/public/agentstory/AgentScrollStory.svelte";
+  import { sessionRestoreMs } from "$lib/public/fcstory/metrics.js";
 </script>
 
 <svelte:head>
   <title>One microVM per agent session · ember/agents</title>
   <meta
     name="description"
-    content="How this site runs its AI agents: one Firecracker microVM per session, restored from a shared base snapshot in 2.5 ms, killed 20 s after the last turn, rebuilt from a workspace tiered to S3. Credentials stay outside the VM."
+    content="How this site runs its AI agents: one Firecracker microVM per session, restored from a shared base snapshot in {sessionRestoreMs} ms, killed 20 s after the last turn, rebuilt from a workspace tiered to S3. Credentials stay outside the VM."
   />
   <noscript>
     <style>


### PR DESCRIPTION
Four live-page fixes from the 2026-08-22 audit.

- Homepage `HomepageRack` eyebrow is built from `stats.cluster` (same source as the ticker) instead of a hardcoded "52 CPUs · 112 GB" that disagreed with the ticker above it.
- `/ember/agents` no longer publishes brick hostnames, the object-store bucket name, object prefixes, or the placeholder token format.
- `/ember` roadmap: transport auth (bearer token behind the ingress policy, `1f701123c` / `abb4f9fee`) and encryption at rest (`b9d950dc6` / `054306edc`) are marked shipped; per-node mTLS is still described as the upgrade path.
- `sessionRestoreMs` (2.5) and `servingWakeMs` (78) added to `fcstory/metrics.js`; the agent story and EmberVM landing import them instead of literals.
- CV: "Caremad" to "Care mad" to match the homepage.

Local `ci`: `Executed 3 out of 742 tests: 742 tests pass` (frontend build included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmPs7fYVAUDcpyhzboWvWf