### PR TITLE
chore(monolith): enforce prefixed logger names

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -6389,10 +6389,6 @@ semgrep_target_test(
         # in-memory upload bytes (NOT a filesystem path), so there is no path
         # traversal; the rule false-positives on any Image.open of request data.
         "tainted-path-traversal-pillow-fastapi",  # keep
-        # TODO: fix dr_jobs, ships, hikes, stars logger names to use "monolith."
-        # prefix. semgrep-core does not honour inline # nosemgrep, so excluded
-        # here until all callers are updated.
-        "logger-name-missing-monolith-prefix",  # keep
         # shotter/hosts.py's HOST_SERVICE_MAP is the baked mapping design ADR
         # embervm/035 section 3 and 4 call for on purpose: a Cloudflare-routed
         # lookup would faithfully screenshot private.jomcgi.dev's login wall
@@ -7192,10 +7188,6 @@ semgrep_target_test(
         "boto3-endpoint-url-missing-scheme",  # keep
         "test-hardcoded-past-timestamp",  # keep
         "tainted-path-traversal-pillow-fastapi",
-        # TODO: fix dr_jobs, ships, hikes, stars, app/main_public.py logger names
-        # to use "monolith." prefix. semgrep-core does not honour inline
-        # # nosemgrep, so excluded here until all callers are updated.
-        "logger-name-missing-monolith-prefix",  # keep
     ],
     rules = ["//bazel/semgrep/rules:python_rules"],
     target = ":main_public",
@@ -7348,7 +7340,6 @@ semgrep_target_test(
         "avoid-sqlalchemy-text",
         "boto3-endpoint-url-missing-scheme",  # keep
         "generic-sql-fastapi",  # keep
-        "logger-name-missing-monolith-prefix",  # keep
         "sqlmodel-datetime-without-factory",
         "tainted-fastapi-http-request-httpx",
         "tainted-path-traversal-pillow-fastapi",

--- a/projects/monolith/dr_jobs/jobs.py
+++ b/projects/monolith/dr_jobs/jobs.py
@@ -25,7 +25,7 @@ import httpx
 from dr_jobs import models
 from dr_jobs.scraper import fetch_vacancies
 
-logger = logging.getLogger("dr_jobs")
+logger = logging.getLogger("monolith.dr_jobs")
 
 # Client-level ceiling; per-request timeouts in scraper.py are tighter.
 SCRAPE_TIMEOUT_SECS = 60.0

--- a/projects/monolith/dr_jobs/router.py
+++ b/projects/monolith/dr_jobs/router.py
@@ -25,7 +25,7 @@ from sqlmodel import Session, select
 from core.db import get_session
 from dr_jobs.models import Vacancy
 
-logger = logging.getLogger("dr_jobs")
+logger = logging.getLogger("monolith.dr_jobs")
 
 router = APIRouter(prefix="/api/dr-jobs", tags=["dr_jobs"])
 

--- a/projects/monolith/dr_jobs/scraper.py
+++ b/projects/monolith/dr_jobs/scraper.py
@@ -29,7 +29,7 @@ from datetime import date
 
 import httpx
 
-logger = logging.getLogger("dr_jobs")
+logger = logging.getLogger("monolith.dr_jobs")
 
 BASE_URL = "https://apply.jobs.scot.nhs.uk"
 

--- a/projects/monolith/hikes/forecast.py
+++ b/projects/monolith/hikes/forecast.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta, timezone
 
 import httpx
 
-logger = logging.getLogger("hikes")
+logger = logging.getLogger("monolith.hikes")
 
 FORECAST_URL = "https://api.met.no/weatherapi/locationforecast/2.0/compact"
 # met.no requires an identifying User-Agent.

--- a/projects/monolith/hikes/jobs.py
+++ b/projects/monolith/hikes/jobs.py
@@ -21,7 +21,7 @@ from hikes.walkhighlands import Walk as ScrapedWalk
 from hikes.walkhighlands import fetch_all_walks
 from shared.forecast_freshness import top_of_hour
 
-logger = logging.getLogger("hikes")
+logger = logging.getLogger("monolith.hikes")
 
 # Generous client-level ceiling; per-request timeouts in the fetch helpers are
 # tighter. An explicit timeout keeps the client from hanging the loop forever.

--- a/projects/monolith/hikes/router.py
+++ b/projects/monolith/hikes/router.py
@@ -38,7 +38,7 @@ from core.db import get_session
 from hikes.models import Walk, WalkHour
 from shared.forecast_freshness import top_of_hour
 
-logger = logging.getLogger("hikes")
+logger = logging.getLogger("monolith.hikes")
 
 router = APIRouter(prefix="/api/hikes", tags=["hikes"])
 

--- a/projects/monolith/hikes/walkhighlands.py
+++ b/projects/monolith/hikes/walkhighlands.py
@@ -21,7 +21,7 @@ from bs4 import BeautifulSoup
 from pydantic import BaseModel, Field, ValidationError
 from timelength import TimeLength
 
-logger = logging.getLogger("hikes")
+logger = logging.getLogger("monolith.hikes")
 
 BASE_URL = "https://www.walkhighlands.co.uk/"
 # Desktop User-Agent carried over from the original scraper.

--- a/projects/monolith/ships/ais.py
+++ b/projects/monolith/ships/ais.py
@@ -15,7 +15,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
-logger = logging.getLogger("ships")
+logger = logging.getLogger("monolith.ships")
 
 # Deduplication settings (read from env, same names/defaults as the old backend).
 # Skip a position if within this distance (meters) and speed below threshold.

--- a/projects/monolith/ships/heat.py
+++ b/projects/monolith/ships/heat.py
@@ -32,7 +32,7 @@ from datetime import date, datetime, timedelta
 
 from sqlmodel import Session, text
 
-logger = logging.getLogger("ships")
+logger = logging.getLogger("monolith.ships")
 
 # ~500m square cells at Salish Sea latitude (~48N). A degree of longitude is
 # shorter than a degree of latitude there, so the lon step is larger to keep

--- a/projects/monolith/ships/ingest.py
+++ b/projects/monolith/ships/ingest.py
@@ -21,7 +21,7 @@ import time
 
 from ships.ais import parse_message
 
-logger = logging.getLogger("ships")
+logger = logging.getLogger("monolith.ships")
 
 # WebSocket reconnection settings (same names/defaults as the old ingest).
 INITIAL_RECONNECT_DELAY = 1.0

--- a/projects/monolith/ships/retention.py
+++ b/projects/monolith/ships/retention.py
@@ -24,7 +24,7 @@ from sqlmodel import Session, text
 
 from ships.heat import LAT_STEP, LON_STEP, MIN_SPEED_KN, bank_day_sql
 
-logger = logging.getLogger("ships")
+logger = logging.getLogger("monolith.ships")
 
 # Keep position data for this many days. A partition is only dropped once its
 # WHOLE day is older than this window.

--- a/projects/monolith/ships/router.py
+++ b/projects/monolith/ships/router.py
@@ -27,7 +27,7 @@ from ships.heat import LAT_STEP as HEAT_LAT_STEP
 from ships.heat import LON_STEP as HEAT_LON_STEP
 from ships.models import HeatCell, HeatCellHistorical, LatestPosition, Position, Vessel
 
-logger = logging.getLogger("ships")
+logger = logging.getLogger("monolith.ships")
 
 router = APIRouter(prefix="/api/ships", tags=["ships"])
 


### PR DESCRIPTION
## What

- Prefix the remaining `dr_jobs`, `ships`, and `hikes` logger names with `monolith.`.
- Remove the `logger-name-missing-monolith-prefix` exclusion from the three monolith Semgrep targets.

## Why

The bare logger names bypass the monolith logging namespace used by configuration and SigNoz filters. With every offender corrected, Semgrep can enforce the rule across the full monolith again.

## Validation

- Remote CI: `1407 tests, 0 failures, 6 skipped`
- Remote CI: `16 tests, 0 failures`
- Bazel summary: `Executed 82 out of 744 tests: 744 tests pass.`
- Push-time remote CI hook passed.
- `git show --check` passed.

Closes #4218

🤖 Generated with [Claude Code](https://claude.com/claude-code)