### PR TITLE
feat(model-bench): add five agentic tasks from real merged fixes

### DIFF
--- a/projects/model-bench/tasks/docs-public-markers-01/task.yaml
+++ b/projects/model-bench/tasks/docs-public-markers-01/task.yaml
@@ -1,0 +1,218 @@
+id: docs-public-markers-01
+version: v1
+class: code-fix
+# hard: a new module with nine marker categories and several deliberate
+# lookalike boundaries (dotted key paths, bare env names, public IP space);
+# getting the acceptance/rejection split exactly right trips most candidates.
+tier: hard
+mode: agentic
+# Real fix 1897c3d20 (PR #5193, "fix(docs): reject internal markers from public
+# content"): gen_posts_manifest published post bodies with NO content check while
+# gen_docs_manifest carried an inline three-marker check; the fix extracts a
+# shared knowledge/tools/public_content.py with a much fuller marker list and
+# wires both generators to it. The snapshot pins the fix's PARENT (no shared
+# module yet, posts unchecked).
+source_commit: 1897c3d209ce7593fe8da96086105ba90bf86144
+snapshot:
+  commit: 7bbcc70e0f575caf9d5026910934ce13b695f7e6
+  paths:
+    - projects/monolith/knowledge/tools
+  strip_components: 2
+  exclude:
+    - "*_test.py"
+    - BUILD
+agent:
+  max_turns: 30
+prompt: |
+  This is the documentation pipeline package (knowledge/tools) from a real repo.
+  Two generators produce manifests of documents published on the public site:
+
+    - gen_docs_manifest.py indexes project docs behind a path allowlist. It
+      already guards content: an inline check_public_content(rel_path, content)
+      raises SystemExit naming "<rel_path>:<line>" when a document contains an
+      internal-only identifier. Today it knows only three markers: in-cluster
+      ".svc.cluster.local" hostnames, "op://" references, and
+      "vaults/<vault>/items/" item paths.
+    - gen_posts_manifest.py publishes Markdown posts gated by frontmatter. It
+      validates the frontmatter of "public: true" posts but does NOT check post
+      body content at all, so an internal identifier pasted into a published post
+      body reaches the public site unguarded.
+
+  Make two changes:
+
+  1. Create knowledge/tools/public_content.py exporting
+     check_public_content(rel_path, content). It must raise SystemExit with the
+     message "<rel_path>:<line>: public doc contains <label>" for the FIRST
+     matching marker, where <line> is the 1-based line number of the match within
+     content. It must reject every one of these categories:
+
+       - in-cluster service hostnames (anything ending .svc.cluster.local)
+       - 1Password op:// references
+       - 1Password vault item paths (vaults/<name>/items/...)
+       - private IPv4 addresses in 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+       - cluster node names of the form node-<digits>
+       - brick names of the form brick-<digits>
+       - s3:// bucket URIs
+       - hostnames ending in ".internal", BUT NOT dotted key paths where
+         ".internal" is just a path segment followed by another dot-word (the
+         string "egress.internal.allowlist" is a YAML key path, not a host)
+       - secret-shaped env var assignments: an UPPERCASE_SNAKE name ending in
+         TOKEN, SECRET, PASSWORD, PASSPHRASE, API_KEY, or PRIVATE_KEY followed by
+         "=" or ":" and a value. A bare name with NO value next to it is already
+         public API surface in this repo and must stay acceptable.
+
+     Concretely, each of these must be REJECTED:
+
+       see http://gw.mcp.svc.cluster.local:80/mcp
+       token from op://vault/item/field
+       create vaults/k8s-homelab/items/thing first
+       the pod sits at 10.42.0.17 on the overlay
+       curl 172.16.4.9:8080/health
+       router at 192.168.1.1
+       scratch lives on node-4
+       the guest landed on brick-2
+       artifacts in s3://artifacts/ambient-evals/
+       fetched from ca.egress.internal:80
+       export EMBERVM_NODED_BEARER_TOKEN=abc123
+       AUTH_ENCRYPTION_SECRET: hunter2
+
+     and each of these must still PASS:
+
+       # fine
+
+       plain prose
+       egress.internal.allowlist is one global list
+       `OPENROUTER_API_KEY` must be set; it syncs `AUTH_ENCRYPTION_SECRET`
+       reach 8.8.8.8 or 172.32.0.1 from v10.4
+       a node-local cache, brick-shaped, node-N
+
+  2. Wire both generators to the shared guard. gen_docs_manifest.py must use the
+     shared function instead of its private copy (same call sites and behaviour,
+     now catching the fuller marker set, and check_public_content must remain
+     importable from knowledge.tools.gen_docs_manifest). In
+     gen_posts_manifest.py, build_manifest() must run the shared check on every
+     PUBLISHED post's body after frontmatter validation, before its entry is
+     appended; drafts (public: false or ungated) must keep passing through
+     untouched.
+
+  Do not change any other behaviour of either generator.
+target_files:
+  - knowledge/tools/public_content.py
+  - knowledge/tools/gen_docs_manifest.py
+  - knowledge/tools/gen_posts_manifest.py
+verifier:
+  kind: pytest
+  args:
+    tests:
+      knowledge/tools/public_content_gold_test.py: |
+        """Hidden grader for docs-public-markers-01."""
+
+        from pathlib import Path
+
+        import pytest
+
+        from knowledge.tools.gen_docs_manifest import (
+            check_public_content as check_from_docs,
+        )
+        from knowledge.tools.gen_posts_manifest import build_manifest
+        from knowledge.tools.public_content import check_public_content
+
+
+        def write_post(root: Path, name: str, frontmatter: str, body: str = "Body.\n") -> str:
+            posts = root / "docs" / "posts"
+            posts.mkdir(parents=True, exist_ok=True)
+            (posts / name).write_text(f"---\n{frontmatter}---\n{body}", encoding="utf-8")
+            return f"docs/posts/{name}"
+
+
+        def public_frontmatter(
+            *, title: str = "Example", date: str = "2026-01-15", summary: str = "One sentence."
+        ) -> str:
+            return f"title: \"{title}\"\ndate: {date}\nsummary: '{summary}'\npublic: true\n"
+
+
+        def test_docs_generator_reexports_the_shared_guard():
+            # The docs generator must use the shared module, not keep a copy.
+            assert check_from_docs is check_public_content
+
+
+        @pytest.mark.parametrize(
+            "body",
+            [
+                "see http://gw.mcp.svc.cluster.local:80/mcp",
+                "token from op://vault/item/field",
+                "create vaults/k8s-homelab/items/thing first",
+                "the pod sits at 10.42.0.17 on the overlay",
+                "curl 172.16.4.9:8080/health",
+                "router at 192.168.1.1",
+                "scratch lives on node-4",
+                "the guest landed on brick-2",
+                "artifacts in s3://artifacts/ambient-evals/",
+                "fetched from ca.egress.internal:80",
+                "export EMBERVM_NODED_BEARER_TOKEN=abc123",
+                "AUTH_ENCRYPTION_SECRET: hunter2",
+            ],
+        )
+        def test_check_public_content_rejects_internal_markers(body: str):
+            with pytest.raises(SystemExit):
+                check_public_content("projects/x/README.md", body)
+
+
+        @pytest.mark.parametrize(
+            "body",
+            [
+                "# fine\n\nplain prose\n",
+                # Dotted values key path, not a hostname.
+                "egress.internal.allowlist is one global list",
+                # Bare secret env var names are already in the public source tree.
+                "`OPENROUTER_API_KEY` must be set; it syncs `AUTH_ENCRYPTION_SECRET`",
+                # Public address space and version-ish numbers.
+                "reach 8.8.8.8 or 172.32.0.1 from v10.4",
+                "a node-local cache, brick-shaped, node-N",
+            ],
+        )
+        def test_check_public_content_accepts_public_prose(body: str):
+            check_public_content("projects/x/README.md", body)
+
+
+        def test_marker_error_names_the_line():
+            with pytest.raises(SystemExit, match=r"^projects/x/README\.md:3:") as excinfo:
+                check_public_content("projects/x/README.md", "one\ntwo\nsee node-4\n")
+            assert "node" in str(excinfo.value)
+
+
+        def test_public_post_with_internal_marker_fails(tmp_path: Path):
+            path = write_post(
+                tmp_path,
+                "2026-01-15-leak.md",
+                public_frontmatter(),
+                "Call http://monolith-web.monolith.svc.cluster.local/api\n",
+            )
+
+            with pytest.raises(SystemExit, match=r"docs/posts/2026-01-15-leak.md:1"):
+                build_manifest(tmp_path, [path])
+
+
+        def test_draft_post_with_internal_marker_is_skipped(tmp_path: Path):
+            path = write_post(
+                tmp_path,
+                "2026-01-15-draft.md",
+                "title: Draft\ndate: 2026-01-15\nsummary: One sentence.\npublic: false\n",
+                "Call http://monolith-web.monolith.svc.cluster.local/api\n",
+            )
+
+            assert build_manifest(tmp_path, [path]) == []
+
+
+        def test_clean_public_post_still_publishes(tmp_path: Path):
+            path = write_post(
+                tmp_path,
+                "2026-01-15-clean.md",
+                public_frontmatter(),
+                "Reach the site at https://example.com.\n",
+            )
+
+            entries = build_manifest(tmp_path, [path])
+            assert [entry["slug"] for entry in entries] == ["clean"]
+    targets: ["knowledge/tools/public_content_gold_test.py"]
+    timeout_s: 120

