### PR TITLE
fix(embervm): route guest plain-HTTP egress through the lane

### DIFF
--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -47,6 +47,38 @@ MAX_TURN_DIFF_BYTES = 5 * 1024 * 1024
 MAX_TURN_DIFF_COMPRESSED_BYTES = 1024 * 1024
 
 
+def egress_proxy_env():
+    """Proxy variables for a CLI child, deliberately in BOTH letter cases.
+
+    curl reads ``http_proxy`` in LOWERCASE ONLY. Uppercase ``HTTP_PROXY`` is
+    ignored on purpose, because a CGI environment can forge it from a request's
+    Proxy: header, and curl has refused to honour it since that class of bug.
+    Every other variable here (``HTTPS_PROXY``, ``NO_PROXY``) is read in either
+    case.
+
+    That asymmetry is not cosmetic inside a guest. A session guest boots with NO
+    NIC at all, so a request that misses the proxy has no route and no resolver:
+    it dies as "Could not resolve host", which reads like a broken service rather
+    than a bypassed lane. Pi's web_search hit exactly this against the in-cluster
+    SearXNG endpoint (an http:// URL) while its web_fetch over https:// worked,
+    because only the https lane was ever pointed at the forwarder.
+
+    So set both cases once, here, and let every adapter share it. A tool that
+    shells out to curl is the normal case in these guests, not the exception.
+    """
+    egress_port = os.environ.get(EGRESS_PORT_ENV, str(DEFAULT_EGRESS_PORT))
+    proxy_url = "http://%s:%s" % (EGRESS_LOCALHOST, egress_port)
+    no_proxy = "127.0.0.1,localhost"
+    return {
+        "HTTPS_PROXY": proxy_url,
+        "HTTP_PROXY": proxy_url,
+        "NO_PROXY": no_proxy,
+        "https_proxy": proxy_url,
+        "http_proxy": proxy_url,
+        "no_proxy": no_proxy,
+    }
+
+
 def _emit_turn_diff_outcome(checkout_dir, phase, outcome):
     """Emit one best-effort diagnostic for a turn diff capture outcome."""
     try:
@@ -1591,16 +1623,8 @@ class ClaudeProcess:
         if session_id:
             command.extend(["--resume", session_id])
         command.extend(["--append-system-prompt", compose_system_prompt(system_prompt)])
-        egress_port = os.environ.get(EGRESS_PORT_ENV, str(DEFAULT_EGRESS_PORT))
-        proxy_url = "http://%s:%s" % (EGRESS_LOCALHOST, egress_port)
         child_env = os.environ.copy()
-        child_env.update(
-            {
-                "HTTPS_PROXY": proxy_url,
-                "HTTP_PROXY": proxy_url,
-                "NO_PROXY": "127.0.0.1,localhost",
-            }
-        )
+        child_env.update(egress_proxy_env())
         process = subprocess.Popen(
             command,
             cwd=spawn_workspace,
@@ -2092,8 +2116,6 @@ class CodexProcess:
             return os.path.isdir(self.workspace)
 
     def _child_env(self):
-        egress_port = os.environ.get(EGRESS_PORT_ENV, str(DEFAULT_EGRESS_PORT))
-        proxy_url = "http://%s:%s" % (EGRESS_LOCALHOST, egress_port)
         # The CLI state dir must live under the WORKSPACE, not $HOME: the guest's
         # $HOME is on the read-only rootfs and the codex CLI refuses to start when
         # CODEX_HOME does not exist (observed live as a 422 on every codex turn).
@@ -2108,14 +2130,8 @@ class CodexProcess:
         # key is not part of ChatGPT subscription mode and must not confuse
         # the CLI or the egress sidecar.
         child_env.pop("OPENAI_API_KEY", None)
-        child_env.update(
-            {
-                "CODEX_HOME": codex_home,
-                "HTTPS_PROXY": proxy_url,
-                "HTTP_PROXY": proxy_url,
-                "NO_PROXY": "127.0.0.1,localhost",
-            }
-        )
+        child_env.update(egress_proxy_env())
+        child_env["CODEX_HOME"] = codex_home
         return child_env
 
     @staticmethod
@@ -2678,8 +2694,6 @@ class PiProcess:
             return os.path.isdir(self.workspace)
 
     def _child_env(self):
-        egress_port = os.environ.get(EGRESS_PORT_ENV, str(DEFAULT_EGRESS_PORT))
-        proxy_url = "http://%s:%s" % (EGRESS_LOCALHOST, egress_port)
         # Same constraint as the codex adapter: $HOME is read-only rootfs in the
         # guest, so pi's state dir lives under the writable workspace, which is
         # also where session files must sit to survive bank/relight.
@@ -2687,15 +2701,9 @@ class PiProcess:
         _ensure_cli_dir(pi_home)
         _ensure_cli_dir(os.path.join(pi_home, "agent"))
         child_env = os.environ.copy()
-        child_env.update(
-            {
-                "PI_HOME": pi_home,
-                "PI_CODING_AGENT_DIR": os.path.join(pi_home, "agent"),
-                "HTTPS_PROXY": proxy_url,
-                "HTTP_PROXY": proxy_url,
-                "NO_PROXY": "127.0.0.1,localhost",
-            }
-        )
+        child_env.update(egress_proxy_env())
+        child_env["PI_HOME"] = pi_home
+        child_env["PI_CODING_AGENT_DIR"] = os.path.join(pi_home, "agent")
         return child_env
 
     def _write_model_config(self, pi_home):

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -42,7 +42,17 @@ egress_env_path = os.environ.get("FAKE_EGRESS_ENV")
 if egress_env_path:
     with open(egress_env_path, "w") as stream:
         json.dump(
-            {key: os.environ.get(key) for key in ("HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY")},
+            {
+                key: os.environ.get(key)
+                for key in (
+                    "HTTPS_PROXY",
+                    "HTTP_PROXY",
+                    "NO_PROXY",
+                    "https_proxy",
+                    "http_proxy",
+                    "no_proxy",
+                )
+            },
             stream,
         )
 api_key = os.environ.get("FAKE_API_KEY", "none")
@@ -3215,8 +3225,36 @@ def test_spawn_sets_egress_proxy_environment(tmp_path, monkeypatch):
         "HTTPS_PROXY": "http://127.0.0.1:1042",
         "HTTP_PROXY": "http://127.0.0.1:1042",
         "NO_PROXY": "127.0.0.1,localhost",
+        # Lowercase is not redundant. curl honours http_proxy in lowercase ONLY,
+        # so a guest tool that curls an http:// URL with just HTTP_PROXY set
+        # bypasses the egress lane and dies resolving the host in a guest that
+        # has no NIC. See shim.egress_proxy_env.
+        "https_proxy": "http://127.0.0.1:1042",
+        "http_proxy": "http://127.0.0.1:1042",
+        "no_proxy": "127.0.0.1,localhost",
     }
     manager._close_process(kill=True)
