### PR TITLE
perf(embervm): expand Pi context to 120K

### DIFF
--- a/projects/embervm/runtimes/claude/pi_context_window_sync_test.py
+++ b/projects/embervm/runtimes/claude/pi_context_window_sync_test.py
@@ -1,10 +1,9 @@
-"""Guard that PI_CONTEXT_WINDOW and PI_CONTEXT_WINDOW_HEADROOM satisfy the invariant.
+"""Guard that Pi's per-session windows fit NInfer's shared KV pool.
 
-PI_CONTEXT_WINDOW is deliberately set below vLLM's --max-model-len to absorb
-pi's estimate error. A too-large window (matching vLLM's real limit exactly)
-silently re-arms the bug where pi's clampMaxTokensToContext computes available
-output tokens using a false budget. A too-small window defeats the headroom's
-purpose. This guard verifies both the upper bound and minimum headroom.
+NInfer dynamically shares one KV page pool across its generation lanes. Pi's
+advertised context multiplied by that lane count, plus shared headroom for
+estimation error, must fit the pool. This test reads the deployment values so
+a server-side capacity or concurrency change cannot silently break the budget.
 """
 
 import os
@@ -27,14 +26,12 @@ def _repo_path(*parts: str) -> Path:
 
 
 def test_pi_context_window_stays_under_inference_config():
-    """PI_CONTEXT_WINDOW must be below the served context with minimum headroom.
+    """All concurrent Pi windows plus headroom must fit the shared KV pool.
 
-    PI_CONTEXT_WINDOW is deliberately set below the server's max context to absorb
-    pi's estimate error. The gap converts pi's fixed safety margin into a larger
-    effective margin that accounts for the chars/4 estimation heuristic. Measured
-    in prod on 2026-08-07, a turn with repetitive-ASCII tool results undercounted
-    by 4097 tokens. This test ensures pi can never believe it has more room than
-    the model actually provides, and that the headroom gap is sufficient.
+    Pi's chars/4 heuristic undercounted repetitive-ASCII tool results by 4097
+    tokens in production. The shared gap protects both active lanes from that
+    estimation error while preserving the full server window for a lone direct
+    API request.
     """
     import yaml
 
@@ -43,27 +40,37 @@ def test_pi_context_window_stays_under_inference_config():
     with open(values_path) as stream:
         config = yaml.safe_load(stream)
 
-    # The served window is NInfer's --max-context (#5155). PI_CONTEXT_WINDOW is
-    # far below it on purpose: raising pi's window to use the 262K the server
-    # admits is a separate decision about per-turn cost, not a sync fix.
-    max_model_len = config.get("ninfer", {}).get("maxContext")
-    assert max_model_len is not None, "ninfer.maxContext not found in values.yaml"
+    ninfer = config.get("ninfer", {})
+    max_context = ninfer.get("maxContext")
+    kv_capacity = ninfer.get("kvCapacity")
+    max_concurrency = ninfer.get("maxConcurrency")
+    assert max_context is not None, "ninfer.maxContext not found in values.yaml"
+    assert kv_capacity is not None, "ninfer.kvCapacity not found in values.yaml"
+    assert max_concurrency is not None, "ninfer.maxConcurrency not found in values.yaml"
 
