### PR TITLE
chore(embervm): re-key the ping base for the image-lane inventory

### DIFF
--- a/projects/embervm/chart/templates/workload-ping.yaml
+++ b/projects/embervm/chart/templates/workload-ping.yaml
@@ -21,6 +21,11 @@ spec:
       readyPath: {{ .Values.pingWorkload.readyPath | quote }}
       initEnv:
         EMBER_HYPERVISOR_EPOCH: {{ .Values.hypervisorEpoch | quote }}
+        # Base-signature re-key only: nothing here reaches the guest (the
+        # ping binary reads no env). Bump to force a rebuild when the noded
+        # build path itself changes, as the image-lane inventory registration
+        # (ADR 038) did.
+        EMBER_BASE_EPOCH: {{ .Values.pingWorkload.baseEpoch | quote }}
   resources:
     vcpus: {{ .Values.pingWorkload.vcpus }}
     memMib: {{ .Values.pingWorkload.memMib }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1854,6 +1854,9 @@ pingWorkload:
   idleBankSeconds: 120
   bankedTtlSeconds: 3600
   nodeLocalWake: true
+  # Base-signature re-key for the ping workload (see the template's
+  # EMBER_BASE_EPOCH). Inert to the guest; bumping it forces a rebuild.
+  baseEpoch: "image-lane-1"
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/ping
     tag: latest


### PR DESCRIPTION
Follow-up to #5218 (ADR 038). The image-lane inventory registration happens at BuildBase time, and ping's existing base predates it — the signature is unchanged, so nothing re-runs the build on its own. Bumps pingWorkload.baseEpoch, a new inert base-signature input rendered as EMBER_BASE_EPOCH next to the hypervisor epoch in workload-ping.yaml (the documented re-key mechanism: an entry here re-keys and rebuilds this workload's base alone).

Remote ci green on the chart targets. No behaviour change beyond forcing one rebuild.