### PR TITLE
fix(embervm): make the destroy intent precondition loud in the gated teardown path

### DIFF
--- a/projects/embervm/control/lib/embervm/op_log.ex
+++ b/projects/embervm/control/lib/embervm/op_log.ex
@@ -115,9 +115,10 @@ defmodule Embervm.OpLog do
     :session_expired,
     :session_evicted,
     # session_destroying is the durable destroy INTENT (ADR embervm/014 decision 5):
-    # appended BEFORE the node-confirmed teardown RPC, so a CP crash mid-destroy
-    # rebuilds as destroying and re-drives; session_destroyed follows only on node
-    # confirmation. Only written under the EMBERVM_NODE_CONFIRMED_DESTROY gate.
+    # appended by SessionManager BEFORE any teardown, regardless of the
+    # EMBERVM_NODE_CONFIRMED_DESTROY gate, so a CP crash mid-destroy rebuilds as
+    # destroying and re-drives. The gate only decides whether session_destroyed
+    # waits for node confirmation (#4804).
     :session_destroying,
     :session_destroyed,
     :session_failed,

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -3472,9 +3472,13 @@ defmodule Embervm.SessionManager do
   #
   # Two orderings, selected by EMBERVM_NODE_CONFIRMED_DESTROY (ADR embervm/014
   # decision 5):
-  #   * off (default): record destroying first, then tear the VM down
-  #     asynchronously. A banked session (no VM) is evicted synchronously.
-  #   * on, live VM: record the destroying intent, run the node-confirmed teardown
+  # For a live session the destroying intent is written by the CALLER
+  # (handle_call({:destroy, _})) before the continue that lands here, in both
+  # orderings and regardless of the gate:
+  #   * off (default): tear the VM down, then record destroyed whether or not the
+  #     node confirmed. A banked session (no VM) is evicted synchronously with no
+  #     intent op.
+  #   * on, live VM: run the node-confirmed teardown
   #     RPC, and record session_destroyed ONLY when the node confirms teardown. An
   #     unconfirmed teardown (RPC failure or teardown_confirmed=false) leaves the
   #     session in destroying for the reconcile loop to re-drive.
@@ -3552,10 +3556,20 @@ defmodule Embervm.SessionManager do
     end
   end
 
-  # Gate-on path for a live-VM session: destroying intent -> node-confirmed teardown
-  # -> destroyed only on confirmation. Relight waiters drain immediately (the session
+  # Gate-on path for a live-VM session: (caller-written) destroying intent ->
+  # node-confirmed teardown -> destroyed only on confirmation. Relight waiters drain immediately (the session
   # is going away regardless of how long teardown takes).
   defp destroy_live_node_confirmed(state, session, _resumed) do
+    # 1. Durable destroying intent is already on the log. The only caller is
+    #    handle_continue({:do_destroy_live, _}), which dispatches a :destroying
+    #    row that handle_call({:destroy, _}) transitioned to :session_destroying
+    #    before continuing, and that write happens regardless of
+    #    EMBERVM_NODE_CONFIRMED_DESTROY. This function never writes the
+    #    intent itself (#4804: a second write site here was unreachable and read
+    #    as the primary one). The match makes the precondition loud: a new
+    #    caller that skips the intent crashes here instead of tearing down a VM
+    #    whose destroy a CP restart would forget.
+    :destroying = session.state
     state = drain_relight_waiters(state, session.session_id, {:error, {:gone, "destroyed"}})
 
     # 2. Terminate the process and issue the node-confirmed teardown RPC. A

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -1953,6 +1953,9 @@ defmodule Embervm.SessionManagerTest do
     assert :session_destroyed in kinds
     # destroying is appended BEFORE destroyed.
     assert index_of(kinds, :session_destroying) < index_of(kinds, :session_destroyed)
+    # ...and exactly once: the intent is written by the destroy call, never again
+    # by the gated teardown path (#4804).
+    assert Enum.count(kinds, &(&1 == :session_destroying)) == 1
   end
 
   test "gated: destroy with an unconfirming node stays destroying, no destroyed op" do


### PR DESCRIPTION
## What

- `destroy_live_node_confirmed/3`: add `:destroying = session.state` with a comment naming the real intent write site (`handle_call({:destroy, _})`). The dead `else` branch from #4804 was already deleted in f53629099; this lands the loud precondition the issue preferred over silently relying on it.
- `op_log.ex`: the `:session_destroying` comment said the intent is only written under `EMBERVM_NODE_CONFIRMED_DESTROY`. It is written unconditionally; the gate only decides whether `session_destroyed` waits for node confirmation.
- `destroy_live/2` header: gate-off ordering described correctly (caller writes intent, then teardown, then destroyed regardless of confirmation).
- Test: the gated destroy test now asserts `:session_destroying` appears exactly once, so a second write site cannot come back unnoticed.

## Why

The false comments were the source of the false premise in #4758. See #4804.

Closes #4804

## Verified

`ci`: ExUnit genrule `1407 tests, 0 failures, 6 skipped`; `Executed 0 out of 744 tests: 744 tests pass` (cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)