### PR TITLE
fix(embervm): run live session destroy off the SessionManager process

### DIFF
--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -618,8 +618,14 @@ defmodule Embervm.SessionManager do
     end
   end
 
-  def handle_info({:destroy_done, session_id, confirmed}, state) do
-    {:noreply, finish_destroy(state, session_id, confirmed)}
+  def handle_info({:destroy_done, session_id, ref, confirmed}, state) do
+    case Map.get(state.destroy_workers, session_id) do
+      {_pid, _monitor_ref, _timer_ref, ^ref, _resumed} ->
+        {:noreply, finish_destroy(state, session_id, confirmed)}
+
+      _ ->
+        {:noreply, state}
+    end
   end
 
   def handle_info({:destroy_timeout, ref}, state) do
@@ -1634,10 +1640,11 @@ defmodule Embervm.SessionManager do
       |> Map.update!(:banking, &Map.delete(&1, session_id))
 
     case SessionStore.get(state.session_store, session_id) do
-      # Destroyed/expired mid-bank: the durable state is already terminal. On a
-      # successful bank the produced snapshot is orphaned and adoption reaps it; drain
-      # any mid-bank parked callers gone. Never resurrect a terminal session.
-      {:ok, %{state: st}} when st in [:expired, :evicted, :destroyed, :failed] ->
+      # Destroying/destroyed/expired mid-bank: teardown or a terminal state already
+      # owns the row. On a successful bank the produced snapshot is orphaned and
+      # adoption reaps it; drain any mid-bank parked callers gone. Never resurrect
+      # the session.
+      {:ok, %{state: st}} when st in [:destroying, :expired, :evicted, :destroyed, :failed] ->
         drain_relight_waiters(state, session_id, {:error, {:gone, to_string(st)}})
 
       _ ->
@@ -1703,9 +1710,21 @@ defmodule Embervm.SessionManager do
 
       case SessionStore.get(state.session_store, session_id) do
         {:ok, session} ->
-          fail_session_and_destroy(state, session)
-          # Any mid-bank parked callers: the session is failed now.
-          drain_relight_waiters(state, session_id, {:error, {:gone, "failed"}})
+          destroying? =
+            session.state == :destroying or
+              MapSet.member?(state.destroy_inflight, session_id)
+
+          state =
+            if destroying? do
+              state
+            else
+              fail_session_and_destroy(state, session)
+            end
+
+          # Any mid-bank parked callers: the session is failed now, or its destroy
+          # worker already owns teardown.
+          gone_state = if destroying?, do: "destroying", else: "failed"
+          drain_relight_waiters(state, session_id, {:error, {:gone, gone_state}})
 
         :error ->
           state
@@ -2362,11 +2381,11 @@ defmodule Embervm.SessionManager do
   # and reply the error to parked callers (they may retry, re-relighting).
   defp finish_relight(state, session_id, outcome) do
     case SessionStore.get(state.session_store, session_id) do
-      # The session went terminal mid-relight (a concurrent destroy/expire): the
-      # relight's live VM, if any, is orphaned and adoption/next-sweep reaps it. Drain
-      # any parked callers gone and drop the ledger. Never start a process for a
-      # terminal session.
-      {:ok, %{state: st}} when st in [:expired, :evicted, :destroyed, :failed] ->
+      # The session began teardown or went terminal mid-relight (a concurrent
+      # destroy/expire): the relight's live VM, if any, is orphaned and
+      # adoption/next-sweep reaps it. Drain any parked callers gone and drop the
+      # ledger. Never start a process for a session that is going away.
+      {:ok, %{state: st}} when st in [:destroying, :expired, :evicted, :destroyed, :failed] ->
         drain_relight_waiters(state, session_id, {:error, {:gone, to_string(st)}})
 
       _ ->
@@ -3522,15 +3541,21 @@ defmodule Embervm.SessionManager do
               _, _ -> false
             end
 
-          send(owner, {:destroy_done, session_id, confirmed})
+          send(owner, {:destroy_done, session_id, ref, confirmed})
         end)
 