-    # (a) PI_CONTEXT_WINDOW must never exceed the model's real capacity
-    assert shim.PI_CONTEXT_WINDOW <= max_model_len, (
+    # A single Pi request must never exceed the server's per-request ceiling.
+    assert shim.PI_CONTEXT_WINDOW <= max_context, (
         "PI_CONTEXT_WINDOW (%s) exceeds ninfer.maxContext (%s). "
         "Lower PI_CONTEXT_WINDOW in projects/embervm/runtimes/claude/shim.py or "
         "raise ninfer.maxContext in projects/inference/deploy/values.yaml."
-        % (shim.PI_CONTEXT_WINDOW, max_model_len)
+        % (shim.PI_CONTEXT_WINDOW, max_context)
     )
 
-    # (b) Headroom must be at least the declared minimum
-    actual_headroom = max_model_len - shim.PI_CONTEXT_WINDOW
+    # Every generation lane may host a full Pi session concurrently.
+    allocated = shim.PI_CONTEXT_WINDOW * max_concurrency
+    actual_headroom = kv_capacity - allocated
     assert actual_headroom >= shim.PI_CONTEXT_WINDOW_HEADROOM, (
-        "Headroom (%s tokens) falls below PI_CONTEXT_WINDOW_HEADROOM (%s). "
+        "%s Pi windows allocate %s of %s KV tokens, leaving %s headroom. "
+        "This falls below PI_CONTEXT_WINDOW_HEADROOM (%s). "
         "Lower PI_CONTEXT_WINDOW in shim.py to widen the gap, or lower "
         "PI_CONTEXT_WINDOW_HEADROOM if a smaller margin is genuinely justified. "
         "The gap must absorb pi's estimate error, which measured at ~4097 tokens "
         "for repetitive ASCII tool results."
-        % (actual_headroom, shim.PI_CONTEXT_WINDOW_HEADROOM)
+        % (
+            max_concurrency,
+            allocated,
+            kv_capacity,
+            actual_headroom,
+            shim.PI_CONTEXT_WINDOW_HEADROOM,
+        )
     )

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -358,35 +358,28 @@ CODEX_SUBSCRIPTION_BASE_URL_ENV = "CODEX_SUBSCRIPTION_BASE_URL"
 DEFAULT_CODEX_SUBSCRIPTION_BASE_URL = "http://chatgpt.com/backend-api/"
 CODEX_DUMMY_ACCOUNT_ID = "guest-subscription-account"
 PI_MODELS = {
-    # Must match the vLLM --served-model-name (projects/inference/deploy/
+    # Must match the inference server's public model id (projects/inference/deploy/
     # values.yaml); a wrong name 404s at the provider ("The model does not
     # exist"), proven live in #4252.
     "qwen": "qwen3.6-27b",
 }
 DEFAULT_PI_MODEL = "qwen"
 
-# PI context configuration. This constant is deliberately set BELOW vLLM's
-# --max-model-len (projects/inference/deploy/values.yaml) because pi's
-# clampMaxTokensToContext computes available output tokens by subtracting a
-# fixed CONTEXT_SAFETY_TOKENS margin, and pi's estimateContextTokens uses a
-# chars/4 heuristic rather than a tokenizer. The gap between PI_CONTEXT_WINDOW
-# and the real vLLM limit absorbs estimate error. Measured in prod on
-# 2026-08-07, a turn carrying two 50 KiB repetitive-ASCII tool results
-# undercounted by 4097 tokens against pi's fixed 4096 margin, failing with a
-# 400 error by one token. Setting PI_CONTEXT_WINDOW to 30000 converts the fixed
-# 4096 margin into an effective margin of (32768 - 30000) + 4096 = 6864 tokens,
-# approximately 1.7x the observed worst-case undercount. This gap also lowers
-# the compaction trigger from 22528 to 19760 tokens, providing more mid-run
-# runway before the window fills. This matters because pi does not check
-# compaction between tool iterations. Do NOT "correct" this value upward to
-# match vLLM's --max-model-len; the gap is the point.
-PI_CONTEXT_WINDOW = 30000
-# MINIMUM required gap between PI_CONTEXT_WINDOW and vLLM's real
-# --max-model-len, enforced by pi_context_window_sync_test. It is a floor, not
-# the actual gap: today the real gap is 32768 - 30000 = 2768. Lowering this
-# constant weakens the guard, so treat a test failure against it as a signal to
-# lower PI_CONTEXT_WINDOW rather than to lower this floor.
-PI_CONTEXT_WINDOW_HEADROOM = 2048
+# Pi gets a 120K per-session budget from NInfer's shared 262144-token KV pool.
+# NInfer has two generation lanes, so two full Pi contexts consume 245760
+# tokens and leave 16384 tokens of shared headroom. A lone direct API request
+# can still use the server's full 262144-token maxContext because the server
+# does not statically partition its page pool.
+#
+# The shared gap also absorbs pi's context-estimation error. Pi uses a chars/4
+# heuristic for trailing messages rather than the model tokenizer. Measured in
+# prod on 2026-08-07, two 50 KiB repetitive-ASCII tool results undercounted by
+# 4097 tokens. Pi also subtracts its fixed 4096-token safety margin inside each
+# advertised window. Keep this value and PI_CONTEXT_WINDOW_HEADROOM aligned
+# with ninfer.kvCapacity and ninfer.maxConcurrency; the cross-file sync test
+# enforces the relationship.
+PI_CONTEXT_WINDOW = 122880
+PI_CONTEXT_WINDOW_HEADROOM = 16384
 # pi's hardcoded safety margin in clampMaxTokensToContext.
 PI_CONTEXT_SAFETY_TOKENS = 4096
 # Maximum output tokens pi will attempt to generate. This caps reply length to
@@ -404,7 +397,8 @@ PI_CONTEXT_SAFETY_TOKENS = 4096
 # the turn with agent_end and no assistant text, and the shim raised
 # "pi turn produced no output" (3 of 5 graded long reps in the #5051
 # baseline). model-bench runs the same model at 16384 and passes 6/7 hard
-# tasks; 12288 keeps the compaction reserve just over half the window.
+# tasks; 12288 still fits alongside pi's fixed safety margin in the compaction
+# reserve.
 PI_MAX_OUTPUT_TOKENS = 12288
 
 # Thinking level for the pi lane. "off" makes pi send
@@ -441,12 +435,10 @@ def _resolve_thinking_level(value):
 # reserve mid-execution can still produce short replies.
 PI_COMPACTION_RESERVE_TOKENS = 16896
 
-# Tokens to keep after compaction. pi's default keepRecentTokens (20000)
-# exceeds the usable budget after pi's default 16384 reserve (32768 - 16384 =
-# 16384), so post-compaction context would land straight back above the
-# threshold. This value must be less than
-# (PI_CONTEXT_WINDOW - PI_COMPACTION_RESERVE_TOKENS) so compaction actually
-# helps when it fires.
+# Tokens to keep after compaction. Keeping 8000 recent tokens preserves the
+# latest tool exchange while leaving ample runway below the 105984-token
+# compaction trigger. This value must remain less than PI_CONTEXT_WINDOW minus
+# PI_COMPACTION_RESERVE_TOKENS so compaction actually helps when it fires.
 PI_COMPACTION_KEEP_RECENT_TOKENS = 8000
 MAX_REQUEST_BODY_BYTES = 1 << 20
 MAX_TOOL_INPUT_BYTES = 4096

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -4322,8 +4322,8 @@ sys.exit(1)
 def test_pi_argv_constrains_the_context_budget(tmp_path, monkeypatch):
     """pi must be launched with the context budget pinned down.
 
-    Qwen serves a 32768-token window. These flags are the entire reason pi was
-    chosen over the claude CLI, and losing any of them fails SILENTLY: the turn
+    Pi gets one bounded share of NInfer's shared KV pool. These flags keep that
+    budget available to the task. Losing any of them fails SILENTLY: the turn
     still succeeds, it just spends the window on discovered context or a default
     prompt instead of the task, and the answers quietly get worse.
     """
@@ -4358,14 +4358,12 @@ def test_pi_argv_constrains_the_context_budget(tmp_path, monkeypatch):
 
 
 def test_pi_models_json_declares_correct_context_window(tmp_path, monkeypatch):
-    """models.json must declare contextWindow and maxTokens matching vLLM.
+    """models.json must declare the bounded per-session NInfer budget.
 
     If these values are wrong, pi's clampMaxTokensToContext computes available
-    tokens using a false budget. With contextWindow=128000 (pi's hardcoded
-    default), pi believes available tokens is about 107k even when the real
-    window is 32768, leading to a loud 400 error as soon as input tokens
-    exceed 30000 - 4096 (exactly half the real window). The arithmetic
-    must ensure that input + max_output_tokens <= real_budget for all inputs.
+    tokens using a false budget. Pi's 128000-token default would let two active
+    sessions consume 256000 tokens, leaving less than the required shared
+    headroom in NInfer's 262144-token page pool.
     """
     manager = _pi_manager(tmp_path, monkeypatch)
     manager.turn("hello", model="qwen")
@@ -4376,7 +4374,7 @@ def test_pi_models_json_declares_correct_context_window(tmp_path, monkeypatch):
         - shim.PI_CONTEXT_SAFETY_TOKENS
         > 0
     ), "Context window too small: max output tokens plus safety margin exceeds budget"
-    assert shim.PI_CONTEXT_WINDOW == 30000
+    assert shim.PI_CONTEXT_WINDOW == 122880
 
     models_path = tmp_path / "workspace" / ".pi" / "agent" / "models.json"
     models = json.loads(models_path.read_text())
@@ -4392,22 +4390,29 @@ def test_pi_models_json_declares_correct_context_window(tmp_path, monkeypatch):
 
 
 def test_pi_context_window_headroom_relationship():
-    """PI_CONTEXT_WINDOW plus PI_CONTEXT_WINDOW_HEADROOM must not exceed vLLM capacity.
+    """Two Pi windows plus shared headroom must fit NInfer's KV capacity.
 
-    The headroom gap absorbs pi's estimate error. This test uses only constants,
-    so it runs without file I/O or temporary paths, and verifies the invariant
-    even without the Bazel data dependency.
+    The cross-file test reads the deployment values. This fast unit test pins
+    the approved production arithmetic even without its Bazel data dependency.
     """
-    # vLLM is configured to serve 32768 tokens in projects/inference/deploy/values.yaml
-    vllm_max_model_len = 32768
+    ninfer_kv_capacity = 262144
+    ninfer_max_concurrency = 2
     declared_window = shim.PI_CONTEXT_WINDOW
     declared_headroom = shim.PI_CONTEXT_WINDOW_HEADROOM
+    assert declared_window == 122880
+    assert declared_headroom == 16384
 
-    total = declared_window + declared_headroom
-    assert total <= vllm_max_model_len, (
-        "PI_CONTEXT_WINDOW (%s) + PI_CONTEXT_WINDOW_HEADROOM (%s) = %s exceeds "
-        "vLLM capacity (%s). Raise vLLM's --max-model-len or lower PI_CONTEXT_WINDOW."
-        % (declared_window, declared_headroom, total, vllm_max_model_len)
+    total = declared_window * ninfer_max_concurrency + declared_headroom
+    assert total == ninfer_kv_capacity, (
+        "%s Pi contexts at %s tokens plus %s headroom = %s, which does not "
+        "exactly account for NInfer KV capacity %s."
+        % (
+            ninfer_max_concurrency,
+            declared_window,
+            declared_headroom,
+            total,
+            ninfer_kv_capacity,
+        )
     )
 
 


### PR DESCRIPTION
## Summary

- raise Pi contextWindow from 30000 to 122880 tokens per session
- reserve 16384 tokens of shared NInfer KV headroom across two generation lanes
- move Pi compaction from roughly 13104 to 105984 tokens
- keep the NInfer page pool dynamic so a lone direct API request can still use the full 262144-token server window
- update stale 32768-token vLLM documentation and invariants

## Capacity invariant

Two Pi sessions at 122880 tokens plus 16384 shared headroom exactly account for the 262144-token NInfer KV pool.

The cross-file test reads ninfer.maxContext, ninfer.kvCapacity, and ninfer.maxConcurrency from the deployment values so future server changes cannot silently invalidate the Pi budget.

## Validation

- pytest -q projects/embervm/runtimes/claude/pi_context_window_sync_test.py (1 passed)
- pytest -q projects/embervm/runtimes/claude/shim_test.py -k pi (38 passed)
- repository ci lint hook
- remote ci test push hook

## Post-deploy validation

Run a focused two-session Pi soak past 100K tokens per session. The direct NInfer leaderboard does not exercise Pi context or compaction behavior.