### PR TITLE
fix(embervm): a restore capability with generation 0 matches any artifact generation

### DIFF
--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -2167,10 +2167,14 @@ defmodule Embervm.SessionManager do
   defp restore_bundle(state, node_id, dial_id, session, snapshot_ref) do
     workload = session.workload
     ref = %ArtifactRef{kind: :ARTIFACT_KIND_SESSION, workload: workload, ref: snapshot_ref}
+    # generation 0 = any: the session row's generation is its bank counter,
+    # not the artifact's export generation that noded compares against, and
+    # the two diverge after a relight (dev, 2026-08-23). The store's own
+    # generation fence still applies on write.
     ctx = %{
       principal: session.principal,
       lineage: session.lineage_id,
-      generation: Map.get(session, :generation, 0) || 0
+      generation: 0
     }
 
     case safe_restore_artifact(state, node_id, dial_id, ref, ctx) do

--- a/projects/embervm/noded/server/capability.go
+++ b/projects/embervm/noded/server/capability.go
@@ -113,7 +113,13 @@ func parseAndVerifyCapability(raw []byte, macKey []byte, now time.Time, want cap
 	if got.Kind != want.Kind {
 		return nil, ErrCapabilityKindMismatch
 	}
-	if got.Generation != want.Generation {
+	// Generation 0 in the capability means "any": the control plane stamps it
+	// when the artifact generation is not the fact it holds (a session row
+	// carries its bank counter, meta.json carries the export generation, and
+	// the two diverge after a relight). The store's own ErrStaleGeneration
+	// fence still governs which generation may be written; the capability's
+	// job is scoping the data key to principal, lineage, brick, workload, ref.
+	if got.Generation != 0 && got.Generation != want.Generation {
 		return nil, ErrCapabilityGenerationMismatch
 	}
 	if want.Principal != "" && got.Principal != want.Principal {

--- a/projects/embervm/noded/server/capability_test.go
+++ b/projects/embervm/noded/server/capability_test.go
@@ -71,6 +71,9 @@ func TestParseAndVerifyCapability(t *testing.T) {
 		{name: "wrong_ref", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Ref = "other" }), wantErr: ErrCapabilityRefMismatch},
 		{name: "wrong_kind", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Kind = "stateful" }), wantErr: ErrCapabilityKindMismatch},
 		{name: "wrong_generation", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Generation++ }), wantErr: ErrCapabilityGenerationMismatch},
+		{name: "zero_generation_is_wildcard", raw: func() []byte {
+			return mintCapability(t, macKey, dataKey, now.Add(time.Minute), withScope(want, func(s *capabilityScope) { s.Generation = 0 }))
+		}, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Generation = 123 }), wantErr: nil},
 		{name: "wrong_principal", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Principal = "acct:bob" }), wantErr: ErrCapabilityPrincipalMismatch},
 		{name: "wrong_lineage", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Lineage = "lineage-2" }), wantErr: ErrCapabilityLineageMismatch},
 		{name: "bad_key_length", raw: func() []byte { return mintCapability(t, macKey, dataKey[:31], now.Add(time.Minute), want) }, macKey: macKey, want: want, wantErr: ErrCapabilityKeyLength},


### PR DESCRIPTION
Refs #4691. Found by the dev end-to-end test: the CP stamped the session row's generation (bank counter), noded compared against meta.json's export generation, and the enveloped relight from S3 was refused with `restore capability generation mismatch`. Every earlier layer worked (envelope written, capability minted with the bearer HMAC, MAC and scope verified on the brick).

Generation 0 in the capability now means any (test added), and session bundle restores stamp 0. The store's `ErrStaleGeneration` fence still governs writes.

`ci`: Elixir 1407 tests 0 failures; Bazel 744 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RgXAQ5A9sgqg7N64om7mP