-      %{
+      state = %{
         state
         | destroy_workers:
             Map.put(state.destroy_workers, session_id, {pid, monitor_ref, timeout_ref, ref, resumed}),
           destroy_inflight: MapSet.put(state.destroy_inflight, session_id)
       }
+
+      if state.node_confirmed_destroy do
+        drain_relight_waiters(state, session_id, {:error, {:gone, "destroyed"}})
+      else
+        state
+      end
     end
   end
 

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -89,7 +89,8 @@ defmodule Embervm.SessionManager do
   @default_wake_max 30
   @default_wake_window_ms 60_000
   @create_worker_timeout_ms 130_000
-  @reconcile_destroy_timeout_ms 15_000
+  @destroy_worker_timeout_ms 30_000
+  @destroy_rpc_timeout_ms 15_000
 
   # Three consecutive bank failures fail the session and destroy its VM: a session
   # that cannot bank must not squat live capacity forever.
@@ -305,6 +306,11 @@ defmodule Embervm.SessionManager do
       create_inflight: %{},
       create_next_ref: 0,
       create_workers: %{},
+      # session_id -> {pid, monitor_ref, timeout_ref, worker_ref, resumed}. Live
+      # teardown must not run on this process because a stuck node RPC would block
+      # creates, routing, sweeps, and the reconcile pass that can redrive it.
+      destroy_workers: %{},
+      destroy_inflight: MapSet.new(),
       # #4306/#4313 review fix 2 (TOCTOU): the set of restore_lineage values
       # a restoring create currently has in flight (added synchronously in
       # handle_call({:create,...}) when accepted, removed in finish_create
@@ -408,8 +414,7 @@ defmodule Embervm.SessionManager do
   def handle_continue({:do_destroy_live, session_id}, state) do
     case SessionStore.get(state.session_store, session_id) do
       {:ok, %{state: :destroying} = session} ->
-        {_reply, state} = destroy_live(state, session, false)
-        {:noreply, state}
+        {:noreply, spawn_destroy_worker(state, session, false)}
 
       _ ->
         {:noreply, state}
@@ -499,6 +504,9 @@ defmodule Embervm.SessionManager do
     case SessionStore.get(state.session_store, session_id) do
       {:ok, %{state: session_state}} when session_state in [:expired, :evicted, :destroyed, :failed] ->
         {:reply, {:ok, :already_terminal}, state}
+
+      {:ok, %{state: :destroying}} ->
+        {:reply, {:ok, :destroying}, state}
 
       {:ok, %{state: session_state} = session} when session_state in [:banked, :parked] ->
         {reply, state} = destroy_live(state, session)
@@ -610,11 +618,35 @@ defmodule Embervm.SessionManager do
     end
   end
 
+  def handle_info({:destroy_done, session_id, confirmed}, state) do
+    {:noreply, finish_destroy(state, session_id, confirmed)}
+  end
+
+  def handle_info({:destroy_timeout, ref}, state) do
+    case Enum.find(state.destroy_workers, fn {_session_id, {_pid, _monitor_ref, _timer_ref, worker_ref, _resumed}} ->
+           worker_ref == ref
+         end) do
+      {session_id, {pid, _monitor_ref, _timer_ref, _worker_ref, _resumed}} ->
+        Process.exit(pid, :kill)
+        {:noreply, finish_destroy(state, session_id, false)}
+
+      nil ->
+        {:noreply, state}
+    end
+  end
+
   def handle_info({:DOWN, monitor_ref, :process, _pid, reason}, state) do
     case Enum.find(state.create_workers, fn {_ref, {_pid, mref, _timer_ref}} -> mref == monitor_ref end) do
       {ref, _worker} ->
         {:noreply, finish_create(state, ref, {:error, {:create_worker_crashed, reason}})}
-      nil -> {:noreply, state}
+
+      nil ->
+        case Enum.find(state.destroy_workers, fn {_session_id, {_pid, mref, _timer_ref, _worker_ref, _resumed}} ->
+               mref == monitor_ref
+             end) do
+          {session_id, _worker} -> {:noreply, finish_destroy(state, session_id, false)}
+          nil -> {:noreply, state}
+        end
     end
   end
 
@@ -2583,6 +2615,9 @@ defmodule Embervm.SessionManager do
     end
 
     cond do
+      MapSet.member?(state.destroy_inflight, sid) ->
+        state
+
       # Owner still reports the VM: retry the node-confirmed teardown. Terminate any
       # lingering process first (a same-CP retry after a failed RPC), then re-issue
       # the Destroy; a CP-crash re-drive has no process, so this is a no-op there.
@@ -2591,13 +2626,7 @@ defmodule Embervm.SessionManager do
 
         if node_reporting?(state, dial_key) do
           emit_redrive_intent.()
-          confirmed = stop_session_process(state, sid, session)
-
-          if confirmed do
-            record_session_destroyed(state, session, "teardown")
-          else
-            state
-          end
+          spawn_destroy_worker(state, session, true)
         else
           state
           |> maybe_warn_dead_destroy_instance(session, dial_key)
@@ -3464,6 +3493,148 @@ defmodule Embervm.SessionManager do
   defp schedule(_msg, interval) when interval <= 0, do: :ok
   defp schedule(msg, interval), do: Process.send_after(self(), msg, interval)
 
+  # Live teardown runs in a monitored worker so a slow or stuck node cannot occupy
+  # the SessionManager. The manager remains the single writer for the terminal
+  # transition and owns all worker cleanup.
+  defp spawn_destroy_worker(state, session, resumed) do
+    session_id = session.session_id
+
+    if MapSet.member?(state.destroy_inflight, session_id) do
+      state
+    else
+      owner = self()
+      ref = make_ref()
+      timeout_ref = Process.send_after(owner, {:destroy_timeout, ref}, @destroy_worker_timeout_ms)
+
+      {pid, monitor_ref} =
+        spawn_monitor(fn ->
+          confirmed =
+            try do
+              if is_binary(session.node_id) and is_binary(session.vm_id) do
+                stop_session_process(state, session_id, session)
+              else
+                _ = stop_session_process(state, session_id, session)
+                true
+              end
+            rescue
+              _ -> false
+            catch
+              _, _ -> false
+            end
+
+          send(owner, {:destroy_done, session_id, confirmed})
+        end)
+
+      %{
+        state
+        | destroy_workers:
+            Map.put(state.destroy_workers, session_id, {pid, monitor_ref, timeout_ref, ref, resumed}),
+          destroy_inflight: MapSet.put(state.destroy_inflight, session_id)
+      }
+    end
+  end
+
+  defp finish_destroy(state, session_id, confirmed) do
+    case Map.pop(state.destroy_workers, session_id) do
+      {nil, _workers} ->
+        state
+
+      {{_pid, _monitor_ref, _timeout_ref, _worker_ref, resumed} = worker, workers} ->
+        cleanup_destroy_worker(worker)
+
+        state = %{
+          state
+          | destroy_workers: workers,
+            destroy_inflight: MapSet.delete(state.destroy_inflight, session_id)
+        }
+
+        case SessionStore.get(state.session_store, session_id) do
+          {:ok, %{state: session_state}}
+          when session_state in [:expired, :evicted, :destroyed, :failed] ->
+            state
+
+          {:ok, %{state: :destroying} = session} ->
+            finish_destroying_session(state, session, confirmed, resumed)
+
+          _ ->
+            state
+        end
+    end
+  end
+
+  defp finish_destroying_session(state, session, confirmed, resumed) do
+    # The second arm preserves the legacy gate-off ordering for callers that start
+    # from a pre-destroying state. Workers normally observe :destroying, so an
+    # unconfirmed live teardown remains eligible for reconcile redrive.
+    finish? = confirmed or (not state.node_confirmed_destroy and session.state != :destroying)
+
+    state =
+      if state.node_confirmed_destroy or finish? do
+        drain_relight_waiters(state, session.session_id, {:error, {:gone, "destroyed"}})
+      else
+        state
+      end
+
+    if finish? do
+      retire_session_volume(state, session)
+
+      if resumed do
+        record_session_destroyed(state, session, "teardown")
+      else
+        reply =
+          SessionStore.transition(
+            state.session_store,
+            session.session_id,
+            :destroy,
+            :session_destroyed,
+            %{reason: :destroyed},
+            %{}
+          )
+
+        if match?({:ok, _}, reply) do
+          node_confirmed =
+            if state.node_confirmed_destroy do
+              confirmed
+            else
+              if(vm_resident?(session), do: confirmed, else: nil)
+            end
+
+          Embervm.SpecTrace.emit(:adoption, :confirm_destroy, %{
+            "session_id" => session.session_id,
+            "vm_id" => session.vm_id,
+            "node_id" => session.node_id,
+            "had_vm" => vm_resident?(session),
+            "node_confirmed" => node_confirmed,
+            "gate" => state.node_confirmed_destroy,
+            "confirmed_by" => if(state.node_confirmed_destroy, do: "teardown", else: "none")
+          })
+        end
+
+        Logger.info("embervm session destroyed",
+          session_id: session.session_id,
+          workload: session.workload,
+          principal: session.principal
+        )
+
+        state
+      end
+    else
+      Logger.warning("embervm session teardown unconfirmed, left destroying",
+        session_id: session.session_id,
+        workload: session.workload,
+        vm_id: session.vm_id
+      )
+
+      state
+    end
+  end
+
+  defp cleanup_destroy_worker({pid, monitor_ref, timeout_ref, _worker_ref, _resumed}) do
+    Process.cancel_timer(timeout_ref)
+    Process.demonitor(monitor_ref, [:flush])
+    if Process.alive?(pid), do: Process.exit(pid, :kill)
+  end
+
   # Destroy a session: tear down whatever it holds. A live session (running/banking/
   # relighting) has a process + VM, stopped and destroyed here; a banked session has
   # only a snapshot, evicted here. Any parked relight waiters are drained gone (the
@@ -3660,16 +3831,14 @@ defmodule Embervm.SessionManager do
     # Dial the OWNING instance running this live vm_id, not the node-name alias.
     dial_key = Embervm.WakeInstance.dial_for_session_vm(state.capacity_table, node_id, vm_id)
 
-    case state.channel_fun.(dial_key) do
+    case safe_channel(state.channel_fun, dial_key) do
       {:ok, channel} ->
         opts = state.session_opts
 
         destroy_fun =
           Keyword.get(opts, :destroy_fun, fn ch, id ->
-            # Reconcile runs this on the SessionManager process, so a wedged node
-            # RPC must release the GenServer within a bounded interval.
             Embervm.Node.V1.NodeService.Stub.destroy(ch, %Embervm.Node.V1.DestroyRequest{vm_id: id},
-              timeout: @reconcile_destroy_timeout_ms
+              timeout: @destroy_rpc_timeout_ms
             )
           end)
 

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -683,6 +683,7 @@ defmodule Embervm.SessionManagerTest do
     put_session_workload(ctx, "wl-gone")
     {:ok, created} = SessionManager.create(ctx.mgr, "wl-gone", "p1")
     {:ok, _} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :destroyed).state == :destroyed
 
     assert {:error, {:gone, "destroyed"}} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
   end
