### PR TITLE
feat(monolith-public): audit destination-scoped egress

### DIFF
--- a/projects/monolith-public/chart/BUILD
+++ b/projects/monolith-public/chart/BUILD
@@ -10,6 +10,14 @@ filegroup(
     visibility = ["//projects/monolith:__pkg__"],
 )
 
+# Guard (#5142): the destination-scoped egress policies must stay scoped. The
+# test lives in //projects/monolith for the same reason as the HTTPRoute guard.
+filegroup(
+    name = "cilium_scoped_egress_template",
+    srcs = ["templates/cilium-policy-scoped-egress.yaml"],
+    visibility = ["//projects/monolith:__pkg__"],
+)
+
 # Guard (ADR 005): the Turnstile *secret* must stay in the backend ("web"); the
 # frontend may reference only the public site-key literal. The test asserting
 # this lives in the Python-native //projects/monolith package and reads this

--- a/projects/monolith-public/chart/templates/cilium-policy-scoped-egress.yaml
+++ b/projects/monolith-public/chart/templates/cilium-policy-scoped-egress.yaml
@@ -1,0 +1,185 @@
+# Destination-scoped egress for the public tier (#5142, THREAT-MODEL finding 3).
+#
+# cilium-policy.yaml's egress policies grant every public-tier pod
+# `toEntities: [cluster, host, remote-node]`, which is "anything in the cluster":
+# a compromised public pod can dial any pod on any port. These policies replace
+# that with one `toEndpoints` rule per real dependency, on its real port.
+#
+# ROLLOUT IS TWO STEPS, gated by ciliumPolicy.egress.scoped in deploy/values:
+#
+#   "off"      this file renders nothing.
+#   "audit"    these policies render with `enableDefaultDeny.egress: false`, so
+#              they ADD allows and never switch an endpoint to default-deny on
+#              their own. Enforcement is unchanged: the broad policies in
+#              cilium-policy.yaml still carry the deny and the `cluster` allow.
+#              What changes is Hubble's policy correlation: every allowed egress
+#              flow now names every policy that allowed it, so a flow allowed
+#              ONLY by the broad policy is a dependency this file missed.
+#              Read it for a day of public traffic:
+#
+#                hubble observe --from-namespace monolith-public --type policy-verdict -o json \
+#                  | jq -c 'select(.flow.egress_allowed_by != null)
+#                           | select([.flow.egress_allowed_by[].name] | any(endswith("-scoped")) | not)
+#                           | {src: .flow.source.pod_name, dst: .flow.destination, l4: .flow.l4}'
+#
+#              An empty result over the window means the list below is complete.
+#   "enforce"  NOT IN THIS CHART YET. The follow-up PR adds it: the broad
+#              `toEntities: cluster` rules come out of cilium-policy.yaml, the
+#              Turnstile allow moves here, and these policies carry the deny. A
+#              dependency still missing at that point fails as a SILENT DIAL
+#              TIMEOUT, which is why the audit window comes first.
+#
+# Not a true Cilium audit mode: that is an agent-wide flag (policy-audit-mode)
+# that would stop enforcing every policy in the cluster, or an imperative
+# per-endpoint `cilium endpoint config` that GitOps cannot carry. The
+# additive-policy shape above is the one the cluster can express declaratively.
+#
+# Why these destinations (each is an env var on the live pod, or observed in
+# hubble): the backend reads and writes the CNPG cluster directly (monolith-pg-ro
+# and -rw select the instance pods, there is no pooler), calls inference and
+# embeddings, signs and serves S3 objects from SeaweedFS, invokes EmberVM for
+# the public /functions router, and exports OTLP to the SigNoz collector. The
+# frontend calls only the backend and forwards browser traces to the
+# host-networked SigNoz agent, which Cilium classifies as `host` on the same
+# node and `remote-node` elsewhere: that is the ONLY reason those two entities
+# survive, and they are pinned to 4318. imgproxy fetches from SeaweedFS alone.
+# Every pod resolves through kube-dns. The apiserver is absent because the
+# public tier holds no RBAC. FC_INVOKE_URL in chart/values.yaml points at a
+# Service that no longer exists, so it gets no rule.
+#
+# Kept as separate objects rather than extra rules on the existing policies on
+# purpose: Hubble correlates by policy NAME, so the audit only works if the
+# scoped allows live in their own objects.
+
+{{- $mode := .Values.ciliumPolicy.egress.scoped | default "off" }}
+{{- if not (has $mode (list "off" "audit")) }}
+{{- fail (printf "ciliumPolicy.egress.scoped must be off or audit (enforce lands with the follow-up to #5142); got %q" $mode) }}
+{{- end }}
+{{- if and .Values.ciliumPolicy.egress.enabled (eq $mode "audit") }}
+{{- $audit := true }}
+{{- $dns := .Values.ciliumPolicy.egress.scopedTargets.dns }}
+{{- $t := .Values.ciliumPolicy.egress.scopedTargets }}
+{{- if .Values.web.enabled }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "monolith-public.fullname" . }}-web-egress-scoped
+  labels:
+    {{- include "monolith-public.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "monolith-public.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  {{- if $audit }}
+  enableDefaultDeny:
+    egress: false
+  {{- end }}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ $dns.namespace }}
+            {{- toYaml $dns.matchLabels | nindent 12 }}
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    {{- range $dep := list $t.postgres $t.inference $t.embeddings $t.seaweedfs $t.embervm $t.otelCollector }}
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ $dep.namespace }}
+            {{- toYaml $dep.matchLabels | nindent 12 }}
+      toPorts:
+        - ports:
+            - port: {{ $dep.port | quote }}
+              protocol: TCP
+    {{- end }}
+{{- end }}
+{{- if .Values.frontend.enabled }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "monolith-public.fullname" . }}-frontend-egress-scoped
+  labels:
+    {{- include "monolith-public.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "monolith-public.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  {{- if $audit }}
+  enableDefaultDeny:
+    egress: false
+  {{- end }}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ $dns.namespace }}
+            {{- toYaml $dns.matchLabels | nindent 12 }}
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            {{- include "monolith-public.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: web
+      toPorts:
+        - ports:
+            - port: {{ .Values.web.containerPort | quote }}
+              protocol: TCP
+    # Browser traces via the same-origin /otel proxy go to the SigNoz k8s-infra
+    # agent DaemonSet, which is hostNetwork, so the destination identity is the
+    # node itself rather than a pod. Pinned to the OTLP/HTTP port.
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: {{ $t.otelAgentHostPort | quote }}
+              protocol: TCP
+{{- end }}
+{{- if .Values.imgproxy.enabled }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "monolith-public.fullname" . }}-imgproxy-egress-scoped
+  labels:
+    {{- include "monolith-public.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "monolith-public.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: imgproxy
+  {{- if $audit }}
+  enableDefaultDeny:
+    egress: false
+  {{- end }}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ $dns.namespace }}
+            {{- toYaml $dns.matchLabels | nindent 12 }}
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ $t.seaweedfs.namespace }}
+            {{- toYaml $t.seaweedfs.matchLabels | nindent 12 }}
+      toPorts:
+        - ports:
+            - port: {{ $t.seaweedfs.port | quote }}
+              protocol: TCP
+{{- end }}
+{{- end }}

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -699,6 +699,65 @@ ciliumPolicy:
     enabled: false
   egress:
     enabled: false
