### PR TITLE
fix(signoz): drop httpcheck target for the removed cluster-agents service

### DIFF
--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -178,9 +178,6 @@ k8s-infra:
               headers:
                 CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
                 CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
-            # Cluster agents (internal health check - no public domain)
-            - endpoint: http://cluster-agents.cluster-agents.svc.cluster.local:8080/health
-              method: GET
         # Cloudflare Pages (static sites) - no auth required
         httpcheck/cloudflare-pages:
           targets:


### PR DESCRIPTION
## What

Removes the `httpcheck/k8s-services` target `http://cluster-agents.cluster-agents.svc.cluster.local:8080/health` from `projects/platform/signoz/values-prod.yaml`.

## Why

`cluster-agents` was folded into the monolith in c1b79cb72. Verified read-only against the cluster: no `cluster-agents` namespace, no Service or Deployment by that name anywhere (`kubectl get ns`, `kubectl get svc -A`). The probe could only ever fail, which is noise that trains people to ignore a real synthetic. No SigNoz alert rule or doc references the URL, so dropping the target is the whole fix.

Platform charts deploy on HEAD, so this lands on merge.

`ci test`: Executed 2 out of 744 tests: 744 tests pass (ExUnit 1407 tests, 0 failures).

Closes #4650

🤖 Generated with [Claude Code](https://claude.com/claude-code)