### PR TITLE
fix(monolith): size moving leg tag stagger by label width

### DIFF
--- a/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
+++ b/projects/monolith/frontend/src/routes/friends/moving/+page.svelte
@@ -51,6 +51,7 @@
   let calendarDialog = $state();
   let rolesDialog = $state();
   let plotCard = $state();
+  let plotTrackWidth = $state(0);
   let tooltip = $state(null);
 
   const now = new Date();
@@ -119,6 +120,7 @@
           ),
         }))
         .filter((span) => span.position != null),
+      { trackWidthPx: plotTrackWidth },
     ),
   );
   const plotPadTop = $derived(
@@ -425,7 +427,7 @@
             style:height={`${plotHeight}px`}
             style:--pad-top={`${plotPadTop}px`}
           >
-            <div class="plot-scale">
+            <div class="plot-scale" bind:clientWidth={plotTrackWidth}>
               {#each timeline.months.slice(1) as month (month.value)}
                 <span class="vline" style:left={`${month.position}%`}></span>
               {/each}

--- a/projects/monolith/frontend/src/routes/friends/moving/moving.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving.js
@@ -354,12 +354,33 @@ export function packLaneBars(bars) {
   };
 }
 
-// Leg tags carry no known text width (unlike bars, which are sized by
-// date span), so overlap is approximated by how close two tags start,
-// rather than measuring pixels.
+// Leg tags are sized by their text, not their date span, so the packer
+// estimates each tag's width from its label and date line at the plot's
+// type sizes (12.5px bold label, 9.5px mono date) when the caller supplies
+// the track width in pixels. Without one it falls back to a fixed start
+// gap, which is blind to label width (#5017).
 const LEG_TAG_MIN_GAP_PERCENT = 24;
+const LEG_TAG_LABEL_CHAR_PX = 7;
+const LEG_TAG_DATE_CHAR_PX = 5.8;
+const LEG_TAG_CLEARANCE_PX = 14;
 
-export function packLegTags(tags, minGapPercent = LEG_TAG_MIN_GAP_PERCENT) {
+export function estimateLegTagWidthPx(tag) {
+  const label = String(tag.label ?? "");
+  const date =
+    tag.starts_on || tag.ends_on
+      ? formatDateRange(tag.starts_on, tag.ends_on)
+      : "";
+  return (
+    Math.max(
+      label.length * LEG_TAG_LABEL_CHAR_PX,
+      date.length * LEG_TAG_DATE_CHAR_PX,
+    ) + LEG_TAG_CLEARANCE_PX
+  );
+}
+
+export function packLegTags(tags, options = {}) {
+  const { trackWidthPx, minGapPercent = LEG_TAG_MIN_GAP_PERCENT } = options;
+  const measured = Number.isFinite(trackWidthPx) && trackWidthPx > 0;
   const list = tags ?? [];
   const order = list
     .map((_, index) => index)
@@ -373,14 +394,15 @@ export function packLegTags(tags, minGapPercent = LEG_TAG_MIN_GAP_PERCENT) {
 
   for (const index of order) {
     const tag = list[index];
-    let stagger = levelEnds.findIndex(
-      (levelEnd) => tag.position >= levelEnd + minGapPercent,
-    );
+    const end = measured
+      ? tag.position + (estimateLegTagWidthPx(tag) / trackWidthPx) * 100
+      : tag.position + minGapPercent;
+    let stagger = levelEnds.findIndex((levelEnd) => tag.position >= levelEnd);
     if (stagger === -1) {
       stagger = levelEnds.length;
-      levelEnds.push(tag.position);
+      levelEnds.push(end);
     } else {
-      levelEnds[stagger] = tag.position;
+      levelEnds[stagger] = end;
     }
     staggerByIndex[index] = stagger;
   }

--- a/projects/monolith/frontend/src/routes/friends/moving/moving.test.js
+++ b/projects/monolith/frontend/src/routes/friends/moving/moving.test.js
@@ -251,6 +251,86 @@ describe("leg tag staggering", () => {
   it("handles no tags", () => {
     expect(packLegTags([])).toEqual({ tags: [], staggerCount: 0 });
   });
+
+  it("staggers a long label that clears the start gap but not its own width", () => {
+    // 25% apart clears the fixed 24% fallback, but on a 600px track
+    // "Pack out and leave Vancouver" is wider than 25% of the track.
+    const tags = [
+      {
+        id: "span-move",
+        label: "Pack out and leave Vancouver",
+        starts_on: "2026-10-01",
+        ends_on: "2026-10-10",
+        position: 50,
+      },
+      {
+        id: "span-japan",
+        label: "Japan",
+        starts_on: "2026-10-11",
+        ends_on: "2026-10-25",
+        position: 75,
+      },
+    ];
+
+    expect(packLegTags(tags).staggerCount).toBe(1);
+    expect(packLegTags(tags, { trackWidthPx: 600 }).staggerCount).toBe(2);
+  });
+
+  it("keeps short labels on one row when the track is wide enough", () => {
+    // 8% apart trips the fixed fallback, but on a 1600px track "Japan"
+    // is well under 8% wide.
+    const tags = [
+      {
+        id: "span-japan",
+        label: "Japan",
+        starts_on: "2026-10-11",
+        ends_on: "2026-10-25",
+        position: 50,
+      },
+      {
+        id: "span-uk",
+        label: "UK",
+        starts_on: "2026-10-26",
+        ends_on: "2026-11-02",
+        position: 58,
+      },
+    ];
+
+    expect(packLegTags(tags).staggerCount).toBe(2);
+    expect(packLegTags(tags, { trackWidthPx: 1600 }).staggerCount).toBe(1);
+  });
+
+  it("measures the date line too, so a short label with a long range is not packed tight", () => {
+    const tags = [
+      {
+        id: "a",
+        label: "UK",
+        starts_on: "2026-09-28",
+        ends_on: "2026-11-30",
+        position: 50,
+      },
+      {
+        id: "b",
+        label: "Go",
+        starts_on: "2026-12-01",
+        ends_on: "2026-12-02",
+        position: 54,
+      },
+    ];
+
+    // "28 Sep \u2013 30 Nov" is about 16 mono characters: wider than
+    // 4% of a 1200px track even though "UK" alone would fit.
+    expect(packLegTags(tags, { trackWidthPx: 1200 }).staggerCount).toBe(2);
+  });
+
+  it("ignores a non-positive track width and falls back to the start gap", () => {
+    const tags = [
+      { id: "a", label: "Pack out and leave Vancouver", position: 50 },
+      { id: "b", label: "Japan", position: 75 },
+    ];
+
+    expect(packLegTags(tags, { trackWidthPx: 0 }).staggerCount).toBe(1);
+  });
 });
 
 describe("milestone grouping by date", () => {


### PR DESCRIPTION
## Summary

- estimate moving-leg tag width from the label and displayed date range
- convert estimated pixels to plot percentages using the live track width
- preserve the fixed-gap fallback before layout measurement and cover both paths with tests

## Validation

- `ci test`: 746 tests passed
- BuildBuddy: https://app.buildbuddy.io/invocation/757419e5-c287-4447-8466-2d34f144c432
- pre-push `ci test`: passed

Closes #5017