### PR TITLE
fix(monolith): server-side apply for the migrations ConfigMap

### DIFF
--- a/projects/monolith/chart/chart_env_vars_test.py
+++ b/projects/monolith/chart/chart_env_vars_test.py
@@ -185,3 +185,28 @@ def test_env_vars_in_chart(chart_context):
             debug_info += "\nRendered env section (first 1500 chars):\n"
             debug_info += env_section.group(0)[:1500]
         assert False, debug_info
+
+
+def test_migrations_configmap_uses_server_side_apply(chart_context):
+    """The migrations ConfigMap must opt into server-side apply (#5150).
+
+    Every chart/migrations/*.sql file is globbed into one ConfigMap. Under
+    client-side apply, kubectl stores the whole object in the
+    last-applied-configuration annotation, which the apiserver caps at
+    262144 bytes; the live object sat at ~244 KiB on 2026-08-22. Server-side
+    apply does not write that annotation, so the cap stops being a ceiling on
+    migration history. The resource-level sync option keeps every other object
+    on the Application's default apply mode.
+    """
+    rendered = chart_context["rendered"]
+    docs = [
+        d
+        for d in rendered.split("\n---")
+        if "-migrations\n" in d and "kind: ConfigMap" in d
+    ]
+    assert len(docs) == 1, (
+        f"expected exactly one migrations ConfigMap, found {len(docs)}"
+    )
+    assert "argocd.argoproj.io/sync-options: ServerSideApply=true" in docs[0], (
+        "migrations ConfigMap is missing the ServerSideApply=true sync option"
+    )

--- a/projects/monolith/chart/templates/migrations-configmap.yaml
+++ b/projects/monolith/chart/templates/migrations-configmap.yaml
@@ -4,6 +4,15 @@ metadata:
   name: {{ include "monolith.fullname" . }}-migrations
   labels:
     {{- include "monolith.labels" . | nindent 4 }}
+  annotations:
+    # Every migrations/*.sql file lands in this one object. Client-side apply
+    # copies the whole object into kubectl.kubernetes.io/last-applied-
+    # configuration, which the apiserver caps at 256 KiB; the live annotation
+    # reached ~244 KiB on 2026-08-22 (#5150), two or three migrations short of
+    # every monolith sync failing with `metadata.annotations: Too long`.
+    # Server-side apply never writes that annotation. Scoped to this resource
+    # so the rest of the chart keeps the Application's apply mode.
+    argocd.argoproj.io/sync-options: ServerSideApply=true
 data:
   {{- range $path, $_ := .Files.Glob "migrations/*.sql" }}
   {{ base $path }}: |


### PR DESCRIPTION
## What

Adds `argocd.argoproj.io/sync-options: ServerSideApply=true` to the `monolith-migrations` ConfigMap template, plus a chart test that asserts it renders.

## Why

Closes #5150. The ConfigMap holds every `chart/migrations/*.sql` file, and client-side apply copies the whole object into the `last-applied-configuration` annotation (cap 262144 bytes). Live on 2026-08-22: 244400 bytes (prod) and 244424 (dev). Two or three more migrations and every monolith sync fails with `metadata.annotations: Too long`, which is the gotcha already in CLAUDE.md.

Server-side apply does not write that annotation. The resource-level annotation (ArgoCD docs, "Server-Side Apply", supported since 2.5; cluster runs 3.1.8) scopes the mode change to this one object. ArgoCD's default `ClientSideApplyMigration` hands field ownership to `argocd-controller` on the first sync.

## Verification

- `helm template monolith projects/monolith/chart/ -f projects/monolith/deploy/values.yaml`: annotation renders on `monolith-migrations`, no other object changes.
- Same with the dev overlay: renders on `monolith-dev-migrations`.
- ConfigMap `data` is untouched, so Atlas reads the same mounted files.
- `ci lint` clean; `ci test` summary in the PR timeline below.

After the write-back bump lands and ArgoCD syncs, the check is `kubectl get cm -n monolith monolith-migrations -o jsonpath='{.metadata.managedFields[*].manager}'` showing `argocd-controller` with operation `Apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
