### PR TITLE
fix(embervm): persist invoke failure before replying

### DIFF
--- a/projects/embervm/control/lib/embervm/session.ex
+++ b/projects/embervm/control/lib/embervm/session.ex
@@ -188,19 +188,20 @@ defmodule Embervm.Session do
 
       {:error, reason} ->
         # A daemon transport/timeout/suspect failure: the session is failed and its
-        # VM destroyed. Reply the error to this caller, drain the rest as :failed,
-        # and stop (a failed session has no process).
-        GenServer.reply(from, {:error, reason})
-        fail_and_stop(state, reason)
+        # VM destroyed. Mirror the success branch: append session_failed BEFORE
+        # replying (#4644, durable-before-observed), so a caller told {:error, _}
+        # can read :failed straight back. Then reply, destroy the VM best-effort
+        # off the caller's critical path, drain the rest as :failed, and stop (a
+        # failed session has no process).
+        fail_and_stop(state, reason, from)
     end
   end
 
   # A worker died without reporting (it always sends {:invoke_done, ...}): treat as
-  # a transport failure, same as a reported error.
+  # a transport failure, same as a reported error (same durable-before-reply order).
   def handle_info({:DOWN, ref, :process, pid, down_reason}, %{worker: {pid, ref, from}} = state) do
     state = %{state | worker: nil}
-    GenServer.reply(from, {:error, {:worker_down, down_reason}})
-    fail_and_stop(state, {:worker_down, down_reason})
+    fail_and_stop(state, {:worker_down, down_reason}, from)
   end
 
   # The idle-bank timer fired. ASK the manager to bank ONLY if still quiescent (no
@@ -438,18 +439,32 @@ defmodule Embervm.Session do
     _, _ -> :error
   end
 
-  # Fail the session (destroy the VM, append session_failed), drain queued callers
-  # as :failed, and stop this process. Called on any daemon-level invoke failure.
-  defp fail_and_stop(state, reason) do
+  # Fail the session: append session_failed, reply {:error, reason} to the in-flight
+  # caller, destroy the VM, drain queued callers as :failed, and stop this process.
+  # Called on any daemon-level invoke failure.
+  #
+  # Ordering (#4644): the transition is awaited BEFORE the reply so the caller never
+  # observes a failure the op-log has not accounted (invariant 7, the same order
+  # record_invoke/reply uses on success). destroy_vm runs AFTER the reply: it is a
+  # gRPC call to a daemon that just failed, so it must not sit on the caller's error
+  # path, and its result was always discarded anyway (a failed destroy already left
+  # "row :failed, VM alive", which the orphan sweep reconciles, invariant 5).
+  #
+  # The armed rejoin_failure_fun branch is deliberately NOT reordered: it does not
+  # fail the session, it hands the outcome to the manager by message (which parks
+  # the session, see SessionManager handle_info({:rejoin_assign_failed, ...})), and
+  # a synchronous call back into the manager from this process could deadlock
+  # against a manager that is itself calling this session. The park is therefore
+  # observed-before-durable by design, and nothing reads :failed from it.
+  defp fail_and_stop(state, reason, from) do
     if is_function(state.rejoin_failure_fun, 1) do
       failure_fun = state.rejoin_failure_fun
       state = disarm_rejoin_failure(state)
+      GenServer.reply(from, {:error, reason})
       _ = failure_fun.(reason)
       drain_queue_as_failed(state)
       {:stop, :normal, %{state | queue: :queue.new()}}
     else
-      _ = destroy_vm(state)
-
       _ =
         Embervm.SessionStore.transition(
           state.session_store,
@@ -460,6 +475,8 @@ defmodule Embervm.Session do
           %{}
         )
 
+      GenServer.reply(from, {:error, reason})
+      _ = destroy_vm(state)
       drain_queue_as_failed(state)
       {:stop, :normal, %{state | queue: :queue.new()}}
     end

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -1830,6 +1830,74 @@ defmodule Embervm.SessionManagerTest do
     assert session.terminal_reason == "failed"
   end
 
+  # #4644: durable-before-observed (ARCHITECTURE.md invariant 7) on the FAILURE path.
+  # The caller's error reply must not be sent before session_failed is appended, the
+  # same ordering the success branch already honours (record_invoke before reply).
+  # destroy_fun blocks until released so the old reply -> destroy -> transition
+  # ordering deterministically reads :running here, not merely racily.
+  test "invoke failure is durable before the caller is unblocked" do
+    parent = self()
+
+    fail_assign = fn _ch, _req ->
+      {:ok, %SessionAssignResponse{response: nil, usage: nil, suspect: true}}
+    end
+
+    blocking_destroy = fn _ch, vm ->
+      send(parent, {:destroy_started, self(), vm})
+
+      receive do
+        :release_destroy -> :ok
+      end
+
+      {:ok, %{teardown_confirmed: true}}
+    end
+
+    ctx = start_stack(assign_fun: fail_assign, destroy_fun: blocking_destroy)
+    put_session_workload(ctx, "wl-fail-order")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-fail-order", "p1")
+
+    assert {:error, :suspect} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
+
+    # No barrier on purpose: the reply itself is the guarantee.
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :failed
+    assert :session_failed in op_kinds_for(ctx, created.session_id)
+
+    # The VM destroy still runs, best-effort, after the caller is unblocked.
+    assert_receive {:destroy_started, destroyer, _vm}, 1_000
+    send(destroyer, :release_destroy)
+  end
+
+  test "a worker that dies without reporting fails the session durably before replying" do
+    parent = self()
+
+    dying_assign = fn _ch, _req -> exit(:worker_boom) end
+
+    blocking_destroy = fn _ch, vm ->
+      send(parent, {:destroy_started, self(), vm})
+
+      receive do
+        :release_destroy -> :ok
+      end
+
+      {:ok, %{teardown_confirmed: true}}
+    end
+
+    ctx = start_stack(assign_fun: dying_assign, destroy_fun: blocking_destroy)
+    put_session_workload(ctx, "wl-down-order")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-down-order", "p1")
+
+    assert {:error, {:worker_down, :worker_boom}} =
+             SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :failed
+    assert :session_failed in op_kinds_for(ctx, created.session_id)
+
+    assert_receive {:destroy_started, destroyer, _vm}, 1_000
+    send(destroyer, :release_destroy)
+  end
+
   # -- destroy ---------------------------------------------------------------
 
   test "destroy from running tears down the process and records session_destroyed" do


### PR DESCRIPTION
Move the session_failed transition ahead of the caller reply on daemon and worker failures, matching the success path's durable-before-observed invariant. Keep VM teardown after the reply so a failing daemon cannot delay the error path. Add deterministic coverage for both reported failures and worker exits.

Closes #4644
