### PR TITLE
fix(site): pass data.stats to HomepageRack so the homepage renders again

### DIFF
--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -226,7 +226,7 @@
 </div>
 
 <!-- ═══ Project stack ═══ -->
-<HomepageRack {stats} />
+<HomepageRack stats={data.stats} />
 
 <!-- ═══ Footer ═══ -->
 <Footer />


### PR DESCRIPTION
## What
One-line fix: `<HomepageRack stats={data.stats} />`.

## Why
ea37b7f7b introduced `<HomepageRack {stats} />` on the public homepage, but `stats` is not a binding in that component (the loader exposes `data.stats`). SvelteKit SSR throws `ReferenceError: stats is not defined` and `GET /` on jomcgi.dev has been 500 since that deploy (confirmed in `monolith-public-frontend` logs and with curl, 3/3 500s).

`ci`: `Executed 3 out of 744 tests: 744 tests pass.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)