--- a/projects/model-bench/tasks/embervm-capability-generation-01/task.yaml
+++ b/projects/model-bench/tasks/embervm-capability-generation-01/task.yaml
@@ -1,0 +1,157 @@
+id: embervm-capability-generation-01
+version: v1
+class: code-fix
+# standard: one file, a fully specified comparison-semantics change; the work is
+# reading the framing contract carefully and not loosening anything else.
+tier: standard
+mode: agentic
+# Real fix f50b711b9 (PR #5175): the control plane stamped session restore
+# capabilities with the session row's bank counter while noded compared it to the
+# artifact export generation in meta.json, so the two diverged after a relight and
+# valid restores were refused with ErrCapabilityGenerationMismatch. Generation 0 in
+# the capability now means "any". The snapshot pins the fix's PARENT and keeps only
+# capability.go, which is stdlib-only and self-contained.
+source_commit: f50b711b9b4d592457b3c09bf046395ec477896f
+snapshot:
+  commit: 2b70e6c8e3e48727a91c0389491c6fadbe6294e0
+  paths:
+    - projects/embervm/noded/server/capability.go
+  strip_components: 4
+agent:
+  max_turns: 20
+prompt: |
+  capability.go implements noded's restore-capability bearer token: a versioned,
+  MAC-authenticated framing around a capabilityScope tuple (principal, lineage,
+  node, pod_uid, workload, ref, kind, generation) plus a 32-byte data key. Read the
+  whole file first. parseAndVerifyCapability validates framing and HMAC, then
+  compares every scope field against the caller's expected scope and fails with a
+  specific ErrCapability* error before returning the data key on success.
+
+  There is a production bug in the generation comparison. For session restores the
+  control plane stamps the capability with the session row's generation, which
+  counts bank rebuilds and is NOT the artifact export generation recorded in the
+  artifact's meta.json that noded compares against. After a relight the two
+  numbers diverge, so a perfectly authorized restore is refused with
+  ErrCapabilityGenerationMismatch.
+
+  Change the semantics so that a capability whose Generation is 0 means "any":
+  it must verify successfully regardless of the expected scope's Generation.
+  A non-zero capability generation must continue to require exact equality with
+  the expected scope. Nothing else may loosen: the MAC, version, expiry, key
+  length, node, pod_uid, workload, ref, kind, principal, and lineage checks all
+  stay exactly as they are, and the minting/framing code does not change.
+target_files:
+  - capability.go
+verifier:
+  kind: command
+  args:
+    # The fixture is the single real source file; go.mod is dropped in by the
+    # verifier at grade time (hidden from the model) so `go test ./...` runs
+    # without any module setup.
+    write_files:
+      go.mod: |
+        module github.com/jomcgi/homelab/projects/embervm/noded/server
+
+        go 1.25
+      capability_gold_test.go: |
+        package server
+
+        import (
+        	"bytes"
+        	"crypto/hmac"
+        	"crypto/sha256"
+        	"encoding/binary"
+        	"encoding/json"
+        	"errors"
+        	"testing"
+        	"time"
+        )
+
+        func mintCapability(t *testing.T, macKey, dataKey []byte, expiry time.Time, scope capabilityScope) []byte {
+        	t.Helper()
+        	tuple, err := json.Marshal(scope)
+        	if err != nil {
+        		t.Fatal(err)
+        	}
+        	var framed bytes.Buffer
+        	framed.WriteByte(0x01)
+        	var n [8]byte
+        	binary.BigEndian.PutUint64(n[:], uint64(expiry.UnixMilli()))
+        	framed.Write(n[:])
+        	var short [2]byte
+        	binary.BigEndian.PutUint16(short[:], uint16(len(dataKey)))
+        	framed.Write(short[:])
+        	framed.Write(dataKey)
+        	binary.BigEndian.PutUint16(short[:], uint16(len(tuple)))
+        	framed.Write(short[:])
+        	framed.Write(tuple)
+        	h := hmac.New(sha256.New, macKey)
+        	h.Write([]byte(restoreCapabilityLabel))
+        	h.Write(framed.Bytes())
+        	framed.Write(h.Sum(nil))
+        	return framed.Bytes()
+        }
+
+        func withScope(scope capabilityScope, change func(*capabilityScope)) capabilityScope {
+        	change(&scope)
+        	return scope
+        }
+
+        func TestParseAndVerifyCapability(t *testing.T) {
+        	macKey := []byte("shared-bearer")
+        	dataKey := bytes.Repeat([]byte{0x5a}, 32)
+        	now := time.UnixMilli(1_800_000_000_000)
+        	want := capabilityScope{
+        		Principal: "acct:alice", Lineage: "lineage-1", Node: "node-a", PodUID: "pod-a",
+        		Workload: "sandbox-session", Ref: "session-1", Kind: "session", Generation: 9,
+        	}
+        	valid := mintCapability(t, macKey, dataKey, now.Add(time.Minute), want)
+
+        	got, err := parseAndVerifyCapability(valid, macKey, now, want)
+        	if err != nil || !bytes.Equal(got, dataKey) {
+        		t.Fatalf("valid capability = (%x, %v), want data key", got, err)
+        	}
+
+        	tests := []struct {
+        		name    string
+        		raw     func() []byte
+        		macKey  []byte
+        		want    capabilityScope
+        		wantErr error
+        	}{
+        		{name: "no_mac_key", raw: func() []byte { return valid }, want: want, wantErr: ErrNoCapabilityKey},
+        		{name: "missing", raw: func() []byte { return nil }, macKey: macKey, want: want, wantErr: ErrMissingCapability},
+        		{name: "malformed", raw: func() []byte { return []byte{0x01} }, macKey: macKey, want: want, wantErr: ErrMalformedCapability},
+        		{name: "bad_version", raw: func() []byte { b := append([]byte(nil), valid...); b[0] = 2; return b }, macKey: macKey, want: want, wantErr: ErrBadCapabilityVersion},
+        		{name: "mac_mismatch", raw: func() []byte { b := append([]byte(nil), valid...); b[len(b)-1] ^= 1; return b }, macKey: macKey, want: want, wantErr: ErrCapabilityMACMismatch},
+        		{name: "expired", raw: func() []byte { return mintCapability(t, macKey, dataKey, now, want) }, macKey: macKey, want: want, wantErr: ErrCapabilityExpired},
+        		{name: "wrong_node", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Node = "node-b" }), wantErr: ErrCapabilityNodeMismatch},
+        		{name: "wrong_pod_uid", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.PodUID = "pod-b" }), wantErr: ErrCapabilityPodUIDMismatch},
+        		{name: "wrong_workload", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Workload = "other" }), wantErr: ErrCapabilityWorkloadMismatch},
+        		{name: "wrong_ref", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Ref = "other" }), wantErr: ErrCapabilityRefMismatch},
+        		{name: "wrong_kind", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Kind = "stateful" }), wantErr: ErrCapabilityKindMismatch},
+        		{name: "wrong_generation", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Generation++ }), wantErr: ErrCapabilityGenerationMismatch},
+        		{name: "zero_generation_is_wildcard", raw: func() []byte {
+        			return mintCapability(t, macKey, dataKey, now.Add(time.Minute), withScope(want, func(s *capabilityScope) { s.Generation = 0 }))
+        		}, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Generation = 123 }), wantErr: nil},
+        		{name: "zero_capability_still_scoped_by_principal", raw: func() []byte {
+        			return mintCapability(t, macKey, dataKey, now.Add(time.Minute), withScope(want, func(s *capabilityScope) { s.Generation = 0 }))
+        		}, macKey: macKey, want: withScope(want, func(s *capabilityScope) {
+        			s.Generation = 123
+        			s.Principal = "acct:bob"
+        		}), wantErr: ErrCapabilityPrincipalMismatch},
+        		{name: "wrong_principal", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Principal = "acct:bob" }), wantErr: ErrCapabilityPrincipalMismatch},
+        		{name: "wrong_lineage", raw: func() []byte { return valid }, macKey: macKey, want: withScope(want, func(s *capabilityScope) { s.Lineage = "lineage-2" }), wantErr: ErrCapabilityLineageMismatch},
+        		{name: "bad_key_length", raw: func() []byte { return mintCapability(t, macKey, dataKey[:31], now.Add(time.Minute), want) }, macKey: macKey, want: want, wantErr: ErrCapabilityKeyLength},
+        	}
+        	for _, tt := range tests {
+        		t.Run(tt.name, func(t *testing.T) {
+        			_, err := parseAndVerifyCapability(tt.raw(), tt.macKey, now, tt.want)
+        			if !errors.Is(err, tt.wantErr) {
+        				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+        			}
+        		})
+        	}
+        }
+    cmd: ["go", "test", "./..."]
+    timeout_s: 240

