### PR TITLE
fix(monolith-public): drop inert FC_INVOKE_URL env

### DIFF
--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -251,18 +251,6 @@ web:
     # chart does.
     - name: EMBERVM_URL
       value: "http://embervm-embervm.embervm.svc.cluster.local:8080"
-    # fc-invoke URL for the public semgrep demo (ember_public router,
-    # /api/ember/semgrep). In-cluster service URL literal (NOT a secret, NOT a
-    # code default); semgrep_scan.client raises if unset. The public tier calls
-    # fc-invoke as its own allow-listed SA (system:serviceaccount:monolith-public
-    # :monolith-public), admitted by the fc-invoke daemon's TokenReview gate and
-    # its CiliumNetworkPolicy fromNamespaces list. In-cluster egress is permitted
-    # by this chart's Cilium policy (cluster entity). This chart uses the
-    # homelab-library deployment helper, which does NOT derive FC_INVOKE_URL from
-    # semgrep.fcInvokeUrl the way the monolith chart does, so it is set here as a
-    # literal.
-    - name: FC_INVOKE_URL
-      value: "http://fc-invoke.monolith.svc.cluster.local:8080"
     # Demo-postgres DSN (ember_public router, /api/ember/postgres): the SAME
     # serving Service, port, and password the private monolith chart uses for
     # scratchPostgres.demoListenPort (5401), so both tiers wake the ONE demo


### PR DESCRIPTION
## What

Delete `FC_INVOKE_URL` and its comment block from `projects/monolith-public/chart/values.yaml`.

## Why

It pointed at `fc-invoke.monolith.svc.cluster.local:8080`, a Service that has not existed since the fc-invoke daemon was retired (`kubectl get svc -A` shows nothing named fc-invoke). Nothing in the public binary reads the variable either: the only consumer in the tree is `projects/monolith/demos/loadtest.py`, and `demos/` is private-tier only by design, so the var was inert on both counts. No replacement target exists, so deletion is the whole fix.

Verified with `helm template monolith-public projects/monolith-public/chart/ -f projects/monolith-public/deploy/values.yaml`: zero `FC_INVOKE`/`fc-invoke` references remain, `EMBERVM_URL` still renders. `ci`: `Executed 1 out of 744 tests: 744 tests pass`, ExUnit `1407 tests, 0 failures`.

Follow-up for the dead private-tier loadtest demo: #5163.

Closes #4651

🤖 Generated with [Claude Code](https://claude.com/claude-code)