### PR TITLE
chore(embervm): require restore capabilities in dev

### DIFF
--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -68,6 +68,11 @@ kekRoot:
     itemPath: "vaults/k8s-homelab/items/embervm-kek-root"
 
 noded:
+  # Step 3 of the #4691 rollout (2026-08-23): an enveloped artifact restores
+  # only with a valid control-plane capability. Dev's first banked session
+  # exported with aes-256-gcm-v1 files and a 168-byte envelope; this flip rolls
+  # the brick, so the next relight must restore from S3 through a capability.
+  requireRestoreCapability: true
   # The wildcard DaemonSet, off. See the scratchPrep note below for why this
   # matters: it selects homelab.io/firecracker=true, which all four nodes carry
   # including the three etcd masters.


### PR DESCRIPTION
Refs #4691, rollout step 3 (dev). Step 2 verified: session `s-01M0P15RFCHBN8BZG43J57F7F4` banked and exported with `encryption: aes-256-gcm-v1` on every file and a 168-byte envelope in `meta.json`; a local relight worked.

`noded.requireRestoreCapability: true` in dev. The brick roll this causes makes the next relight restore from S3, which is the end-to-end capability test (refused without a valid capability, so a success proves the path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP