### PR TITLE
fix(embervm): keep the session bankable after an invoke watchdog reap

### DIFF
--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -257,10 +257,11 @@ session:
   # deadline is a header the SERVER enforces, so on an orphaned channel (#4419)
   # nothing fires and the invoke worker wedges forever, pinning the session's
   # slot against the workload cap. The control plane kills the worker and fails
-  # the session once the invoke has run for the workload's timeoutSeconds plus
-  # the 5s transport headroom plus this margin. It must stay strictly above zero
-  # so the server-enforced deadline always fires first and the client-side kill
-  # is last resort. Matches the dispatcher's assign watchdog margin.
+  # the TURN (the session itself stays live to serve its queue and bank) once
+  # the invoke has run for the workload's timeoutSeconds plus the 5s transport
+  # headroom plus this margin. It must stay strictly above zero so the
+  # server-enforced deadline always fires first and the client-side kill is
+  # last resort. Matches the dispatcher's assign watchdog margin.
   invokeWatchdogMarginMs: 15000
 
 # Metering, audit, and quotas (Task 12). Quota is OPT-IN and asymmetric to the

--- a/projects/embervm/control/lib/embervm/session.ex
+++ b/projects/embervm/control/lib/embervm/session.ex
@@ -42,6 +42,16 @@ defmodule Embervm.Session do
   silently. The parked caller gets the error; every still-queued caller gets a
   `{:error, :failed}` (the router 410s them). This process then stops.
 
