### PR TITLE
fix(embervm): charge relight workload memory admission

### DIFF
--- a/projects/embervm/noded/server/pressure_test.go
+++ b/projects/embervm/noded/server/pressure_test.go
@@ -210,3 +210,98 @@ func TestUnknownBudgetAdmitsBothModels(t *testing.T) {
 		}
 	}
 }
+
+// TestRelightChargesWorkloadNeed (#4186): Relight used to ask the memory
+// admission question with need=0, so a banked 4 GiB session admitted on a brick
+// with floor-only headroom and then faulted multiple GiB back in. The need is
+// resolved from the registry the same way Prime's is (primeNeedMib), using the
+// banked snapshot's recorded workload, with the request trace as the fallback a
+// post-rescan bundle (no recorded identity) needs. The registry-absent case still
+// degrades to the floor-only gate, exactly as Prime does.
+func TestRelightChargesWorkloadNeed(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		snapWorkload  string
+		traceWorkload string
+		registry      []workloadEntry
+		headroom      uint64
+		wantCode      codes.Code
+	}{
+		{
+			name:         "snapshot workload need above headroom rejects",
+			snapWorkload: "sandbox-session",
+			registry:     []workloadEntry{{Workload: "sandbox-session", MemMib: 4096}},
+			headroom:     2000, // < 4096 + 512 floor
+			wantCode:     codes.ResourceExhausted,
+		},
+		{
+			name:         "snapshot workload need within headroom admits",
+			snapWorkload: "sandbox-session",
+			registry:     []workloadEntry{{Workload: "sandbox-session", MemMib: 4096}},
+			headroom:     8192, // >= 4096 + 512
+			wantCode:     codes.OK,
+		},
+		{
+			name:          "trace workload is the fallback when the bundle has no identity",
+			snapWorkload:  "",
+			traceWorkload: "sandbox-session",
+			registry:      []workloadEntry{{Workload: "sandbox-session", MemMib: 4096}},
+			headroom:      2000,
+			wantCode:      codes.ResourceExhausted,
+		},
+		{
+			name:          "snapshot workload outranks a different trace workload",
+			snapWorkload:  "echo",
+			traceWorkload: "sandbox-session",
+			registry:      []workloadEntry{{Workload: "sandbox-session", MemMib: 4096}, {Workload: "echo", MemMib: 256}},
+			headroom:      2000, // >= 256 + 512, < 4096 + 512
+			wantCode:      codes.OK,
+		},
+		{
+			name:         "registry-absent workload gates on the floor alone",
+			snapWorkload: "sandbox-session",
+			registry:     nil,
+			headroom:     2000, // >= 0 + 512
+			wantCode:     codes.OK,
+		},
+		{
+			name:         "unknown headroom fails open regardless of need",
+			snapWorkload: "sandbox-session",
+			registry:     []workloadEntry{{Workload: "sandbox-session", MemMib: 16384}},
+			headroom:     0,
+			wantCode:     codes.OK,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			drv := &fakeDriver{}
+			client, srv := newSessionTestServer(t, drv, &fakeTransport{}, 8)
+			srv.registry.sync(tc.registry)
+			srv.memHeadroom = func() uint64 { return tc.headroom }
+
+			drv.mu.Lock()
+			if drv.sessionBundles == nil {
+				drv.sessionBundles = map[string]string{}
+			}
+			drv.sessionBundles["need-ref"] = "state"
+			drv.mu.Unlock()
+			srv.sessionSnap.add(sessionSnapshotEntry{snapshotRef: "need-ref", workload: tc.snapWorkload})
+
+			_, err := client.Relight(context.Background(), &nodev1.RelightRequest{
+				Trace:       &nodev1.Trace{Workload: tc.traceWorkload},
+				SnapshotRef: "need-ref",
+			})
+			if got := status.Code(err); got != tc.wantCode {
+				t.Fatalf("Relight code = %v (%v), want %v", got, err, tc.wantCode)
+			}
+			if tc.wantCode == codes.ResourceExhausted {
+				if !strings.Contains(err.Error(), string(reasonPressureMem)) {
+					t.Fatalf("Relight error %q must carry reason %q", err.Error(), reasonPressureMem)
+				}
+				// Cheap rejection: the snapshot was never restored.
+				if drv.restoreSessions != 0 {
+					t.Fatalf("rejected Relight restored %d sessions, want 0", drv.restoreSessions)
+				}
+			}
+		})
+	}
+}

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1505,9 +1505,6 @@ func (s *Server) Relight(ctx context.Context, req *nodev1.RelightRequest) (*node
 	if s.slotsExhausted() {
 		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
 	}
-	if err := s.admitOrReject(0, classMemOnly); err != nil {
-		return nil, err
-	}
 	snapshot, ok := s.sessionSnap.get(ref)
 	if !ok {
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: unknown session snapshot_ref %q", ref)
@@ -1518,6 +1515,14 @@ func (s *Server) Relight(ctx context.Context, req *nodev1.RelightRequest) (*node
 		// path, so use the control plane's adoption trace until the next Bank writes
 		// the identity into the in-memory registry.
 		workload = req.GetTrace().GetWorkload()
+	}
+	// Memory admission charges the workload's declared need, resolved from the
+	// registry exactly as Prime does (#4186). A restore faults the whole banked
+	// memory back in, so asking with need=0 admitted a 4 GiB session onto a brick
+	// with floor-only headroom. The lookup runs after the ref check so an unknown
+	// ref still reports FAILED_PRECONDITION rather than a spurious pressure reject.
+	if err := s.admitOrReject(s.primeNeedMib(workload), classMemOnly); err != nil {
+		return nil, err
 	}
 	trackDirtyPages := s.cfg.DiffBanking && diffBankingWorkload(s.cfg.DiffBankingWorkloads, workload)
 	h, err := s.sessionDriver.RestoreSession(ctx, ref, trackDirtyPages)


### PR DESCRIPTION
## What

- Resolve a Relight request workload from the banked snapshot, with the trace workload as fallback.
- Charge the workload declared memory through `primeNeedMib` before restoring the session.
- Preserve `FAILED_PRECONDITION` for unknown snapshot references by performing admission after reference lookup.
- Add table-driven coverage for admission, rejection, identity precedence, fallback, and unknown-headroom behavior.

## Why

Relight previously called the memory admission gate with `need=0`. A multi-GiB banked session could therefore pass on floor-only headroom and fault its full memory back into an already pressured node.

## Validation

- Rebased cleanly onto current `origin/main`; rebase format hook passed.
- Remote CI: `1409 tests, 0 failures, 6 skipped`.
- Remote CI: `16 tests, 0 failures`.
- Bazel summary: `Executed 3 out of 744 tests: 744 tests pass.`
- Push-time remote CI hook passed.
- Commit-time changed-file lint passed.
- `git show --check` passed.

Closes #4186

🤖 Generated with [Claude Code](https://claude.com/claude-code)