### PR TITLE
fix(gpu): pin CUDA 13.1 compatible driver

### DIFF
--- a/projects/platform/nvidia-gpu-operator/values.yaml
+++ b/projects/platform/nvidia-gpu-operator/values.yaml
@@ -9,6 +9,7 @@ gpu-operator:
   # Driver configuration
   driver:
     enabled: true
+    version: "590.48.01"
     # Build drivers from source (pre-compiled not available for all kernels)
     usePrecompiled: false
 


### PR DESCRIPTION
## Summary

- pin the GPU Operator driver to NVIDIA 590.48.01
- provide the native CUDA 13.1 driver required by the NInfer runtime
- avoid unsupported forward compatibility on the GeForce RTX 4090

## Validation

- `git diff --check`
- `helm template nvidia-gpu-operator projects/platform/nvidia-gpu-operator`
- rendered `ClusterPolicy` contains `driver.version: "590.48.01"`
- pre-push remote workflow test passed

## Rollout impact

The GPU Operator will rebuild and replace the node-4 driver pod. GPU workloads will be unavailable during that rolling driver update.