### PR TITLE
feat(platform): enable WARP private-network routing on the prod tunnel

### DIFF
--- a/projects/platform/cloudflare-gateway/templates/tunnel-configmap.yaml
+++ b/projects/platform/cloudflare-gateway/templates/tunnel-configmap.yaml
@@ -12,6 +12,10 @@ data:
     metrics: {{ .Values.tunnel.metrics.address }}
     {{- end }}
     no-autoupdate: {{ .Values.tunnel.noAutoupdate }}
+    {{- if .Values.tunnel.warpRouting.enabled }}
+    warp-routing:
+      enabled: true
+    {{- end }}
     ingress:
     {{- range .Values.tunnel.ingress.routes }}
     - hostname: {{ .hostname }}

--- a/projects/platform/cloudflare-gateway/values-prod.yaml
+++ b/projects/platform/cloudflare-gateway/values-prod.yaml
@@ -37,6 +37,13 @@ tunnel:
   # Revert to "" (quic) only once the egress path is confirmed to hold UDP.
   protocol: http2
 
+  # kubectl from off-LAN: WARP client -> tunnel private network route
+  # (192.168.1.119/32, apiserver, added in Zero Trust by hand) -> k3s. TLS
+  # stays end to end so the client cert kubeconfig works unchanged. TCP only
+  # while protocol is http2; UDP through this route needs quic back.
+  warpRouting:
+    enabled: true
+
   ingress:
     routes:
       # argocd, longhorn, and signoz retired: they now serve under

--- a/projects/platform/cloudflare-gateway/values.yaml
+++ b/projects/platform/cloudflare-gateway/values.yaml
@@ -74,6 +74,12 @@ tunnel:
   protocol: ""
   noAutoupdate: true
 
+  # Routes WARP-enrolled clients into the LAN ranges added under the tunnel's
+  # Private Network config in Zero Trust. Off by default; prod turns it on for
+  # kubectl access to the k3s apiserver from outside the LAN.
+  warpRouting:
+    enabled: false
+
   secret:
     type: onepassword
     onepassword:


### PR DESCRIPTION
Adds a `tunnel.warpRouting` toggle to the cloudflare-gateway chart, default off, enabled in `values-prod.yaml`. With it on, WARP-enrolled devices can reach LAN ranges routed through the tunnel's Zero Trust private network config.

First consumer: kubectl against the k3s apiserver (`192.168.1.119:6443`) from outside the LAN. TLS stays end to end through the tunnel, so the existing client-cert kubeconfig works with no changes.

**Manual Zero Trust steps after merge (dashboard, not git):**
1. Tunnel > Private Network: add `192.168.1.119/32`
2. Settings > WARP Client: device enrollment policy
3. Split Tunnel Exclude mode ships with `192.168.0.0/16` excluded, which silently defeats the route: remove it (or switch to Include mode)
4. Install WARP on the laptop, enroll, connect

Notes:
- `projects/platform/*` deploys on HEAD, so this rolls on merge.
- Tunnel stays on `protocol: http2` (QUIC flap pin), fine for TCP/kubectl; UDP through the route would need QUIC back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEFVjQnEajNPMYakKpeX5i