### PR TITLE
fix(egress-proxy): bind requests and bound hostile input

### DIFF
--- a/projects/firecracker/substrate/egress-proxy/cmd/main.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/main.go
@@ -47,6 +47,7 @@
 //   - EGRESS_INTERNAL_DEFAULT: "deny" (default) or "allow" for internal ones.
 //   - EGRESS_INTERNAL_ALLOWLIST: comma-separated host[:port] permitted internally.
 //   - EGRESS_INTERNAL_CIDRS: comma-separated extra CIDRs classified as internal.
+//   - EGRESS_MAX_CONNS: maximum concurrent guest connections (default 256).
 //   - EGRESS_SECRETS: the credential catalog; enables the plaintext inject lane.
 //   - EGRESS_CA_CERT_FILE / EGRESS_CA_KEY_FILE: optional, adds the TLS-MITM lane.
 package main
@@ -60,11 +61,18 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
-// dialTimeout bounds the upstream connect; it does not cap a tunnel's lifetime.
-const dialTimeout = 30 * time.Second
+const (
+	// dialTimeout bounds the upstream connect; it does not cap a tunnel's lifetime.
+	dialTimeout      = 30 * time.Second
+	maxPreambleBytes = 1024
+	defaultMaxConns  = 256
+)
+
+var handshakeTimeout = 10 * time.Second
 
 // exitFn is os.Exit, indirected so the fail-closed config paths are testable.
 var exitFn = os.Exit
