### PR TITLE
fix(inference): ignore AppleDouble model artifacts

### DIFF
--- a/projects/inference/deploy/templates/deployment.yaml
+++ b/projects/inference/deploy/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              MODEL=$(find {{ .Values.ninfer.modelVolume.mountPath }} -maxdepth 2 -name '*.ninfer' -type f | sort | head -1)
+              MODEL=$(find {{ .Values.ninfer.modelVolume.mountPath }} -maxdepth 2 -name '*.ninfer' ! -name '._*' -type f | sort | head -1)
               if [ -z "$MODEL" ]; then
                 echo "ERROR: no .ninfer artifact found under {{ .Values.ninfer.modelVolume.mountPath }}" >&2
                 exit 1


### PR DESCRIPTION
## Summary

- exclude macOS AppleDouble sidecar files from NInfer model discovery
- ensure `ninfer-serve` selects the real `.ninfer` artifact from the OCI image volume

## Validation

- `git diff --check`
- `helm template inference projects/inference/deploy`
- pre-push remote workflow test passed

## Rollout context

The live pod currently selects `._qwen3_8_27b.ninfer` and exits during model loading. This change selects `qwen3_8_27b.ninfer` instead.