+    # Destination-scoped egress rollout (#5142): "off" or "audit". See
+    # templates/cilium-policy-scoped-egress.yaml for what each does and how to
+    # read the audit. Only meaningful while egress.enabled is true.
+    scoped: off
+    # The public tier's real egress destinations, one selector + port each,
+    # rendered as toEndpoints rules by the scoped policies. Selectors mirror the
+    # target Service's own selector (plus the namespace label Cilium needs for a
+    # cross-namespace match), so a rename on the far side shows up here as a
+    # silent dial timeout: re-verify against `kubectl get svc -o jsonpath=
+    # '{.spec.selector}'` when one of these services moves.
+    scopedTargets:
+      dns:
+        namespace: kube-system
+        matchLabels:
+          k8s-app: kube-dns
+      # Both the -ro (replica) and -rw (primary) Services select on the cluster
+      # label; the backend holds both credentials (DATABASE_URL and
+      # PUBLIC_WRITER_DATABASE_URL). There is no pooler.
+      postgres:
+        namespace: monolith
+        matchLabels:
+          cnpg.io/cluster: monolith-pg
+        port: 5432
+      inference:
+        namespace: inference
+        matchLabels:
+          app.kubernetes.io/name: inference
+          app.kubernetes.io/component: inference
+        port: 8080
+      embeddings:
+        namespace: inference
+        matchLabels:
+          app.kubernetes.io/name: inference
+          app.kubernetes.io/component: embeddings
+        port: 8080
+      seaweedfs:
+        namespace: seaweedfs
+        matchLabels:
+          app.kubernetes.io/name: seaweedfs
+          app.kubernetes.io/component: s3
+        port: 8333
+      # EMBERVM_URL: the public /functions/<name> router.
+      embervm:
+        namespace: embervm
+        matchLabels:
+          app.kubernetes.io/name: embervm
+          app.kubernetes.io/instance: embervm
+        port: 8080
+      # OTEL_EXPORTER_OTLP_ENDPOINT (grpc) from the backend.
+      otelCollector:
+        namespace: signoz
+        matchLabels:
+          app.kubernetes.io/name: signoz
+          app.kubernetes.io/component: otel-collector
+        port: 4317
+      # OTEL_COLLECTOR_HTTP_URL from the frontend's /otel proxy reaches the
+      # hostNetwork SigNoz k8s-infra agent, so it is a host/remote-node entity
+      # on this port rather than a pod selector.
+      otelAgentHostPort: 4318
     # Cloudflare's published IP ranges, the toCIDRSet allow for the ONE
     # sanctioned off-cluster egress from the backend "web" pod: Turnstile
     # siteverify (challenges.cloudflare.com) on port 443. Pinned as CIDRs rather

