### PR TITLE
fix(bazel): fetch each apk whole so Bazel's resume cannot collide with rules_apko's Range header

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,6 +40,21 @@ bazel_dep(name = "gazelle", version = "0.47.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "rules_oci", version = "2.2.6")
 bazel_dep(name = "rules_apko", version = "1.5.52")
+
+# apk_import upstream fetches each apk as three ranged requests (signature,
+# control, data). Bazel's downloader resumes a dropped transfer by reconnecting
+# with its own `Range: bytes=N-` and merges it with the caller's headers via
+# buildOrThrow(), so on a flaky link the resume itself aborts the fetch with
+# "Multiple entries with same key: Range=[...] and Range=[...]" and the whole
+# run dies in analysis. The patch downloads the apk once with no Range header
+# and cuts the segments out locally, still checking them against the lockfile
+# checksums. Drop it once upstream (rules_apko or Bazel) handles the collision.
+# See #4849.
+single_version_override(
+    module_name = "rules_apko",
+    patch_strip = 1,
+    patches = ["//:bazel/patches/rules_apko_no_range.patch"],
+)
 bazel_dep(name = "rules_multirun", version = "0.13.0")
 bazel_dep(name = "tar.bzl", version = "0.6.0")
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -55,6 +55,7 @@ single_version_override(
     patch_strip = 1,
     patches = ["//:bazel/patches/rules_apko_no_range.patch"],
 )
+
 bazel_dep(name = "rules_multirun", version = "0.13.0")
 bazel_dep(name = "tar.bzl", version = "0.6.0")
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/bazel/patches/rules_apko_no_range.patch
+++ b/bazel/patches/rules_apko_no_range.patch
@@ -1,0 +1,184 @@
+diff -ur a/apko/private/apk.bzl b/apko/private/apk.bzl
+--- a/apko/private/apk.bzl	2026-08-22 18:28:49
++++ b/apko/private/apk.bzl	2026-08-22 18:28:49
+@@ -41,14 +41,6 @@
+         },
+     }
+ 
+-def _download(rctx, url, rng, **kwargs):
+-    return rctx.download(
+-        url = [url],
+-        headers = {"Range": [rng]},
+-        auth = _auth(rctx, url),
+-        **kwargs
+-    )
+-
+ def _apk_import_impl(rctx):
+     repo = util.repo_url(rctx.attr.url, rctx.attr.architecture)
+     repo_escaped = util.url_escape(repo)
+@@ -62,44 +54,37 @@
+     data_output = "{}/{}.dat.tar.gz".format(output, data_sha256)
+     apk_output = "{}/{}/{}-{}.apk".format(repo_escaped, rctx.attr.architecture, rctx.attr.package_name, rctx.attr.version)
+ 
++    # Fetch the whole apk with one plain request and cut the segments out of
++    # it locally, instead of issuing one ranged request per segment as
++    # upstream does. Bazel's downloader resumes an interrupted transfer by
++    # reconnecting with its own open-ended `Range: bytes=N-` header, and it
++    # merges that with the caller's headers via ImmutableMap.buildOrThrow(),
++    # so a caller-supplied Range turns the first dropped connection into
++    # "Multiple entries with same key: Range=[...] and Range=[...]" and the
++    # fetch fails outright (jomcgi-org/homelab#4849). With no Range on the
++    # request the resume path works as designed. The segment checksums from
++    # the lockfile are still enforced, by the split script rather than by
++    # rctx.download(integrity=).
++    rctx.download(
++        url = [rctx.attr.url],
++        output = apk_output,
++        auth = _auth(rctx, rctx.attr.url),
++    )
++
+     # Some apks (notably most wolfi packages) ship without an in-apk
+-    # signature segment; the lockfile encodes that as an empty range. Issuing
+-    # a Range request with an empty value would cause the origin to ignore
+-    # the header and return the full file as the "signature", which then
+-    # gets concatenated with control+data to produce a doubled apk.
++    # signature segment; the lockfile encodes that as an empty range, so
++    # there is no segment to cut out.
+     sig_output = None
++    segments = []
+     if rctx.attr.signature_range:
+         sig_output = "{}/{}.sig.tar.gz".format(output, control_sha256)
+-        _download(
+-            rctx,
+-            url = rctx.attr.url,
+-            rng = rctx.attr.signature_range,
+-            output = sig_output,
+-            # TODO: signatures does not have stable checksums. find a way to fail gracefully.
+-            # integrity = rctx.attr.signature_checksum,
+-        )
+-    _download(
+-        rctx,
+-        url = rctx.attr.url,
+-        rng = rctx.attr.control_range,
+-        output = control_output,
+-        integrity = rctx.attr.control_checksum,
+-    )
+-    _download(
+-        rctx,
+-        url = rctx.attr.url,
+-        rng = rctx.attr.data_range,
+-        output = data_output,
+-        integrity = rctx.attr.data_checksum,
+-    )
+ 
+-    util.concatenate_gzip_segments(
+-        rctx,
+-        output = apk_output,
+-        signature = sig_output,
+-        control = control_output,
+-        data = data_output,
+-    )
++        # TODO: signatures does not have stable checksums. find a way to fail gracefully.
++        segments.append((rctx.attr.signature_range, sig_output, ""))
++    segments.append((rctx.attr.control_range, control_output, rctx.attr.control_checksum))
++    segments.append((rctx.attr.data_range, data_output, rctx.attr.data_checksum))
++
++    util.split_apk_segments(rctx, apk = apk_output, segments = segments)
+     rctx.file("BUILD.bazel", APK_IMPORT_TMPL)
+ 
+ apk_import = repository_rule(
+diff -ur a/apko/private/util.bzl b/apko/private/util.bzl
+--- a/apko/private/util.bzl	2026-08-22 18:28:49
++++ b/apko/private/util.bzl	2026-08-22 18:31:50
+@@ -101,32 +101,75 @@
+         fail("""normalize_sri failed.\nstderr: {}\nstdout: {}""".format(r.stdout, r.stderr))
+     return r.stdout
+ 
+-# TODO: this shouldn't be necessary in the first place. change apko so that it except to find the original apk in the cache
+-def _concatenate_gzip_segments(rctx, output, control, data, signature = None):
+-    """concatenates gzip segments into one gzip file in signature, control, data order
++_SPLIT_SH = """\
++#!/bin/sh
++# usage: split.sh APK (RANGE OUTPUT SRI)...
++# RANGE is an HTTP byte range "bytes=START-END" (inclusive, per RFC 7233).
++# SRI is "sha1-<b64>" or "sha256-<b64>", or empty to skip verification.
++set -eu
++apk=$1
++shift
++while [ $# -gt 0 ]; do
++  range=$1
++  out=$2
++  sri=$3
++  shift 3
++  start=${range#bytes=}
++  end=${start#*-}
++  start=${start%-*}
++  mkdir -p "$(dirname "$out")"
++  tail -c +$((start + 1)) "$apk" | head -c $((end - start + 1)) > "$out"
++  actual_len=$(wc -c < "$out" | tr -d ' ')
++  if [ "$actual_len" -ne $((end - start + 1)) ]; then
++    echo "$out: wanted $((end - start + 1)) bytes from $range but $apk only yielded $actual_len" >&2
++    exit 1
++  fi
++  if [ -n "$sri" ]; then
++    algo=${sri%%-*}
++    want=$(printf '%s' "${sri#*-}" | base64 -d | od -An -v -tx1 | tr -d ' \\n')
++    case $algo in
++      sha1) bits=1 ;;
++      sha256) bits=256 ;;
++      *) echo "$out: unsupported integrity algorithm $algo" >&2; exit 1 ;;
++    esac
++    if command -v "sha${bits}sum" >/dev/null 2>&1; then
++      got=$("sha${bits}sum" "$out" | cut -d' ' -f1)
++    else
++      got=$(shasum -a "$bits" "$out" | cut -d' ' -f1)
++    fi
++    if [ "$got" != "$want" ]; then
++      echo "$out: checksum mismatch, wanted $algo $want but got $got" >&2
++      exit 1
++    fi
++  fi
++done
++"""
+ 
++def _split_apk_segments(rctx, apk, segments):
++    """cuts the signature, control and data gzip segments out of a whole apk
++
++    The apk is the concatenation of those segments, so the cut files are
++    byte-identical to what a ranged download of each would have produced.
++    Each segment is checked against the lockfile checksum when one is given.
++
+     Args:
+         rctx: repository_ctx
+-        output: final output path
+-        control: path to the control segment
+-        data: path to the data segment
+-        signature: path to the signature segment, or None for unsigned apks
++        apk: path to the downloaded apk
++        segments: list of (range, output path, SRI checksum or "") tuples
+     Returns:
+         None
+     """
+-    p = rctx.path("gzip_seg.sh")
+-    rctx.file(p, """out=$1; shift; cat "$@" > "$out" """, executable = True)
+-    args = [p, output]
+-    if signature:
+-        args.append(signature)
+-    args.append(control)
+-    args.append(data)
++    p = rctx.path("split.sh")
++    rctx.file(p, _SPLIT_SH, executable = True)
++    args = [p, apk]
++    for rng, output, sri in segments:
++        args.extend([rng, output, sri])
+     r = rctx.execute(args)
+     if r.return_code != 0:
+-        fail("""concatenate_gzip_segments failed.\nstderr: {}\nstdout: {}""".format(r.stdout, r.stderr))
++        fail("""split_apk_segments failed.\nstderr: {}\nstdout: {}""".format(r.stderr, r.stdout))
+ 
+ util = struct(
+-    concatenate_gzip_segments = _concatenate_gzip_segments,
++    split_apk_segments = _split_apk_segments,
+     normalize_sri = _normalize_sri,
+     parse_lock = _parse_lock,
+     sanitize_string = _sanitize_string,


### PR DESCRIPTION
Closes #4849

## What

Patches `rules_apko` (v1.5.52, via `single_version_override`) so `apk_import` downloads each `.apk` once with no `Range` header, then cuts the signature/control/data segments out of it locally and checks each against the lockfile checksum. The files the repo ends up holding (`<sha1>.ctl.tar.gz`, `<sha256>.dat.tar.gz`, the `.apk`) are byte-identical to what upstream's three ranged downloads produce, so apko's cache layout is unchanged.

## Why

Upstream passes a bounded `Range: bytes=a-b` to `rctx.download` per segment. When a transfer drops mid-way, Bazel's `RetryingInputStream` reconnects with its own `Range: bytes=N-` and `HttpConnectorMultiplexer` merges the two maps with `ImmutableMap.buildOrThrow()`, so the resume aborts the fetch with `Multiple entries with same key: Range=[...] and Range=[...]`. The build dies in analysis, nothing is cached, and the run is lost. Bazel 9.1.0 and current master both still have the `buildOrThrow()`; rules_apko through v1.5.55 still sends the caller `Range`; neither has an issue filed.

With no caller `Range` the resume path works as designed (`Content-Range` checked, up to 3 resumes, then the `DownloadManager` retry loop).

## Frequency (the gate the issue asked for)

Scanned every failed BuildBuddy invocation since 2026-08-06 (1158 failed, 474 test/build) for the signature. Four hits in 16 days, all cold-fetch CI-role runs, none saved by Bazel's own retry:

| when (UTC) | invocation | branch | apk |
|---|---|---|---|
| 2026-08-13 02:28 | `0799bd57` | main | erlang-27 (55 MB) |
| 2026-08-13 16:44 | `dc1899e6` | feat/embervm-provenance-and-relit-split | git (9.7 MB) |
| 2026-08-14 05:18 | `bb4e7e7d` | perf/apko-single-config | icu78-data-full (14 MB) |
| 2026-08-22 17:57 | `d7cea606` | gh-readonly-queue/main/pr-5094 | chromium (171 MB) |

So it is not only the largest apk, and the latest one ejected a PR from the merge queue. The amd64-only lock work reduced exposure but did not close it.

## Verification

- Split script exercised locally against `wolfi-baselayout-20230201-r29.apk` with the lock's ranges and checksums: segments match, concatenation is byte-identical to the apk, a wrong checksum and a short range both fail loudly.
- First `ci test` run cold-fetched every apk through the patched path and failed on `xxd: not found` inside `rctx.execute` on the runner; replaced with POSIX `od` and a `shasum` fallback. Second `ci test` is running; this is CI-only verifiable so please judge by pr-checks and the `Executed N out of M tests` line. **Not auto-merged on purpose.**

## Notes

- The patch is in `bazel/patches/` next to the pnpm patches and referenced as `//:bazel/patches/...` (same root-package resolution the pnpm ones use, no new BUILD file).
- Drop the override once upstream handles the collision. Worth filing against both rules_apko and Bazel; I did not file anything externally.
- The whole-file download carries no `integrity`, so Bazel's repository cache cannot serve it by checksum on a fresh output base. Cold runners have an empty repository cache anyway, and warm snapshots already hold the repos, so this costs nothing in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
