### PR TITLE
fix(embervm): answer BuildBase readiness over vsock in the ping prover

### DIFF
--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -676,8 +676,9 @@ workloads:
   runtimePi:
     rootfsPath: /var/lib/embervm/scratch/embervm-noded/runtime-pi/rootfs.ext4
     harnessInit: /usr/local/bin/ember-runtime-guest-init
-  # Internal serving-path prover. The Go server is PID 1, so its image binary
-  # path is also the per-image harness init used for cold serving boots.
+  # Internal serving-path prover. The go_image entrypoint binary is the PID-1
+  # init the kernel boots (the repo go_image macro installs it at /opt/app) and
+  # it serves both the vsock readiness contract and the tap-facing serving port.
   pingWorkload:
     rootfsPath: /var/lib/embervm/scratch/embervm-noded/ping/rootfs.ext4
     harnessInit: /opt/app

--- a/projects/embervm/runtimes/ping/BUILD
+++ b/projects/embervm/runtimes/ping/BUILD
@@ -1,14 +1,39 @@
 # gazelle:ignore
-load("@rules_go//go:def.bzl", "go_binary")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
 load("//bazel/tools/oci:go_image.bzl", "go_image")
 
-# Minimal serving-class prover. The pure Go binary is the guest's PID 1 and
-# listens directly on the tap-facing HTTP port. go_image publishes the same
+# Minimal serving-class prover. One binary, two listeners: the guest answers
+# BuildBase's HTTP-over-vsock readiness probe on vsockproto.GuestHTTPPort and
+# serves live traffic on the tap-facing TCP port. go_image publishes the same
 # :image and public :image.info targets that helm_chart consumes for the pi
 # runtime, so the chart can inject a content-addressed guest image reference.
