### PR TITLE
feat(agents): serve the offered model list from per-env config

### DIFF
--- a/projects/monolith/agent_sessions/__init__.py
+++ b/projects/monolith/agent_sessions/__init__.py
@@ -1,14 +1,42 @@
 """Voice-drivable Claude Code agent sessions."""
 
+import os
+
 # Every model a caller may name, ordered by family (codex, claude, pi). This is
-# the single source for selectable models: the Discord /agent choice list is
-# built from it, so a model added here appears there without a second edit and
-# the two can never disagree about what model_family accepts.
+# the single source for selectable models: the Discord /agent choice list and
+# GET /api/agents/models are built from it, so a model added here appears
+# everywhere without a second edit and nothing can disagree about what
+# model_family accepts.
 #
-# Deliberately no imports in this module. chat.bot reads SUPPORTED_MODELS at
-# import time to build its slash-command choices, and anything imported here
-# would land in that path (see the agent_sessions.api cycle in chat/bot.py).
+# Deliberately no FIRST-PARTY imports in this module. chat.bot reads
+# SUPPORTED_MODELS at import time to build its slash-command choices, and any
+# first-party module imported here would land in that path, dragging a Bazel
+# dep onto every target that imports chat.bot without one (see the drift test
+# in chat/bot_on_message_test.py). The stdlib os import below is safe: it ships
+# with every interpreter.
 SUPPORTED_MODELS = ("luna", "terra", "sol", "opus", "sonnet", "fable", "qwen")
+
+# Per-env allowlist narrowing what the console picker and the Discord /agent
+# command OFFER (issue #4859). Comma-separated names; empty or unset means
+# every supported model. This is configuration we own, not a boundary: names
+# here never widen past SUPPORTED_MODELS, and unknown names are ignored rather
+# than rejected. Wired from chart value agents.models.
+MODEL_ENV_VAR = "AGENT_MODELS"
+
+
+def offered_models(configured: str | None = None) -> tuple[str, ...]:
+    """Return SUPPORTED_MODELS narrowed by the AGENT_MODELS allowlist.
+
+    ``configured`` overrides the environment read for tests; None means read
+    MODEL_ENV_VAR. An empty or unset allowlist means "offer everything": prod
+    keeps the full selection by default while dev narrows it to the free
+    in-cluster lane with a single values edit.
+    """
+    raw = os.environ.get(MODEL_ENV_VAR, "") if configured is None else configured
+    allowed = {part.strip() for part in raw.split(",") if part.strip()}
+    if not allowed:
+        return SUPPORTED_MODELS
+    return tuple(model for model in SUPPORTED_MODELS if model in allowed)
 
 
 def model_family(model: str | None) -> str:

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -14,7 +14,13 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlmodel import Session, func, select
 
