### PR TITLE
chore(embervm): re-key ping again so the new binary registers the inventory

### DIFF
--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1856,7 +1856,7 @@ pingWorkload:
   nodeLocalWake: true
   # Base-signature re-key for the ping workload (see the template's
   # EMBER_BASE_EPOCH). Inert to the guest; bumping it forces a rebuild.
-  baseEpoch: "image-lane-1"
+  baseEpoch: "image-lane-2"
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/ping
     tag: latest


### PR DESCRIPTION
Follow-up to the image-lane-1 re-key (#5219): that rebuild ran on the pre-5218 noded binary because the brick roll landed minutes after the CR sync, so no brick registered the handler-less serving-images inventory entry and wakes still refuse. One more signature bump (image-lane-2) forces BuildBase on the current binary.

The underlying gap (no boot-time backfill for image-lane entries; single-endpoint activator selection) is tracked in #5221. No behaviour change beyond forcing one rebuild.