+go_library(
+    name = "ping_lib",
+    srcs = [
+        "main.go",
+        "vsock_linux.go",
+        "vsock_other.go",
+    ],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/runtimes/ping",
+    visibility = ["//visibility:private"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "@org_golang_x_sys//unix",
+            "//projects/firecracker/substrate/vsockproto",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix",
+            "//projects/firecracker/substrate/vsockproto",
+        ],
+        "//conditions:default": [
+            "//projects/firecracker/substrate/vsockproto",
+        ],
+    }),
+)
+
 go_binary(
     name = "ping",
-    srcs = ["main.go"],
+    embed = [":ping_lib"],
 )
 
 go_image(

--- a/projects/embervm/runtimes/ping/BUILD
+++ b/projects/embervm/runtimes/ping/BUILD
@@ -18,12 +18,12 @@ go_library(
     visibility = ["//visibility:private"],
     deps = select({
         "@rules_go//go/platform:android": [
-            "@org_golang_x_sys//unix",
             "//projects/firecracker/substrate/vsockproto",
+            "@org_golang_x_sys//unix",
         ],
         "@rules_go//go/platform:linux": [
-            "@org_golang_x_sys//unix",
             "//projects/firecracker/substrate/vsockproto",
+            "@org_golang_x_sys//unix",
         ],
         "//conditions:default": [
             "//projects/firecracker/substrate/vsockproto",

--- a/projects/embervm/runtimes/ping/main.go
+++ b/projects/embervm/runtimes/ping/main.go
@@ -1,23 +1,36 @@
 // Command ping is the minimal HTTP guest used to prove the EmberVM serving
 // path. It has no outbound dependencies and serves only health and identity.
+//
+// One handler set, two listeners:
+//
+//   - AF_VSOCK on vsockproto.GuestHTTPPort: the readiness contract BuildBase
+//     probes over HTTP-over-vsock before cutting a base snapshot (the tap NIC
+//     does not exist during the build boot).
+//   - TCP :8080 on 0.0.0.0: live serving traffic, DNAT'd by noded onto the
+//     tap interface once the VM is published.
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
+
+	"github.com/jomcgi/homelab/projects/firecracker/substrate/vsockproto"
 )
 
-const listenAddress = ":8080"
+const (
+	listenAddress   = ":8080"
+	vsockHTTPPort   = vsockproto.GuestHTTPPort
+	shutdownGraceMs = 2000
+)
 
-func main() {
-	hostname, err := os.Hostname()
-	if err != nil {
-		log.Fatalf("read hostname: %v", err)
-	}
-
+func newMux(hostname string) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -26,9 +39,43 @@ func main() {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		_, _ = fmt.Fprintf(w, "embervm ping from %s at %s\n", hostname, time.Now().UTC().Format(time.RFC3339Nano))
 	})
+	return mux
+}
 
-	log.Printf("embervm ping listening on %s", listenAddress)
-	if err := http.ListenAndServe(listenAddress, mux); err != nil {
-		log.Fatal(err)
+func main() {
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Fatalf("read hostname: %v", err)
 	}
+	mux := newMux(hostname)
+
+	vln, err := listenVsock(vsockHTTPPort)
+	if err != nil {
+		log.Fatalf("vsock listen port=%d: %v", vsockHTTPPort, err)
+	}
+	tln, err := net.Listen("tcp", listenAddress)
+	if err != nil {
+		log.Fatalf("tcp listen %s: %v", listenAddress, err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	srv := &http.Server{Handler: mux}
+	errCh := make(chan error, 2)
+	go func() { errCh <- srv.Serve(vln) }()
+	go func() { errCh <- srv.Serve(tln) }()
+
+	log.Printf("embervm ping listening on tcp:%s and vsock:%d", listenAddress, vsockHTTPPort)
+	select {
+	case err := <-errCh:
+		if err != nil && err != http.ErrServerClosed {
+			log.Fatalf("serve: %v", err)
+		}
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownGraceMs*time.Millisecond)
+	defer cancel()
+	_ = srv.Shutdown(shutdownCtx)
 }

--- a/projects/embervm/runtimes/ping/vsock_linux.go
+++ b/projects/embervm/runtimes/ping/vsock_linux.go
@@ -1,0 +1,58 @@
+//go:build linux
+
+// ListenVsock binds an AF_VSOCK stream socket to (VMADDR_CID_ANY, port) and
+// returns it as a net.Listener, mirroring the semgrep guest-init's scanserver
+// helper. Replicated rather than imported because that helper is internal to
+// the semgrep guest-init package.
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func listenVsock(port uint32) (net.Listener, error) {
+	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, fmt.Errorf("socket: %w", err)
+	}
+	if err := unix.Bind(fd, &unix.SockaddrVM{CID: unix.VMADDR_CID_ANY, Port: port}); err != nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("bind port=%d: %w", port, err)
+	}
+	if err := unix.Listen(fd, 16); err != nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("listen port=%d: %w", port, err)
+	}
+	return &vsockListener{fd: fd, port: port}, nil
+}
+
+type vsockListener struct {
+	fd   int
+	port uint32
+}
+
+func (l *vsockListener) Accept() (net.Conn, error) {
+	nfd, _, err := unix.Accept(l.fd)
+	if err != nil {
+		return nil, err
+	}
+	f := os.NewFile(uintptr(nfd), fmt.Sprintf("vsock-http:%d", l.port))
+	return &vsockConn{File: f}, nil
+}
+
+func (l *vsockListener) Close() error   { return unix.Close(l.fd) }
+func (l *vsockListener) Addr() net.Addr { return vsockAddr{port: l.port} }
+
+type vsockConn struct{ *os.File }
+
+func (c *vsockConn) LocalAddr() net.Addr  { return vsockAddr{} }
+func (c *vsockConn) RemoteAddr() net.Addr { return vsockAddr{} }
+
+type vsockAddr struct{ port uint32 }
+
+func (a vsockAddr) Network() string { return "vsock" }
+func (a vsockAddr) String() string  { return fmt.Sprintf("vsock:%d", a.port) }

--- a/projects/embervm/runtimes/ping/vsock_other.go
+++ b/projects/embervm/runtimes/ping/vsock_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+// Off-Linux stub: AF_VSOCK is Linux-only. The guest image builds under the
+// linux/amd64 platform transition, so this file never compiles into it.
+package main
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+)
+
+func listenVsock(port uint32) (net.Listener, error) {
+	return nil, fmt.Errorf("AF_VSOCK unsupported on %s", runtime.GOOS)
+}


### PR DESCRIPTION
Cherry-pick of the follow-up fix for #5180; the original branch's PR auto-merged before this commit landed, orphaning it (see pr-workflow: never push to a merged branch).

Drill round 1 failure: BuildBase probes guest readiness over HTTP-over-vsock (`vsockproto.GuestHTTPPort`); a plain TCP server has no vsock listener, so every attempt timed out at /healthz.

- The ping binary now serves one handler set on two listeners: AF_VSOCK on GuestHTTPPort (replicating the semgrep scanserver ListenVsock helper, internal to that package) for build readiness, TCP :8080 for live serving traffic over the tap.
- Fixes the missing go_image macro load (first cut never compiled remotely; the repo macro installs the binary at /opt/app, which is why harnessInit is /opt/app).

Remote ci green on the ping + chart targets (744 tests).