### PR TITLE
docs(swarm): record the gated-run wait cost model in the chart

### DIFF
--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1166,8 +1166,14 @@ swarm:
   # .../decision or agent_run_decide (ADR agents/060); 0 makes escalation
   # terminal as before.
   decisionTimeoutSeconds: 86400
-  # Each gated run holds a DBOS worker thread while it waits (#4781 tracks
-  # sizing the pool or moving the wait off-thread).
+  # Each gated run holds one idle DBOS executor thread while it waits: sync
+  # DBOS.sleep is time.sleep on the workflow's thread (dbos 2.29.0). The pool
+  # is unbounded (no runtimeConfig, so max_workers=sys.maxsize) and parent run
+  # workflows are started off-queue, so gated runs hold no codex queue slot and
+  # cannot starve dispatch; the real cost is one thread plus ~12k recorded
+  # sleep/poll step rows per fully timed-out day. Do NOT bound this with
+  # runtimeConfig.max_executor_threads: gated runs would occupy every slot and
+  # stall all workflows, recovery included.
   # Concurrent Codex dispatches. Three concurrent dispatches have been killed
   # before, so this stays at 2 until there is evidence it can go higher.
   codexConcurrency: 2


### PR DESCRIPTION
Closes out the open question under #4781 (review finding 10 of the ADR agents/060 console slice).

**Claim under review:** each gated run parks a DBOS worker thread for up to 24h, and N concurrent gated runs could exhaust the pool.

**Verified against dbos 2.29.0 (the pinned wheel):**
- Mechanism is real: sync `DBOS.sleep` is `time.sleep` on the workflow's executor thread (`dbos/_dbos.py:1691`). Durable across recovery (recorded step, skipped when elapsed) but the thread is held.
- There is no pool to exhaust: `runtime.py` passes no `runtimeConfig`, so the executor launches with `max_workers=sys.maxsize` (`_dbos.py:561-567`) and threads spawn lazily per workflow.
- Parent run workflows are started via bare `start_workflow` (`swarm/router.py:246,255`), not enqueued on the codex queue (`queues.py` caps only child session workflows). Gated runs hold no queue slot and cannot starve dispatch.

**Real cost per concurrent gated run:** one idle thread plus ~5761 sleep step rows + poll read rows per fully timed-out day in the dbos schema. At this deployment's scale that is noise.

**Anti-fix warning recorded in the comment:** do not set `runtimeConfig.max_executor_threads`. Capping would let gated runs occupy every slot and stall ALL workflows including recovery - it manufactures the deadlock the finding feared.

No behavior change; comment only.