-from agent_sessions import model_family, store, transport as transport_module, voice_ui
+from agent_sessions import (
+    model_family,
+    offered_models,
+    store,
+    transport as transport_module,
+    voice_ui,
+)
 from agent_sessions.codex_login import codex_login_gate, watch_for_login
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.mcp import (
@@ -220,6 +226,25 @@ def list_sessions(
     return _rows(session, status, limit)
 
 
+@router.get("/models")
+def list_offered_models() -> dict:
+    """Model catalogue the console picker offers (issue #4859).
+
+    SUPPORTED_MODELS narrowed by the AGENT_MODELS env var, which the chart
+    wires from agents.values. The frontend has no built-in list: an empty
+    catalogue renders an empty picker rather than a bundled fallback, so a
+    misconfigured env is visible instead of silently masked. Entries carry
+    name and family; family is the display hint that lets the picker label
+    the free in-cluster (pi) lane. No auth dependency and no cluster reads,
+    matching GET /sessions next to which it ships.
+    """
+    return {
+        "models": [
+            {"name": model, "family": model_family(model)} for model in offered_models()
+        ]
+    }
+
+
 # Control-plane session states collapsed to what the console renders. The
 # guest lifecycle is the control plane's truth, not the monolith's local
 # binding: a park (idleBankSeconds after the last invoke) happens without
@@ -287,8 +312,8 @@ async def _refresh_cp_state() -> None:
     # would leave them out of the published map entirely. The console reads an
     # absent session_id as "off" (frontend status.js vmState), so a live qwen
     # guest would render "vm off" and "waking vm" for its whole turn. On
-    # monolith-dev that is total, because localModelsOnly restricts the picker
-    # to qwen alone.
+    # monolith-dev that is total, because the configured model list restricts
+    # the picker to qwen alone.
     #
     # Aggregating here does NOT contradict list_sessions defaulting to one
     # lane: that default serves the operator tool, where the per-workload

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -110,6 +110,55 @@ def test_list_sessions_with_status_filter(client, session):
     assert [item["local_session_id"] for item in body] == ["done"]
 
 
+def test_models_endpoint_offers_everything_when_env_unset(client, monkeypatch):
+    """Unset AGENT_MODELS means the full supported catalogue (prod default)."""
+    from agent_sessions import SUPPORTED_MODELS
+
+    monkeypatch.delenv("AGENT_MODELS", raising=False)
+    body = client.get("/api/agents/models").json()
+
+    assert [entry["name"] for entry in body["models"]] == list(SUPPORTED_MODELS)
+    for entry in body["models"]:
+        assert entry["family"] in {"codex", "claude", "pi"}
+
+
+def test_models_endpoint_narrows_to_configured_list(client, monkeypatch):
+    """AGENT_MODELS narrows the catalogue; entries keep name and family."""
+    monkeypatch.setenv("AGENT_MODELS", "qwen")
+    body = client.get("/api/agents/models").json()
+
+    assert body == {"models": [{"name": "qwen", "family": "pi"}]}
+
+
+def test_models_endpoint_ignores_unknown_names_and_blank_parts(client, monkeypatch):
+    """Configuration we own, not a boundary: unknown names never widen the
+    catalogue past SUPPORTED_MODELS and are dropped rather than rejected."""
+    monkeypatch.setenv("AGENT_MODELS", " qwen ,, luna, not-a-model ")
+    body = client.get("/api/agents/models").json()
+
+    assert [entry["name"] for entry in body["models"]] == ["luna", "qwen"]
+
+
+def test_models_endpoint_empty_value_means_all(client, monkeypatch):
+    from agent_sessions import SUPPORTED_MODELS
+
+    monkeypatch.setenv("AGENT_MODELS", "")
+    body = client.get("/api/agents/models").json()
+
+    assert [entry["name"] for entry in body["models"]] == list(SUPPORTED_MODELS)
+
+
+def test_models_endpoint_empty_config_renders_visibly_empty(client, monkeypatch):
+    """An allowlist that matches nothing yields an EMPTY catalogue.
+
+    The frontend has no bundled fallback list, so this response is what an
+    empty picker looks like: the honest rendering of a misconfigured value.
+    """
+    monkeypatch.setenv("AGENT_MODELS", "not-a-model")
+
+    assert client.get("/api/agents/models").json() == {"models": []}
+
+
 def test_list_sessions_ordering(client, session):
     # A NULL last_turn_at is unrepresentable: the column is NOT NULL DEFAULT
     # NOW() in Postgres, and the model's default_factory backfills an explicit
@@ -270,7 +319,7 @@ def test_refresh_cp_state_polls_every_lane(client, monkeypatch):
     sessions out of the published map. The console reads an absent session_id
     as "off" (frontend status.js vmState), so a live qwen guest would render
     "vm off" for its whole turn, and on monolith-dev that is every session
-    because localModelsOnly restricts the picker to qwen.
+    because the configured model list restricts the picker to qwen.
     """
     lanes = []
 

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -146,6 +146,15 @@ spec:
             - name: AGENT_PI_WORKLOAD
               value: {{ .Values.agentSessions.piWorkload | quote }}
             {{- end }}
+            {{- if .Values.agents }}
+            # Offered model catalogue for the console picker and the Discord
+            # /agent command (issue #4859). Comma-separated subset of
+            # agent_sessions.SUPPORTED_MODELS; empty offers everything. Served
+            # by GET /api/agents/models and read at chat.bot import, so both
+            # surfaces follow one values edit.
+            - name: AGENT_MODELS
+              value: {{ .Values.agents.models | default "" | quote }}
+            {{- end }}
             {{- if .Values.swarm.enabled }}
             # DBOS swarm layer (ADR agents/038, agents/053). SWARM_ENABLED is
             # the master switch the module reads: with it false the router still
@@ -595,8 +604,6 @@ spec:
           env:
             - name: API_BASE
               value: "http://localhost:8000"
-            - name: AGENTS_LOCAL_MODELS_ONLY
-              value: {{ .Values.agents.localModelsOnly | quote }}
             - name: OTEL_COLLECTOR_HTTP_URL
               value: {{ .Values.frontend.otelCollectorUrl | quote }}
             {{- if .Values.imgproxySigning.enabled }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -77,11 +77,19 @@ progress:
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
     pullPolicy: IfNotPresent
 
-# Restrict the agents console model picker to the in-cluster model when true.
-# Production keeps the full model list; dev overrides this to avoid offering
-# providers that are not intended for dev use.
+# Offered model catalogue for the agents console picker and the Discord
+# /agent slash command (issue #4859). Comma-separated subset of
+# agent_sessions.SUPPORTED_MODELS, served by GET /api/agents/models and read
+# by chat.bot from AGENT_MODELS; empty means offer every supported model.
+# This is configuration we own, not a boundary: names never widen past
+# SUPPORTED_MODELS and unknown names are ignored, but an allowlist matching
+# nothing renders an EMPTY picker (there is no bundled fallback list), so a
+# typo is visible rather than masked. Adding a model to the offer is a values
+# edit here once it exists in SUPPORTED_MODELS.
 agents:
-  localModelsOnly: false
+  # Current production selection: every supported model, listed explicitly so
+  # prod renders unchanged and stays unchanged when code adds a model later.
+  models: "luna,terra,sol,opus,sonnet,fable,qwen"
 
 # Off-pod batch-job execution via Argo CronWorkflows.
 #

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -51,13 +51,37 @@ logger = logging.getLogger(__name__)
 # model_family accepts. A model pins the session's adapter family for its
 # whole life, so this is chosen once at /agent time and not per turn.
 DEFAULT_AGENT_MODEL = "luna"
-# Kept as a LITERAL, not imported from agent_sessions. A module-level import
-# here would put agent_sessions into the Bazel dep graph of every target that
-# imports chat.bot, which is why every other agent_sessions import in this file
-# is function-local. The pairing is enforced instead by a drift test
-# (test_agent_model_choices_match_supported_models), in a target that already
-# depends on both.
-AGENT_MODEL_CHOICES = ("luna", "terra", "sol", "opus", "sonnet", "fable", "qwen")
+# The full universe of selectable models, kept as a LITERAL, not imported from
+# agent_sessions. A module-level import there would put agent_sessions into the
+# Bazel dep graph of every target that imports chat.bot, which is why every
+# other agent_sessions import in this file is function-local. Two things keep
+# this copy honest instead: the drift test (test_agent_model_choices_match_
+# supported_models) in a target that already depends on both, and the filter
+# below mirroring agent_sessions.offered_models, which the same test checks
+# for behavioural equality across env settings.
+_ALL_AGENT_MODEL_CHOICES = ("luna", "terra", "sol", "opus", "sonnet", "fable", "qwen")
+
+
+def _filter_agent_models(models, configured: str) -> tuple:
+    """Narrow ``models`` to a comma-separated allowlist; empty means all.
+
+    Mirrors agent_sessions.offered_models (same semantics, no import: see
+    above). The drift test in chat/bot_on_message_test.py asserts behavioural
+    equality between the two across every setting the chart can produce.
+    """
+    allowed = {part.strip() for part in (configured or "").split(",") if part.strip()}
+    if not allowed:
+        return tuple(models)
+    return tuple(model for model in models if model in allowed)
+
+
+# Per-env narrowing (issue #4859), read at import like the rest of this
+# module's config: AGENT_MODELS is a comma-separated subset; empty or unset
+# offers everything. Wired from chart value agents.models so dev offers only
+# what it routes (the free qwen lane) without shipping a different image.
+AGENT_MODEL_CHOICES = _filter_agent_models(
+    _ALL_AGENT_MODEL_CHOICES, os.environ.get("AGENT_MODELS", "")
+)
 AGENT_REACTION_QUEUED = "⏳"
 
 

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -1656,21 +1656,44 @@ class TestStartAgentFlowOrchestrator:
             assert start_session.await_args.kwargs["model"] == expected
 
     def test_agent_model_choices_match_supported_models(self):
-        """chat.bot's picker list must equal agent_sessions.SUPPORTED_MODELS.
+        """chat.bot's picker list must track agent_sessions' catalogue.
 
         The list is duplicated on purpose: importing agent_sessions at module
         scope in chat.bot would drag it into the Bazel dep graph of every target
         importing chat.bot (~38 of them fail with ModuleNotFoundError), which is
         why every other agent_sessions import in that file is function-local.
-        This test is the seam that keeps the two copies honest, and it lives here
-        because this target already depends on both.
+        This test is the seam that keeps the copies honest: the literal
+        universes must be equal, and bot.py's env filter must behave
+        identically to agent_sessions.offered_models across every setting the
+        chart can produce (issue #4859). The filter is a pure function in
+        bot.py, so each scenario runs without re-importing the module.
         """
-        from agent_sessions import SUPPORTED_MODELS, model_family
+        from agent_sessions import SUPPORTED_MODELS, model_family, offered_models
 
-        from chat.bot import AGENT_MODEL_CHOICES
+        from chat.bot import (
+            AGENT_MODEL_CHOICES,
+            _ALL_AGENT_MODEL_CHOICES,
+            _filter_agent_models,
+        )
 
-        assert tuple(AGENT_MODEL_CHOICES) == tuple(SUPPORTED_MODELS)
-        # Discord caps a slash-command choice list at 25.
+        scenarios = [
+            None,
+            "",
+            "qwen",
+            "qwen,luna",
+            " luna , terra ",
+            "not-a-model",
+            "bogus,qwen",
+        ]
+        for configured in scenarios:
+            env_value = "" if configured is None else configured
+            assert tuple(_filter_agent_models(SUPPORTED_MODELS, env_value)) == tuple(
+                offered_models(env_value)
+            ), f"AGENT_MODELS={configured!r}"
+
+        # The universe itself cannot drift from what model_family accepts,
+        # and Discord caps a slash-command choice list at 25.
+        assert tuple(_ALL_AGENT_MODEL_CHOICES) == tuple(SUPPORTED_MODELS)
         assert 0 < len(AGENT_MODEL_CHOICES) <= 25
         for name in AGENT_MODEL_CHOICES:
             assert model_family(name) in {"codex", "claude", "pi"}

--- a/projects/monolith/dev/deploy/values.yaml
+++ b/projects/monolith/dev/deploy/values.yaml
@@ -19,8 +19,11 @@
 # poking at behaviour without spending on a metered or subscription provider.
 # This is a values choice, not a guard. Nothing rejects a paid model here, so
 # a NEW model-consuming feature has to be pointed at the free lane in this
-# file too, or dev will quietly inherit production's provider. See issue #4859
-# for the fuller console configuration change this defers.
+# file too, or dev will quietly inherit production's provider. Since #4859
+# that includes what dev OFFERS: the console picker and Discord /agent list
+# are served from agents.models below, so the offered catalogue is
+# deliberately env-scoped even though routes, templates and migrations stay
+# identical to prod.
 
 backend:
   # THE side-effect mute. One switch covers all five leader singletons (Discord
@@ -169,7 +172,11 @@ jobs:
   image: ""
 
 agents:
-  localModelsOnly: true
+  # What dev OFFERS in the console picker and the Discord /agent command
+  # (GET /api/agents/models, issue #4859): qwen alone. Dev routes only the
+  # free in-cluster lane (see the model paragraphs below), so offering the
+  # paid providers here would be UI dishonesty, not a capability.
+  models: "qwen"
 
 # EVERY MODEL IN DEV POINTS AT THE IN-CLUSTER QWEN.
 #

--- a/projects/monolith/frontend/src/routes/private/agents/+page.server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.server.js
@@ -1,20 +1,33 @@
 // No URL fallback: API_BASE is injected via values.yaml in prod; a localhost
 // dev run sets it in the environment. A missing var fails loudly instead of
 // silently serving from the wrong backend.
+//
+// The offered model catalogue (GET /api/agents/models, issue #4859) loads
+// here alongside the sessions list. It is passed through untouched: the page
+// has no bundled fallback list, so an empty response renders an empty picker.
 const API_BASE = process.env.API_BASE;
 
 export async function load({ fetch }) {
   try {
-    const res = await fetch(`${API_BASE}/api/agents/sessions`, {
-      signal: AbortSignal.timeout(15000),
-    });
-    if (!res.ok) return { sessions: [], error: true };
-    const body = await res.json();
+    const [sessionsRes, modelsRes] = await Promise.all([
+      fetch(`${API_BASE}/api/agents/sessions`, {
+        signal: AbortSignal.timeout(15000),
+      }),
+      fetch(`${API_BASE}/api/agents/models`, {
+        signal: AbortSignal.timeout(15000),
+      }),
+    ]);
+    if (!sessionsRes.ok || !modelsRes.ok) {
+      return { sessions: [], models: [], error: true };
+    }
+    const sessions = await sessionsRes.json();
+    const models = await modelsRes.json();
     return {
-      sessions: Array.isArray(body) ? body : (body.sessions ?? []),
+      sessions: Array.isArray(sessions) ? sessions : (sessions.sessions ?? []),
+      models: Array.isArray(models.models) ? models.models : [],
       error: false,
     };
   } catch {
-    return { sessions: [], error: true };
+    return { sessions: [], models: [], error: true };
   }
 }

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -56,6 +56,7 @@
     walkthroughTurns,
   } from "./session-view.js";
   import { periodForHour } from "$lib/private/period.js";
+  import { modelEntries, modelLabel, modelName } from "./model-list.js";
 
   const MOBILE_MEDIA_QUERY = "(max-width: 760px)";
   const VOICE_POLL_MS = 2000;
@@ -63,8 +64,11 @@
 
   let { data } = $props();
 
-  const MODELS = ["opus", "fable", "sonnet", "luna", "terra", "sol", "qwen"];
-  const DEV_MODELS = ["qwen"];
+  // The offered model catalogue comes from GET /api/agents/models via the
+  // server load (issue #4859). There is deliberately NO hardcoded fallback:
+  // an empty or failed catalogue leaves the picker visibly empty instead of
+  // silently offering models this environment may not route.
+  let modelCatalog = $state(modelEntries(data));
   // Retry logic for initial run load before concluding engine is absent.
   // A transient network failure on first load should not blank the page.
   const RUNS_LOAD_MAX_ATTEMPTS = 3;
@@ -107,7 +111,12 @@
     }
   }
   let sessions = $state(data.sessions ?? []);
