### PR TITLE
feat(embervm): first serving-class workload, an internal serving-path prover

### DIFF
--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -37,6 +37,7 @@ multirun(
         "//projects/embervm/runtimes/k3s/k3s-agent:image.push",
         "//projects/embervm/runtimes/k3s/k3s-server:image.push",
         "//projects/embervm/runtimes/pi:image.push",
+        "//projects/embervm/runtimes/ping:image.push",
         "//projects/embervm/runtimes/postgres:image.push",
         "//projects/embervm/runtimes/python:image.push",
         "//projects/embervm/runtimes/shotter:image.push",

--- a/bazel/images/digests/BUILD
+++ b/bazel/images/digests/BUILD
@@ -19,6 +19,7 @@ oci_digest_manifest(
         "//projects/embervm/runtimes/k3s/k3s-agent:image.info": "//projects/embervm/runtimes/k3s/k3s-agent:image.push",
         "//projects/embervm/runtimes/k3s/k3s-server:image.info": "//projects/embervm/runtimes/k3s/k3s-server:image.push",
         "//projects/embervm/runtimes/pi:image.info": "//projects/embervm/runtimes/pi:image.push",
+        "//projects/embervm/runtimes/ping:image.info": "//projects/embervm/runtimes/ping:image.push",
         "//projects/embervm/runtimes/postgres:image.info": "//projects/embervm/runtimes/postgres:image.push",
         "//projects/embervm/runtimes/python:image.info": "//projects/embervm/runtimes/python:image.push",
         "//projects/embervm/runtimes/shotter:image.info": "//projects/embervm/runtimes/shotter:image.push",

--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -53,6 +53,10 @@ helm_chart(
         # entry, and the Workload's source.image.ref all resolve to the same
         # digest.
         "runtimePi.guestImage": "//projects/embervm/runtimes/pi:image.info",
+        # First serving-class workload (#5180): the internal serving-path
+        # prover, a minimal Go HTTP guest. Distinct FLAT top-level key,
+        # digest-pinned from its .info.
+        "pingWorkload.guestImage": "//projects/embervm/runtimes/ping:image.info",
         # R4 stateful consumer (D-R4.PR-11.1): the scratch-postgres base image.
         # Distinct FLAT top-level key (D14a.6), digest-pinned from its .info.
         "scratchPostgres.guestImage": "//projects/embervm/runtimes/postgres:image.info",

--- a/projects/embervm/chart/templates/workload-ping.yaml
+++ b/projects/embervm/chart/templates/workload-ping.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.pingWorkload.enabled }}
+# Internal serving-path prover. EndpointPublisher publishes the serving host to
+# node Envoy only; there is deliberately no edge HTTPRoute or egress policy.
+apiVersion: embervm.dev/v1alpha1
+kind: Workload
+metadata:
+  name: {{ .Values.pingWorkload.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    {{- include "embervm.labels" . | nindent 4 }}
+spec:
+  class: serving
+  source:
+    image:
+      # Bazel-pinned from the ping guest image's .info provider. This is the
+      # same ref the rootfs builder bakes and node image identity publishes.
+      ref: "{{ .Values.pingWorkload.guestImage.repository }}@{{ .Values.pingWorkload.guestImage.digest }}"
+      port: {{ .Values.pingWorkload.port }}
+      readyPath: {{ .Values.pingWorkload.readyPath | quote }}
+      initEnv:
+        EMBER_HYPERVISOR_EPOCH: {{ .Values.hypervisorEpoch | quote }}
+  resources:
+    vcpus: {{ .Values.pingWorkload.vcpus }}
+    memMib: {{ .Values.pingWorkload.memMib }}
+  concurrency:
+    cap: {{ .Values.pingWorkload.maxInstances }}
+  serving:
+    port: {{ .Values.pingWorkload.port }}
+    healthPath: {{ .Values.pingWorkload.healthPath | quote }}
+    host: {{ .Values.pingWorkload.host | quote }}
+    minInstances: {{ .Values.pingWorkload.minInstances }}
+    maxInstances: {{ .Values.pingWorkload.maxInstances }}
+    idleBankSeconds: {{ .Values.pingWorkload.idleBankSeconds }}
+    bankedTtlSeconds: {{ .Values.pingWorkload.bankedTtlSeconds }}
+    nodeLocalWake: {{ .Values.pingWorkload.nodeLocalWake }}
+{{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -675,6 +675,11 @@ workloads:
   runtimePi:
     rootfsPath: /var/lib/embervm/scratch/embervm-noded/runtime-pi/rootfs.ext4
     harnessInit: /usr/local/bin/ember-runtime-guest-init
+  # Internal serving-path prover. The Go server is PID 1, so its image binary
+  # path is also the per-image harness init used for cold serving boots.
+  pingWorkload:
+    rootfsPath: /var/lib/embervm/scratch/embervm-noded/ping/rootfs.ext4
+    harnessInit: /opt/app
   # R4 scratch-postgres stateful base (ADR embervm/001, D-R4.PR-11.1). Its PID-1
   # ember-postgres-init mounts the writable volume, decodes POSTGRES_PASSWORD from
   # the mmds_env boot-args, and runs initdb-if-empty then postgres. The key must
@@ -1784,3 +1789,26 @@ piRuntimeWorkload:
     # returns a specific shim error instead of a generic transport cancel.
     # Dropping this below 600 inverts that for a few minutes of a held cap slot.
     timeoutSeconds: 900
+
+# The first serving-class workload. It is cluster-internal only: the
+# EndpointPublisher owns the vhost below for node Envoy, with no edge HTTPRoute
+# and no egress lane. A zero floor exercises miss-wake, idle bank, and relight;
+# nodeLocalWake also proves the brick-local activator path during a CP gap.
+pingWorkload:
+  enabled: true
+  name: ping
+  port: 8080
+  readyPath: /healthz
+  healthPath: /healthz
+  host: ping.embervm.internal
+  vcpus: 1
+  memMib: 128
+  minInstances: 0
+  maxInstances: 1
+  idleBankSeconds: 120
+  bankedTtlSeconds: 3600
+  nodeLocalWake: true
+  guestImage:
+    repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/ping
+    tag: latest
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000

--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -356,6 +356,11 @@ workloads:
   # which is where production's bricks live.
   shotter:
     rootfsPath: /var/lib/embervm/scratch/dev/embervm-noded/shotter/rootfs.ext4
+  # The serving-path prover (#5180) RUNS in dev (enabled true): it is the
+  # serving-class soak lane, so its builder path is mandatory under the dev
+  # scratch for the same unbacked-mkfs reason as every entry above.
+  pingWorkload:
+    rootfsPath: /var/lib/embervm/scratch/dev/embervm-noded/ping/rootfs.ext4
 
 # The serving lane, off. Dev exercises task-class lifecycle for the conformance
 # harness, not serving or stateful workloads.

--- a/projects/embervm/runtimes/ping/BUILD
+++ b/projects/embervm/runtimes/ping/BUILD
@@ -1,0 +1,18 @@
+# gazelle:ignore
+load("@rules_go//go:def.bzl", "go_binary")
+load("//bazel/tools/oci:go_image.bzl", "go_image")
+
+# Minimal serving-class prover. The pure Go binary is the guest's PID 1 and
+# listens directly on the tap-facing HTTP port. go_image publishes the same
+# :image and public :image.info targets that helm_chart consumes for the pi
+# runtime, so the chart can inject a content-addressed guest image reference.
+go_binary(
+    name = "ping",
+    srcs = ["main.go"],
+)
+
+go_image(
+    name = "image",
+    binary = ":ping",
+    repository = "ghcr.io/jomcgi/homelab/projects/embervm/runtimes/ping",
+)

--- a/projects/embervm/runtimes/ping/main.go
+++ b/projects/embervm/runtimes/ping/main.go
@@ -1,0 +1,34 @@
+// Command ping is the minimal HTTP guest used to prove the EmberVM serving
+// path. It has no outbound dependencies and serves only health and identity.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+const listenAddress = ":8080"
+
+func main() {
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Fatalf("read hostname: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = fmt.Fprintf(w, "embervm ping from %s at %s\n", hostname, time.Now().UTC().Format(time.RFC3339Nano))
+	})
+
+	log.Printf("embervm ping listening on %s", listenAddress)
+	if err := http.ListenAndServe(listenAddress, mux); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Closes #5180.

The Serving class was Built-but-never-exercised: no serving-class Workload existed anywhere (2026-08-22 audit verdict UNTESTED). This stands up the minimal prover decided on the issue:

- `projects/embervm/runtimes/ping`: tiny Go HTTP guest (GET /healthz 200; GET / identifying body) as PID 1 on the tap-facing port, built and Bazel-pinned via go_image :image.info exactly like runtimes/pi.
- Chart values pingWorkload (enabled true) + templates/workload-ping.yaml: class serving, host ping.embervm.internal (internal-only vhost; EndpointPublisher routes on spec.serving.host, endpoint_publisher.ex:28), min 0/max 1 instances, idleBankSeconds 120, bankedTtlSeconds 3600, nodeLocalWake true so a CP roll exercises noded L7 activator.
- Dev arms it with the mandatory scratch-dev rootfsPath override (builders gate separately from CRs); the dev-rootfs conformance test caught the first cut inheriting the unbacked production path.

Validation: remote ci green on //projects/embervm/chart targets (744 tests pass). Reviewer findings were folded in pre-commit (agent dispatch was down, so the review ran in the main loop against the checklist: CRD field conformance verified programmatically, pi conventions matched, images-map collision ruled out by construction).

Post-merge drill (evidence goes on #5180): cold miss wake -> splice -> 200 on the internal vhost, idle bank at 120s, relight, then activator-during-roll.