### PR TITLE
fix(embervm): bound session invoke wall clock

### DIFF
--- a/projects/embervm/chart/chart_env_identity_test.py
+++ b/projects/embervm/chart/chart_env_identity_test.py
@@ -175,7 +175,7 @@ def test_renders_are_non_empty(renders):
     )
 
 
-def test_dev_brick_controller_and_warmth_gc_envs_render(renders):
+def test_control_plane_runtime_envs_render(renders):
     def control_plane_env(rendered: str) -> dict[str, str]:
         deployments = [
             doc
@@ -205,6 +205,8 @@ def test_dev_brick_controller_and_warmth_gc_envs_render(renders):
     assert prod_env.get("EMBERVM_ENVELOPE_REWRAP_MAX_ARTIFACTS") == "100"
     assert prod_env.get("EMBERVM_ENVELOPE_REWRAP_CONCURRENCY") == "8"
     assert prod_env.get("EMBERVM_ENVELOPE_REWRAP_INTERVAL_MS") == "3600000"
+    assert prod_env.get("EMBERVM_SESSION_INVOKE_WATCHDOG_MARGIN_MS") == "15000"
+    assert dev_env.get("EMBERVM_SESSION_INVOKE_WATCHDOG_MARGIN_MS") == "15000"
 
 
 def test_noded_bearer_secret_flips_control_plane_and_bricks_together():

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -260,6 +260,10 @@ spec:
             - name: EMBERVM_PRINCIPAL_SHARE_FRACTION
               value: {{ .Values.dispatcher.principalShareFraction | quote }}
             {{- end }}
+            # Session invoke wall-clock watchdog margin (#4434): last-resort kill
+            # of a SessionAssign worker that outlived the server-enforced deadline.
+            - name: EMBERVM_SESSION_INVOKE_WATCHDOG_MARGIN_MS
+              value: {{ .Values.session.invokeWatchdogMarginMs | quote }}
             # Metering + quotas (Task 12). Per-principal daily vCPU-second budgets
             # rendered as `principal=budget` pairs (quota OFF when the map is
             # empty), an optional blanket default, and the usage-read admin list.

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -251,6 +251,18 @@ dispatcher:
   # the others. Set a fraction in (0, 1] to fix each principal's share instead.
   principalShareFraction: ""
 
+# Session-process tuning (control-plane env).
+session:
+  # Invoke wall-clock watchdog margin (#4434), in ms. A session invoke's gRPC
+  # deadline is a header the SERVER enforces, so on an orphaned channel (#4419)
+  # nothing fires and the invoke worker wedges forever, pinning the session's
+  # slot against the workload cap. The control plane kills the worker and fails
+  # the session once the invoke has run for the workload's timeoutSeconds plus
+  # the 5s transport headroom plus this margin. It must stay strictly above zero
+  # so the server-enforced deadline always fires first and the client-side kill
+  # is last resort. Matches the dispatcher's assign watchdog margin.
+  invokeWatchdogMarginMs: 15000
+
 # Metering, audit, and quotas (Task 12). Quota is OPT-IN and asymmetric to the
 # auth allow-list: an empty budget map means quota is OFF (principals with no
 # configured budget are allowed), NOT deny-all. Budgets are per-principal DAILY

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -955,10 +955,14 @@ defmodule Embervm.Application do
 
   defp pool_opts, do: [op_log: op_log_mod(), op_log_mod: op_log_mod()]
 
-  # Extra opts threaded into every Embervm.Session the SessionManager starts. Empty
-  # in production (the session process uses its real NodeChannel/SessionAssign
-  # defaults); tests inject fake daemon seams here.
-  defp session_opts, do: []
+  # Extra opts threaded into every Embervm.Session the SessionManager starts. The
+  # session process uses its real NodeChannel/SessionAssign defaults in production
+  # (tests inject fake daemon seams here); the one chart-wired knob is the invoke
+  # wall-clock watchdog margin (#4434), added on top of the transport deadline so
+  # a wedged SessionAssign on an orphaned channel cannot pin the session forever.
+  defp session_opts do
+    [invoke_watchdog_margin_ms: env_ms("EMBERVM_SESSION_INVOKE_WATCHDOG_MARGIN_MS", 15_000)]
+  end
 
   # SessionManager config: the session-process seams plus the R2 policy knobs the
   # chart wires from values (the reconcile/sweep cadences, the snapshot-disk low

--- a/projects/embervm/control/lib/embervm/session.ex
+++ b/projects/embervm/control/lib/embervm/session.ex
@@ -72,6 +72,11 @@ defmodule Embervm.Session do
   alias Embervm.Node.V1.{GuestRequest, GuestResponse, SessionAssignRequest, SessionAssignResponse, Trace}
   alias Embervm.SessionTrace
 
+  # Default margin the invoke watchdog adds on top of transport_timeout/1. Matches
+  # the dispatcher's @assign_watchdog_margin_ms; overridable per deploy through
+  # EMBERVM_SESSION_INVOKE_WATCHDOG_MARGIN_MS.
+  @invoke_watchdog_margin_ms 15_000
+
   # -- Client API ------------------------------------------------------------
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -121,6 +126,18 @@ defmodule Embervm.Session do
       # round-trip timeout, and (PR-4) the idle-bank delay.
       queue_cap: Keyword.fetch!(opts, :queue_cap),
       timeout_ms: Keyword.get(opts, :timeout_ms, 90_000),
+      # Invoke wall-clock watchdog (#4434). The gRPC deadline on SessionAssign is
+      # a header the SERVER enforces, so on an orphaned channel (#4419) nothing
+      # fires and the worker sits in build_stream/2 forever, pinning `worker` and
+      # the session's slot. The watchdog budget is transport_timeout(timeout_ms)
+      # plus this margin, so the server-enforced deadline always gets first shot
+      # and the client-side kill is genuinely last resort. Chart-wired via
+      # EMBERVM_SESSION_INVOKE_WATCHDOG_MARGIN_MS (values session.invokeWatchdogMarginMs).
+      invoke_watchdog_margin_ms:
+        Keyword.get(opts, :invoke_watchdog_margin_ms, @invoke_watchdog_margin_ms),
+      # Test-only seam: when set, IS the watchdog budget (tests avoid waiting out
+      # the 5s transport headroom floor). nil in production.
+      invoke_watchdog_ms: Keyword.get(opts, :invoke_watchdog_ms, nil),
       # The guest path a bare invoke (no explicit X-Ember-Guest-Path) is forwarded
       # to. Defaults to the shim's only route, /invoke; the create/restart paths pass
       # the workload's configured invokePath so a custom path is honored.
@@ -137,7 +154,8 @@ defmodule Embervm.Session do
       destroy_fun: Keyword.get(opts, :destroy_fun, &default_destroy/2),
       rejoin_failure_fun: Keyword.get(opts, :rejoin_failure_fun),
       # FIFO of {from, req} waiting their turn; the head runs when no worker is in
-      # flight. `worker` is the {pid, ref, from} of the in-flight invoke, or nil.
+      # flight. `worker` is the {pid, ref, from, watchdog_timer} of the in-flight
+      # invoke, or nil.
       queue: :queue.new(),
       worker: nil,
       # The armed idle-bank timer ref (nil when disarmed).
@@ -172,8 +190,11 @@ defmodule Embervm.Session do
   end
 
   @impl true
-  def handle_info({:invoke_done, pid, outcome}, %{worker: {pid, ref, from}} = state) do
+  def handle_info({:invoke_done, pid, outcome}, %{worker: {pid, ref, from, timer}} = state) do
     Process.demonitor(ref, [:flush])
+    # Defensive cancellation: a late {:invoke_timeout, ref} is harmless because
+    # the handler compares the ref against the live worker.
+    _ = Process.cancel_timer(timer)
     state = %{state | worker: nil}
 
     case outcome do
@@ -199,10 +220,38 @@ defmodule Embervm.Session do
 
   # A worker died without reporting (it always sends {:invoke_done, ...}): treat as
   # a transport failure, same as a reported error (same durable-before-reply order).
-  def handle_info({:DOWN, ref, :process, pid, down_reason}, %{worker: {pid, ref, from}} = state) do
+  def handle_info({:DOWN, ref, :process, pid, down_reason}, %{worker: {pid, ref, from, timer}} = state) do
+    _ = Process.cancel_timer(timer)
     state = %{state | worker: nil}
     fail_and_stop(state, {:worker_down, down_reason}, from)
   end
+
+  # The invoke wall-clock watchdog fired (#4434): the worker has outlived the
+  # server-enforced gRPC deadline plus margin, so nothing is going to complete it.
+  # Kill it, answer the parked caller, and fail the session exactly as a transport
+  # timeout would (the guest is in an unknown mid-request state, the failure
+  # posture above): the VM is destroyed, queued callers drain as :failed, and the
+  # process stops, releasing the session's slot. Keyed on the unique monitor ref
+  # (the SessionManager create_timeout pattern), so a stale timer for a finished
+  # worker, or a reused pid, never kills the wrong thing.
+  def handle_info({:invoke_timeout, ref}, %{worker: {pid, ref, from, _timer}} = state) do
+    Process.demonitor(ref, [:flush])
+
+    Logger.warning(
+      "session invoke worker watchdog fired (budget=#{invoke_watchdog_ms(state)}ms)",
+      session_id: state.session_id,
+      workload: state.workload,
+      node_id: state.node_id
+    )
+
+    Process.exit(pid, :kill)
+    state = %{state | worker: nil}
+    # Preserve the durable-before-observed failure ordering from #4644: append
+    # session_failed before the timed-out caller receives its error.
+    fail_and_stop(state, :invoke_timeout, from)
+  end
+
+  def handle_info({:invoke_timeout, _stale_ref}, state), do: {:noreply, state}
 
   # The idle-bank timer fired. ASK the manager to bank ONLY if still quiescent (no
   # worker, empty queue); a stale timer (idle_timer already cleared) is ignored. On
@@ -280,7 +329,10 @@ defmodule Embervm.Session do
     case :queue.out(state.queue) do
       {{:value, {from, req, enqueued_at}}, rest} ->
         {pid, ref} = spawn_invoke_worker(state, req, enqueued_at)
-        %{state | queue: rest, worker: {pid, ref, from}}
+        # Last-resort wall clock (#4434): must fire AFTER the gRPC deadline the
+        # server enforces, so the normal DEADLINE_EXCEEDED path gets first shot.
+        timer = Process.send_after(self(), {:invoke_timeout, ref}, invoke_watchdog_ms(state))
+        %{state | queue: rest, worker: {pid, ref, from, timer}}
 
       {:empty, _} ->
         arm_idle_timer(state)
@@ -288,6 +340,14 @@ defmodule Embervm.Session do
   end
 
   defp maybe_start_next(state), do: state
+
+  # The watchdog budget: the injected test value, or the transport deadline (which
+  # already exceeds the guest's timeout_ms by @headroom_ms) plus the margin. Same
+  # shape as the dispatcher's assign watchdog; the two must stay strictly above
+  # their respective server-enforced deadlines.
+  defp invoke_watchdog_ms(state) do
+    state.invoke_watchdog_ms || transport_timeout(state.timeout_ms) + state.invoke_watchdog_margin_ms
+  end
 
   defp spawn_invoke_worker(state, req, enqueued_at) do
     owner = self()

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -113,7 +113,9 @@ defmodule Embervm.SessionManagerTest do
       channel_fun: Keyword.get(opts, :session_channel_fun, fn _node -> {:ok, :ch} end),
       assign_fun: assign_fun,
       destroy_fun: Keyword.get(opts, :destroy_fun, fn _ch, _vm -> {:ok, %{teardown_confirmed: true}} end),
-      invalidate_fun: fn _node, _ch -> :ok end
+      invalidate_fun: fn _node, _ch -> :ok end,
+      # Test-only watchdog budget (#4434); nil keeps the production formula.
+      invoke_watchdog_ms: Keyword.get(opts, :invoke_watchdog_ms)
     ]
 
     mgr_opts =
