### PR TITLE
fix(embervm): keep the op-log connection breathing so it is not reaped

### DIFF
--- a/projects/embervm/control/lib/embervm/op_log/postgres.ex
+++ b/projects/embervm/control/lib/embervm/op_log/postgres.ex
@@ -75,6 +75,50 @@ defmodule Embervm.OpLog.Postgres do
   @default_compact_batch_size 500
   @marker_key "compacted_through_seq"
 
+  # TCP keepalive for the one long-lived postgrex connection, and the reason it
+  # is not optional here.
+  #
+  # This connection is idle between appends, sometimes for an hour. Cilium is
+  # eBPF L4 with no L7 proxy on this path, so a TCP flow carrying no packets
+  # eventually has its conntrack entry reaped, and the next INSERT writes into a
+  # black hole: it HANGS rather than failing, until some timeout above it fires.
+  # That is not a slow database, and it does not look like one from the server
+  # (Postgres sees the cancel, never the statement).
+  #
+  # This cluster has already paid for this lesson one layer down. The
+  # control-plane to noded gRPC connection lost multi-GB base exports the same
+  # way, with the same "the connection is closed" error, because neither side
+  # set gRPC keepalive; see projects/embervm/noded/server/store.go:505. There it
+  # was fixed by making the long call async. Here the flow simply has to keep
+  # breathing.
+  #
+  # SO_KEEPALIVE alone is not enough: Linux defaults to probing only after
+  # tcp_keepalive_time, 7200 seconds, which is far longer than the datapath's
+  # patience. The raw options are the load-bearing part, so the first probe
+  # lands a minute into an idle period and a genuinely dead socket is known
+  # within about 105s (60 + 3 x 15) instead of hanging.
+  #
+  # The raw option numbers are Linux (IPPROTO_TCP 6; TCP_KEEPIDLE 4,
+  # TCP_KEEPINTVL 5, TCP_KEEPCNT 6). The control plane is an amd64 Linux image
+  # and every node is Linux, so this is not conditioned on the platform; a port
+  # to another OS has to revisit these three numbers, which is why they are
+  # named rather than inlined.
+  @tcp_keepidle_seconds 60
+  @tcp_keepintvl_seconds 15
+  @tcp_keepcnt 4
+
+  # Postgrex's own query timeout, made explicit rather than inherited, because
+  # the append budget below is defined RELATIVE to it.
+  @query_timeout_ms 15_000
+
+  # The append call budget, deliberately ABOVE @query_timeout_ms. The old value
+  # was the implicit GenServer 5000, which expired BEFORE the database layer's
+  # own timeout: the caller gave up first and died while the transaction might
+  # still commit, and every store that appends died with it under
+  # :rest_for_one. With the database's timeout firing first, the reply is
+  # authoritative and a slow append degrades to a slow append.
+  @append_timeout_ms 20_000
+
   @ddl [
     """
     CREATE TABLE IF NOT EXISTS ops (
@@ -317,9 +361,14 @@ defmodule Embervm.OpLog.Postgres do
     end
   end
 
+  @doc false
+  # Reachable so a test can assert it stays ABOVE the database's own timeout.
+  # That ordering is the whole point of the value, and nothing else enforces it.
+  def append_timeout_ms, do: @append_timeout_ms
+
   @impl Embervm.OpLog
   def append(server \\ __MODULE__, %Op{} = op) do
-    GenServer.call(server, {:append, op})
+    GenServer.call(server, {:append, op}, @append_timeout_ms)
   end
 
   @impl Embervm.OpLog
@@ -448,22 +497,47 @@ defmodule Embervm.OpLog.Postgres do
   # Postgrex.Utils.default_opts/1 has no public DSN parser, so we accept
   # either a full "postgres://user:pass@host:port/db" DSN (parsed here) or,
   # for tests, opts already in Postgrex's own keyword shape.
-  defp connect(dsn) when is_binary(dsn) do
+  defp connect(dsn) when is_binary(dsn), do: dsn |> connect_opts() |> Postgrex.start_link()
+
+  # Opts already in Postgrex's own keyword shape (tests). Keepalive is put_new,
+  # so a test that pins its own socket_options still wins.
+  defp connect(opts) when is_list(opts) do
+    opts
+    |> Keyword.put(:name, nil)
+    |> Keyword.put_new(:socket_options, keepalive_socket_options())
+    |> Postgrex.start_link()
+  end
+
+  @doc false
+  # Split out from connect/1 and left reachable so the keepalive settings are
+  # assertable without a live database: CI has no Postgres for the control
+  # plane, and a silently dropped socket option would only surface as the
+  # months-apart connection reap this exists to prevent.
+  def connect_opts(dsn) when is_binary(dsn) do
     uri = URI.parse(dsn)
     [user, pass] = String.split(uri.userinfo || ":", ":", parts: 2)
     database = String.trim_leading(uri.path || "", "/")
 
-    Postgrex.start_link(
+    [
       hostname: uri.host,
       port: uri.port || 5432,
       username: nil_if_empty(user),
       password: nil_if_empty(pass),
       database: nil_if_empty(database),
-      name: nil
-    )
+      name: nil,
+      timeout: @query_timeout_ms,
+      socket_options: keepalive_socket_options()
+    ]
   end
 
-  defp connect(opts) when is_list(opts), do: Postgrex.start_link(Keyword.put(opts, :name, nil))
+  defp keepalive_socket_options do
+    [
+      {:keepalive, true},
+      {:raw, 6, 4, <<@tcp_keepidle_seconds::native-32>>},
+      {:raw, 6, 5, <<@tcp_keepintvl_seconds::native-32>>},
+      {:raw, 6, 6, <<@tcp_keepcnt::native-32>>}
+    ]
+  end
 
   defp nil_if_empty(""), do: nil
   defp nil_if_empty(v), do: v
@@ -556,7 +630,31 @@ defmodule Embervm.OpLog.Postgres do
 
   # -- append + projection -------------------------------------------------
 
+  # A transport fault must NOT kill this GenServer. It is the FIRST child under
+  # :rest_for_one (see Embervm.Application), so its death restarts every store
+  # behind it and Bandit last, which is how a dropped connection turned into a
+  # failed liveness probe and a control-plane restart. Postgrex reconnects on
+  # its own, so the honest answer to the caller is that this append did not
+  # land. Callers already match on {:error, _}.
   defp do_append(conn, %Op{} = op) do
+    do_append_now(conn, op)
+  rescue
+    error in DBConnection.ConnectionError ->
+      Logger.warning(
+        "embervm op-log append failed on a dead connection: #{Exception.message(error)}"
+      )
+
+      {:error, :unavailable}
+  catch
+    # DBConnection raises for a broken socket but EXITS when the connection
+    # process itself is gone. Both are the same event to a caller, and neither
+    # may take this GenServer with it.
+    :exit, reason ->
+      Logger.warning("embervm op-log append exited: #{inspect(reason)}")
+      {:error, :unavailable}
+  end
+
+  defp do_append_now(conn, %Op{} = op) do
     if op.kind not in Embervm.OpLog.kinds() do
       {:error, {:unknown_kind, op.kind}}
     else

--- a/projects/embervm/control/test/embervm/op_log/postgres_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/postgres_test.exs
@@ -14,6 +14,8 @@ defmodule Embervm.OpLog.PostgresTest do
 
   alias Embervm.OpLog.Postgres
 
+  @dsn "postgres://embervm:secret@monolith-pg-rw.monolith.svc.cluster.local:5432/embervm_oplog"
+
   test "implements every Embervm.OpLog callback" do
     behaviours = Postgres.__info__(:attributes) |> Keyword.get_values(:behaviour) |> List.flatten()
     assert Embervm.OpLog in behaviours
@@ -54,5 +56,46 @@ defmodule Embervm.OpLog.PostgresTest do
     # No connection is started; db_size/1 never touches the GenServer or dials
     # out, so this is safe to call against an address with nothing listening.
     assert Postgres.db_size(:no_such_server) == {:error, :not_supported}
+  end
+
+  describe "connect_opts/1" do
+    test "parses the DSN into Postgrex's keyword shape" do
+      opts = Postgres.connect_opts(@dsn)
+
+      assert opts[:hostname] == "monolith-pg-rw.monolith.svc.cluster.local"
+      assert opts[:port] == 5432
+      assert opts[:username] == "embervm"
+      assert opts[:password] == "secret"
+      assert opts[:database] == "embervm_oplog"
+      # nil name: this connection is owned by the GenServer, never registered.
+      assert opts[:name] == nil
+    end
+
+    test "keeps the connection breathing so an idle flow is not reaped" do
+      # The op-log connection sits idle between appends, sometimes for an hour.
+      # Cilium is eBPF L4 on this path, so a flow with no packets has its
+      # conntrack entry collected, and the next INSERT hangs instead of failing.
+      # That took the control plane down twice on 2026-08-23 (see the issue this
+      # test cites). SO_KEEPALIVE alone does not help: Linux would not probe for
+      # 7200 seconds. The raw options are what make the probe land in time, so
+      # assert the values and not merely that keepalive is on.
+      socket_options = Postgres.connect_opts(@dsn)[:socket_options]
+
+      assert {:keepalive, true} in socket_options
+      # IPPROTO_TCP 6; TCP_KEEPIDLE 4, TCP_KEEPINTVL 5, TCP_KEEPCNT 6 (Linux).
+      assert {:raw, 6, 4, <<60::native-32>>} in socket_options
+      assert {:raw, 6, 5, <<15::native-32>>} in socket_options
+      assert {:raw, 6, 6, <<4::native-32>>} in socket_options
+    end
+
+    test "the append budget outlives the database's own timeout" do
+      # Ordering, not magnitude, is the property. The old append budget was the
+      # implicit GenServer 5000, which expired BEFORE the database gave up: the
+      # caller died while its transaction might still commit, and because the
+      # op-log is the first child under :rest_for_one, every store behind it
+      # restarted too. Whichever way these two numbers are tuned, the database
+      # has to be the one that decides.
+      assert Postgres.append_timeout_ms() > Postgres.connect_opts(@dsn)[:timeout]
+    end
   end
 end


### PR DESCRIPTION
Fixes the control-plane outage in #5235. Twice on 2026-08-23 a session or stateful invoke came back as `"the connection is closed"` with `retryable: false`, and at 20:00Z it went as far as a failed liveness probe and a pod restart.

## The database is not slow

That was my first read and it was wrong. The primary's checkpoints **sync in 2 to 62 milliseconds** and write under 4% of shared buffers; the long `write=` figures are deliberate spread-out checkpointing, not storage pressure. That is a nearly idle database.

What the Postgres log actually shows is a connection opened at **20:00:37Z** whose **first** `INSERT INTO ops`, over an hour later at **21:05:29Z**, was the one cancelled (`session_line_num: 2`, so nothing else ever ran on it). The server never saw a slow statement. It saw a cancel arrive for work that had not reached it.

## What is happening

`Embervm.OpLog.Postgres` holds one long-lived postgrex connection, and `connect/1` set no `socket_options`, so there was no TCP keepalive anywhere in `control/lib`. Idle between appends, the flow carries no packets, the Cilium eBPF datapath collects its conntrack entry, and the next INSERT writes into a black hole and hangs instead of failing.

This cluster has already paid for this exact closer one layer down, with the same error string, when neither side of the control-plane to noded gRPC link set keepalive. From `noded/server/store.go:505`:

> a long in-progress call with zero server->client frames is eventually reaped by an on-path L4 idle timeout (Cilium is eBPF L4 with no L7 proxy in this path, so a stale conntrack/NAT entry for a no-packet TCP flow is the closer, not a mesh proxy) and the CP saw `{:error, "the connection is closed"}` mid-upload.

There it was fixed by making the long call async. Here the flow simply has to keep breathing.

## Changes

**The fix.** SO_KEEPALIVE plus the raw `TCP_KEEPIDLE` / `TCP_KEEPINTVL` / `TCP_KEEPCNT` options on the postgrex socket. Keepalive alone would not help: Linux waits 7200 seconds before its first probe, far longer than the datapath's patience. At 60/15/4 the first probe lands a minute into an idle period and a genuinely dead socket is known in about 105 seconds.

**Blast radius, since a connection can still die.** The op-log is the FIRST child under `:rest_for_one`, so its death restarts every store behind it and Bandit last, which is how a dropped socket became a failed liveness probe.

- `do_append/2` no longer lets a `DBConnection` fault kill the GenServer, rescuing the raise and catching the exit. Postgrex reconnects on its own, and the honest answer to the caller is that this append did not land; callers already match on `{:error, _}`.
- The append call budget moves above the database's own timeout. The implicit `5000` expired FIRST, so the caller gave up and died while its transaction might still commit.

Deliberately **not** widening to a connection pool (fix 3 on the issue): a pool of idle connections has the same problem, in parallel.

## Testing

Three new cases in `postgres_test.exs`, which is the existing no-connection suite (CI has no Postgres for the control plane): the DSN parses into Postgrex's keyword shape, the keepalive raw options carry the documented values rather than merely being present, and the append budget stays above the database timeout as a drift guard on a coupling nothing else enforces.

**I could not compile or run the suite locally.** This sandbox has no elixir, mix or bazel, so PR CI is the gate rather than a local `ci` run. Worth a careful look at the `rescue`/`catch` block and the raw socket option syntax on that account.

## Verifying after deploy

The signature to watch is the absence of `GenServer.call(Embervm.OpLog.Postgres, {:append, ...})` timeouts in the control-plane logs across an idle hour, and no further `canceling statement due to user request` on `INSERT INTO ops` from the CP's pod IP. Both were reliably reproducing about hourly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeBfGWXvX7AEQru8Wa5pEf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeBfGWXvX7AEQru8Wa5pEf)_