--- a/projects/monolith-public/deploy/values.yaml
+++ b/projects/monolith-public/deploy/values.yaml
@@ -74,3 +74,10 @@ ciliumPolicy:
     enabled: true
   egress:
     enabled: true
+    # #5142 step 1: destination-scoped egress policies in AUDIT shape (additive
+    # allows, enforcement unchanged). Flipped here in the same PR as the
+    # template on purpose: the previous chart has no reader for this key, so
+    # the value is inert until the new chart publishes, and nothing misrenders
+    # in between. Read hubble for a day (recipe in the template header) before
+    # the follow-up PR moves to enforcement.
+    scoped: audit

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -5395,7 +5395,6 @@ py_test(
     srcs = ["public_cilium_scoped_egress_guard_test.py"],
     data = ["//projects/monolith-public/chart:cilium_scoped_egress_template"],
     imports = ["."],
-    deps = ["@pip//pytest"],
 )
 
 # Guard: the packaged homelab-library must deploy images by content digest, not
@@ -7435,4 +7434,17 @@ semgrep_target_test(
     ],
     rules = ["//bazel/semgrep/rules:python_rules"],
     target = ":gen_posts_manifest",
+)
+
+semgrep_test(
+    name = "public_cilium_scoped_egress_guard_test_semgrep_test",
+    srcs = ["public_cilium_scoped_egress_guard_test.py"],
+    exclude_rules = [
+        "avoid-sqlalchemy-text",
+        "sqlmodel-datetime-without-factory",
+        "tainted-fastapi-http-request-httpx",
+        "tainted-path-traversal-pillow-fastapi",
+        "tainted-path-traversal-stdlib-fastapi",
+    ],
+    rules = ["//bazel/semgrep/rules:python_rules"],
 )

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -5387,6 +5387,17 @@ py_test(
     deps = ["@pip//pytest"],
 )
 
+# Guard (#5142): the public tier's destination-scoped Cilium egress policies
+# must never regain `toEntities: cluster`. Same cross-package data-dep shape as
+# the HTTPRoute guard above.
+py_test(
+    name = "public_cilium_scoped_egress_guard_test",
+    srcs = ["public_cilium_scoped_egress_guard_test.py"],
+    data = ["//projects/monolith-public/chart:cilium_scoped_egress_template"],
+    imports = ["."],
+    deps = ["@pip//pytest"],
+)
+
 # Guard: the packaged homelab-library must deploy images by content digest, not
 # by the build-timestamped tag that push-changed.sh frequently never pushes.
 # Reads the packaged tarball (what actually ships) rather than the library