--- a/projects/model-bench/tasks/embervm-pi-tools-01/task.yaml
+++ b/projects/model-bench/tasks/embervm-pi-tools-01/task.yaml
@@ -1,0 +1,201 @@
+id: embervm-pi-tools-01
+version: v1
+class: code-fix
+# standard (floor): the navigation is real (a 4000-line shim) but the edit itself
+# is a pointed argv-construction change once the pi CLI contract is understood.
+tier: standard
+mode: agentic
+# Real fix 46a0966f3 (PR #5223, "fix(embervm): allow Pi web extension tools"): Pi
+# treats --tools as a complete session allowlist, so naming only the built-ins
+# blocked the trusted web-research extension's tools from ever activating. The
+# snapshot pins the fix's PARENT (buggy state) and keeps only shim.py; the tests
+# are the hidden grader and BUILD/apko packaging is irrelevant to the edit.
+source_commit: 46a0966f35cab26c4c4ee262cd4051341ac64bd9
+snapshot:
+  commit: 1ec19160f44e63d773fc60759e0a45c8a2896679
+  paths:
+    - projects/embervm/runtimes/claude/shim.py
+  strip_components: 4
+agent:
+  max_turns: 25
+prompt: |
+  shim.py is the HTTP-over-vsock shim that hosts an agentic coding agent inside a
+  Firecracker microVM. Class PiProcess spawns the "pi" coding CLI in RPC mode and
+  builds its full command line in _spawn.
+
+  The guest image ships a trusted web-research extension for pi, and every spawn
+  passes it via --extension (the PI_WEB_RESEARCH_EXTENSION constant), so the web
+  tools that extension registers should be available in every pi session. They are
+  not: sessions come up with only the four default built-in tools, and anything
+  the extension registers never activates.
+
+  The pi CLI's contract on this point: --tools is a COMPLETE tool allowlist for
+  the session, not a selector scoped to pi's built-ins. Naming built-ins there
+  prevents explicitly loaded extensions from registering their own tools at
+  session_start. With no --tools flag at all, pi enables those same four built-ins
+  by default AND lets explicitly loaded extension tools join them.
+
+  Fix the argv construction in _spawn so that pi sessions keep the four built-in
+  tools while the trusted extension's tools can also activate, keeping every other
+  flag, value, and ordering exactly as it is today. Do not change anything outside
+  the spawn argv construction, and do not disable discovery flags or any other
+  existing behaviour.
+target_files:
+  - shim.py
+verifier:
+  kind: pytest
+  args:
+    tests:
+      shim_gold_test.py: |
+        """Hidden grader for embervm-pi-tools-01: the pi spawn argv must keep the
+        trusted web-research extension loadable without allowlisting away its tools.
+
+        The fake pi CLI and manager helper are extracted verbatim from the fix
+        commit's shim_test.py; the fake CLI itself asserts the fixed contract, so
+        on the buggy snapshot the spawn dies before the RPC handshake completes.
+        """
+
+        import ast
+        import json
+        import os
+
+        import shim
+
+        FAKE_PI_CLI = r"""#!/usr/bin/env python3
+        import json
+        import os
+        import sys
+        import time
+
+        args_path = os.environ.get("FAKE_PI_ARGS")
+        if args_path:
+            with open(args_path, "a") as stream:
+                json.dump(sys.argv[1:], stream)
+                stream.write("\n")
+        assert "--provider" in sys.argv
+        assert sys.argv[sys.argv.index("--provider") + 1] == "openai-completions"
+        assert sys.argv[sys.argv.index("--model") + 1] == "qwen3.6-27b"
+        for flag in ("--no-context-files", "--no-extensions", "--no-skills", "--no-prompt-templates"):
+            assert flag in sys.argv
+        assert sys.argv[sys.argv.index("--extension") + 1] == "/usr/share/ember-pi/extensions/web-research.ts"
+        assert "--tools" not in sys.argv
+        assert "disposable Firecracker microVM" in sys.argv[sys.argv.index("--system-prompt") + 1]
+        rpc_path = os.environ.get("FAKE_PI_RPC")
+        state = {"sessionId": "pi-session", "model": {"id": "qwen3.6-27b"}}
+        def record(value):
+            if rpc_path:
+                with open(rpc_path, "a") as stream:
+                    json.dump(value, stream)
+                    stream.write("\n")
+        def emit(value):
+            print(json.dumps(value), flush=True)
+        def response(command, success=True, data=None):
+            value = {"type": "response", "command": command, "success": success}
+            if data is not None:
+                value["data"] = data
+            emit(value)
+        for line in sys.stdin:
+            request = json.loads(line)
+            record(request)
+            command = request["type"]
+            if command == "get_state":
+                response(command, data=state)
+            elif command == "set_model":
+                state["model"] = {"id": request["modelId"]}
+                response(command, data=state["model"])
+            elif command == "set_thinking_level":
+                response(command, data={"level": request["level"]})
+            elif command == "switch_session":
+                if os.environ.get("FAKE_PI_SWITCH") == "failed":
+                    response(command, success=False)
+                else:
+                    state["sessionId"] = os.path.basename(request["sessionPath"]).split(".")[0]
+                    response(command, data={"cancelled": os.environ.get("FAKE_PI_SWITCH") == "cancelled"})
+            elif command == "prompt":
+                response(command)
+                if os.environ.get("FAKE_PI_MODE") == "death":
+                    print("fake pi died mid-turn", file=sys.stderr, flush=True)
+                    sys.exit(17)
+                if os.environ.get("FAKE_PI_MODE") == "interruptible":
+                    emit({"type": "agent_start"})
+                    abort_request = json.loads(sys.stdin.readline())
+                    record(abort_request)
+                    response("abort")
+                    emit({"type": "agent_end", "messages": []})
+                    continue
+                if os.environ.get("FAKE_PI_SLEEP"):
+                    time.sleep(float(os.environ["FAKE_PI_SLEEP"]))
+                if os.environ.get("FAKE_PI_MODE") == "provider-error":
+                    emit({"type": "agent_end", "messages": [{"role": "assistant", "content": [],
+                          "errorMessage": "provider failed: ECONNREFUSED"}]})
+                elif os.environ.get("FAKE_PI_MODE") == "textless":
+                    emit({"type": "agent_end", "messages": []})
+                elif os.environ.get("FAKE_PI_MODE") == "telemetry":
+                    emit({"type": "message_start", "message": {"role": "assistant"}})
+                    emit({"type": "message_end", "message": {"role": "assistant",
+                          "content": [], "stopReason": "toolUse", "usage": {}}})
+                    emit({"type": "tool_execution_start", "toolCallId": "read-1",
+                          "toolName": "read", "args": {"path": "a.txt"}})
+                    emit({"type": "tool_execution_end", "toolCallId": "read-1"})
+                    emit({"type": "tool_execution_start", "toolCallId": "bash-1",
+                          "toolName": "bash", "args": {"command": "echo pi"}})
+                    emit({"type": "tool_execution_end", "toolCallId": "bash-1"})
+                    emit({"type": "message_start", "message": {"role": "assistant"}})
+                    emit({"type": "message_end", "message": {"role": "assistant",
+                          "content": [{"type": "text", "text": "Telemetry done"}],
+                          "stopReason": "stop", "usage": {"input": 5, "output": 7}}})
+                    emit({"type": "agent_end", "messages": []})
+                elif os.environ.get("FAKE_PI_MODE") == "no-tools":
+                    emit({"type": "message_start", "message": {"role": "assistant"}})
+                    emit({"type": "message_end", "message": {"role": "assistant",
+                          "content": [{"type": "text", "text": "No tools needed"}],
+                          "stopReason": "stop", "usage": {"input": 2, "output": 3}}})
+                    emit({"type": "agent_end", "messages": []})
+                else:
+                    emit({"type": "tool_start", "toolName": "bash",
+                          "args": {"command": "echo pi"}})
+                    emit({"type": "message_end", "message": {"role": "assistant",
+                          "content": [{"type": "text", "text": "Done <voice>Pi completed the work.</voice>"}],
+                          "stopReason": "stop", "usage": {"input": 5, "output": 7}}})
+                    emit({"type": "agent_end", "messages": []})
+            elif command == "abort":
+                response(command)
+                emit({"type": "agent_end", "messages": []})
+        """
+
+
+        def test_fake_pi_cli_fixture_syntax_is_valid():
+            """The embedded fake CLI stays valid Python."""
+            ast.parse(FAKE_PI_CLI)
+
+
+        def _pi_manager(tmp_path, monkeypatch):
+            workspace = tmp_path / "workspace"
+            workspace.mkdir()
+            executable = tmp_path / "fake-pi"
+            executable.write_text(FAKE_PI_CLI)
+            os.chmod(executable, 0o755)
+            home = tmp_path / "home"
+            home.mkdir()
+            monkeypatch.setenv("HOME", str(home))
+            monkeypatch.setenv("FAKE_PI_ARGS", str(tmp_path / "pi-args.jsonl"))
+            monkeypatch.setenv("FAKE_PI_RPC", str(tmp_path / "pi-rpc.jsonl"))
+            monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
+            return shim.PiProcess(str(workspace), str(executable))
+
+
+        def test_pi_argv_does_not_allowlist_away_extension_tools(tmp_path, monkeypatch):
+            """Pi's built-in allowlist must not block the trusted web extension."""
+            manager = _pi_manager(tmp_path, monkeypatch)
+            manager.turn("hello", model="qwen")
+            argv = json.loads((tmp_path / "pi-args.jsonl").read_text().splitlines()[0])
+
+            assert argv[argv.index("--extension") + 1] == shim.PI_WEB_RESEARCH_EXTENSION
+            # Pi treats --tools as a COMPLETE allowlist. Naming only read,bash,
+            # edit,write silently prevented web_search and web_fetch from becoming
+            # active at session_start. With no allowlist, Pi keeps those same four
+            # default built-ins and permits the loaded extension tools to join them.
+            assert "--tools" not in argv
+            manager._close_process()
+    targets: ["shim_gold_test.py"]
+    timeout_s: 180