+
+
+@pytest.mark.parametrize("manager_factory", (_codex_manager, _pi_manager))
+def test_cli_child_env_points_plain_http_at_the_egress_lane(
+    manager_factory, tmp_path, monkeypatch
+):
+    """Every adapter's children must reach the lane over http:// as well as https://.
+
+    Pi's web_search queries the in-cluster SearXNG endpoint over plain HTTP with
+    curl, which reads only the lowercase name. With uppercase alone the request
+    left the proxy behind, found no resolver in a NIC-less guest, and surfaced as
+    a SearXNG outage rather than a routing gap.
+    """
+    monkeypatch.setenv(shim.EGRESS_PORT_ENV, "1042")
+    child_env = manager_factory(tmp_path, monkeypatch)._child_env()
+    assert child_env["http_proxy"] == "http://127.0.0.1:1042"
+    assert child_env["https_proxy"] == "http://127.0.0.1:1042"
+    assert child_env["no_proxy"] == "127.0.0.1,localhost"
+    assert child_env["HTTP_PROXY"] == child_env["http_proxy"]
+    assert child_env["HTTPS_PROXY"] == child_env["https_proxy"]
+    assert child_env["NO_PROXY"] == child_env["no_proxy"]
 
 
 def test_egress_forwarder_opens_one_vsock_connection_per_accept(monkeypatch):

--- a/projects/embervm/runtimes/pi/BUILD
+++ b/projects/embervm/runtimes/pi/BUILD
@@ -16,9 +16,15 @@ load("//bazel/tools/pytest:defs.bzl", "py_test")
 # fork, and forking one would be a second copy of 3700 lines policed by nothing.
 
 # First-class web research tools for Pi. The extension deliberately uses curl
