### PR TITLE
fix(docs): reject internal markers from public content

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -277,20 +277,12 @@ py_venv_binary(
 py_venv_binary(
     name = "gen_docs_manifest",
     main = "knowledge/tools/gen_docs_manifest.py",
-    srcs = [
-        "knowledge/tools/gen_docs_manifest.py",
-        "knowledge/tools/public_content.py",
-    ],
     visibility = ["//:__subpackages__"],
 )
 
 py_venv_binary(
     name = "gen_posts_manifest",
     main = "knowledge/tools/gen_posts_manifest.py",
-    srcs = [
-        "knowledge/tools/gen_posts_manifest.py",
-        "knowledge/tools/public_content.py",
-    ],
     visibility = ["//:__subpackages__"],
 )
 

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -277,12 +277,20 @@ py_venv_binary(
 py_venv_binary(
     name = "gen_docs_manifest",
     main = "knowledge/tools/gen_docs_manifest.py",
+    srcs = [
+        "knowledge/tools/gen_docs_manifest.py",
+        "knowledge/tools/public_content.py",
+    ],
     visibility = ["//:__subpackages__"],
 )
 
 py_venv_binary(
     name = "gen_posts_manifest",
     main = "knowledge/tools/gen_posts_manifest.py",
+    srcs = [
+        "knowledge/tools/gen_posts_manifest.py",
+        "knowledge/tools/public_content.py",
+    ],
     visibility = ["//:__subpackages__"],
 )
 

--- a/projects/monolith/knowledge/gen_docs_manifest_test.py
+++ b/projects/monolith/knowledge/gen_docs_manifest_test.py
@@ -172,14 +172,40 @@ def test_manifest_json_round_trips(tmp_path: Path):
     assert json.loads(json.dumps(entries)) == entries
 
 
-def test_check_public_content_rejects_internal_markers():
-    import pytest
-
-    for body in (
+@pytest.mark.parametrize(
+    "body",
+    [
         "see http://gw.mcp.svc.cluster.local:80/mcp",
         "token from op://vault/item/field",
         "create vaults/k8s-homelab/items/thing first",
-    ):
-        with pytest.raises(SystemExit):
-            check_public_content("projects/x/README.md", body)
-    check_public_content("projects/x/README.md", "# fine\n\nplain prose\n")
+        "the pod sits at 10.42.0.17 on the overlay",
+        "curl 172.16.4.9:8080/health",
+        "router at 192.168.1.1",
+        "scratch lives on node-4",
+        "the guest landed on brick-2",
+        "artifacts in s3://artifacts/ambient-evals/",
+        "fetched from ca.egress.internal:80",
+        "export EMBERVM_NODED_BEARER_TOKEN=abc123",
+        "AUTH_ENCRYPTION_SECRET: hunter2",
+    ],
+)
+def test_check_public_content_rejects_internal_markers(body: str):
+    with pytest.raises(SystemExit):
+        check_public_content("projects/x/README.md", body)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "# fine\n\nplain prose\n",
+        # Dotted values key path, not a hostname.
+        "egress.internal.allowlist is one global list",
+        # Bare secret env var names are already in the public source tree.
+        "`OPENROUTER_API_KEY` must be set; it syncs `AUTH_ENCRYPTION_SECRET`",
+        # Public address space and version-ish numbers.
+        "reach 8.8.8.8 or 172.32.0.1 from v10.4",
+        "a node-local cache, brick-shaped, node-N",
+    ],
+)
+def test_check_public_content_accepts_public_prose(body: str):
+    check_public_content("projects/x/README.md", body)

--- a/projects/monolith/knowledge/gen_posts_manifest_test.py
+++ b/projects/monolith/knowledge/gen_posts_manifest_test.py
@@ -179,3 +179,26 @@ def test_entries_sort_newest_first_then_slug(tmp_path: Path):
     entries = build_manifest(tmp_path, paths)
 
     assert [entry["slug"] for entry in entries] == ["alpha", "zebra", "old"]