--- a/projects/model-bench/tasks/frontend-moving-legtags-01/task.yaml
+++ b/projects/model-bench/tasks/frontend-moving-legtags-01/task.yaml
@@ -1,0 +1,163 @@
+id: frontend-moving-legtags-01
+version: v1
+class: code-fix
+# standard: pure-function layout arithmetic over a self-contained module; the
+# subtlety is the measured-vs-fallback split and keeping the old behaviour byte
+# for byte when unmeasured.
+tier: standard
+mode: agentic
+# Real fix 069d25d1a (PR #5187, "fix(monolith): size moving leg tag stagger by
+# label width"): packLegTags() staggered tags on a fixed 24% start gap, blind to
+# how wide each label renders. The snapshot pins the fix's PARENT and keeps only
+# moving.js, which is dependency-free ESM.
+source_commit: 069d25d1a96b5fea85928a570f9ae102b0ede874
+snapshot:
+  commit: c4e0a1395ea728ac50283fe3df14588e8814e9c7
+  paths:
+    - projects/monolith/frontend/src/routes/friends/moving/moving.js
+  strip_components: 7
+agent:
+  max_turns: 25
+prompt: |
+  moving.js is the dependency-free timeline layout module behind the friends/moving
+  page. Its packLegTags(tags) assigns each trip "leg tag" a stagger level so
+  overlapping tags on the gantt plot do not collide: tags are processed in position
+  order, and a tag lands on the first existing level that has cleared, else opens a
+  new level. Today "has cleared" is approximated with a FIXED start gap
+  (LEG_TAG_MIN_GAP_PERCENT = 24): a level is reusable when the new tag starts at
+  least 24 percentage points after the tag currently occupying it started.
+
+  That fixed gap is blind to how wide each tag actually renders. A tag's rendered
+  width comes from its TEXT, not its date span: long labels overlap anyway on a
+  narrow track, and short labels get pushed onto needless second rows on a wide
+  one.
+
+  Rework the packing so that when the caller supplies the measured plot track
+  width, each tag's footprint is estimated in pixels from its text and converted
+  to a percentage of that track:
+
+    - the label renders at roughly 7px per character (12.5px bold),
+    - the optional date-range line (formatDateRange(starts_on, ends_on); empty
+      when the tag has neither date) renders at roughly 5.8px per character
+      (9.5px mono),
+    - a tag's pixel footprint is the larger of those two plus 14px of clearance,
+    - a level becomes reusable once the new tag's START reaches the previous
+      occupant's estimated END (its position plus its footprint as a percent of
+      the track), instead of a fixed distance after its start.
+
+  Callers pass options as the second argument: packLegTags(tags,
+  { trackWidthPx }). Without a usable track width (undefined, non-finite, or <= 0,
+  e.g. SSR, tests, or not yet measured) the packer must behave EXACTLY as it does
+  today, including the fixed-gap fallback semantics. A null/empty tag list and the
+  returned shape ({ tags: [...each original tag plus its stagger],
+  staggerCount }) stay unchanged. Existing exports keep their names; only
+  packLegTags' second parameter changes shape, and you may add a small exported
+  width-estimation helper next to it if that keeps things readable. The page
+  itself will supply the measured track width; you do not need to touch any
+  .svelte file.
+target_files:
+  - moving.js
+verifier:
+  kind: command
+  args:
+    write_files:
+      # node treats an extensionless-package .js as CommonJS without this hint;
+      # moving.js is ESM.
+      package.json: |
+        {"type": "module"}
+      legtags_gold_test.mjs: |
+        import assert from "node:assert/strict";
+        import { packLegTags } from "./moving.js";
+
+        // Fixed 24% fallback clears two tags 25% apart...
+        const longShort = [
+          {
+            id: "span-move",
+            label: "Pack out and leave Vancouver",
+            starts_on: "2026-10-01",
+            ends_on: "2026-10-10",
+            position: 50,
+          },
+          {
+            id: "span-japan",
+            label: "Japan",
+            starts_on: "2026-10-11",
+            ends_on: "2026-10-25",
+            position: 75,
+          },
+        ];
+        assert.equal(packLegTags(longShort).staggerCount, 1);
+        // ...but on a 600px track "Pack out and leave Vancouver" is wider than
+        // 25% of the track, so the pair must stagger.
+        assert.equal(packLegTags(longShort, { trackWidthPx: 600 }).staggerCount, 2);
+
+        // 8% apart trips the fixed fallback, but short labels fit side by side
+        // on a wide track.
+        const shortLabels = [
+          {
+            id: "span-japan",
+            label: "Japan",
+            starts_on: "2026-10-11",
+            ends_on: "2026-10-25",
+            position: 50,
+          },
+          { id: "span-uk", label: "UK", starts_on: "2026-10-26", ends_on: "2026-11-02", position: 58 },
+        ];
+        assert.equal(packLegTags(shortLabels).staggerCount, 2);
+        assert.equal(packLegTags(shortLabels, { trackWidthPx: 1600 }).staggerCount, 1);
+
+        // The date line measures too: a short label with a long range must not
+        // be packed tight against a follower 4% away on a 1200px track.
+        const dateLine = [
+          {
+            id: "a",
+            label: "UK",
+            starts_on: "2026-09-28",
+            ends_on: "2026-11-30",
+            position: 50,
+          },
+          { id: "b", label: "Go", starts_on: "2026-12-01", ends_on: "2026-12-02", position: 54 },
+        ];
+        assert.equal(packLegTags(dateLine, { trackWidthPx: 1200 }).staggerCount, 2);
+
+        // Non-positive / non-finite widths fall back to the fixed gap.
+        assert.equal(
+          packLegTags(
+            [
+              { id: "a", label: "Pack out and leave Vancouver", position: 50 },
+              { id: "b", label: "Japan", position: 75 },
+            ],
+            { trackWidthPx: 0 },
+          ).staggerCount,
+          1,
+        );
+        assert.equal(
+          packLegTags(
+            [
+              { id: "a", label: "Pack out and leave Vancouver", position: 50 },
+              { id: "b", label: "Japan", position: 75 },
+            ],
+            { trackWidthPx: Number.NaN },
+          ).staggerCount,
+          1,
+        );
+
+        // Shape and degenerate input stay stable.
+        assert.deepEqual(packLegTags([]), { tags: [], staggerCount: 0 });
+        assert.deepEqual(packLegTags(null), { tags: [], staggerCount: 0 });
+        const tagged = packLegTags([
+          { id: "a", label: "A", position: 10 },
+          { id: "b", label: "B", position: 40 },
+        ]);
+        assert.deepEqual(
+          tagged.tags.map((t) => [t.id, t.stagger]),
+          [
+            ["a", 0],
+            ["b", 0],
+          ],
+        );
+        assert.equal(tagged.staggerCount, 1);
+
+        console.log("legtags gold: all assertions passed");
+    cmd: ["node", "legtags_gold_test.mjs"]
+    timeout_s: 120