@@ -1801,6 +1803,66 @@ defmodule Embervm.SessionManagerTest do
     assert {:error, :queue_full} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "y"})
 
     Enum.each(callers, fn pid -> Process.exit(pid, :kill) end)
+  end
+
+  test "a wedged invoke worker is killed by the wall-clock watchdog and releases the slot" do
+    # #4434: a SessionAssign stuck in the client stream (orphaned channel, the
+    # server never sees the deadline header) must not pin the session forever.
+    # The first assign sleeps forever; any later one (a new session) answers.
+    {:ok, assigns} = Agent.start_link(fn -> 0 end)
+
+    assign_fun = fn _ch, req ->
+      case Agent.get_and_update(assigns, fn n -> {n, n + 1} end) do
+        0 ->
+          :timer.sleep(:infinity)
+
+        _ ->
+          {:ok,
+           %SessionAssignResponse{
+             response: %GuestResponse{status_code: 200, headers: %{}, body: req.request.body},
+             usage: %UsageStats{cpu_ms: 1, peak_rss_mib: 1, wall_ms: 1},
+             suspect: false
+           }}
+      end
+    end
+
+    ctx = start_stack(assign_fun: assign_fun, invoke_watchdog_ms: 150)
+    put_session_workload(ctx, "wl-wedge", cap: 1, max_sessions: 8)
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-wedge", "p1")
+
+    # The wedged invoke plus one caller queued behind it.
+    wedged = Task.async(fn -> SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"}) end)
+    assert eventually(fn -> Agent.get(assigns, & &1) == 1 end)
+    queued = Task.async(fn -> SessionManager.invoke(ctx.mgr, created.session_id, %{body: "y"}) end)
+    Process.sleep(50)
+    # Nothing has fired yet: the caller is still parked (no spurious early kill).
+    assert nil == Task.yield(wedged, 0)
+
+    # The watchdog fires: the parked caller gets the timeout, the queued caller
+    # drains as :failed, and the session is failed (unknown guest state).
+    assert {:error, :invoke_timeout} = Task.await(wedged, 2_000)
+    assert {:error, :failed} = Task.await(queued, 2_000)
+
+    assert eventually(fn ->
+             match?({:ok, %{state: :failed}}, SessionStore.get(ctx.store, created.session_id))
+           end)
+
+    # The slot is released: with cap 1, a fresh create on the workload is admitted
+    # and its invoke completes on the healthy assign path.
+    assert {:ok, fresh} = SessionManager.create(ctx.mgr, "wl-wedge", "p1")
+    assert {:ok, %{status_code: 200, body: "z"}} = SessionManager.invoke(ctx.mgr, fresh.session_id, %{body: "z"})
+  end
+
+  test "a fast invoke completes without the watchdog firing" do
+    ctx = start_stack(invoke_watchdog_ms: 150)
+    put_session_workload(ctx, "wl-fast-invoke")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-fast-invoke", "p1")
+
+    assert {:ok, %{status_code: 200, body: "a"}} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "a"})
+    # Well past the budget: the session is still running and serves the next invoke.
+    Process.sleep(300)
+    assert {:ok, %{status_code: 200, body: "b"}} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "b"})
+    assert {:ok, %{state: :running}} = SessionStore.get(ctx.store, created.session_id)
   end
 
   test "a suspect/transport failure on invoke fails the session and 502s the caller" do


### PR DESCRIPTION
## What\n\n- add a last-resort wall-clock watchdog for each session invoke\n- start the watchdog after the server-enforced transport deadline plus a configurable margin\n- kill a wedged invoke worker, fail the session, drain queued callers, and release its capacity slot\n- expose the 15 second default through production and development Helm environments\n- add regression coverage for wedged and fast invokes plus rendered chart identity\n\n## Why\n\nA SessionAssign stream can wedge before the server observes its deadline. The worker then remains live indefinitely, pinning the session and its capacity slot.\n\n## Validation\n\n- fresh repository remote CI: 1409 tests, 0 failures, 6 skipped\n- fresh repository remote CI: 16 tests, 0 failures\n- fresh repository remote CI: build completed successfully\n- fresh repository remote CI: 744 tests pass\n- rebase formatting hook passed\n- push-time remote CI hook passed\n- git show --check passed\n\nCloses #4434\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)