+
+
+def test_public_post_with_internal_marker_fails(tmp_path: Path):
+    path = write_post(
+        tmp_path,
+        "2026-01-15-leak.md",
+        public_frontmatter(),
+        "Call http://monolith-web.monolith.svc.cluster.local/api\n",
+    )
+
+    with pytest.raises(SystemExit, match=r"docs/posts/2026-01-15-leak.md:1"):
+        build_manifest(tmp_path, [path])
+
+
+def test_draft_post_with_internal_marker_is_skipped(tmp_path: Path):
+    path = write_post(
+        tmp_path,
+        "2026-01-15-draft.md",
+        "title: Draft\ndate: 2026-01-15\nsummary: One sentence.\npublic: false\n",
+        "Call http://monolith-web.monolith.svc.cluster.local/api\n",
+    )
+
+    assert build_manifest(tmp_path, [path]) == []

--- a/projects/monolith/knowledge/tools/gen_docs_manifest.py
+++ b/projects/monolith/knowledge/tools/gen_docs_manifest.py
@@ -29,6 +29,9 @@ from pathlib import Path
 try:  # imported as knowledge.tools.* by tests, run as a bare script by CI
     from knowledge.tools.public_content import check_public_content
 except ImportError:  # pragma: no cover - script invocation
+    # py_venv_binary executes the main without adding its source directory to
+    # sys.path, even though public_content.py is present beside it in runfiles.
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
     from public_content import check_public_content
 
 PUBLIC_PROJECTS = (

--- a/projects/monolith/knowledge/tools/gen_docs_manifest.py
+++ b/projects/monolith/knowledge/tools/gen_docs_manifest.py
@@ -26,6 +26,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+try:  # imported as knowledge.tools.* by tests, run as a bare script by CI
+    from knowledge.tools.public_content import check_public_content
+except ImportError:  # pragma: no cover - script invocation
+    from public_content import check_public_content
+
 PUBLIC_PROJECTS = (
     ("embervm", "projects/embervm"),
     ("monolith", "projects/monolith"),
@@ -118,25 +123,6 @@ def iter_doc_paths(root: Path) -> list[str]:
     """Return tracked public doc paths in project and document-kind order."""
     tracked = _git_ls_files(root)
     return [path for path in _DOC_BY_PATH if path in tracked]
-
-
-# Content that must never reach the public site. The allowlist is by path, so
-# a doc that is correctly public can still paste an internal identifier into
-# itself; this is the only content check and it fails the generator loudly.
-_INTERNAL_MARKERS: tuple[tuple[str, re.Pattern[str]], ...] = (
-    ("in-cluster service hostname", re.compile(r"\.svc\.cluster\.local")),
-    ("1Password op:// reference", re.compile(r"op://")),
-    ("1Password vault item path", re.compile(r"vaults/[\w-]+/items/")),
-)
-
-
-def check_public_content(rel_path: str, content: str) -> None:
-    """Raise if a public doc contains an internal-only identifier."""
-    for label, pattern in _INTERNAL_MARKERS:
-        match = pattern.search(content)
-        if match:
-            line = content.count("\n", 0, match.start()) + 1
-            raise SystemExit(f"{rel_path}:{line}: public doc contains {label}")
 
 
 def build_manifest(root: Path, paths: list[str]) -> list[dict]:

--- a/projects/monolith/knowledge/tools/gen_posts_manifest.py
+++ b/projects/monolith/knowledge/tools/gen_posts_manifest.py
@@ -2,8 +2,10 @@
 
 Tracked Markdown files under ``docs/posts`` are considered, except README.md.
 Files with a ``public`` key are parsed and validated, and only those declaring
-the exact gate ``public: true`` are published. The committed manifest contains
-the metadata and post bodies used by the SvelteKit server routes.
+the exact gate ``public: true`` are published, and each published body must
+pass the same internal-marker check as the public docs manifest
+(``public_content.check_public_content``). The committed manifest contains the
+metadata and post bodies used by the SvelteKit server routes.
 """
 
 from __future__ import annotations
@@ -15,6 +17,11 @@ import subprocess
 import sys
 from datetime import date
 from pathlib import Path
+
+try:  # imported as knowledge.tools.* by tests, run as a bare script by CI
+    from knowledge.tools.public_content import check_public_content
+except ImportError:  # pragma: no cover - script invocation
+    from public_content import check_public_content
 
 POSTS_PREFIX = "docs/posts/"
 MANIFEST_REL = "projects/monolith/frontend/src/lib/public/posts/posts-manifest.json"
@@ -166,6 +173,7 @@ def build_manifest(root: Path, paths: list[str]) -> list[dict]:
             _validate_public_post(rel_path, metadata)
         except ValueError as exc:
             raise ValueError(f"{rel_path}: {exc}") from exc
+        check_public_content(rel_path, body)
         slug = make_slug(rel_path)
         previous_path = path_by_slug.get(slug)
         if previous_path is not None:

--- a/projects/monolith/knowledge/tools/gen_posts_manifest.py
+++ b/projects/monolith/knowledge/tools/gen_posts_manifest.py
@@ -21,6 +21,9 @@ from pathlib import Path
 try:  # imported as knowledge.tools.* by tests, run as a bare script by CI
     from knowledge.tools.public_content import check_public_content
 except ImportError:  # pragma: no cover - script invocation
+    # py_venv_binary executes the main without adding its source directory to
+    # sys.path, even though public_content.py is present beside it in runfiles.
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
     from public_content import check_public_content
 
 POSTS_PREFIX = "docs/posts/"

--- a/projects/monolith/knowledge/tools/public_content.py
+++ b/projects/monolith/knowledge/tools/public_content.py
@@ -1,0 +1,57 @@
+"""Content guard for documents that reach jomcgi.dev.
+
+The public docs and posts pipelines allowlist by path (a fixed project list, a
+``public: true`` frontmatter gate). A doc that is correctly public can still
+paste an internal identifier into itself, which is how an in-cluster hostname
+reached the public site twice on 2026-08-22 (#5144). This is the only content
+check and it fails the generator loudly; the generators run in CI's Format
+stage, so the failure lands on the PR rather than on the merge-time regen.
+
+The repository itself is public, so the markers target in-cluster addressing
+and pasted credentials, not identifiers that already appear in source.
+"""
+
+from __future__ import annotations
+
+import re
+
+_INTERNAL_MARKERS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("in-cluster service hostname", re.compile(r"\.svc\.cluster\.local")),
+    ("1Password op:// reference", re.compile(r"op://")),
+    ("1Password vault item path", re.compile(r"vaults/[\w-]+/items/")),
+    (
+        "private IPv4 address",
+        re.compile(
+            r"\b(?:10\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])|192\.168)"
+            r"(?:\.\d{1,3}){2}\b"
+        ),
+    ),
+    ("cluster node name", re.compile(r"\bnode-\d+\b")),
+    ("brick name", re.compile(r"\bbrick-\d+\b")),
+    ("S3 bucket URI", re.compile(r"\bs3://")),
+    # A hostname ending in .internal (ca.egress.internal). The lookahead keeps
+    # dotted YAML key paths such as egress.internal.allowlist out of it.
+    (
+        ".internal hostname",
+        re.compile(r"\b[\w-]+(?:\.[\w-]+)*\.internal\b(?!\.\w)"),
+    ),
+    # A secret-shaped env var WITH a value pasted next to it. Bare names are
+    # already in the public source tree, so only the assignment is a leak.
+    (
+        "secret env var assignment",
+        re.compile(
+            r"\b[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*_"
+            r"(?:TOKEN|SECRET|PASSWORD|PASSPHRASE|API_KEY|PRIVATE_KEY)"
+            r"[ \t]*[=:][ \t]*\S"
+        ),
+    ),
+)
+
+
+def check_public_content(rel_path: str, content: str) -> None:
+    """Raise ``SystemExit`` if a public document contains an internal marker."""
+    for label, pattern in _INTERNAL_MARKERS:
+        match = pattern.search(content)
+        if match:
+            line = content.count("\n", 0, match.start()) + 1
+            raise SystemExit(f"{rel_path}:{line}: public doc contains {label}")


### PR DESCRIPTION
## Summary

- centralize public-content checks shared by docs and posts manifest generation
- reject private IPs, cluster node and brick names, S3 URIs, internal hostnames, and assigned secret-shaped environment variables
- validate published post bodies while continuing to skip draft posts
- ship the shared guard in both Bazel generator targets and cover rejected and accepted prose

## Validation

- `pytest projects/monolith/knowledge/gen_docs_manifest_test.py projects/monolith/knowledge/gen_posts_manifest_test.py`: 49 passed
- `ci test`: 746 tests passed
- BuildBuddy: https://app.buildbuddy.io/invocation/86cb8933-dbb9-4b09-812b-4fa12fcd63d2
- pre-push `ci test`: passed

Closes #5144