### PR TITLE
test(embervm): couple hypervisorEpoch to the vendored Firecracker version

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -76,6 +76,13 @@ exports_files(
     visibility = ["//bazel/tools/ci:__pkg__"],
 )
 
+# The EmberVM chart test that couples hypervisorEpoch to the vendored
+# Firecracker version (#4409) reads the kata_firecracker_archive pin from here.
+exports_files(
+    ["MODULE.bazel"],
+    visibility = ["//projects/embervm/chart:__pkg__"],
+)
+
 # Produce aspect_rules_py targets rather than rules_python
 # gazelle:map_kind py_binary py_venv_binary @aspect_rules_py//py/private/py_venv:defs.bzl
 # gazelle:map_kind py_library py_library @aspect_rules_py//py:defs.bzl

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -616,7 +616,8 @@ multiarch_http_archive(
 # is version-locked) and nothing rebuilds them automatically: the base
 # signature has no hypervisor input, so any version change here MUST move
 # hypervisorEpoch in projects/embervm/chart/values.yaml in the same PR, which
-# re-keys every workload base via initEnv. Banked session and stateful memory
+# re-keys every workload base via initEnv. //projects/embervm/chart:chart_hypervisor_epoch_test
+# fails CI if the two drift (#4409). Banked session and stateful memory
 # snapshots are not covered by that knob and fail over cold at rollout.
 kata_firecracker_archive = use_repo_rule("//bazel/tools/http:kata_firecracker_archive.bzl", "kata_firecracker_archive")
 

--- a/bazel/tools/http/kata_firecracker_archive.bzl
+++ b/bazel/tools/http/kata_firecracker_archive.bzl
@@ -15,7 +15,8 @@ EmberVM warm-restore fleet needs (#4389: upstream #5688 in v1.15.0, #5882 in
 v1.16.0, #5958 in v1.16.1). Snapshot formats are version-locked and nothing
 rebuilds existing snapshots automatically when this pin moves (the base
 signature has no hypervisor input), so any version change here must move
-hypervisorEpoch in projects/embervm/chart/values.yaml in the same PR.
+hypervisorEpoch in projects/embervm/chart/values.yaml in the same PR
+(//projects/embervm/chart:chart_hypervisor_epoch_test enforces it, #4409).
 
 The per-arch kata-static bundle is large (~1.5 GiB amd64) and unpacks to several
 GiB, but only the kernel plus the upstream Firecracker and snapshot-editor ride

--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -137,6 +137,25 @@ py_test(
     deps = ["@pip//pytest"],
 )
 
+py_test(
+    name = "chart_hypervisor_epoch_test",
+    srcs = ["chart_hypervisor_epoch_test.py"],
+    data = [
+        "values.yaml",
+        "//:MODULE.bazel",
+    ],
+    env = {
+        "MODULE_BAZEL": "$(rootpath //:MODULE.bazel)",
+    },
+    deps = ["@pip//pytest"],
+)
+
+semgrep_test(
+    name = "chart_hypervisor_epoch_test_semgrep_test",
+    srcs = ["chart_hypervisor_epoch_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
 semgrep_test(
     name = "chart_sync_wave_test_semgrep_test",
     srcs = ["chart_sync_wave_test.py"],

--- a/projects/embervm/chart/chart_hypervisor_epoch_test.py
+++ b/projects/embervm/chart/chart_hypervisor_epoch_test.py
@@ -1,0 +1,101 @@
+"""Couple hypervisorEpoch to the vendored Firecracker version (#4409).
+
+Firecracker snapshot formats are version-locked, and the base signature has no
+hypervisor input, so a Firecracker bump that forgets to move hypervisorEpoch
+leaves every workload base restoring a stale snapshot under the new binary
+(every dispatch fails, discovered post-merge: #4389, #4406). Nothing tied the two
+values together before this test. It reads the `firecracker_version` attr of the
+`kata_firecracker_archive` repo in MODULE.bazel and asserts the chart's
+hypervisorEpoch names exactly that version, so CI goes red the moment they drift.
+
+The epoch participates in the base signature via initEnv, so the value itself
+is load-bearing: changing it rebuilds every image-lane base. The pinned-value
+test guards the coupling from changing the epoch as a side effect.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+# Shape of a valid epoch: `fc-<firecracker version>` with an optional `-rN`
+# re-key suffix for moving the epoch without moving the binary (r2 was the
+# post-roll re-key after the v1.16.1 race, see the values.yaml comment).
+_EPOCH = re.compile(r"^fc-(?P<version>v\d+\.\d+\.\d+)(?:-r(?P<rekey>\d+))?$")
+
+# The epoch live today. Changing how the epoch is derived must not change this
+# value; a deliberate epoch move updates this constant in the same PR.
+_CURRENT_EPOCH = "fc-v1.16.1-r2"
+
+
+def _chart_values() -> Path:
+    return Path(__file__).resolve().parent / "values.yaml"
+
+
+def _module_bazel() -> Path:
+    return Path(os.environ["MODULE_BAZEL"])
+
+
+def _firecracker_version() -> str:
+    text = _module_bazel().read_text()
+    block = re.search(
+        r"^kata_firecracker_archive\(\n(?P<body>.*?)^\)$",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block, "MODULE.bazel has no kata_firecracker_archive(...) call"
+    attr = re.search(
+        r'^\s*firecracker_version = "(?P<v>[^"]+)",$', block["body"], re.MULTILINE
+    )
+    assert attr, "kata_firecracker_archive has no firecracker_version attr"
+    return attr["v"]
+
+
+def _hypervisor_epoch() -> str:
+    text = _chart_values().read_text()
+    matches = re.findall(r'^hypervisorEpoch: "(?P<epoch>[^"]+)"$', text, re.MULTILINE)
+    assert len(matches) == 1, (
+        f"expected exactly one top-level hypervisorEpoch, got {matches}"
+    )
+    return matches[0]
+
+
+def test_firecracker_version_is_pinned() -> None:
+    version = _firecracker_version()
+    assert re.fullmatch(r"v\d+\.\d+\.\d+", version), version
+
+
+def test_epoch_names_the_vendored_firecracker_version() -> None:
+    epoch = _hypervisor_epoch()
+    parsed = _EPOCH.match(epoch)
+    assert parsed, f"hypervisorEpoch {epoch!r} is not of the form fc-vX.Y.Z[-rN]"
+    version = _firecracker_version()
+    assert parsed["version"] == version, (
+        f"hypervisorEpoch {epoch!r} names Firecracker {parsed['version']} but MODULE.bazel "
+        f"kata_firecracker_archive pins {version}. Snapshot formats are version-locked: "
+        f"move hypervisorEpoch to fc-{version} in the same PR as the binary (and see #4407 "
+        "for the roll-window sequencing caveat)."
+    )
+
+
+def test_epoch_value_unchanged_by_coupling() -> None:
+    assert _hypervisor_epoch() == _CURRENT_EPOCH
+
+
+@pytest.mark.parametrize(
+    "epoch",
+    ["fc-v1.16.1", "fc-v1.16.1-r2", "fc-v1.16.1-r10"],
+)
+def test_epoch_pattern_accepts_rekey_suffix(epoch: str) -> None:
+    assert _EPOCH.match(epoch)["version"] == "v1.16.1"
+
+
+@pytest.mark.parametrize(
+    "epoch",
+    ["v1.16.1", "fc-1.16.1", "fc-v1.16.1-rc1", "fc-v1.16.1r2", "fc-v1.16"],
+)
+def test_epoch_pattern_rejects_malformed(epoch: str) -> None:
+    assert _EPOCH.match(epoch) is None

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -33,7 +33,8 @@ scratchSizeGi: 35
 # are version-locked: a base rebuild does not happen on its own when the binary
 # moves (the signature has no hypervisor input), and a v-old snapshot loaded by
 # a v-new hypervisor fails every dispatch (#4389). Bump this in the SAME PR as
-# any Firecracker version change. Banked session and stateful memory snapshots
+# any Firecracker version change: chart_hypervisor_epoch_test asserts the
+# version in this value equals MODULE.bazel's firecracker_version (#4409). Banked session and stateful memory snapshots
 # are separate artifacts this knob does not rebuild; they must be drained or
 # left to fail over cold at rollout.
 # r2: the first fc-v1.16.1 re-key raced the brick roll. The CR update landed


### PR DESCRIPTION
## What

Adds `//projects/embervm/chart:chart_hypervisor_epoch_test`, which reads `firecracker_version` from `MODULE.bazel`'s `kata_firecracker_archive` and asserts `hypervisorEpoch` in `projects/embervm/chart/values.yaml` is exactly `fc-<that version>[-rN]`. `MODULE.bazel` is exported to the chart package for the test's `data`. The three "bump in the same PR" comments (values.yaml, MODULE.bazel, the repo rule) now point at the test.

## Why

The two values were a manual contract. A future Firecracker bump that forgets the epoch reproduces the #4389 / #4406 failure (every dispatch failing on version-locked snapshots), discovered post-merge. Now it is red CI instead.

## Value provably unchanged

`hypervisorEpoch` is a base-signature input via `initEnv`, so the epoch must not move as a side effect. The chart default is still `fc-v1.16.1-r2` (no deploy/dev override exists) and `test_epoch_value_unchanged_by_coupling` pins it; the only values.yaml change is a comment. Rendered manifests are identical apart from nothing: no template touched.

Negative check: with `firecracker_version` edited to `v1.17.0` the test fails with `hypervisorEpoch 'fc-v1.16.1-r2' names Firecracker v1.16.1 but MODULE.bazel kata_firecracker_archive pins v1.17.0 ... move hypervisorEpoch to fc-v1.17.0`.

Out of scope: #4407 (hypervisor version as a first-class base identity input) and the zip-lane re-key path noted in #4409.

`ci test`: Executed 6 out of 746 tests: 746 tests pass (ExUnit 1407 tests, 0 failures).

Closes #4409

🤖 Generated with [Claude Code](https://claude.com/claude-code)