### PR TITLE
chore(embervm): encrypt production principal artifacts

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -152,6 +152,15 @@ kekRoot:
   onepassword:
     itemPath: "vaults/k8s-homelab/items/embervm-kek-root"
 
+# Principal-artifact envelope encryption (ADR embervm/033, #4691), rollout
+# step 2. The reader and capability validator have already run fleet-wide, and
+# the production KEK root is Ready. Arm the control-plane wrap endpoint and the
+# noded writer together so newly exported mutable artifacts carry an envelope.
+# Restore-capability enforcement stays off until a production bank and relight
+# proves the complete path.
+artifactEncryption:
+  enabled: true
+
 # Node capacity override (cluster-specific; the chart default of 8 is a
 # conservative backstop). node-4 is a ~62Gi box (27% used), and the two platform
 # pools alone (semgrep floor 4 + sandbox floor 4) consume all 8 default slots,
@@ -189,6 +198,10 @@ noded:
   # present, and the gateway starts checking them when s3.enableAuth flips in
   # projects/platform/seaweedfs.
   store:
+    # The reader is already unconditional on every brick. New session,
+    # session-workspace, stateful, volume, and group-set exports are encrypted;
+    # shared immutable bases remain plaintext and deduplicable.
+    encrypt: true
     credentials:
       enabled: true
       onepassword:


### PR DESCRIPTION
Refs #4691.

This is production rollout step 2 for ADR embervm/033. The production KEK root is Ready and verified live. This change arms the control-plane wrap endpoint and noded writer so new mutable principal artifacts are envelope-encrypted. The reader and capability validator are already fleet-wide. Restore-capability enforcement remains disabled until a production bank and relight prove the path.

Shared immutable bases remain plaintext and deduplicable. Rollback is setting `artifactEncryption.enabled` and `noded.store.encrypt` back to false; existing encrypted artifacts remain readable because the reader is unconditional.

Validation:
- `git diff --check`
- full `chart_env_identity_test.py` with its BUILD environment: `16 passed`
- pre-push remote `ci test` passed