### PR TITLE
feat(embervm): image-lane serving fresh boot (ADR embervm/038)

### DIFF
--- a/projects/embervm/noded/server/activator_test.go
+++ b/projects/embervm/noded/server/activator_test.go
@@ -154,6 +154,35 @@ func TestActivatorColdBootAndProxyFiltersHeaders(t *testing.T) {
 	}
 }
 
+func TestActivatorColdBootsFromImageLaneInventory(t *testing.T) {
+	port, _ := activatorGuest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == defaultReadyPath {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write([]byte("image lane"))
+	}))
+	s, _, driver := newServingTestServer(t)
+	s.servingImage = newServingImageRegistry()
+	s.servingImage.add(servingImageEntry{
+		baseKey:         "image-base",
+		workload:        "wl-serve",
+		runtimeImageRef: "img-a",
+	})
+	enableActivatorWorkload(s, "wl-serve", port)
+
+	rec := activatorRequest(t, s.ActivatorHandler(), "wl-serve", "/invoke", "request")
+	if rec.Code != http.StatusOK || rec.Body.String() != "image lane" {
+		t.Fatalf("activator response = %d %q, want 200 image lane", rec.Code, rec.Body.String())
+	}
+	if driver.claims != 1 {
+		t.Errorf("ClaimServing calls = %d, want 1", driver.claims)
+	}
+	if driver.lastHandlerDiskPath != "" || driver.lastHandlerZipBytes != 0 {
+		t.Errorf("image-lane activator attached handler drive %q (%d bytes)", driver.lastHandlerDiskPath, driver.lastHandlerZipBytes)
+	}
+}
+
 func TestActivatorDenyListFiltersBothDirections(t *testing.T) {
 	headers := make(http.Header, len(activatorDeniedHeaders)+1)
 	for denied := range activatorDeniedHeaders {

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -814,26 +814,29 @@ func (s *Server) driveBuild(ctx context.Context, req *nodev1.BuildBaseRequest, b
 	// can attach it as a read-only drive and import the handler off disk. This is
 	// strictly ADDITIVE: the base memory snapshot above is still produced (the task
 	// lane needs it if the workload is also task-class), and a non-serving build never
-	// enters this branch. Only the zip lane carries an archive; an image-lane serving
-	// base has no handler zip and is left for a later rung.
+	// enters this branch. Only the zip lane carries an archive. An image-lane serving
+	// base has no handler zip, so ADR embervm/038 registers its rootfs with no handler.
 	servingImageRef := ""
-	if req.GetServing() && archive != nil && s.servingDriver != nil {
-		path, artifactBytes, werr := s.servingDriver.WriteServingHandlerArtifact(baseKey, imageDigest, archive)
-		if werr != nil {
-			// A handler-artifact write failure fails the build: a serving base that
-			// reports READY without a usable cold-boot artifact would place and then
-			// FAILED_PRECONDITION at StartServing, which is worse than failing here.
-			s.bases.failBuild(baseKey, werr.Error())
-			s.signalChange()
-			return nil, status.Errorf(codes.FailedPrecondition, "noded: write serving handler artifact for %q: %v", baseKey, werr)
-		}
-		s.servingImage.add(servingImageEntry{
+	if req.GetServing() && s.servingDriver != nil {
+		simg := servingImageEntry{
 			baseKey:         baseKey,
 			workload:        workload,
-			handlerPath:     path,
-			runtimeImageRef: imageDigest, // the zip lane's imageDigest IS the runtime ref
-			sizeBytes:       artifactBytes,
-		})
+			runtimeImageRef: imageDigest,
+		}
+		if archive != nil {
+			path, artifactBytes, werr := s.servingDriver.WriteServingHandlerArtifact(baseKey, imageDigest, archive)
+			if werr != nil {
+				// A handler-artifact write failure fails the build: a serving base that
+				// reports READY without a usable cold-boot artifact would place and then
+				// FAILED_PRECONDITION at StartServing, which is worse than failing here.
+				s.bases.failBuild(baseKey, werr.Error())
+				s.signalChange()
+				return nil, status.Errorf(codes.FailedPrecondition, "noded: write serving handler artifact for %q: %v", baseKey, werr)
+			}
+			simg.handlerPath = path
+			simg.sizeBytes = artifactBytes
+		}
+		s.servingImage.add(simg)
 		servingImageRef = baseKey
 	}
 

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -1244,12 +1244,10 @@ func TestBuildBaseZipUnknownRuntime(t *testing.T) {
 	}
 }
 
-// TestBuildBaseZipServingWritesHandlerArtifact: a serving-class zip BuildBase MUST
-// additionally write the cold-boot handler artifact and report serving_image_ref
-// (D-R3.11.2), while STILL snapshotting the base (strictly additive; amendment 2, A3
-// deferred). A non-serving build must NOT write the artifact and reports no serving
-// image ref, proving the task lane is byte-unchanged.
-func TestBuildBaseZipServingWritesHandlerArtifact(t *testing.T) {
+// TestBuildBaseServingRegistersImage: a serving BuildBase always registers a serving
+// image. The zip lane MUST write its cold-boot handler artifact, while the image lane
+// registers the runtime rootfs with no handler artifact (ADR embervm/038).
+func TestBuildBaseServingRegistersImage(t *testing.T) {
 	archive := []byte("PK\x03\x04 serving handler zip bytes")
 	ctx := context.Background()
 
@@ -1303,8 +1301,22 @@ func TestBuildBaseZipServingWritesHandlerArtifact(t *testing.T) {
 		}
 		// The handler artifact was written for the base key, with the exact archive bytes.
 		baseKey := resp.GetSnapshotRef()
-		if _, ok := fsd.ServingHandlerArtifactPath(baseKey); !ok {
+		artifactPath, ok := fsd.ServingHandlerArtifactPath(baseKey)
+		if !ok {
 			t.Errorf("no handler artifact written for serving base %q", baseKey)
+		}
+		if got := fsd.handlerArtifactWriteCount(); got != 1 {
+			t.Errorf("WriteServingHandlerArtifact calls = %d, want 1", got)
+		}
+		images := s.servingImage.snapshot()
+		if len(images) != 1 {
+			t.Fatalf("serving image inventory entries = %d, want 1", len(images))
+		}
+		if images[0].handlerPath != artifactPath || artifactPath == "" {
+			t.Errorf("zip-lane inventory handler path = %q, want written path %q", images[0].handlerPath, artifactPath)
+		}
+		if images[0].sizeBytes != int64(len(archive)) {
+			t.Errorf("zip-lane inventory size bytes = %d, want %d", images[0].sizeBytes, len(archive))
 		}
 		// The response and NodeStatus both report serving_image_ref == the base key.
 		if resp.GetServingImageRef() != baseKey {
@@ -1318,6 +1330,65 @@ func TestBuildBaseZipServingWritesHandlerArtifact(t *testing.T) {
 		}
 		if wc == nil || wc.GetServingImageRef() != baseKey {
 			t.Errorf("NodeStatus serving_image_ref = %+v, want %q", wc, baseKey)
+		}
+	})
+
+	t.Run("image lane registers rootfs without writing artifact", func(t *testing.T) {
+		s, build, fsd, _ := newServer()
+		resp, err := s.BuildBase(ctx, &nodev1.BuildBaseRequest{
+			Trace:            &nodev1.Trace{Workload: "serving-image-lane"},
+			ImageRef:         "runtime-python:1",
+			WorkloadRevision: "r1",
+			ReadyPath:        "/shim/ready",
+			Resources:        &nodev1.ResourceSpec{Vcpus: 1, MemMib: 512},
+			Serving:          true,
+		})
+		if err != nil {
+			t.Fatalf("BuildBase serving image lane: %v", err)
+		}
+		if build.snapshots != 1 {
+			t.Errorf("snapshots = %d, want 1", build.snapshots)
+		}
+		if got := fsd.handlerArtifactWriteCount(); got != 0 {
+			t.Errorf("WriteServingHandlerArtifact calls = %d, want 0", got)
+		}
+		images := s.servingImage.snapshot()
+		if len(images) != 1 {
+			t.Fatalf("serving image inventory entries = %d, want 1", len(images))
+		}
+		got := images[0]
+		if got.workload != "serving-image-lane" {
+			t.Errorf("inventory workload = %q, want serving-image-lane", got.workload)
+		}
+		if got.baseKey != resp.GetSnapshotRef() {
+			t.Errorf("inventory base key = %q, want %q", got.baseKey, resp.GetSnapshotRef())
+		}
+		if got.handlerPath != "" {
+			t.Errorf("inventory handler path = %q, want empty", got.handlerPath)
+		}
+		if got.runtimeImageRef != "runtime-python:1" {
+			t.Errorf("inventory runtime image ref = %q, want runtime-python:1", got.runtimeImageRef)
+		}
+		if got.sizeBytes != 0 {
+			t.Errorf("inventory size bytes = %d, want 0", got.sizeBytes)
+		}
+		if resp.GetServingImageRef() != got.baseKey {
+			t.Errorf("serving_image_ref = %q, want %q", resp.GetServingImageRef(), got.baseKey)
+		}
+	})
+
+	t.Run("zip artifact write failure fails build", func(t *testing.T) {
+		s, _, fsd, url := newServer()
+		fsd.failHandlerWrite = context.Canceled
+		_, err := s.BuildBase(ctx, zipReq(url, true))
+		if status.Code(err) != codes.FailedPrecondition {
+			t.Fatalf("artifact write failure code = %v, want FailedPrecondition", status.Code(err))
+		}
+		if got := fsd.handlerArtifactWriteCount(); got != 1 {
+			t.Errorf("WriteServingHandlerArtifact calls = %d, want 1", got)
+		}
+		if got := len(s.servingImage.snapshot()); got != 0 {
+			t.Errorf("serving image inventory entries = %d, want 0 after failed write", got)
 		}
 	})
 

--- a/projects/embervm/noded/server/serving.go
+++ b/projects/embervm/noded/server/serving.go
@@ -66,12 +66,12 @@ func (s *Server) startServing(ctx context.Context, req *nodev1.StartServingReque
 	}
 }
 
-// startServingFresh cold-boots a serving VM from the workload's cold-boot handler
-// artifact WITH a freshly allocated tap NIC and its static IP baked into boot-args,
-// then health-gates over the tap. servingImageRef names a SERVING IMAGE (a built
-// cold-boot handler artifact in the serving-images inventory), NOT a base snapshot to
-// resume (D-R3.4.2, D-R3.11.2): the runtime rootfs is drive 1 and the handler artifact
-// is drive 2, from which the guest imports the handler before serving.
+// startServingFresh cold-boots a serving VM from a built serving image WITH a freshly
+// allocated tap NIC and its static IP baked into boot-args, then health-gates over the
+// tap. servingImageRef names a SERVING IMAGE in the serving-images inventory, NOT a
+// base snapshot to resume (D-R3.4.2, D-R3.11.2): the runtime rootfs is drive 1 and a
+// zip-lane handler artifact is drive 2, from which the guest imports the handler before
+// serving. An image-lane entry has no handler artifact (ADR embervm/038).
 func (s *Server) startServingFresh(ctx context.Context, req *nodev1.StartServingRequest, servingImageRef, workload string, port uint32, healthPath string, origin nodev1.InstanceOrigin) (*nodev1.StartServingResponse, error) {
 	// A FRESH serving cold boot is new-work placement. A stale registry (boot
 	// cache, no live sync) refuses it; RELIGHT of an existing serving snapshot
@@ -115,10 +115,15 @@ func (s *Server) startServingFresh(ctx context.Context, req *nodev1.StartServing
 		// daemon probes and publishes: GET http://ip:port{healthPath} (D-R3.11.1).
 		ServingPort: port,
 	}
-	// Attach the handler artifact as the second read-only drive (D-R3.11.2); the guest
-	// imports the handler off it before serving. The exact byte length lets the guest
-	// read only the payload, not the block device's sector padding.
-	h, err := s.servingDriver.ClaimServing(ctx, img.RootfsPath, harnessInit, int(res.GetVcpus()), int(res.GetMemMib()), nic, simg.handlerPath, simg.sizeBytes)
+	handlerPath := ""
+	var handlerSizeBytes int64
+	if simg.handlerPath != "" {
+		// Attach the zip-lane handler artifact as the second read-only drive
+		// (D-R3.11.2). The exact byte length excludes the device's sector padding.
+		handlerPath = simg.handlerPath
+		handlerSizeBytes = simg.sizeBytes
+	}
+	h, err := s.servingDriver.ClaimServing(ctx, img.RootfsPath, harnessInit, int(res.GetVcpus()), int(res.GetMemMib()), nic, handlerPath, handlerSizeBytes)
 	if err != nil {
 		s.servingNet.ReleaseTap(ctx, ip)
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: cold-boot serving vm: %v", err)

--- a/projects/embervm/noded/server/serving_test.go
+++ b/projects/embervm/noded/server/serving_test.go
@@ -143,8 +143,10 @@ type fakeServingDriver struct {
 	banked             map[string]string // snapshotRef -> pinnedIP
 	handlers           map[string]string // baseKey -> handler artifact path (written)
 	handlerRuntimeRefs map[string]string // baseKey -> runtime image ref sidecar
+	handlerWriteCalls  int
 	servingDir         string
 	failClaim          error
+	failHandlerWrite   error
 	lastClaimNIC       substrate.NICSpec
 	// lastHandlerDiskPath/lastHandlerZipBytes record the handler-disk args the last
 	// ClaimServing carried, so a test can assert the serving cold boot attached the
@@ -189,10 +191,20 @@ func (f *fakeServingDriver) ClaimServing(_ context.Context, _ string, _ string, 
 func (f *fakeServingDriver) WriteServingHandlerArtifact(baseKey, runtimeImageRef string, zip []byte) (string, int64, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.handlerWriteCalls++
+	if f.failHandlerWrite != nil {
+		return "", 0, f.failHandlerWrite
+	}
 	path := filepath.Join(f.servingDir, "..", "bases", baseKey, "handler.zip")
 	f.handlers[baseKey] = path
 	f.handlerRuntimeRefs[baseKey] = runtimeImageRef
 	return path, int64(len(zip)), nil
+}
+
+func (f *fakeServingDriver) handlerArtifactWriteCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.handlerWriteCalls
 }
 
 // ServingHandlerArtifactPath reports the recorded artifact path for a base key.
@@ -447,6 +459,39 @@ func TestStartServingFresh(t *testing.T) {
 		t.Errorf("live_vms = %d want 1", ns.GetLiveVms())
 	}
 	_ = fsn
+}
+
+func TestStartServingFreshImageLaneOmitsHandlerDrive(t *testing.T) {
+	_, port := healthServer(t, servingHealthPath)
+	s, _, fsd := newServingTestServer(t)
+	s.servingImage = newServingImageRegistry()
+	s.servingImage.add(servingImageEntry{
+		baseKey:         "image-base",
+		workload:        "wl-serve",
+		runtimeImageRef: "img-a",
+	})
+
+	resp, err := s.StartServing(context.Background(), &nodev1.StartServingRequest{
+		Source:     &nodev1.StartServingRequest_Fresh{Fresh: &nodev1.FreshSource{ServingImageRef: "image-base"}},
+		Port:       port,
+		HealthPath: servingHealthPath,
+		Trace:      &nodev1.Trace{Workload: "wl-serve"},
+	})
+	if err != nil {
+		t.Fatalf("StartServing(fresh image lane): %v", err)
+	}
+	if resp.GetVmId() == "" {
+		t.Fatal("StartServing(fresh image lane) returned no vm_id")
+	}
+	if fsd.claims != 1 {
+		t.Errorf("ClaimServing calls = %d want 1", fsd.claims)
+	}
+	if fsd.lastHandlerDiskPath != "" {
+		t.Errorf("image-lane handler disk path = %q want empty", fsd.lastHandlerDiskPath)
+	}
+	if fsd.lastHandlerZipBytes != 0 {
+		t.Errorf("image-lane handler zip bytes = %d want 0", fsd.lastHandlerZipBytes)
+	}
 }
 
 // TestStartServingProjectsPodEndpoint proves the D-R3.11.4 projection: with a pod IP


### PR DESCRIPTION
Phase 4 of #5180, implementing ADR embervm/038 (queued as #5216).

Closes #5180.

## What

An image-source serving BuildBase (serving=true, no archive) now registers its built rootfs as a serving-images inventory entry with an empty handlerPath. startServingFresh attaches the zip-lane handler-artifact drive only when the entry has one; the real driver already gated attachment on a non-empty path (driver.go:1077), so image-lane boots attach rootfs + tap and run the image entrypoint directly. Zip lane byte-for-byte unchanged.

## Why

Drill round 2 (#5180): the first serving-class workload built cleanly and reported Ready, then failed every wake — activator 'no serving image provisioned', startServingFresh 'no cold-boot handler artifact built' — because the inventory only ever held zip-lane entries (D-R3.11.2 deferred image-lane to 'a later rung'). No proto or control-plane change is needed: the CP already stamps serving from the workload class (base_builder.ex:1977) and reports serving_image_ref from this inventory.

## Tests

- Image-lane BuildBase registers exactly one handler-less entry; fake driver records zero artifact writes.
- Zip-lane regression: artifact written, handlerPath populated.
- startServingFresh boots WITHOUT an artifact drive on an image-lane entry and WITH the drive on a zip-lane entry.
- L7 activator cold-boots from an image-lane-only inventory.

Remote ci green on //projects/embervm/noded/server:server_test. Review pass ran in the main loop (agent dispatch unavailable): consumers of handlerPath audited (only ClaimServing call site + disk rescan, which cannot produce empty-path entries), NodeStatus reporting verified correct with handler-less entries.