### PR TITLE
fix(embervm): log a heartbeat and pending strikes from the armed gRPC sweeper

### DIFF
--- a/projects/embervm/control/lib/embervm/grpc_connection_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/grpc_connection_sweeper.ex
@@ -219,8 +219,7 @@ defmodule Embervm.GrpcConnectionSweeper do
       |> Enum.filter(&(not is_nil(&1)))
 
     new_state = %{state | strikes: strikes}
-    log_sweep(new_state, reaped)
-    log_pending(new_state, reapable)
+    log_sweep(new_state, reaped, reapable, children, keep_set)
     {reaped, new_state}
   end
 
@@ -404,45 +403,39 @@ defmodule Embervm.GrpcConnectionSweeper do
 
   defp address_in_set?(_addr, _set), do: false
 
-  # Log the sweep results. If gate is off, log a dry-run summary; if gate is
-  # on, log an info line with the count and reasons reaped.
-  defp log_sweep(_state, []), do: :ok
+  # Log the sweep results. Every pass ends with a heartbeat line so "swept and
+  # found nothing" is distinguishable from "never ran" (#4419: the armed
+  # sweeper used to be silent until it killed something). Pids accumulating
+  # strikes are listed in BOTH modes so a kill is visible before it lands.
+  defp log_sweep(state, reaped, reapable, children, keep_set) do
+    prefix = log_prefix(state)
 