-# through pi.exec rather than runtime fetch(): curl honors the HTTP_PROXY,
-# HTTPS_PROXY and CA variables installed by the shared shim, so every request
-# stays inside EmberVM's brokered egress policy.
+# through pi.exec rather than runtime fetch(), so every request stays inside
+# EmberVM's brokered egress policy.
+#
+# Note which variable curl actually reads. For an http:// URL it honors
+# lowercase http_proxy ONLY, ignoring uppercase HTTP_PROXY on purpose (a CGI
+# environment can forge that one from a Proxy: header). The shared shim exports
+# both cases for exactly this reason, and the extension also passes --proxy
+# explicitly, because a guest has no NIC and a request that misses the lane
+# fails as an unresolvable host rather than as a routing error.
 tar(
     name = "web_research_extension_tar",
     srcs = ["web-research.ts"],

--- a/projects/embervm/runtimes/pi/web-research.ts
+++ b/projects/embervm/runtimes/pi/web-research.ts
@@ -3,6 +3,7 @@ import { Type } from "typebox";
 
 const SEARXNG_URL =
   "http://monolith-searxng.monolith.svc.cluster.local:8080/search";
+const NO_PROXY_HOSTS = "127.0.0.1,localhost";
 const USER_AGENT = "EmberVM-Pi-WebResearch/1.0";
 const MAX_DOWNLOAD_BYTES = 1024 * 1024;
 const DEFAULT_PAGE_CHARS = 16000;
@@ -91,6 +92,30 @@ function validateUrl(raw: string): string {
   return parsed.toString();
 }
 
+// The guest has no NIC: every request has to ride the shim's local forwarder,
+// and one that misses it fails as "Could not resolve host" rather than as a
+// routing error. curl reads http_proxy in LOWERCASE ONLY for an http:// URL
+// (uppercase HTTP_PROXY is ignored on purpose, since a CGI environment can
+// forge that one from a Proxy: header), which is how SearXNG looked down from
+// here while web_fetch over https:// worked.
+//
+// The shim exports both cases now (shim.egress_proxy_env). Naming the proxy on
+// the command line as well is not redundancy for its own sake: this extension
+// runs INSIDE pi, where the variable is certain to exist, so the flag does not
+// depend on how pi.exec assembles a child environment.
+function egressProxy(): string {
+  const env =
+    (globalThis as { process?: { env?: Record<string, string | undefined> } })
+      .process?.env ?? {};
+  const candidate =
+    env.http_proxy ??
+    env.HTTP_PROXY ??
+    env.https_proxy ??
+    env.HTTPS_PROXY ??
+    "";
+  return candidate.trim();
+}
+
 function curlArgs(url: string, includeMetadata = false): string[] {
   const args = [
     "--silent",
@@ -112,6 +137,10 @@ function curlArgs(url: string, includeMetadata = false): string[] {
     "--user-agent",
     USER_AGENT,
   ];
+  const proxy = egressProxy();
+  if (proxy) {
+    args.push("--proxy", proxy, "--noproxy", NO_PROXY_HOSTS);
+  }
   if (includeMetadata) {
     args.push(
       "--write-out",


### PR DESCRIPTION
## What broke

A qwen session reported that `web_search` was down and that the SearXNG host was unresolvable, while `web_fetch` worked. The natural reading is a dead service or a missing allowlist entry. Neither: `monolith-searxng.monolith.svc.cluster.local:8080` has been on `egress.internal.allowlist` since the tools landed, and the destination was never dialled at all.

curl reads `http_proxy` in **lowercase only** for an `http://` URL. Uppercase `HTTP_PROXY` is ignored deliberately, because a CGI environment can forge it from a request's `Proxy:` header. Every other variable (`HTTPS_PROXY`, `NO_PROXY`) is honored in either case.

The shim exported only the uppercase pair, so:

* `web_fetch` over `https://` picked up `HTTPS_PROXY`, rode the vsock forwarder, and worked.
* `web_search` over `http://` ignored `HTTP_PROXY`, tried to connect directly, and died in a guest that boots with no NIC and no resolver. The failure surfaces as `Could not resolve host`, which reads like a broken service rather than a bypassed lane.

Confirmed against curl 8.5.0: with `HTTP_PROXY` set to a closed port and an `http://` target, curl never touches the proxy; with `http_proxy` it does; `HTTPS_PROXY` works for `https://` either way.

## What changed

* `shim.egress_proxy_env()` is one shared helper returning both letter cases, used by the claude, codex and pi adapters, so they cannot drift and any tool that shells out to curl (the normal case in these guests) reaches the lane. That covers the Bash tool too, not just this extension.
* `web-research.ts` also passes `--proxy` explicitly. The extension runs inside pi, where the variable is certain to exist, so the tool no longer depends on how `pi.exec` assembles a child environment.
* The `runtimes/pi/BUILD` comment claimed curl honors `HTTP_PROXY`. Corrected to name what curl actually reads.

No allowlist, chart or values change: the destination was already permitted, and nothing here widens what a guest may reach.

## Testing

* `pytest shim_test.py`: 190 passed, including the updated egress-env assertion and a new parametrized test covering the codex and pi child environments.
* `pytest shim_hydration_test.py cleartext_lane_guard_test.py pi_context_window_sync_test.py rootfs_reclaim_guard_test.py package_parity_test.py`: 33 passed.
* prettier clean on the extension.

## Rollout note

This is a guest-image change: it takes effect for guests booted from the rebuilt pi and claude runtime rootfs after the chart publish. Sessions already banked keep the old image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeBfGWXvX7AEQru8Wa5pEf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeBfGWXvX7AEQru8Wa5pEf)_