### PR TITLE
chore(monolith): delete dead replan-timeout knob and unused cfIngress.todo values

### DIFF
--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -510,8 +510,6 @@ spec:
             {{- end }}
             - name: ORCHESTRATOR_TIMEOUT_S
               value: {{ .Values.orchestrator.timeoutSeconds | quote }}
-            - name: ORCHESTRATOR_REPLAN_TIMEOUT_S
-              value: {{ .Values.orchestrator.replanTimeoutSeconds | quote }}
             {{- end }}
             - name: AUTH_AUTHENTIK_JWKS_URL
               value: {{ .Values.auth.authentik.jwksUrl | quote }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1253,10 +1253,6 @@ orchestrator:
   # Initial-compile budget: covers BOTH the route-decision call and the
   # submit_plan tool call (plan construction is real work, not a quick classify).
   timeoutSeconds: 60
-  # Replan budget (the capped goose escape hatch): a replan runs after goose has
-  # opened the task and reported what it learned, so it gets a more generous
-  # budget than the initial compile.
-  replanTimeoutSeconds: 120
 
 # WhatsApp channel gateway (ADR 039): a transport-only Go whatsmeow service in
 # its own single-replica Deployment. Disabled by default; Joe flips

--- a/projects/monolith/chat/orchestrator_client.py
+++ b/projects/monolith/chat/orchestrator_client.py
@@ -44,8 +44,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
 # Initial-compile budget (Task 8). Covers BOTH the route-decision ``call()`` and
 # the ``submit_plan`` ``call_tool()``, since plan construction is real work, not a
-# quick classification. Overridable via ``ORCHESTRATOR_TIMEOUT_S``. The separate
-# replan budget lives in ``orchestrator._replan_timeout_s`` (default 120s).
+# quick classification. Overridable via ``ORCHESTRATOR_TIMEOUT_S``.
 _DEFAULT_TIMEOUT_S = 60.0
 
 

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -33,7 +33,10 @@ frontend:
   otelCollectorUrl: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318"
 
 postgres:
-  # Nightly logical refresh of monolith-dev-pg from this cluster's REPLICA.
+  # Nightly logical refresh of monolith-dev-pg, dumped from the production
+  # PRIMARY (monolith-pg-rw), not the -ro replica: standby recovery conflicts
+  # killed every run (see the env comment in
+  # chart/templates/cnpg-dev-refresh-cronworkflow.yaml).
   # Enabled here rather than in the chart default so the chart stays inert for
   # anyone rendering it, matching how every other environment choice is made in
   # this repo. The hand-made half of its credentials (monolith-pg-dump-reader)
@@ -134,27 +137,6 @@ cfIngress:
     authentik:
       onepassword:
         itemPath: vaults/k8s-homelab/items/moving-oidc
-  todo:
-    public:
-      enabled: false
-      tier: public
-      hostname: todo.jomcgi.dev
-      servicePort: 8000
-      gateway:
-        name: cloudflare-ingress
-        namespace: envoy-gateway-system
-      rateLimit:
-        requests: 100
-        unit: Minute
-    admin:
-      enabled: false
-      tier: trusted
-      hostname: todo-admin.jomcgi.dev
-      servicePort: 8000
-      gateway:
-        name: cloudflare-ingress
-        namespace: envoy-gateway-system
-      team: jomcgi
 
 knowledge:
   enabled: true


### PR DESCRIPTION
Closes #5237. Also lands both #5240 items.

Deletion-only cleanup of dead configuration found by audit:

- `orchestrator.replanTimeoutSeconds` + the `ORCHESTRATOR_REPLAN_TIMEOUT_S` env pair: no reader anywhere, the replan path it describes does not exist. Stale `orchestrator_client.py` comment fixed.
- `cfIngress.todo.public/admin` in deploy values: consumed by no template (grep-proven; flipping `enabled: true` was a no-op).
- Dev-refresh comment corrected: the nightly dump comes from the production PRIMARY, not the replica (standby recovery conflicts killed replica dumps).

Render-diff proof: `helm template` before/after differs only by the removed env pair. Local: orchestrator_client pytest 23 passed; `ci` green (754 tests pass, 225 executed).

Implemented by ox-alpha via opencode, reviewed on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K