### PR TITLE
fix(monolith): drive cd_health chart lag from a configurable Kargo app list

### DIFF
--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -304,6 +304,13 @@ spec:
               value: {{ .Values.cdHealth.chartLagSeconds | quote }}
             - name: CD_HEALTH_CI_RED_WINDOW_S
               value: {{ .Values.cdHealth.ciRedWindowSeconds | quote }}
+            # Which Kargo-managed production apps the chart-lag check covers
+            # (#4890), rendered as the JSON list cd_health._parse_apps reads.
+            # One entry per promotion pipeline; see cdHealth.apps in values.yaml
+            # for the three fields each entry carries. Rendered even when empty:
+            # an empty list faults loudly rather than watching nothing silently.
+            - name: CD_HEALTH_KARGO_APPS
+              value: {{ .Values.cdHealth.apps | toJson | quote }}
             - name: CD_PROBE_INTERVAL_S
               value: {{ .Values.cdHealth.probeIntervalSeconds | quote }}
             {{- if .Values.whatsapp.enabled }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1034,6 +1034,18 @@ cdHealth:
   # main's CI red for longer than this trips it. Red is only a fault once it
   # persists; a run being actively fixed must not page.
   ciRedWindowSeconds: 3600
+  # Which Kargo-managed production apps the chart-lag clock covers (#4890).
+  # One entry per promotion pipeline, mirroring projects/platform/kargo/
+  # values.yaml promotion.pipelines: `app` is the ArgoCD Application whose
+  # deployed revision counts as production, `kargo_namespace` is the Kargo
+  # project namespace whose Warehouse discovers its chart Freight, and
+  # `chart_repo_suffix` selects that chart out of a Freight's repoURL. The
+  # clock stays "oldest unpromoted Freight" per app, and the whole component
+  # stays advisory: it pages nobody. Empty (the default) keeps the chart inert,
+  # and the check then reports a fault rather than a vacuous healthy, because
+  # a signal watching nothing must not read as green. Adding a pipeline in the
+  # kargo chart means adding it here (or in the deploy values) too.
+  apps: []
   # How often the private tier recomputes cd health and writes the latch. The
   # public reader treats a row older than 2.5x this as a dead writer.
   probeIntervalSeconds: 300

--- a/projects/monolith/cluster/cd_health.py
+++ b/projects/monolith/cluster/cd_health.py
@@ -11,12 +11,19 @@ This component is advisory. A deploy in progress or production behind a chart
 is not the public site being down, so the signal is reported as metadata and
 does not make the health endpoint return 503.
 
-1. Production's live monolith chart is older than the oldest unpromoted monolith
-   chart Kargo has discovered, for longer than the lag window. The old ArgoCD
-   sweep faulted on permanently unconvergeable OutOfSync/Healthy diffs in authentik,
-   argocd, kyverno, and context-forge-gateway, so it was always red and
-   monitored nothing. The original #4597 fault class, a targetRevision for a
-   chart that was never published, is structurally impossible now that Kargo
+Coverage is configured, not hardcoded (#4890): ``CD_HEALTH_KARGO_APPS`` lists
+every Kargo-managed production app (monolith and embervm today, rendered from
+``cdHealth.apps`` in the chart), and the lag judgement below runs once per
+entry. Before embervm joined, its four-version lag on 2026-08-14 (#4884) was
+invisible here while `Synced`/`Healthy` stayed true, because those describe
+agreement with the pinned version, not currency with main.
+
+1. A production app's live chart is older than the oldest unpromoted chart
+   Kargo has discovered for it, for longer than the lag window. The old ArgoCD
+   sweep faulted on permanently unconvergeable OutOfSync/Healthy diffs in
+   authentik, argocd, kyverno, and context-forge-gateway, so it was always red
+   and monitored nothing. The original #4597 fault class, a targetRevision for
+   a chart that was never published, is structurally impossible now that Kargo
    owns targetRevision and only promotes discovered Freight. What can still
    happen is production sitting on an old chart while newer charts pile up.
 2. main's CI: the most recent commit WITH A COMPLETED STATUS is red and older
@@ -43,6 +50,7 @@ which is when it starts to matter.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
@@ -80,8 +88,49 @@ def _parse_ts(value: str | None) -> datetime | None:
         return None
 
 
-PROD_APP_NAME = "monolith"
-KARGO_NAMESPACE = "kargo-monolith"
+# One entry per Kargo-managed production app, rendered from
+# cdHealth.apps by the chart (issue #4890). Each entry carries the three
+# names the lag check needs: app is the ArgoCD Application whose deployed
+# revision counts as that app's production, kargo_namespace is the Kargo
+# project namespace whose Warehouse discovers its chart Freight, and
+# chart_repo_suffix picks that chart out of a Freight's repoURL. The RBAC
+# for both reads is already ClusterRole-scoped, so a new app costs a values
+# change only.
+def _parse_apps(raw: str | None) -> list[dict]:
+    """Parse CD_HEALTH_KARGO_APPS into per-app check inputs.
+
+    Malformed or incomplete entries are dropped with a warning rather than
+    aborting the rest of the list, but an empty RESULT is not silently
+    healthy: _chart_lag_fault faults on it, mirroring how empty Freight is
+    treated below. A signal watching nothing must not read as green.
+    """
+    if not raw:
+        return []
+    try:
+        entries = json.loads(raw)
+    except ValueError:
+        logger.warning("cd health: CD_HEALTH_KARGO_APPS is not valid JSON")
+        return []
+    if not isinstance(entries, list):
+        logger.warning("cd health: CD_HEALTH_KARGO_APPS is not a JSON list")
+        return []
+    apps = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            logger.warning("cd health: dropping non-object app entry %r", entry)
+            continue
+        app = entry.get("app")
+        namespace = entry.get("kargo_namespace")
+        suffix = entry.get("chart_repo_suffix")
+        if not app or not namespace or not suffix:
+            logger.warning("cd health: dropping incomplete app entry %r", entry)
+            continue
+        apps.append({"app": app, "namespace": namespace, "suffix": suffix})
+    return apps
+
+
+def _configured_apps() -> list[dict]:
+    return _parse_apps(os.environ.get("CD_HEALTH_KARGO_APPS", ""))
 
 
 def _chart_version(value: str | None) -> tuple[int, int, int] | None:
@@ -95,16 +144,23 @@ def _chart_version(value: str | None) -> tuple[int, int, int] | None:
 
 
 def _evaluate_chart_lag(
-    live_version: str | None, freight: list[dict], lag_s: float, now: datetime
+    app: str,
+    live_version: str | None,
+    freight: list[dict],
+    lag_s: float,
+    now: datetime,
 ) -> tuple[str | None, str | None]:
-    """Judge production chart lag without doing any I/O."""
+    """Judge one app's production chart lag without doing any I/O.
+
+    Every message names its app so several apps can share one detail string.
+    """
     live = _chart_version(live_version)
     if live is None:
-        return None, "prod chart version unreadable"
+        return None, f"{app}: prod chart version unreadable"
     if not freight:
         # This component is advisory and pages nobody, so a false positive is
         # acceptable, but a false negative when the entire signal dies is not.
-        return "no monolith Freight found, chart discovery may be broken", None
+        return f"{app}: no Freight found, chart discovery may be broken", None
 
     newer = []
     for item in freight:
@@ -112,7 +168,7 @@ def _evaluate_chart_lag(
         if version is not None and version > live and _parse_ts(item.get("created_at")):
             newer.append(item)
     if not newer:
-        return None, f"prod on {live_version}, up to date"
+        return None, f"{app}: prod on {live_version}, up to date"
 
     # The oldest unpromoted Freight owns the clock. New charts arriving every
     # 20 minutes must not reset how long production has actually been behind.
@@ -127,24 +183,50 @@ def _evaluate_chart_lag(
     # immaterial, but it should not surprise the next reader.
     if age_s > lag_s:
         return (
-            f"prod on {live_version}, {count} chart(s) behind through "
+            f"{app}: prod on {live_version}, {count} chart(s) behind through "
             f"{newest['version']}, waiting {age_s / 60:.0f}m",
             None,
         )
     return None, (
-        f"prod {count} chart(s) behind through {newest['version']} "
+        f"{app}: prod {count} chart(s) behind through {newest['version']} "
         f"for {age_s / 60:.0f}m"
     )
 
 
-async def _chart_lag_fault(lag_s: float) -> tuple[str | None, str | None]:
-    """Read the live Application and Kargo Freight, then judge chart lag."""
+async def _chart_lag_fault(lag_s: float) -> tuple[bool, list[str]]:
+    """Read every configured app's live Application and Kargo Freight.
+
+    Returns (ok, details): ok is False when any app faults. The clock stays
+    the oldest unpromoted Freight per app; nothing about the advisory tier
+    changes with coverage.
+    """
     from cluster.kubernetes import KubernetesClient  # noqa: PLC0415
 
+    apps = _configured_apps()
+    if not apps:
+        # Same treatment as empty Freight: watching nothing is a dead signal
+        # and must fault, never read as an all-clear.
+        return False, ["no Kargo-managed apps configured, chart lag watches nothing"]
+
     kubernetes = KubernetesClient()
-    live = await kubernetes.get_argocd_app_deployed_revision(PROD_APP_NAME)
-    freight = await kubernetes.list_kargo_freight(KARGO_NAMESPACE)
-    return _evaluate_chart_lag(live, freight, lag_s, datetime.now(timezone.utc))
+    ok = True
+    details: list[str] = []
+    for entry in apps:
+        live = await kubernetes.get_argocd_app_deployed_revision(entry["app"])
+        freight = await kubernetes.list_kargo_freight(
+            entry["namespace"], repo_suffix=entry["suffix"]
+        )
+        app_ok = True
+        fault, note = _evaluate_chart_lag(
+            entry["app"], live, freight, lag_s, datetime.now(timezone.utc)
+        )
+        if fault:
+            app_ok = False
+            details.append(fault)
+        if note:
+            details.append(note)
+        ok = ok and app_ok
+    return ok, details
 
 
 async def _ci_fault(red_window_s: float) -> str | None:
@@ -248,19 +330,16 @@ async def cd_health() -> dict:
     ok = True
 
     try:  # nosemgrep: no-broad-except-swallow - reported in-band, logged below
-        chart_lag = await _chart_lag_fault(lag_s)
+        lag_ok, lag_details = await _chart_lag_fault(lag_s)
     except Exception as exc:  # noqa: BLE001
         # Includes the Forbidden an RBAC gap would produce. Report it rather
         # than 503: a broken checker must not masquerade as a broken platform.
         logger.warning("cd health: chart lag check failed: %s", exc)
         details.append(f"chart lag check unavailable ({exc})")
     else:
-        chart_lag_fault, chart_lag_note = chart_lag
-        if chart_lag_fault:
+        if not lag_ok:
             ok = False
-            details.append(chart_lag_fault)
-        if chart_lag_note:
-            details.append(chart_lag_note)
+        details.extend(lag_details)
 
     if not os.environ.get("GITHUB_API_TOKEN", ""):
         details.append("ci check disabled: no GITHUB_API_TOKEN")

--- a/projects/monolith/cluster/cd_health_test.py
+++ b/projects/monolith/cluster/cd_health_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -28,20 +29,40 @@ def _freight(version: str, created_at: datetime) -> dict:
     }
 
 
+def _apps_config() -> str:
+    """The deploy-shaped CD_HEALTH_KARGO_APPS payload: monolith + embervm."""
+    return json.dumps(
+        [
+            {
+                "app": "monolith",
+                "kargo_namespace": "kargo-monolith",
+                "chart_repo_suffix": "/charts/monolith",
+            },
+            {
+                "app": "embervm",
+                "kargo_namespace": "kargo-embervm",
+                "chart_repo_suffix": "/charts/embervm",
+            },
+        ]
+    )
+
+
+# Per-app lag judgement (pure).
 def test_up_to_date_is_ok():
     now = datetime.now(timezone.utc)
     fault, note = mod._evaluate_chart_lag(
-        "0.301.1", [_freight("0.301.0", now)], 7200, now
+        "monolith", "0.301.1", [_freight("0.301.0", now)], 7200, now
     )
     assert fault is None
-    assert note == "prod on 0.301.1, up to date"
+    assert note == "monolith: prod on 0.301.1, up to date"
 
 
 def test_empty_freight_faults_instead_of_saying_up_to_date():
     fault, note = mod._evaluate_chart_lag(
-        "0.301.1", [], 7200, datetime.now(timezone.utc)
+        "monolith", "0.301.1", [], 7200, datetime.now(timezone.utc)
     )
-    assert fault is not None and "no monolith Freight found" in fault
+    assert fault is not None and "no Freight found" in fault
+    assert "monolith" in fault
     assert note is None
     assert "up to date" not in fault
 
@@ -49,7 +70,11 @@ def test_empty_freight_faults_instead_of_saying_up_to_date():
 def test_behind_inside_window_does_not_fault_and_says_how_far():
     now = datetime.now(timezone.utc)
     fault, note = mod._evaluate_chart_lag(
-        "0.301.1", [_freight("0.302.0", now - timedelta(minutes=30))], 7200, now
+        "monolith",
+        "0.301.1",
+        [_freight("0.302.0", now - timedelta(minutes=30))],
+        7200,
+        now,
     )
     assert fault is None
     assert note is not None and "0.302.0" in note and "30m" in note
@@ -58,7 +83,11 @@ def test_behind_inside_window_does_not_fault_and_says_how_far():
 def test_behind_past_window_faults_with_versions_and_age():
     now = datetime.now(timezone.utc)
     fault, note = mod._evaluate_chart_lag(
-        "0.301.1", [_freight("0.302.0", now - timedelta(hours=3))], 7200, now
+        "monolith",
+        "0.301.1",
+        [_freight("0.302.0", now - timedelta(hours=3))],
+        7200,
+        now,
     )
     assert note is None
     assert fault is not None
@@ -71,32 +100,166 @@ def test_oldest_unpromoted_freight_owns_the_clock():
         _freight("0.302.0", now - timedelta(hours=3)),
         _freight("0.303.0", now - timedelta(minutes=10)),
     ]
-    fault, _ = mod._evaluate_chart_lag("0.301.1", freight, 7200, now)
+    fault, _ = mod._evaluate_chart_lag("monolith", "0.301.1", freight, 7200, now)
     assert fault is not None and "180m" in fault
 
 
 def test_unreadable_live_version_reports_rather_than_faulting():
     fault, note = mod._evaluate_chart_lag(
-        "latest", [], 7200, datetime.now(timezone.utc)
+        "monolith", "latest", [], 7200, datetime.now(timezone.utc)
     )
     assert fault is None
-    assert note == "prod chart version unreadable"
+    assert note == "monolith: prod chart version unreadable"
 
 
 def test_unparseable_freight_versions_are_ignored():
     now = datetime.now(timezone.utc)
     fault, note = mod._evaluate_chart_lag(
-        "0.301.1", [_freight("main", now - timedelta(days=2))], 7200, now
+        "monolith", "0.301.1", [_freight("main", now - timedelta(days=2))], 7200, now
     )
-    assert fault is None and note == "prod on 0.301.1, up to date"
+    assert fault is None and note == "monolith: prod on 0.301.1, up to date"
 
 
 def test_freight_older_than_live_is_ignored():
     now = datetime.now(timezone.utc)
     fault, note = mod._evaluate_chart_lag(
-        "0.301.1", [_freight("0.300.9", now - timedelta(days=2))], 7200, now
+        "monolith", "0.301.1", [_freight("0.300.9", now - timedelta(days=2))], 7200, now
     )
-    assert fault is None and note == "prod on 0.301.1, up to date"
+    assert fault is None and note == "monolith: prod on 0.301.1, up to date"
+
+
+# App-list config.
+def test_parse_apps_accepts_the_deploy_shape():
+    apps = mod._parse_apps(_apps_config())
+    assert apps == [
+        {
+            "app": "monolith",
+            "namespace": "kargo-monolith",
+            "suffix": "/charts/monolith",
+        },
+        {
+            "app": "embervm",
+            "namespace": "kargo-embervm",
+            "suffix": "/charts/embervm",
+        },
+    ]
+
+
+def test_parse_apps_treats_unusable_config_as_empty():
+    assert mod._parse_apps("") == []
+    assert mod._parse_apps(None) == []
+    assert mod._parse_apps("not json") == []
+    # A JSON object is not the list the contract names.
+    assert mod._parse_apps('{"app": "monolith"}') == []
+    # An entry missing any of its three names is dropped, not half-honoured.
+    assert mod._parse_apps('[{"app": "monolith"}]') == []
+    assert mod._parse_apps('[{"app": "m", "kargo_namespace": "k"}]') == []
+    assert mod._parse_apps('["monolith"]') == []
+
+
+# Multi-app aggregation through _chart_lag_fault, with the Kubernetes client
+# faked below the seam cd_health imports it at (cluster.kubernetes).
+def _fake_kubernetes(revisions: dict, freight_by_namespace: dict):
+    class _Fake:
+        def __init__(self):
+            self.freight_calls = []
+
+        async def get_argocd_app_deployed_revision(self, name):
+            return revisions.get(name)
+
+        async def list_kargo_freight(self, namespace, repo_suffix="/charts/monolith"):
+            self.freight_calls.append((namespace, repo_suffix))
+            return freight_by_namespace.get(namespace, [])
+
+    # cd_health constructs the client itself, so hand back an INSTANCE for the
+    # patched KubernetesClient() to return.
+    return _Fake()
+
+
+@pytest.mark.asyncio
+async def test_one_app_lagging_and_one_fresh_faults_once(monkeypatch):
+    monkeypatch.setenv("CD_HEALTH_KARGO_APPS", _apps_config())
+    now = datetime.now(timezone.utc)
+    fake = _fake_kubernetes(
+        {"monolith": "0.301.1", "embervm": "0.13.7"},
+        {
+            # monolith sits four hours behind; embervm has a fresh chart inside
+            # the window, which is a note and never a fault.
+            "kargo-monolith": [_freight("0.302.0", now - timedelta(hours=4))],
+            "kargo-embervm": [_freight("0.14.0", now - timedelta(minutes=10))],
+        },
+    )
+    monkeypatch.setattr("cluster.kubernetes.KubernetesClient", lambda: fake)
+
+    ok, details = await mod._chart_lag_fault(7200)
+
+    assert ok is False
+    faults = [d for d in details if "waiting" in d]
+    assert len(faults) == 1 and "monolith" in faults[0] and "0.302.0" in faults[0]
+    # The fresh app contributes its note, not a fault, and names itself.
+    assert any(d.startswith("embervm:") for d in details)
+    # Each app must be queried against ITS namespace and chart suffix, proving
+    # the config list actually flows through rather than a shared constant.
+    assert fake.freight_calls == [
+        ("kargo-monolith", "/charts/monolith"),
+        ("kargo-embervm", "/charts/embervm"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_one_app_lagging_one_fresh_exact_notes(monkeypatch):
+    monkeypatch.setenv("CD_HEALTH_KARGO_APPS", _apps_config())
+    now = datetime.now(timezone.utc)
+    fake = _fake_kubernetes(
+        {"monolith": "0.301.1", "embervm": "0.13.7"},
+        {
+            "kargo-monolith": [_freight("0.302.0", now - timedelta(hours=4))],
+            "kargo-embervm": [_freight("0.14.0", now - timedelta(minutes=10))],
+        },
+    )
+    monkeypatch.setattr("cluster.kubernetes.KubernetesClient", lambda: fake)
+
+    ok, details = await mod._chart_lag_fault(7200)
+
+    assert ok is False
+    assert "embervm: prod 1 chart(s) behind through 0.14.0 for 10m" in details
+
+
+@pytest.mark.asyncio
+async def test_app_with_no_published_chart_yet_faults_others_stay_ok(monkeypatch):
+    monkeypatch.setenv("CD_HEALTH_KARGO_APPS", _apps_config())
+    now = datetime.now(timezone.utc)
+    fake = _fake_kubernetes(
+        {"monolith": "0.301.1", "embervm": "0.12.9"},
+        {
+            # embervm's Warehouse has discovered nothing yet: no published
+            # chart for its suffix means the missing-data treatment, a fault.
+            "kargo-monolith": [_freight("0.301.1", now)],
+            "kargo-embervm": [],
+        },
+    )
+    monkeypatch.setattr("cluster.kubernetes.KubernetesClient", lambda: fake)
+
+    ok, details = await mod._chart_lag_fault(7200)
+
+    assert ok is False
+    faults = [d for d in details if "no Freight found" in d]
+    assert len(faults) == 1 and "embervm" in faults[0]
+    assert "monolith: prod on 0.301.1, up to date" in details
+
+
+@pytest.mark.asyncio
+async def test_empty_app_list_faults_instead_of_vacuous_health(monkeypatch):
+    # Both spellings of "watches nothing": unset env and an explicit empty list.
+    for raw in (None, "[]"):
+        if raw is None:
+            monkeypatch.delenv("CD_HEALTH_KARGO_APPS", raising=False)
+        else:
+            monkeypatch.setenv("CD_HEALTH_KARGO_APPS", raw)
+        ok, details = await mod._chart_lag_fault(7200)
+        assert ok is False
+        assert any("no Kargo-managed apps configured" in d for d in details)
+        assert not any("up to date" in d for d in details)
 
 
 # CI signal. These encode the rules that took several passes to settle.
@@ -157,13 +320,28 @@ async def test_chart_lag_check_error_reports_but_does_not_fault(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_cd_health_reports_degraded_when_any_app_lags(monkeypatch):
+    monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
+
+    async def _lagging(lag_s):
+        return False, [
+            "embervm: prod on 0.12.9, 4 chart(s) behind through 0.13.3, waiting 240m"
+        ]
+
+    monkeypatch.setattr(mod, "_chart_lag_fault", _lagging)
+    result = await mod.cd_health()
+    assert result["ok"] is False
+    assert "embervm" in result["detail"]
+
+
+@pytest.mark.asyncio
 async def test_result_is_cached(monkeypatch):
     monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
     calls = []
 
     async def _counting(lag_s):
         calls.append(1)
-        return None, "prod on 0.301.1, up to date"
+        return True, ["monolith: prod on 0.301.1, up to date"]
 
     monkeypatch.setattr(mod, "_chart_lag_fault", _counting)
     await mod.cd_health()

--- a/projects/monolith/cluster/kubernetes.py
+++ b/projects/monolith/cluster/kubernetes.py
@@ -142,12 +142,18 @@ class KubernetesClient:
             return None
         return result.get("status")
 
-    async def list_kargo_freight(self, namespace: str = "kargo-monolith") -> list[dict]:
-        """Return published monolith chart Freight in creation order-independent form.
+    async def list_kargo_freight(
+        self,
+        namespace: str = "kargo-monolith",
+        repo_suffix: str = "/charts/monolith",
+    ) -> list[dict]:
+        """Return published chart Freight for one app's chart, any pipeline.
 
         Kargo stores ``charts`` at the TOP LEVEL of a Freight object, not under
         ``spec`` or ``status``. For each Freight, use the first chart whose
-        repoURL identifies the monolith chart and skip Freight without one.
+        repoURL ends with ``repo_suffix`` (e.g. "/charts/embervm") and skip
+        Freight without one. The suffix keeps co-discovered charts in the same
+        namespace from cross-contaminating each app's version list.
         """
         api = await self._ensure_client()
         custom = client.CustomObjectsApi(api)
@@ -161,7 +167,7 @@ class KubernetesClient:
         for item in result.get("items", []):
             metadata = item.get("metadata") or {}
             for chart in item.get("charts") or []:
-                if (chart.get("repoURL") or "").endswith("/charts/monolith"):
+                if (chart.get("repoURL") or "").endswith(repo_suffix):
                     freight.append(
                         {
                             "name": metadata.get("name"),

--- a/projects/monolith/cluster/kubernetes_test.py
+++ b/projects/monolith/cluster/kubernetes_test.py
@@ -116,7 +116,7 @@ async def test_list_kargo_freight_parses_real_shape(k8s_client):
 
 
 @pytest.mark.asyncio
-async def test_list_kargo_freight_skips_non_monolith_and_missing_charts(k8s_client):
+async def test_list_kargo_freight_skips_other_charts_and_missing_charts(k8s_client):
     mock_api = MagicMock()
     mock_custom = MagicMock()
     mock_custom.list_namespaced_custom_object = AsyncMock(
@@ -138,6 +138,55 @@ async def test_list_kargo_freight_skips_non_monolith_and_missing_charts(k8s_clie
         patch("cluster.kubernetes.client.CustomObjectsApi", return_value=mock_custom),
     ):
         assert await k8s_client.list_kargo_freight() == []
+
+
+@pytest.mark.asyncio
+async def test_list_kargo_freight_suffix_selects_the_app_chart(k8s_client):
+    mock_api = MagicMock()
+    mock_custom = MagicMock()
+    mock_custom.list_namespaced_custom_object = AsyncMock(
+        return_value={
+            "items": [
+                {
+                    "metadata": {"name": "embervm-freight"},
+                    "charts": [
+                        {
+                            "repoURL": "oci://ghcr.io/jomcgi/homelab/charts/embervm",
+                            "version": "0.13.7",
+                        }
+                    ],
+                },
+                {
+                    "metadata": {"name": "monolith-freight"},
+                    "charts": [
+                        {
+                            "repoURL": "oci://ghcr.io/jomcgi/homelab/charts/monolith",
+                            "version": "0.301.1",
+                        }
+                    ],
+                },
+            ]
+        }
+    )
+    with (
+        patch("cluster.kubernetes.config.load_incluster_config"),
+        patch("cluster.kubernetes.ApiClient", return_value=mock_api),
+        patch("cluster.kubernetes.client.CustomObjectsApi", return_value=mock_custom),
+    ):
+        embervm = await k8s_client.list_kargo_freight(
+            "kargo-embervm", repo_suffix="/charts/embervm"
+        )
+        monolith = await k8s_client.list_kargo_freight(
+            "kargo-monolith", repo_suffix="/charts/monolith"
+        )
+    assert embervm == [
+        {
+            "name": "embervm-freight",
+            "version": "0.13.7",
+            "created_at": None,
+        }
+    ]
+    assert monolith[0]["name"] == "monolith-freight"
 
 
 async def _deployed_revision(k8s_client, result):

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -426,3 +426,19 @@ scratchPostgres:
 ciliumPolicy:
   ingress:
     enabled: true
+
+# cd health chart-lag coverage (#4890): every Kargo-managed production app, so
+# embervm's lag is visible next to monolith's instead of invisible (#4884).
+# Entries mirror projects/platform/kargo/values.yaml promotion.pipelines: app
+# is the pipeline's prod Stage application, kargo_namespace its project,
+# chart_repo_suffix picks its chart out of Freight repoURLs. The clock stays
+# "oldest unpromoted Freight" per app and the component stays advisory: it
+# pages nobody. Adding a Kargo pipeline means adding an entry here.
+cdHealth:
+  apps:
+    - app: monolith
+      kargo_namespace: kargo-monolith
+      chart_repo_suffix: /charts/monolith
+    - app: embervm
+      kargo_namespace: kargo-embervm
+      chart_repo_suffix: /charts/embervm


### PR DESCRIPTION
Closes #4890.

The chart-lag check hardcoded `PROD_APP_NAME=monolith` / `KARGO_NAMESPACE=kargo-monolith`, so embervm prod chart lag was invisible. Coverage now comes from `CD_HEALTH_KARGO_APPS`, rendered from `cdHealth.apps` in chart values, one entry per Kargo pipeline (ArgoCD app, Kargo project namespace, chart repoURL suffix). Deploy values wire monolith + embervm.

Semantics preserved: clock stays oldest unpromoted Freight per app, still advisory (pages nobody). An empty or unusable list faults loudly instead of vacuous-healthy, mirroring the empty-Freight treatment. RBAC unchanged (existing ClusterRole is cluster-wide).

Verified: 58 local pytest pass (cd_health + kubernetes), helm render contains both apps and round-trips as JSON, `ci` green (754 tests pass, 228 executed).

Implemented by ox-alpha via opencode, reviewed on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K