--- a/projects/model-bench/tasks/inference-appledouble-01/task.yaml
+++ b/projects/model-bench/tasks/inference-appledouble-01/task.yaml
@@ -1,0 +1,54 @@
+id: inference-appledouble-01
+version: v1
+class: config-plumbing
+# easy (floor): a pointed template edit once the AppleDouble failure mode is
+# understood; no cross-file plumbing.
+tier: easy
+mode: agentic
+# Real fix 2f58fba4e (PR #5209, "fix(inference): ignore AppleDouble model
+# artifacts"): model discovery on the NInfer deployment matched macOS AppleDouble
+# sidecars (._*.ninfer) staged next to real artifacts. The snapshot pins the fix's
+# PARENT and keeps what a render needs; charts/ stays because the vendored
+# cf-ingress dependency must be present or `helm template` refuses to run.
+# application.yaml, kustomization.yaml, Chart.lock and BUILD are deploy plumbing
+# the edit never touches.
+source_commit: 2f58fba4e828279ca585d541443347dfb6fca218
+snapshot:
+  commit: 30e60f63fc81a7a642f91cc62f26dee38fc465a8
+  paths:
+    - projects/inference/deploy
+  strip_components: 3
+  exclude:
+    - BUILD
+    - Chart.lock
+    - application.yaml
+    - kustomization.yaml
+prompt: |
+  This is the Helm chart that runs the NInfer LLM server. The main container's
+  start command discovers which model artifact to load with a find(1) over the
+  mounted model volume (see templates/deployment.yaml: it searches
+  {{ .Values.ninfer.modelVolume.mountPath }} at maxdepth 2 for *.ninfer files and
+  takes the lexicographically first match, exiting non-zero when none qualifies).
+
+  Model volumes are staged from a macOS workstation, and the staging copy drops
+  AppleDouble metadata sidecars named like "._my-model.ninfer" alongside every
+  real file. Those sidecars match *.ninfer too, so discovery can pick one and the
+  server then tries to load metadata junk as a model and crash-loops.
+
+  Fix discovery so AppleDouble sidecar files are ignored entirely. Everything else
+  about the pipeline stays identical: same mount path from values.yaml, same
+  search depth, same lexicographic-first selection over the remaining matches,
+  same empty-result error handling. Do not change any other template or value.
+target_files:
+  - templates/deployment.yaml
+verifier:
+  kind: helm-template
+  args:
+    release: ninfer
+    chart: .
+    values: values.yaml
+    assert_contains:
+      # Sidecars are excluded...
+      - "! -name '._*'"
+      # ...and normal discovery still finds .ninfer artifacts.
+      - "-name '*.ninfer'"


### PR DESCRIPTION
Five new SWE-bench-style task packs under `projects/model-bench/tasks/`, each snapshotted at the parent of a real merged fix with a hidden fail-to-pass grader:

- `embervm-pi-tools-01` (#5223): Pi `--tools` allowlist blocked the web extension tools
- `docs-public-markers-01` (#5193): public_content marker guard + posts wiring
- `embervm-capability-generation-01` (#5175): capability generation 0 means any generation
- `inference-appledouble-01` (#5209): AppleDouble sidecars in model discovery
- `frontend-moving-legtags-01` (#5187): width-aware leg tag staggering

Fixtures are snapshot-derived (`bench snapshot <id>`) and stay gitignored per `projects/model-bench/.gitignore`; only `task.yaml` lands. Every task proven in both directions locally: verifier fails on the pinned parent state, passes with the merged diff applied. `load_tasks()` validates all 20 packs. `ci` green.

Implemented by ox-alpha via opencode, reviewed on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K