@@ -867,7 +868,7 @@ defmodule Embervm.SessionManagerTest do
 
     :ok = SessionManager.reconcile(ctx.mgr)
 
-    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    session = wait_for_state(ctx, created.session_id, :destroyed)
     assert session.state == :destroyed
 
     kinds = op_kinds_for(ctx, created.session_id)
@@ -1206,6 +1207,7 @@ defmodule Embervm.SessionManagerTest do
 
     original = create_persistence_session(ctx)
     {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+    assert wait_for_state(ctx, original.session_id, :destroyed).state == :destroyed
 
     # The fleet still reports the lineage's volume on an instance co-located
     # with (but distinct from) the base workload brick, modelling the real
@@ -1239,6 +1241,7 @@ defmodule Embervm.SessionManagerTest do
 
     original = create_persistence_session(ctx)
     {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+    assert wait_for_state(ctx, original.session_id, :destroyed).state == :destroyed
 
     assert {:ok, restored} = SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
     assert restored.restored == false
@@ -1260,6 +1263,7 @@ defmodule Embervm.SessionManagerTest do
     ctx = start_stack(prime_fun: fake_prime_fun("vm-restore-source"), channel_fun: fake_channel_fun())
     original = create_persistence_session(ctx, workload: "wl-persist-a")
     {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+    assert wait_for_state(ctx, original.session_id, :destroyed).state == :destroyed
     put_session_workload(ctx, "wl-persist-b", persistence_workload_opts())
 
     assert {:error, {:denied, :lineage_workload_mismatch}} =
@@ -1270,6 +1274,7 @@ defmodule Embervm.SessionManagerTest do
     ctx = start_stack(prime_fun: fake_prime_fun("vm-restore-owner"), channel_fun: fake_channel_fun())
     original = create_persistence_session(ctx, principal: "p1")
     {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+    assert wait_for_state(ctx, original.session_id, :destroyed).state == :destroyed
 
     assert {:error, {:denied, :lineage_principal_mismatch}} =
              SessionManager.create(ctx.mgr, "wl-persist", "p2", original.session_id)
@@ -1306,6 +1311,7 @@ defmodule Embervm.SessionManagerTest do
 
     original = create_persistence_session(ctx)
     {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+    assert wait_for_state(ctx, original.session_id, :destroyed).state == :destroyed
 
     assert {:error, {:denied, _reason}} =
              SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
@@ -1445,6 +1451,7 @@ defmodule Embervm.SessionManagerTest do
     ctx = start_stack(prime_fun: prime_fun, channel_fun: fake_channel_fun())
     original = create_persistence_session(ctx)
     {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+    assert wait_for_state(ctx, original.session_id, :destroyed).state == :destroyed
 
     first =
       Task.async(fn ->
@@ -1480,6 +1487,7 @@ defmodule Embervm.SessionManagerTest do
     ctx = start_stack(prime_fun: fake_prime_fun("vm-inflight-cleared"), channel_fun: fake_channel_fun())
     original = create_persistence_session(ctx)
     {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+    assert wait_for_state(ctx, original.session_id, :destroyed).state == :destroyed
 
     # Completes synchronously (no gate): by the time create/4 returns,
     # finish_create has already cleared original.session_id from
@@ -1488,6 +1496,7 @@ defmodule Embervm.SessionManagerTest do
     assert {:ok, first} = SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
     refute MapSet.member?(:sys.get_state(ctx.mgr).inflight_restore_lineages, original.session_id)
     {:ok, _} = SessionManager.destroy(ctx.mgr, first.session_id)
+    assert wait_for_state(ctx, first.session_id, :destroyed).state == :destroyed
 
     # Restore keys on LINEAGE, not session_id: first is itself a restoring
     # create, so first.session_id != first.lineage_id (original.session_id).
@@ -1838,11 +1847,51 @@ defmodule Embervm.SessionManagerTest do
     assert Registry.lookup(ctx.registry, created.session_id) == []
   end
 
+  test "create is not blocked by a hung live destroy" do
+    parent = self()
+
+    ctx =
+      start_stack(
+        destroy_fun: fn _ch, _vm ->
+          send(parent, {:destroy_started, self()})
+
+          receive do
+            :finish_destroy -> {:ok, %{teardown_confirmed: true}}
+          after
+            5_000 -> {:ok, %{teardown_confirmed: false}}
+          end
+        end
+      )
+
+    put_session_workload(ctx, "wl-hung-destroy")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-hung-destroy", "p1")
+    put_session_workload(ctx, "wl-during-destroy")
+
+    assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert_receive {:destroy_started, destroy_worker}, 1_000
+
+    create_task =
+      Task.async(fn ->
+        started_at = System.monotonic_time(:millisecond)
+        result = SessionManager.create(ctx.mgr, "wl-during-destroy", "p2")
+        {result, System.monotonic_time(:millisecond) - started_at}
+      end)
+
+    assert {{:ok, _other_session}, elapsed_ms} = Task.await(create_task, 500)
+    assert elapsed_ms < 250
+
+    assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
+
+    send(destroy_worker, :finish_destroy)
+    assert wait_for_state(ctx, created.session_id, :destroyed).state == :destroyed
+  end
+
   test "destroy of an already-terminal session is a no-op success" do
     ctx = start_stack()
     put_session_workload(ctx, "wl-d2")
     {:ok, created} = SessionManager.create(ctx.mgr, "wl-d2", "p1")
     {:ok, _} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :destroyed).state == :destroyed
 
     assert {:ok, :already_terminal} = SessionManager.destroy(ctx.mgr, created.session_id)
   end
@@ -1868,6 +1917,10 @@ defmodule Embervm.SessionManagerTest do
 
     assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
     assert wait_for_state(ctx, created.session_id, :destroying).state == :destroying
+
+    assert eventually(fn ->
+             not MapSet.member?(:sys.get_state(ctx.mgr).destroy_inflight, created.session_id)
+           end)
 
     report_session_vm(ctx, created.session_id, "wl-retry-destroy")
     assert :ok = SessionManager.reconcile(ctx.mgr)
@@ -2005,7 +2058,7 @@ defmodule Embervm.SessionManagerTest do
 
     :ok = SessionManager.reconcile(ctx.mgr)
 
-    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    session = wait_for_state(ctx, created.session_id, :destroyed)
     assert session.state == :destroyed
 
     :ok = Embervm.SpecTrace.drain(writer)

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -1886,6 +1886,114 @@ defmodule Embervm.SessionManagerTest do
     assert wait_for_state(ctx, created.session_id, :destroyed).state == :destroyed
   end
 
+  test "stale destroy_done does not clear or stop the live destroy worker" do
+    parent = self()
+
+    ctx =
+      start_stack(
+        destroy_fun: fn _ch, _vm ->
+          send(parent, {:destroy_started, self()})
+
+          receive do
+            :finish_destroy -> {:ok, %{teardown_confirmed: true}}
+          after
+            5_000 -> {:ok, %{teardown_confirmed: false}}
+          end
+        end
+      )
+
+    put_session_workload(ctx, "wl-stale-destroy-done")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-stale-destroy-done", "p1")
+
+    assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert_receive {:destroy_started, destroy_worker}, 1_000
+
+    live_worker = :sys.get_state(ctx.mgr).destroy_workers[created.session_id]
+    {^destroy_worker, _, _, _, _} = live_worker
+
+    send(ctx.mgr, {:destroy_done, created.session_id, make_ref(), false})
+
+    state = :sys.get_state(ctx.mgr)
+    assert MapSet.member?(state.destroy_inflight, created.session_id)
+    assert state.destroy_workers[created.session_id] == live_worker
+    assert Process.alive?(destroy_worker)
+
+    send(destroy_worker, :finish_destroy)
+    assert wait_for_state(ctx, created.session_id, :destroyed).state == :destroyed
+  end
+
+  test "destroying session is not resurrected by relight completion" do
+    parent = self()
+
+    ctx =
+      start_stack(
+        node_confirmed_destroy: true,
+        relight_fun: fn _channel, _req ->
+          send(parent, {:relight_started, self()})
+
+          receive do
+            :finish_relight -> {:ok, %RelightResponse{vm_id: "vm-raced-relight"}}
+          after
+            5_000 -> {:error, :relight_test_timeout}
+          end
+        end,
+        destroy_fun: fn _ch, _vm ->
+          send(parent, {:destroy_started, self()})
+
+          receive do
+            :finish_destroy -> {:ok, %{teardown_confirmed: true}}
+          after
+            5_000 -> {:ok, %{teardown_confirmed: false}}
+          end
+        end
+      )
+
+    put_session_workload(ctx, "wl-relight-destroy-race")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-relight-destroy-race", "p1")
+    assert :ok = SessionManager.bank(ctx.mgr, created.session_id)
+    banked = wait_for_state(ctx, created.session_id, :banked)
+
+    {:ok, fact} = NodeCapacity.fetch(ctx.cap_table, "node-4")
+
+    NodeCapacity.put(
+      ctx.cap_table,
+      "node-4",
+      Map.put(fact, :session_snapshots, [
+        %{session_id: created.session_id, snapshot_ref: banked.snapshot_ref, workload: "wl-relight-destroy-race"}
+      ])
+    )
+
+    invoke_task =
+      Task.async(fn ->
+        SessionManager.invoke(ctx.mgr, created.session_id, %{body: "race"})
+      end)
+
+    assert_receive {:relight_started, relight_worker}, 1_000
+    assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
+
+    # A relighting row has no live vm_id, so the destroy worker confirms without
+    # calling destroy_fun. Gate-on drain still replies the parked invoke gone
+    # before any relight completion can resurrect a process.
+    assert {:error, {:gone, "destroyed"}} = Task.await(invoke_task, 1_000)
+
+    send(
+      ctx.mgr,
+      {:relight_done, created.session_id,
+       {:ok, "node-4", "vm-injected-relight", 1, "node-4"}}
+    )
+
+    # :sys.get_state is sent by this same test process after relight_done, so the
+    # manager has handled that completion before these assertions run.
+    _ = :sys.get_state(ctx.mgr)
+    assert Registry.lookup(ctx.registry, created.session_id) == []
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state in [:destroying, :destroyed]
+    refute session.state == :running
+
+    send(relight_worker, :finish_relight)
+    assert wait_for_state(ctx, created.session_id, :destroyed).state == :destroyed
+  end
+
   test "destroy of an already-terminal session is a no-op success" do
     ctx = start_stack()
     put_session_workload(ctx, "wl-d2")
@@ -2021,6 +2129,10 @@ defmodule Embervm.SessionManagerTest do
     {:ok, created} = SessionManager.create(ctx.mgr, "wl-ncd2", "p1")
 
     assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
+
+    assert eventually(fn ->
+             not MapSet.member?(:sys.get_state(ctx.mgr).destroy_inflight, created.session_id)
+           end)
 
     {:ok, session} = SessionStore.get(ctx.store, created.session_id)
     assert session.state == :destroying


### PR DESCRIPTION
## Summary

A hung noded Destroy RPC currently runs inside `SessionManager` via `handle_continue({:do_destroy_live, ...})` and reconcile redrive. One stuck teardown occupies the GenServer, so every create (180s call timeout), invoke routing, sweep, and the reconcile that would recover it queues behind it.

This is what happened on 2026-08-23: the hourly qwen synthetic (`s-01M0NYS8KPZDDR8FQPG6JRPPX1`) entered `:destroying` at 00:02 UTC and the manager stayed wedged for ~35 minutes. `POST /v1/workloads/pi-runtime/sessions` hung; `GET` listing (`SessionStore`, a different process) returned in 4ms. Bouncing the control-plane pod unstuck it. Session 326 (`/agents?session=326`) failed during the bounce with a disconnect; a follow-up prompt on that session should work now.

#5051 already bounded the reconcile Destroy RPC. That still leaves teardown on the manager, so a 15s timeout that fires every reconcile tick keeps creates queued. This change moves live teardown into a monitored worker (the same shape as create and bank), skips redrive while a worker is in flight, and makes a second `destroy/2` of an already-`:destroying` session idempotent.

## Test plan

- [x] `ci` green locally (`1408 tests, 0 failures` in the EmberVM mix suite, including `create is not blocked by a hung live destroy`)
- [x] HOL test: `destroy_fun` waits on a gate; a concurrent `SessionManager.create` returns in under 250ms; second `destroy/2` returns `{:ok, :destroying}`
- [ ] PR CI
- After merge: confirm a qwen `/agents` session creates a guest without sitting in `running` with no `ember_session_id`

Refs #5051