### PR TITLE
chore(embervm): enable the production KEK root

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -142,6 +142,16 @@ tracing:
   endpoint: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4317"
   serviceName: embervm-control
 
+# Platform KEK root (ADR embervm/036, #4976), rollout step 1 for #4691.
+# This only gives the control plane access to the existing 1Password item;
+# artifact encryption and noded's writer remain disabled until the root is
+# observed live. The secretKeyRef is optional, so a missing item leaves the
+# custodian inert instead of blocking the control-plane rollout.
+kekRoot:
+  enabled: true
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/embervm-kek-root"
+
 # Node capacity override (cluster-specific; the chart default of 8 is a
 # conservative backstop). node-4 is a ~62Gi box (27% used), and the two platform
 # pools alone (semgrep floor 4 + sandbox floor 4) consume all 8 default slots,


### PR DESCRIPTION
Refs #4691 and #4976.

This is rollout step 1 for production principal-artifact encryption. It gives the control plane access to the existing `embervm-kek-root` 1Password item. Artifact encryption, the noded writer, and restore-capability enforcement remain disabled until the root is observed live.

Validation:
- `git diff --check`
- `pytest -q projects/embervm/chart/chart_env_identity_test.py -k kek_root` (`1 passed, 15 deselected`)
- pre-push remote `ci test` passed

Rollback is removing the `kekRoot` override; the optional secret reference keeps a missing item from blocking control-plane startup.