-  defp log_sweep(state, reaped) do
-    count = length(reaped)
-
-    if state.sweep_enabled do
-      Logger.info("embervm grpc connection sweeper: reaped #{count} orchestrator(s)")
-
-      Enum.each(reaped, fn {pid, reason} ->
-        Logger.info("  pid #{inspect(pid)}: #{reason}")
+    pending =
+      Enum.filter(reapable, fn {pid, _reason} ->
+        Map.fetch!(state.strikes, pid) < state.strikes_required
       end)
-    else
-      Logger.info("embervm grpc connection sweeper (DRY RUN, gate off): WOULD reap #{count} orchestrator(s)")
 
-      Enum.each(reaped, fn {pid, reason} ->
-        Logger.info("  pid #{inspect(pid)}: #{reason}")
-      end)
+    Logger.info(
+      "#{prefix}: pass complete (children=#{length(children)}, keep_set=#{MapSet.size(keep_set)}, " <>
+        "reaped=#{length(reaped)}, pending=#{length(pending)})"
+    )
+
+    if reaped != [] do
+      verb = if state.sweep_enabled, do: "reaped", else: "WOULD reap"
+      Logger.info("#{prefix}: #{verb} #{length(reaped)} orchestrator(s)")
+      Enum.each(reaped, fn {pid, reason} -> Logger.info("  pid #{inspect(pid)}: #{reason}") end)
+    end
+
+    if pending != [] do
+      Logger.info("#{prefix}: #{length(pending)} orchestrator(s) accumulating strikes")
+      Enum.each(pending, fn {pid, reason} -> Logger.info("  pid #{inspect(pid)}: #{reason}") end)
     end
 
     :ok
   end
 
-  defp log_pending(%{sweep_enabled: true}, _reapable), do: :ok
-
-  defp log_pending(state, reapable) do
-    pending =
-      reapable
-      |> Enum.filter(fn {pid, _reason} -> Map.fetch!(state.strikes, pid) < state.strikes_required end)
-
-    if not Enum.empty?(pending) do
-      Logger.info("embervm grpc connection sweeper (DRY RUN, gate off): #{length(pending)} orchestrator(s) accumulating strikes")
-
-      Enum.each(pending, fn {pid, reason} ->
-        Logger.info("  pid #{inspect(pid)}: #{reason}")
-      end)
-    end
-  end
+  defp log_prefix(%{sweep_enabled: true}), do: "embervm grpc connection sweeper"
+  defp log_prefix(_state), do: "embervm grpc connection sweeper (DRY RUN, gate off)"
 
   defp schedule_sweep(%{sweep_interval_ms: ms}) when ms > 0 do
     Process.send_after(self(), :sweep, ms)

--- a/projects/embervm/control/test/embervm/grpc_connection_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/grpc_connection_sweeper_test.exs
@@ -261,6 +261,48 @@ defmodule Embervm.GrpcConnectionSweeperTest do
     assert Agent.get(calls, & &1) == [child_pid]
   end
 
+  test "armed sweeper logs accumulating strikes before it reaps (#4419)" do
+    # When the gate is ON the sweeper used to log NOTHING until it killed
+    # something, so "working and finding nothing" and "not running at all"
+    # read identically. Every pass must leave a heartbeat, and a pid climbing
+    # toward the threshold must be visible before the kill lands.
+    supervisor = mock_supervisor()
+    target = "10.42.9.99:9090"
+    child_pid = mock_child(target)
+    MockSupervisor.set_children(supervisor, [child(child_pid)])
+    {terminate_fun, _calls} = terminate_child_collector()
+
+    sweeper =
+      start_sweeper(
+        status_fun: fn -> %{"node-0" => %{address: "10.42.3.34:9090"}} end,
+        supervisor: supervisor,
+        terminate_child_fun: terminate_fun,
+        sweep_enabled: true
+      )
+
+    log = ExUnit.CaptureLog.capture_log(fn -> GrpcConnectionSweeper.sweep_now(sweeper) end)
+    assert log =~ "pass complete (children=1, keep_set=1, reaped=0, pending=1)"
+    assert log =~ "1 orchestrator(s) accumulating strikes"
+    assert log =~ "#{inspect(child_pid)}: target #{inspect(target)} not in live set (strike 1 of 3)"
+    refute log =~ "DRY RUN"
+  end
+
+  test "dry-run sweeper logs a heartbeat on a clean pass" do
+    supervisor = mock_supervisor()
+    live_pid = mock_child("10.42.3.34:9090")
+    MockSupervisor.set_children(supervisor, [child(live_pid)])
+
+    sweeper =
+      start_sweeper(
+        status_fun: fn -> %{"node-0" => %{address: "10.42.3.34:9090"}} end,
+        supervisor: supervisor,
+        sweep_enabled: false
+      )
+
+    log = ExUnit.CaptureLog.capture_log(fn -> GrpcConnectionSweeper.sweep_now(sweeper) end)
+    assert log =~ "(DRY RUN, gate off): pass complete (children=1, keep_set=1, reaped=0, pending=0)"
+  end
+
   test "timeout/wedged branch is protected by strikes" do
     supervisor = mock_supervisor()
 


### PR DESCRIPTION
## What

`GrpcConnectionSweeper` now logs a summary line on every pass, in both armed and dry-run mode:

```
embervm grpc connection sweeper: pass complete (children=9, keep_set=6, reaped=0, pending=0)
```

and lists orchestrators accumulating strikes when armed, not only in dry-run, so a kill is visible before it lands.

## Why

The leak in #4419 (dead-brick gRPC orchestrators redialed forever) was fixed by #4422, #4427 and #4433 and the sweeper has been armed in prod since chart 0.1.447. Verified live today on `embervm-embervm-5fbf7cff4c-qwlbj`: 9 orchestrators for 6 live bricks (duplicates on live addresses are expected), `strikes: %{}`, zero dial failures to non-live IPs. What was never landed is the observability ask from the issue thread: when armed the sweeper was silent until it reaped, so "swept, found nothing" and "never ran" read identically in the logs and the only way to tell was `embervm rpc` into the pod.

## Verification

`ci`: Elixir `1409 tests, 0 failures, 6 skipped` (two new tests assert the heartbeat and the armed-mode pending line via `capture_log`); Bazel `744 tests pass`.

Closes #4419

🤖 Generated with [Claude Code](https://claude.com/claude-code)