### PR TITLE
fix(embervm): TLC driver reports INCOMPLETE, not PASS, when stopAfter truncates

### DIFF
--- a/bazel/tla/BUILD
+++ b/bazel/tla/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 # Prebuilt TLC model checker for the EmberVM TLA+ pilot (ADR embervm/006).
 # See repositories.bzl for why a prebuilt jar + vendored JRE (not a hermetic
@@ -17,4 +18,15 @@ bzl_library(
     srcs = ["repositories.bzl"],
     visibility = ["//visibility:public"],
     deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+# Driver verdict test (#4050): runs tlc.sh against a fake java so a TLC run that
+# exits 0 with states left on the queue (stopAfter fired) reads as INCOMPLETE,
+# never PASS. No JRE or jar needed.
+sh_test(
+    name = "tlc_test",
+    size = "small",
+    srcs = ["tlc_test.sh"],
+    args = ["$(rootpath :tlc.sh)"],
+    data = [":tlc.sh"],
 )

--- a/bazel/tla/tlc.sh
+++ b/bazel/tla/tlc.sh
@@ -78,8 +78,9 @@ fi
 rm -f "trans_check.tla"
 
 # --- Model check ------------------------------------------------------------
-# -Dtlc2.TLC.stopAfter=600 bounds wall time (seconds) so a runaway check fails
-# instead of hanging the CI action; -workers auto uses the executor's cores.
+# -Dtlc2.TLC.stopAfter=600 bounds wall time (seconds) so a runaway check cannot
+# hang the CI action; -workers auto uses the executor's cores. Note TLC exits 0
+# when the bound fires, so pass mode below also checks the queue drained.
 set +e
 "$java" -XX:+UseParallelGC -Dtlc2.TLC.stopAfter=600 \
 	-cp "$jar" tlc2.TLC -workers auto -config "$cfg_name" "$module" >"$out" 2>&1
@@ -92,7 +93,19 @@ if [ "$expect" = "pass" ]; then
 		cat "$out" >&2
 		exit 1
 	fi
-	echo "TLC PASS: $spec_name checked clean." >&2
+	# A zero exit is NOT proof of an exhaustive check: when stopAfter fires, TLC
+	# prints "No error has been found", leaves states on the queue, and still
+	# exits 0 (#4050). Require the completion line to report an empty queue so a
+	# truncated search reads as INCOMPLETE, never as PASS.
+	if ! grep -qE 'states generated, .*, 0 states left on queue' "$out"; then
+		echo "TLC INCOMPLETE: $spec_name was NOT checked exhaustively. TLC exited 0" >&2
+		echo "but its output does not report '0 states left on queue', so the state" >&2
+		echo "space was truncated (most likely the -Dtlc2.TLC.stopAfter wall-time" >&2
+		echo "bound fired) and a clean result proves nothing. Output:" >&2
+		cat "$out" >&2
+		exit 1
+	fi
+	echo "TLC PASS: $spec_name checked clean (exhaustive)." >&2
 elif [ "$expect" = "fail" ]; then
 	# Negative mode: the model must still reproduce the historical violation. A
 	# zero exit means TLC found no error, i.e. the model went blind to the bug it

--- a/bazel/tla/tlc_test.sh
+++ b/bazel/tla/tlc_test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Unit test for the tlc.sh driver's verdicts (#4050). Runs the driver against a
+# fake `java` that answers pcal.trans with a no-op (so the translation freshness
+# check passes) and answers tlc2.TLC with canned output chosen per case, so no
+# JRE or TLC jar is needed and the test is sub-second.
+#
+# The case that motivated this test: TLC exits 0 when -Dtlc2.TLC.stopAfter fires,
+# printing "No error has been found" with states still on the queue. The driver
+# must report that as INCOMPLETE, not PASS.
+set -euo pipefail
+
+driver="$(pwd)/$1"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Fake java. TLC_CASE selects the canned model-check output and exit code.
+fake_java="$work/java"
+cat >"$fake_java" <<'JAVA'
+#!/usr/bin/env bash
+# args: -cp jar pcal.trans ... | -XX:... -Dtlc2.TLC.stopAfter=N -cp jar tlc2.TLC ...
+for a in "$@"; do
+	case "$a" in
+	pcal.trans) exit 0 ;;
+	tlc2.TLC)
+		case "$TLC_CASE" in
+		exhaustive)
+			echo "Model checking completed. No error has been found."
+			echo "156554286 states generated, 30063250 distinct states found, 0 states left on queue."
+			echo "The depth of the complete state graph search is 45."
+			exit 0
+			;;
+		truncated)
+			echo "Model checking completed. No error has been found."
+			echo "12769001 states generated, 3426982 distinct states found, 852718 states left on queue."
+			exit 0
+			;;
+		violation)
+			echo "Error: Invariant NoDoubleDispatch is violated."
+			echo "1234 states generated, 567 distinct states found, 89 states left on queue."
+			exit 12
+			;;
+		esac
+		;;
+	esac
+done
+echo "fake java: unhandled args: $*" >&2
+exit 99
+JAVA
+chmod +x "$fake_java"
+
+: >"$work/tla2tools.jar"
+echo "---- MODULE fake ----" >"$work/fake.tla"
+echo "INIT Init" >"$work/fake.cfg"
+
+run() { # $1 case, $2 expectation; prints driver rc, captures stderr in $work/err
+	local rc=0
+	TLC_CASE="$1" "$driver" "$fake_java" "$work/tla2tools.jar" "$work/fake.tla" \
+		"$work/fake.cfg" "$work/out" "$2" >"$work/err" 2>&1 || rc=$?
+	echo "$rc"
+}
+
+fail() {
+	echo "FAIL: $1" >&2
+	echo "--- driver stderr ---" >&2
+	cat "$work/err" >&2
+	exit 1
+}
+
+# pass mode, exhaustive: PASS
+[ "$(run exhaustive pass)" -eq 0 ] || fail "exhaustive clean run should pass"
+grep -q "TLC PASS" "$work/err" || fail "exhaustive run should print TLC PASS"
+
+# pass mode, truncated: the #4050 case. Must be non-zero and say INCOMPLETE,
+# and must NOT claim PASS.
+[ "$(run truncated pass)" -ne 0 ] || fail "truncated run (states left on queue, exit 0) must not pass"
+grep -q "TLC INCOMPLETE" "$work/err" || fail "truncated run should be reported as INCOMPLETE"
+grep -q "TLC PASS" "$work/err" && fail "truncated run must not be reported as PASS"
+
+# pass mode, violation: still fails
+[ "$(run violation pass)" -ne 0 ] || fail "violation should fail pass mode"
+
+# fail mode, violation: OK; fail mode, exhaustive clean: regressed
+[ "$(run violation fail)" -eq 0 ] || fail "violation should satisfy fail mode"
+[ "$(run exhaustive fail)" -ne 0 ] || fail "clean run must not satisfy fail mode"
+grep -q "NEGATIVE MODE REGRESSED" "$work/err" || fail "clean fail-mode run should report regression"
+
+echo "tlc_test: all cases OK"


### PR DESCRIPTION
TLC exits 0 when -Dtlc2.TLC.stopAfter fires, printing "No error has been
found" with states still on the queue, and pass mode gated only on the
exit code, so a truncated check read as an exhaustive one. Pass mode now
also requires the completion line to report "0 states left on queue" and
fails loudly as TLC INCOMPLETE otherwise.

Adds bazel/tla:tlc_test, which drives tlc.sh with a fake java emitting
canned TLC output (exhaustive, truncated, violation) across both modes.

Closes #4050

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