@@ -84,6 +92,7 @@ func main() {
 	internalDefaultAllow := envOr("EGRESS_INTERNAL_DEFAULT", "deny") == "allow"
 	internalAllowlist := parseAllowlist(os.Getenv("EGRESS_INTERNAL_ALLOWLIST"))
 	extraInternalNets := parseCIDRs(logger, os.Getenv("EGRESS_INTERNAL_CIDRS"))
+	maxConns := maxConnsFromEnv(logger)
 
 	logger.Info("egress-proxy starting",
 		"listen", listen,
@@ -91,6 +100,7 @@ func main() {
 		"internalDefaultAllow", internalDefaultAllow,
 		"internalAllowlist", internalAllowlist,
 		"extraInternalCIDRs", len(extraInternalNets),
+		"maxConns", maxConns,
 	)
 	if !internalDefaultAllow && len(internalAllowlist) == 0 {
 		logger.Warn("internal egress deny-by-default with an empty allowlist; all internal destinations will be denied")
@@ -124,6 +134,7 @@ func main() {
 		brokerURL:            brokerURL,
 		minter:               minter,
 		logger:               logger,
+		conns:                make(chan struct{}, maxConns),
 	}
 
 	ln, err := net.Listen("tcp", listen)
@@ -143,6 +154,12 @@ func main() {
 		// to an 11.24 MiB clone, so disable Nagle on this socket.
 		if tcpConn, ok := conn.(*net.TCPConn); ok {
 			_ = tcpConn.SetNoDelay(true)
+		}
+		if !p.acquireConn() {
+			total := p.rejectedConns.Load()
+			logger.Warn("egress connection cap reached; rejecting", "cap", cap(p.conns), "rejected", total)
+			_ = conn.Close()
+			continue
 		}
 		go p.handle(conn)
 	}
@@ -179,23 +196,66 @@ type proxy struct {
 	// the TLS-MITM lane (the plaintext inject lane does not need it).
 	minter *caMinter
 	logger *slog.Logger
+	// conns bounds concurrent guest connections. A nil channel leaves the proxy
+	// unlimited for tests and other direct construction sites.
+	conns         chan struct{}
+	rejectedConns atomic.Int64
+}
+
+func (p *proxy) acquireConn() bool {
+	if p.conns == nil {
+		return true
+	}
+	select {
+	case p.conns <- struct{}{}:
+		return true
+	default:
+		p.rejectedConns.Add(1)
+		return false
+	}
+}
+
+func (p *proxy) releaseConn() {
+	if p.conns != nil {
+		<-p.conns
+	}
 }
 
 // handle services one guest connection: read the "host:port" preamble, apply the
 // split-horizon guardrail (resolve + classify + pin), then inject a credential for
 // a secret-bearing destination or blind-tunnel to the pinned upstream.
 func (p *proxy) handle(client net.Conn) {
+	defer p.releaseConn()
 	defer client.Close()
 	br := bufio.NewReader(client)
 
-	line, err := br.ReadString('\n')
-	if err != nil {
-		p.logger.Warn("egress preamble read failed", "err", err)
+	if err := client.SetReadDeadline(time.Now().Add(handshakeTimeout)); err != nil {
+		p.logger.Warn("egress preamble deadline failed", "err", err)
 		return
 	}
-	host, port := splitHostPort(strings.TrimSpace(line))
+	line := make([]byte, 0, maxPreambleBytes)
+	for len(line) < maxPreambleBytes {
+		b, err := br.ReadByte()
+		if err != nil {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				p.logger.Warn("egress preamble timeout", "err", err)
+			} else {
+				p.logger.Warn("egress preamble read failed", "err", err)
+			}
+			return
+		}
+		line = append(line, b)
+		if b == '\n' {
+			break
+		}
+	}
+	if len(line) == maxPreambleBytes && line[len(line)-1] != '\n' {
+		p.logger.Warn("egress preamble too long", "limit", maxPreambleBytes)
+		return
+	}
+	host, port := splitHostPort(strings.TrimSpace(string(line)))
 	if host == "" || port == "" {
-		p.logger.Warn("egress preamble invalid", "preamble", strings.TrimSpace(line))
+		p.logger.Warn("egress preamble invalid", "preamble", strings.TrimSpace(string(line)))
 		return
 	}
 	dest := net.JoinHostPort(host, port)
@@ -248,6 +308,9 @@ func (p *proxy) handle(client net.Conn) {
 		}
 		first, err := br.Peek(1)
 		switch {
+		case isTimeout(err):
+			p.logger.Warn("egress preamble timeout", "err", err)
+			return
 		case err != nil:
 			// Nothing to classify; fall through to the blind tunnel below.
 		case first[0] != 0x16:
@@ -260,10 +323,12 @@ func (p *proxy) handle(client net.Conn) {
 				return
 			}
 			p.logger.Info("egress allowed (inject, plaintext)", "dest", dest, "dial", tlsAddr)
+			_ = client.SetReadDeadline(time.Time{})
 			p.swapPlaintext(br, client, tlsAddr, host, sec)
 			return
 		case p.minter != nil:
 			p.logger.Info("egress allowed (inject, tls)", "dest", dest, "dial", dialAddr)
+			_ = client.SetReadDeadline(time.Time{})
 			p.terminateAndSwap(br, client, dialAddr, host, sec)
 			return
 		}
@@ -275,6 +340,7 @@ func (p *proxy) handle(client net.Conn) {
 		// tlsMitmLane=false, and warning per connection would drown the log.
 		p.logger.Debug("secret-bearing TLS destination with no egress CA; credential not injected", "dest", dest)
 	}
+	_ = client.SetReadDeadline(time.Time{})
 	p.logger.Info("egress allowed", "dest", dest, "dial", dialAddr)
 
 	up, err := net.DialTimeout("tcp", dialAddr, dialTimeout)
@@ -299,6 +365,11 @@ func (p *proxy) handle(client net.Conn) {
 	go func() { _, _ = io.Copy(up, newOriginFormReader(br)); done <- struct{}{} }()
 	go func() { _, _ = io.Copy(client, up); done <- struct{}{} }()
 	<-done
+}
+
+func isTimeout(err error) bool {
+	netErr, ok := err.(net.Error)
+	return ok && netErr.Timeout()
 }
 
 // originFormReader is deliberately only a request-line filter, not a reverse
@@ -501,4 +572,17 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func maxConnsFromEnv(logger *slog.Logger) int {
+	raw := os.Getenv("EGRESS_MAX_CONNS")
+	if raw == "" {
+		return defaultMaxConns
+	}
+	maxConns, err := strconv.Atoi(raw)
+	if err != nil || maxConns < 1 {
+		logger.Warn("invalid EGRESS_MAX_CONNS; using default", "value", raw, "default", defaultMaxConns)
+		return defaultMaxConns
+	}
+	return maxConns
 }

--- a/projects/firecracker/substrate/egress-proxy/cmd/main_test.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/main_test.go
@@ -4,9 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+	"log/slog"
+	"net"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestOriginFormReader(t *testing.T) {
@@ -268,5 +271,95 @@ func TestDefaultListenAddrIsLoopback(t *testing.T) {
 	t.Setenv("EGRESS_LISTEN", "")
 	if got := envOr("EGRESS_LISTEN", defaultListenAddr); got != "127.0.0.1:8888" {
 		t.Fatalf("default listen address = %q, want 127.0.0.1:8888", got)
+	}
+}
+
+func TestHandleBoundsPreamble(t *testing.T) {
+	previousTimeout := handshakeTimeout
+	handshakeTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { handshakeTimeout = previousTimeout })
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "oversize preamble without newline", input: strings.Repeat("a", maxPreambleBytes+1)},
+		{name: "slow preamble"},
+		{name: "valid denied internal destination", input: "internal.example:443\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, server := net.Pipe()
+			defer client.Close()
+			p := &proxy{
+				lookupIP: func(string) ([]net.IP, error) {
+					return []net.IP{net.ParseIP("127.0.0.1")}, nil
+				},
+				logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+			go p.handle(server)
+			if tt.input != "" {
+				_, _ = io.WriteString(client, tt.input)
+			}
+
+			done := make(chan error, 1)
+			go func() {
+				var b [1]byte
+				_, err := client.Read(b[:])
+				done <- err
+			}()
+			select {
+			case err := <-done:
+				if err != io.EOF {
+					t.Fatalf("client read error = %v, want EOF", err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("handle did not close the connection within the bound")
+			}
+		})
+	}
+}
+
+func TestConnectionCap(t *testing.T) {
+	p := &proxy{conns: make(chan struct{}, 2)}
+	if !p.acquireConn() || !p.acquireConn() {
+		t.Fatal("first two connections should fit under the cap")
+	}
+	if p.acquireConn() {
+		t.Fatal("third connection should be rejected")
+	}
+	if got := p.rejectedConns.Load(); got != 1 {
+		t.Fatalf("rejected connections = %d, want 1", got)
+	}
+	p.releaseConn()
+	if !p.acquireConn() {
+		t.Fatal("connection should be accepted after a release")
+	}
+
+	unlimited := &proxy{}
+	for i := 0; i < 3; i++ {
+		if !unlimited.acquireConn() {
+			t.Fatal("nil connection semaphore should be unlimited")
+		}
+	}
+}
+
+func TestMaxConnsFromEnv(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	for _, tt := range []struct {
+		name, value string
+		want        int
+	}{
+		{name: "unset", want: defaultMaxConns},
+		{name: "valid", value: "8", want: 8},
+		{name: "zero", value: "0", want: defaultMaxConns},
+		{name: "invalid", value: "abc", want: defaultMaxConns},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("EGRESS_MAX_CONNS", tt.value)
+			if got := maxConnsFromEnv(logger); got != tt.want {
+				t.Fatalf("maxConnsFromEnv() = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }

--- a/projects/firecracker/substrate/egress-proxy/cmd/swap.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/swap.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
@@ -30,6 +31,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"os"
 	"strings"
@@ -38,6 +40,10 @@ import (
 )
 
 const brokerRefreshMargin = 60 * time.Second
+
+const maxHeaderBytes = 64 << 10
+
+var headerTimeout = 30 * time.Second
 
 type brokerTokenResponse struct {
 	AccessToken string    `json:"access_token"`
@@ -435,7 +441,7 @@ func (p *proxy) swapPlaintext(br *bufio.Reader, client net.Conn, dialAddr, host 
 		_ = netConn.SetNoDelay(true)
 	}
 	defer up.Close()
-	p.swapPump(br, client, up, host, sec)
+	p.swapPump(br, client, client, up, host, sec)
 }
 
 // terminateAndSwap MITMs a TLS connection to a secret-bearing destination: it
@@ -466,7 +472,7 @@ func (p *proxy) terminateAndSwap(br *bufio.Reader, client net.Conn, dialAddr, ho
 	}
 	defer up.Close()
 
-	p.swapPump(bufio.NewReader(guest), guest, up, host, sec)
+	p.swapPump(bufio.NewReader(guest), guest, guest, up, host, sec)
 }
 
 // swapPump relays HTTP requests from an already-plaintext guest stream to up,
@@ -476,18 +482,55 @@ func (p *proxy) terminateAndSwap(br *bufio.Reader, client net.Conn, dialAddr, ho
 // guestR carries the guest's request bytes and guestW takes the responses; they
 // are the same connection, split so the TLS and plaintext lanes can share this.
 // It returns when either side closes, or when a request asks to close.
-func (p *proxy) swapPump(guestR *bufio.Reader, guestW io.Writer, up net.Conn, host string, sec *secretEntry) {
+func (p *proxy) swapPump(guestR *bufio.Reader, guestW io.Writer, guestDeadline interface{ SetReadDeadline(time.Time) error }, up net.Conn, host string, sec *secretEntry) {
 	upR := bufio.NewReader(up)
+	guestStream := &replayReader{source: guestR}
 	for {
-		req, err := http.ReadRequest(guestR)
+		if guestDeadline != nil {
+			if err := guestDeadline.SetReadDeadline(time.Now().Add(headerTimeout)); err != nil {
+				p.logger.Debug("egress swap: set header deadline", "dest", host, "err", err)
+				return
+			}
+		}
+		headerR := bufio.NewReaderSize(guestStream, maxHeaderBytes+1)
+		headerBytes, tooLarge, err := readRequestHeader(headerR)
+		if tooLarge {
+			p.logger.Warn("egress swap: header too large; closing connection", "dest", host, "limit", maxHeaderBytes)
+			return
+		}
+		guestStream.prependBuffered(headerR)
+		var (
+			req      *http.Request
+			requestR *bufio.Reader
+		)
+		if err == nil {
+			guestStream.prepend(headerBytes)
+			requestR = bufio.NewReaderSize(guestStream, maxHeaderBytes+1)
+			req, err = http.ReadRequest(requestR)
+		}
 		if err != nil {
 			if err != io.EOF {
 				p.logger.Debug("egress swap: read request", "dest", host, "err", err)
 			}
 			return
 		}
+		if guestDeadline != nil {
+			if err := guestDeadline.SetReadDeadline(time.Time{}); err != nil {
+				p.logger.Debug("egress swap: clear header deadline", "dest", host, "err", err)
+				return
+			}
+		}
+		if authority := mismatchedAuthority(req, headerBytes, host); authority != "" {
+			p.logger.Warn("egress swap: authority mismatch; request denied", "dest", host, "authority", authority)
+			return
+		}
+		req.Host = host
 		if rejectSwapRequest(req) {
 			p.logger.Warn("egress swap: unsupported request mode; closing connection", "dest", host, "method", req.Method)
+			return
+		}
+		if credentialInTrailer(req, sec) {
+			p.logger.Warn("egress swap: credential trailer denied", "dest", host, "header", sec.Header)
 			return
 		}
 		injected := injectRequest(req, sec)
@@ -507,6 +550,7 @@ func (p *proxy) swapPump(guestR *bufio.Reader, guestW io.Writer, up net.Conn, ho
 			p.logger.Warn("egress swap: forward request", "dest", host, "err", err)
 			return
 		}
+		guestStream.prependBuffered(requestR)
 		resp, err := http.ReadResponse(upR, req)
 		// Skip interim responses. Rejecting Expect only stops the guest SOLICITING
 		// a 1xx; a destination can still send 103 Early Hints unasked, and
@@ -536,6 +580,114 @@ func (p *proxy) swapPump(guestR *bufio.Reader, guestW io.Writer, up net.Conn, ho
 			return
 		}
 	}
+}
+
+func readRequestHeader(guestR *bufio.Reader) ([]byte, bool, error) {
+	capacity := guestR.Size()
+	if capacity > maxHeaderBytes {
+		capacity = maxHeaderBytes
+	}
+	header := make([]byte, 0, capacity)
+	lineBytes := 0
+	for {
+		fragment, err := guestR.ReadSlice('\n')
+		if len(header)+len(fragment) > maxHeaderBytes {
+			return nil, true, nil
+		}
+		header = append(header, fragment...)
+		if err == bufio.ErrBufferFull {
+			lineBytes += len(fragment)
+			continue
+		}
+		if err != nil {
+			return nil, false, err
+		}
+		if lineBytes == 0 && (bytes.Equal(fragment, []byte("\r\n")) || bytes.Equal(fragment, []byte("\n"))) {
+			return header, false, nil
+		}
+		lineBytes = 0
+	}
+}
+
+// replayReader lets each bounded-header parse and http.ReadRequest use a fresh
+// bufio.Reader without losing bytes that parser read ahead from the next body or
+// keep-alive request. prependBuffered returns that read-ahead to the single
+// connection stream before the short-lived parser is discarded.
+type replayReader struct {
+	source  io.Reader
+	pending []byte
+}
+
+func (r *replayReader) Read(p []byte) (int, error) {
+	if len(r.pending) > 0 {
+		n := copy(p, r.pending)
+		r.pending = r.pending[n:]
+		return n, nil
+	}
+	return r.source.Read(p)
+}
+
+func (r *replayReader) prepend(data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	pending := make([]byte, 0, len(data)+len(r.pending))
+	pending = append(pending, data...)
+	pending = append(pending, r.pending...)
+	r.pending = pending
+}
+
+func (r *replayReader) prependBuffered(br *bufio.Reader) {
+	if br.Buffered() == 0 {
+		return
+	}
+	buffered, _ := br.Peek(br.Buffered())
+	r.prepend(buffered)
+}
+
+func mismatchedAuthority(req *http.Request, rawHeader []byte, policyHost string) string {
+	want := canonicalAuthority(policyHost)
+	authorities := []string{req.Host}
+	if req.URL != nil {
+		authorities = append(authorities, req.URL.Host)
+	}
+	if host := rawHostHeader(rawHeader); host != "" {
+		authorities = append(authorities, host)
+	}
+	for _, authority := range authorities {
+		if authority != "" && canonicalAuthority(authority) != want {
+			return authority
+		}
+	}
+	return ""
+}
+
+func rawHostHeader(rawHeader []byte) string {
+	r := textproto.NewReader(bufio.NewReader(bytes.NewReader(rawHeader)))
+	if _, err := r.ReadLine(); err != nil {
+		return ""
+	}
+	header, err := r.ReadMIMEHeader()
+	if err != nil {
+		return ""
+	}
+	return header.Get("Host")
+}
+
+func canonicalAuthority(authority string) string {
+	if host, _, err := net.SplitHostPort(authority); err == nil {
+		authority = host
+	}
+	return strings.TrimSuffix(strings.ToLower(authority), ".")
+}
+
+func credentialInTrailer(req *http.Request, sec *secretEntry) bool {
+	for key := range req.Trailer {
+		if strings.EqualFold(key, sec.Header) || (sec.ClaimHeader != "" && strings.EqualFold(key, sec.ClaimHeader)) {
+			return true
+		}
+	}
+	return false
 }
 
 // rejectSwapRequest keeps the swap lane strictly request-then-response. Expect

--- a/projects/firecracker/substrate/egress-proxy/cmd/swap_test.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/swap_test.go
@@ -376,6 +376,7 @@ func TestSwapPumpRejectsUnsupportedRequestModes(t *testing.T) {
 		{"connect", "CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com\r\n\r\n"},
 		{"connection upgrade", "GET / HTTP/1.1\r\nHost: api.example.com\r\nConnection: Upgrade\r\n\r\n"},
 		{"upgrade header", "GET / HTTP/1.1\r\nHost: api.example.com\r\nUpgrade: websocket\r\n\r\n"},
+		{"credential trailer", "POST / HTTP/1.1\r\nHost: api.example.com\r\nTransfer-Encoding: chunked\r\nTrailer: Authorization\r\n\r\n0\r\nAuthorization: Bearer evil\r\n\r\n"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			upClient, upOrigin := net.Pipe()
@@ -383,13 +384,178 @@ func TestSwapPumpRejectsUnsupportedRequestModes(t *testing.T) {
 			defer upOrigin.Close()
 			sec := &secretEntry{Header: "Authorization", value: "real"}
 			p := &proxy{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
-			p.swapPump(bufio.NewReader(strings.NewReader(tt.request)), io.Discard, upClient, "api.example.com", sec)
+			done := make(chan struct{})
+			go func() {
+				p.swapPump(bufio.NewReader(strings.NewReader(tt.request)), io.Discard, nil, upClient, "api.example.com", sec)
+				close(done)
+			}()
 			_ = upOrigin.SetReadDeadline(time.Now().Add(20 * time.Millisecond))
 			var b [1]byte
 			if n, err := upOrigin.Read(b[:]); n != 0 || err == nil {
 				t.Fatalf("unsupported request was forwarded: n=%d err=%v", n, err)
 			}
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("swapPump did not reject the request promptly")
+			}
 		})
+	}
+}
+
+func TestSwapPumpRejectsOversizeHeaders(t *testing.T) {
+	upClient, upOrigin := net.Pipe()
+	defer upClient.Close()
+	defer upOrigin.Close()
+	request := "GET / HTTP/1.1\r\nHost: api.example.com\r\nX-Large: " + strings.Repeat("a", maxHeaderBytes) + "\r\n\r\n"
+	sec := &secretEntry{Header: "Authorization", value: "real"}
+	p := &proxy{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	p.swapPump(bufio.NewReader(strings.NewReader(request)), io.Discard, nil, upClient, "api.example.com", sec)
+
+	_ = upOrigin.SetReadDeadline(time.Now().Add(20 * time.Millisecond))
+	var b [1]byte
+	if n, err := upOrigin.Read(b[:]); n != 0 || err == nil {
+		t.Fatalf("oversize request was forwarded: n=%d err=%v", n, err)
+	}
+}
+
+func TestSwapPumpHeaderDeadline(t *testing.T) {
+	previousTimeout := headerTimeout
+	headerTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { headerTimeout = previousTimeout })
+
+	guestClient, guestProxy := net.Pipe()
+	defer guestClient.Close()
+	defer guestProxy.Close()
+	upClient, upOrigin := net.Pipe()
+	defer upClient.Close()
+	defer upOrigin.Close()
+	done := make(chan struct{})
+	go func() {
+		sec := &secretEntry{Header: "Authorization", value: "real"}
+		p := &proxy{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+		p.swapPump(bufio.NewReader(guestProxy), io.Discard, guestProxy, upClient, "api.example.com", sec)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("swapPump did not return after the header deadline")
+	}
+}
+
+func TestSwapPumpCanonicalizesHost(t *testing.T) {
+	tests := []struct {
+		name, request string
+		wantForward   bool
+	}{
+		{
+			name:        "origin form host with port and mixed case",
+			request:     "GET /v1 HTTP/1.1\r\nHost: API.EXAMPLE.COM:443\r\nConnection: close\r\n\r\n",
+			wantForward: true,
+		},
+		{
+			name:        "absolute form",
+			request:     "POST http://api.example.com/v1 HTTP/1.1\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+			wantForward: true,
+		},
+		{
+			name:        "absolute form with matching host header",
+			request:     "POST http://api.example.com/v1 HTTP/1.1\r\nHost: API.EXAMPLE.COM:443\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+			wantForward: true,
+		},
+		{
+			name:        "origin form host with trailing dot",
+			request:     "GET /v1 HTTP/1.1\r\nHost: api.example.com.\r\nConnection: close\r\n\r\n",
+			wantForward: true,
+		},
+		{
+			name:    "origin form mismatched host",
+			request: "GET / HTTP/1.1\r\nHost: evil.example.com\r\nConnection: close\r\n\r\n",
+		},
+		{
+			name:    "absolute form mismatched host",
+			request: "GET http://evil.example.com/ HTTP/1.1\r\nConnection: close\r\n\r\n",
+		},
+		{
+			name:    "absolute form with mismatched host header",
+			request: "GET http://api.example.com/ HTTP/1.1\r\nHost: evil.example.com\r\nConnection: close\r\n\r\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upClient, upOrigin := net.Pipe()
+			defer upClient.Close()
+			defer upOrigin.Close()
+			type result struct {
+				req *http.Request
+				err error
+			}
+			seen := make(chan result, 1)
+			go func() {
+				_ = upOrigin.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+				req, err := http.ReadRequest(bufio.NewReader(upOrigin))
+				seen <- result{req: req, err: err}
+				if err == nil {
+					_, _ = io.WriteString(upOrigin, "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+				}
+			}()
+
+			sec := &secretEntry{Header: "Authorization", value: "real"}
+			p := &proxy{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+			p.swapPump(bufio.NewReader(strings.NewReader(tt.request)), io.Discard, nil, upClient, "api.example.com", sec)
+			got := <-seen
+			if !tt.wantForward {
+				if got.err == nil {
+					t.Fatalf("mismatched authority was forwarded: Host = %q", got.req.Host)
+				}
+				return
+			}
+			if got.err != nil {
+				t.Fatalf("origin did not receive request: %v", got.err)
+			}
+			if got.req.Host != "api.example.com" {
+				t.Fatalf("forwarded Host = %q, want api.example.com", got.req.Host)
+			}
+		})
+	}
+}
+
+func TestSwapPumpKeepsBodyAttachedAcrossKeepAlive(t *testing.T) {
+	guest := "POST /one HTTP/1.1\r\nHost: api.example.com\r\nContent-Length: 4\r\n\r\nbody" +
+		"GET /two HTTP/1.1\r\nHost: api.example.com\r\nConnection: close\r\n\r\n"
+	upClient, upOrigin := net.Pipe()
+	defer upClient.Close()
+	defer upOrigin.Close()
+	seen := make(chan []string, 1)
+	go func() {
+		upR := bufio.NewReader(upOrigin)
+		var paths []string
+		for i := 0; i < 2; i++ {
+			req, err := http.ReadRequest(upR)
+			if err != nil {
+				seen <- paths
+				return
+			}
+			body, err := io.ReadAll(req.Body)
+			_ = req.Body.Close()
+			if err != nil || (i == 0 && string(body) != "body") {
+				seen <- paths
+				return
+			}
+			paths = append(paths, req.URL.Path)
+			_, _ = io.WriteString(upOrigin, "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+		}
+		seen <- paths
+	}()
+
+	sec := &secretEntry{Header: "Authorization", value: "real"}
+	p := &proxy{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	p.swapPump(bufio.NewReader(strings.NewReader(guest)), io.Discard, nil, upClient, "api.example.com", sec)
+	paths := <-seen
+	if len(paths) != 2 || paths[0] != "/one" || paths[1] != "/two" {
+		t.Fatalf("forwarded paths = %v, want [/one /two]", paths)
 	}
 }
 
@@ -429,7 +595,7 @@ func TestSwapPumpRelaysStreamingResponseIncrementally(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		p := &proxy{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
-		p.swapPump(bufio.NewReader(strings.NewReader(guest)), &back, upClient, "api.example.com", sec)
+		p.swapPump(bufio.NewReader(strings.NewReader(guest)), &back, nil, upClient, "api.example.com", sec)
 		close(done)
 	}()
 
@@ -674,7 +840,7 @@ func TestSwapPumpInjectsOnThePlaintextLane(t *testing.T) {
 
 	var back bytes.Buffer
 	p := &proxy{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
-	p.swapPump(bufio.NewReader(strings.NewReader(guest)), &back, upClient, "api.example.com", sec)
+	p.swapPump(bufio.NewReader(strings.NewReader(guest)), &back, nil, upClient, "api.example.com", sec)
 
 	got := <-seen
 	if got == nil {


### PR DESCRIPTION
## Summary

- bound guest preambles and HTTP headers with explicit deadlines and size limits
- cap concurrent sidecar connections and log cumulative rejections
- validate every request authority against the pinned catalog host, then write the policy host upstream
- preserve request bodies and keep-alive bytes across bounded parsing
- reject credential-bearing trailers and keep response streaming free of a total-duration deadline
- cover slow and oversized input, connection caps, authority mismatches, trailers, body preservation, and keep-alive behavior

## Validation

- commit and rebase lint hooks: passed
- `ci test`: 746 tests passed
- BuildBuddy: https://app.buildbuddy.io/invocation/cf25d127-b1b8-4fe7-baee-0a60186c2253
- pre-push `ci test`: passed

Closes #4115