+  The wall-clock watchdog (#4434) is deliberately gentler, because it fires in
+  the opposite diagnostic situation: the server never enforced its deadline
+  because the exchange never completed through the channel at all (an orphaned
+  channel, #4419), so a fired watchdog is evidence about the CLIENT side of the
+  stream, not about the guest. The wedged worker is killed (its stream dies with
+  its process) and the timed-out caller gets `{:error, :invoke_timeout}`, but
+  the session stays live: queued turns dispatch normally, quiescence re-arms
+  the idle timer, and the session banks, releasing its workload-cap slot
+  without discarding guest state.
+
   ## the idle-bank timer (Task 7)
 
   A live session with ZERO in-flight and ZERO queued invokes for `idle_bank_ms`
@@ -227,13 +237,22 @@ defmodule Embervm.Session do
   end
 
   # The invoke wall-clock watchdog fired (#4434): the worker has outlived the
-  # server-enforced gRPC deadline plus margin, so nothing is going to complete it.
-  # Kill it, answer the parked caller, and fail the session exactly as a transport
-  # timeout would (the guest is in an unknown mid-request state, the failure
-  # posture above): the VM is destroyed, queued callers drain as :failed, and the
-  # process stops, releasing the session's slot. Keyed on the unique monitor ref
-  # (the SessionManager create_timeout pattern), so a stale timer for a finished
-  # worker, or a reused pid, never kills the wrong thing.
+  # server-enforced gRPC deadline plus margin, so neither completion path
+  # ({:invoke_done, ...} or DOWN) is ever coming: the stream is wedged
+  # client-side, which is exactly the case where the server never sees the
+  # deadline header (orphaned channel, #4419). Kill the worker (the wedged
+  # stream dies with its process) and answer the parked caller, but do NOT fail
+  # the session: a reported DEADLINE_EXCEEDED means the guest hung mid-request,
+  # while a fired watchdog says nothing reliable about the guest, and the issue's
+  # acceptance is that the session survive to serve its queued turns and bank.
+  # The queue drains normally through maybe_start_next, quiescence re-arms the
+  # idle timer, and the bank releases the workload-cap slot. The rejoin watcher
+  # disarms like the success branch: it exists to catch a restored volume that
+  # fails delivery, and a client-side wedge does not implicate the volume; a
+  # genuinely broken VM surfaces as an ordinary transport failure on the next
+  # turn. Keyed on the unique monitor ref (the SessionManager create_timeout
+  # pattern), so a stale timer for a finished worker, or a reused pid, never
+  # kills the wrong thing.
   def handle_info({:invoke_timeout, ref}, %{worker: {pid, ref, from, _timer}} = state) do
     Process.demonitor(ref, [:flush])
 
@@ -246,9 +265,8 @@ defmodule Embervm.Session do
 
     Process.exit(pid, :kill)
     state = %{state | worker: nil}
-    # Preserve the durable-before-observed failure ordering from #4644: append
-    # session_failed before the timed-out caller receives its error.
-    fail_and_stop(state, :invoke_timeout, from)
+    GenServer.reply(from, {:error, :invoke_timeout})
+    {:noreply, maybe_start_next(disarm_rejoin_failure(state))}
   end
 
   def handle_info({:invoke_timeout, _stale_ref}, state), do: {:noreply, state}

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -1805,11 +1805,13 @@ defmodule Embervm.SessionManagerTest do
     Enum.each(callers, fn pid -> Process.exit(pid, :kill) end)
   end
 
-  test "a wedged invoke worker is killed by the wall-clock watchdog and releases the slot" do
+  test "a wedged invoke worker is reaped by the wall-clock watchdog and the slot is reusable" do
     # #4434: a SessionAssign stuck in the client stream (orphaned channel, the
     # server never sees the deadline header) must not pin the session forever.
-    # The first assign sleeps forever; any later one (a new session) answers.
+    # The first assign sleeps forever; any later one answers, proving the reap
+    # leaves the session serving.
     {:ok, assigns} = Agent.start_link(fn -> 0 end)
+    {:ok, destroys} = Agent.start_link(fn -> 0 end)
 
     assign_fun = fn _ch, req ->
       case Agent.get_and_update(assigns, fn n -> {n, n + 1} end) do
@@ -1826,8 +1828,25 @@ defmodule Embervm.SessionManagerTest do
       end
     end
 
-    ctx = start_stack(assign_fun: assign_fun, invoke_watchdog_ms: 150)
-    put_session_workload(ctx, "wl-wedge", cap: 1, max_sessions: 8)
+    destroy_fun = fn _ch, _vm ->
+      Agent.update(destroys, &(&1 + 1))
+      {:ok, %{teardown_confirmed: true}}
+    end
+
+    ctx = start_stack(assign_fun: assign_fun, destroy_fun: destroy_fun, invoke_watchdog_ms: 150)
+
+    # A 1s idle bank so the test observes the slot release path the issue names:
+    # quiescence arms the timer and the session banks (a banked session holds
+    # disk only, freeing its live-VM count against the cap-1 workload).
+    put_session_workload(ctx, "wl-wedge", cap: 1,
+      session: %{
+        idle_bank_seconds: 1,
+        max_lifetime_seconds: 3600,
+        banked_ttl_seconds: 3600,
+        max_sessions: 8,
+        invoke_queue_cap: 4
+      })
+
     {:ok, created} = SessionManager.create(ctx.mgr, "wl-wedge", "p1")
 
     # The wedged invoke plus one caller queued behind it.
@@ -1838,17 +1857,24 @@ defmodule Embervm.SessionManagerTest do
     # Nothing has fired yet: the caller is still parked (no spurious early kill).
     assert nil == Task.yield(wedged, 0)
 
-    # The watchdog fires: the parked caller gets the timeout, the queued caller
-    # drains as :failed, and the session is failed (unknown guest state).
+    # The watchdog fires: the wedged caller gets the timeout, but the queued
+    # caller is SERVED (the wedge was client-side; the guest is healthy) and the
+    # session stays running. The VM is NOT destroyed (#4434 keeps the session
+    # bankable; only a reported daemon failure destroys).
     assert {:error, :invoke_timeout} = Task.await(wedged, 2_000)
-    assert {:error, :failed} = Task.await(queued, 2_000)
+    assert {:ok, %{status_code: 200}} = Task.await(queued, 2_000)
+    assert {:ok, %{state: :running}} = SessionStore.get(ctx.store, created.session_id)
 
+    # Quiescence arms the idle timer: the session banks, releasing its live-VM
+    # count against the workload cap.
     assert eventually(fn ->
-             match?({:ok, %{state: :failed}}, SessionStore.get(ctx.store, created.session_id))
-           end)
+             match?({:ok, %{state: :banked}}, SessionStore.get(ctx.store, created.session_id))
+           end, 3_000)
 
-    # The slot is released: with cap 1, a fresh create on the workload is admitted
-    # and its invoke completes on the healthy assign path.
+    assert Agent.get(destroys, & &1) == 0
+
+    # Slot released: with cap 1, a fresh create on the workload is admitted and
+    # its invoke completes on the healthy assign path.
     assert {:ok, fresh} = SessionManager.create(ctx.mgr, "wl-wedge", "p1")
     assert {:ok, %{status_code: 200, body: "z"}} = SessionManager.invoke(ctx.mgr, fresh.session_id, %{body: "z"})
   end


### PR DESCRIPTION
Closes #4434.

The first cut of the invoke wall clock (c0296a921) armed the budget correctly but, on fire, durably failed the session and destroyed the VM. A fired watchdog means the client-side stream wedged before the server saw the deadline header, which says nothing reliable about the guest. The issue's acceptance is that the slot clears, queued invokes drain, and the session banks.

Reap now kills only the wedged worker, replies `{:error, :invoke_timeout}` to its caller, disarms the rejoin watcher like the success branch, and lets `maybe_start_next` serve the queue; quiescence re-arms banking. Tests assert bank-and-reuse plus zero destroys.

Verified: sha-pinned local toolchain, session_manager suite 102 tests 0 failures; full ExUnit in CI 1476 tests 0 failures; `ci` green (758 pass, 224 executed). A router_test shuffle-seed flake seen locally was proven pre-existing (reproduces with the changed files reverted).

Implemented by ox-alpha via opencode, reviewed on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K