-  let availableModels = $state(MODELS);
+  // Names feed `includes` checks and option values; labels carry the
+  // "(local)" display hint for the free pi lane.
+  const availableModels = $derived(modelCatalog.map(modelName));
+  const modelLabels = $derived(
+    new Map(modelCatalog.map((entry) => [modelName(entry), modelLabel(entry)])),
+  );
   let runs = $state([]);
   let terminalRuns = $state([]);
   let runDetail = $state(null);
@@ -381,10 +390,7 @@
       if (!response.ok) throw new Error("Unable to refresh sessions");
       const body = await response.json();
       sessions = Array.isArray(body) ? body : (body.sessions ?? []);
-      availableModels =
-        !Array.isArray(body) && body.localModelsOnly === true
-          ? DEV_MODELS
-          : MODELS;
+      modelCatalog = modelEntries(body);
       await loadRuns();
       errorMessage = null;
       if (
@@ -2211,8 +2217,9 @@
       {#if current && !availableModels.includes(current)}
         <option value={current}>{current}</option>
       {/if}
-      {#each availableModels as model}<option value={model}>{model}</option
-        >{/each}
+      {#each availableModels as model}
+        <option value={model}>{modelLabels.get(model) ?? model}</option>
+      {/each}
     </select>
   </label>
 {/snippet}

--- a/projects/monolith/frontend/src/routes/private/agents/data/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/data/+server.js
@@ -1,24 +1,39 @@
+// The console's poll endpoint. Sessions come from /api/agents/sessions and
+// the offered model catalogue from /api/agents/models (issue #4859), both
+// fetched server-side against API_BASE exactly as every other per-env read
+// in this app. No bundled model list exists here: whatever /models returns
+// is what the picker offers, so an empty catalogue stays visibly empty.
 const API_BASE = process.env.API_BASE;
-const LOCAL_MODELS_ONLY = process.env.AGENTS_LOCAL_MODELS_ONLY === "true";
 
 export async function GET() {
   try {
-    const res = await fetch(`${API_BASE}/api/agents/sessions`, {
-      signal: AbortSignal.timeout(10000),
-    });
-    const body = await res.json();
+    const [sessionsRes, modelsRes] = await Promise.all([
+      fetch(`${API_BASE}/api/agents/sessions`, {
+        signal: AbortSignal.timeout(10000),
+      }),
+      fetch(`${API_BASE}/api/agents/models`, {
+        signal: AbortSignal.timeout(10000),
+      }),
+    ]);
+    if (!sessionsRes.ok || !modelsRes.ok) {
+      throw new Error(`backend ${sessionsRes.status}/${modelsRes.status}`);
+    }
+    const sessions = await sessionsRes.json();
+    const models = await modelsRes.json();
     return new Response(
       JSON.stringify({
-        sessions: Array.isArray(body) ? body : (body.sessions ?? []),
-        localModelsOnly: LOCAL_MODELS_ONLY,
+        sessions: Array.isArray(sessions)
+          ? sessions
+          : (sessions.sessions ?? []),
+        models: Array.isArray(models.models) ? models.models : [],
       }),
       {
-        status: res.status,
+        status: 200,
         headers: { "Content-Type": "application/json" },
       },
     );
   } catch {
-    return new Response(JSON.stringify({ error: "sessions unavailable" }), {
+    return new Response(JSON.stringify({ error: "agents data unavailable" }), {
       status: 502,
       headers: { "Content-Type": "application/json" },
     });

--- a/projects/monolith/frontend/src/routes/private/agents/data/data-server.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/data/data-server.test.js
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The route reads API_BASE at module scope, so stub it before the import
+// (imports are hoisted; only vi.hoisted runs earlier).
+vi.hoisted(() => {
+  process.env.API_BASE = "http://backend";
+});
+
+import { GET } from "./+server.js";
+
+function jsonResponse(body, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 503,
+    json: async () => body,
+  };
+}
+
+describe("agents data poll endpoint", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    globalThis.fetch = undefined;
+  });
+
+  it("returns sessions plus the model catalogue from the backend", async () => {
+    const sessions = [{ id: 7 }];
+    globalThis.fetch = vi.fn(async (url) =>
+      jsonResponse(
+        String(url).includes("models")
+          ? { models: [{ name: "qwen", family: "pi" }] }
+          : sessions,
+      ),
+    );
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.sessions).toEqual(sessions);
+    expect(body.models).toEqual([{ name: "qwen", family: "pi" }]);
+  });
+
+  it("serves an empty catalogue as empty rather than a bundled list", async () => {
+    globalThis.fetch = vi.fn(async (url) =>
+      jsonResponse(String(url).includes("models") ? { models: [] } : []),
+    );
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.models).toEqual([]);
+  });
+
+  it("answers 502 when either backend call fails", async () => {
+    globalThis.fetch = vi.fn(async (url) =>
+      jsonResponse([], !String(url).includes("models")),
+    );
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toBe("agents data unavailable");
+  });
+});

--- a/projects/monolith/frontend/src/routes/private/agents/model-list.js
+++ b/projects/monolith/frontend/src/routes/private/agents/model-list.js
@@ -1,0 +1,31 @@
+// The offered model catalogue (issue #4859). GET /api/agents/models serves
+// SUPPORTED_MODELS narrowed by the AGENT_MODELS env var, and the console has
+// NO bundled fallback list: whatever the endpoint returns is what the picker
+// offers, so an empty or misconfigured catalogue renders visibly empty
+// instead of silently resurrecting a hardcoded selection.
+
+// Extract the raw catalogue entries from a response body. Anything that is
+// not an array, or entries without a usable name, are dropped rather than
+// defaulted: there is no list to fall back to.
+export function modelEntries(body) {
+  const models = body?.models;
+  if (!Array.isArray(models)) return [];
+  return models.filter(
+    (entry) =>
+      entry != null &&
+      (typeof entry === "string" || typeof entry.name === "string"),
+  );
+}
+
+export function modelName(entry) {
+  return typeof entry === "string" ? entry : entry.name;
+}
+
+// Display hint: the pi family runs in-cluster on the free llama.cpp lane, so
+// the picker labels it "(local)". Every other family renders as the bare
+// name; the endpoint carries no presentation beyond family.
+export function modelLabel(entry) {
+  const name = modelName(entry);
+  if (!name) return "";
+  return entry.family === "pi" ? `${name} (local)` : name;
+}

--- a/projects/monolith/frontend/src/routes/private/agents/model-list.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/model-list.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { modelEntries, modelLabel, modelName } from "./model-list.js";
+
+describe("modelEntries", () => {
+  it("passes through the catalogue the endpoint returned", () => {
+    const entries = [
+      { name: "luna", family: "codex" },
+      { name: "qwen", family: "pi" },
+    ];
+
+    expect(modelEntries({ models: entries })).toEqual(entries);
+  });
+
+  it("accepts bare-string entries", () => {
+    expect(modelEntries({ models: ["qwen"] })).toEqual(["qwen"]);
+  });
+
+  it("renders an empty response as an EMPTY catalogue, never a fallback", () => {
+    expect(modelEntries({ models: [] })).toEqual([]);
+  });
+
+  it("treats a missing or malformed list as empty", () => {
+    expect(modelEntries(undefined)).toEqual([]);
+    expect(modelEntries({})).toEqual([]);
+    expect(modelEntries({ models: "qwen" })).toEqual([]);
+  });
+
+  it("drops entries without a usable name", () => {
+    expect(
+      modelEntries({
+        models: [{ name: "luna", family: "codex" }, null, { family: "pi" }, {}],
+      }),
+    ).toEqual([{ name: "luna", family: "codex" }]);
+  });
+});
+
+describe("modelName / modelLabel", () => {
+  it("reads the name from object and string entries alike", () => {
+    expect(modelName({ name: "luna" })).toBe("luna");
+    expect(modelName("luna")).toBe("luna");
+  });
+
+  it("labels only the free in-cluster pi lane as local", () => {
+    expect(modelLabel({ name: "qwen", family: "pi" })).toBe("qwen (local)");
+    expect(modelLabel({ name: "opus", family: "claude" })).toBe("opus");
+    expect(modelLabel({ name: "sol" })).toBe("sol");
+  });
+
+  it("labels a nameless entry as empty rather than undefined", () => {
+    expect(modelLabel({})).toBe("");
+  });
+});

--- a/projects/monolith/frontend/src/routes/private/agents/page.server.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/page.server.test.js
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The route reads API_BASE at module scope, so stub it before the import
+// (imports are hoisted; only vi.hoisted runs earlier).
+vi.hoisted(() => {
+  process.env.API_BASE = "http://backend";
+});
+
+import { load } from "./+page.server.js";
+
+function jsonResponse(body, ok = true) {
+  return { ok, status: ok ? 200 : 503, json: async () => body };
+}
+
+describe("agents /private/agents load", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes sessions and the model catalogue through untouched", async () => {
+    const sessions = [{ id: 1 }];
+    const catalog = {
+      models: [{ name: "qwen", family: "pi" }],
+    };
+    const fetchMock = vi.fn(async (url) =>
+      jsonResponse(String(url).includes("models") ? catalog : sessions),
+    );
+
+    const result = await load({ fetch: fetchMock });
+
+    expect(result).toEqual({
+      sessions,
+      models: catalog.models,
+      error: false,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://backend/api/agents/models",
+      expect.anything(),
+    );
+  });
+
+  it("renders an EMPTY catalogue as empty: no bundled fallback list", async () => {
+    const fetchMock = vi.fn(async (url) =>
+      jsonResponse(String(url).includes("models") ? { models: [] } : []),
+    );
+
+    const result = await load({ fetch: fetchMock });
+
+    expect(result.sessions).toEqual([]);
+    expect(result.models).toEqual([]);
+    expect(result.error).toBe(false);
+  });
+
+  it("marks error and empties both lists when either endpoint fails", async () => {
+    const fetchMock = vi.fn(async (url) =>
+      jsonResponse([], !String(url).includes("models")),
+    );
+
+    const result = await load({ fetch: fetchMock });
+
+    expect(result).toEqual({ sessions: [], models: [], error: true });
+  });
+});


### PR DESCRIPTION
Closes #4859.

The console picker's model list was a bundle literal duplicated in three places, with dev papering over it via `AGENTS_LOCAL_MODELS_ONLY` and a second hardcoded list. One catalogue now serves every surface:

- `agent_sessions.offered_models()` narrows `SUPPORTED_MODELS` by `AGENT_MODELS` (comma-separated, from new chart value `agents.models`; empty = all)
- `GET /api/agents/models` serves name+family; console fetches it alongside /sessions (server-side fetch, no new HTTPRoute rule needed)
- no bundled fallback: an empty catalogue renders a visibly empty picker
- `localModelsOnly` retires; dev values pin `agents.models` to qwen, preserving today's dev behaviour
- drift test now asserts behavioural equality across env settings instead of comparing literals

Verified: backend 114 pytest pass, frontend vitest 307 pass + `vite build` compiles, helm render shows `AGENT_MODELS` in both compositions, `ci` green (754 pass, 227 executed). Transition note: until Kargo promotes the new chart, dev's old template ignores the new value and may briefly offer the full list (dev-only, cosmetic).

Implemented by ox-alpha via opencode, reviewed on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K