--- a/projects/monolith/public_cilium_scoped_egress_guard_test.py
+++ b/projects/monolith/public_cilium_scoped_egress_guard_test.py
@@ -1,0 +1,90 @@
+"""Guard (#5142, THREAT-MODEL finding 3): the public tier's destination-scoped
+egress policies must stay destination-scoped.
+
+``cilium-policy-scoped-egress.yaml`` exists to replace the broad
+``toEntities: cluster`` grant with one ``toEndpoints`` rule per dependency. The
+cheap way for that to regress is someone adding ``cluster`` (or ``world``) back
+into the scoped file to make a dial timeout go away, which silently returns the
+public tier to "anything in the cluster" reach. This reads the raw template
+(Go-templated, so not parseable as YAML) and fails on that shape, and on a
+scoped policy that forgot DNS, which is the first thing every pod needs.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+TEMPLATE = "cilium-policy-scoped-egress.yaml"
+
+
+def _template_path() -> Path:
+    here = Path(__file__).resolve().parent / "templates" / TEMPLATE
+    if here.exists():
+        return here
+    srcdir = os.environ.get("TEST_SRCDIR", "")
+    candidate = (
+        Path(srcdir)
+        / "_main"
+        / "projects"
+        / "monolith-public"
+        / "chart"
+        / "templates"
+        / TEMPLATE
+    )
+    if candidate.exists():
+        return candidate
+    raise FileNotFoundError(
+        f"{TEMPLATE} not found at {here} or {candidate} (TEST_SRCDIR={srcdir!r})"
+    )
+
+
+def _policies(text: str) -> list[str]:
+    """Split the template into one chunk per CiliumNetworkPolicy document."""
+    chunks = re.split(r"^---\s*$", text, flags=re.MULTILINE)
+    return [c for c in chunks if "kind: CiliumNetworkPolicy" in c]
+
+
+def _entities(chunk: str) -> set[str]:
+    found: set[str] = set()
+    for block in re.finditer(r"toEntities:\n((?:\s+- \S+\n)+)", chunk):
+        found.update(re.findall(r"- (\S+)", block.group(1)))
+    return found
+
+
+def test_scoped_egress_never_grants_cluster_or_world():
+    text = _template_path().read_text()
+    policies = _policies(text)
+    assert len(policies) == 3, "expected web, frontend and imgproxy scoped policies"
+    for chunk in policies:
+        entities = _entities(chunk)
+        assert "cluster" not in entities, (
+            "scoped egress must not grant toEntities: cluster"
+        )
+        assert "world" not in entities, "scoped egress must not grant toEntities: world"
+        assert "all" not in entities, "scoped egress must not grant toEntities: all"
+
+
+def test_host_entities_are_port_pinned():
+    """`host`/`remote-node` survive only for the hostNetwork OTLP agent, on one port."""
+    text = _template_path().read_text()
+    for match in re.finditer(r"toEntities:\n((?:\s+- \S+\n)+)(\s+toPorts:)?", text):
+        assert match.group(2), "a toEntities rule in the scoped file must carry toPorts"
+
+
+def test_every_scoped_policy_allows_dns():
+    text = _template_path().read_text()
+    for chunk in _policies(text):
+        assert '- port: "53"' in chunk, (
+            "a scoped egress policy without DNS fails every lookup"
+        )
+        assert "$dns.matchLabels" in chunk
+
+
+def test_audit_mode_is_additive():
+    """Audit mode must not flip an endpoint to default-deny on its own."""
+    text = _template_path().read_text()
+    for chunk in _policies(text):
+        assert "enableDefaultDeny:" in chunk
+        assert re.search(r"enableDefaultDeny:\n\s+egress: false", chunk)


### PR DESCRIPTION
Render additive Cilium policies that name each public-tier dependency by endpoint selector and port while leaving default deny disabled. Enable the audit shape in production so Hubble can reveal flows still covered only by the broad cluster grant before the enforcement follow-up.

Refs #5142
