### PR TITLE
revert(platform): disable WARP private-network routing on the prod tunnel

### DIFF
--- a/projects/platform/cloudflare-gateway/templates/tunnel-configmap.yaml
+++ b/projects/platform/cloudflare-gateway/templates/tunnel-configmap.yaml
@@ -12,10 +12,6 @@ data:
     metrics: {{ .Values.tunnel.metrics.address }}
     {{- end }}
     no-autoupdate: {{ .Values.tunnel.noAutoupdate }}
-    {{- if .Values.tunnel.warpRouting.enabled }}
-    warp-routing:
-      enabled: true
-    {{- end }}
     ingress:
     {{- range .Values.tunnel.ingress.routes }}
     - hostname: {{ .hostname }}

--- a/projects/platform/cloudflare-gateway/values-prod.yaml
+++ b/projects/platform/cloudflare-gateway/values-prod.yaml
@@ -37,13 +37,6 @@ tunnel:
   # Revert to "" (quic) only once the egress path is confirmed to hold UDP.
   protocol: http2
 
-  # kubectl from off-LAN: WARP client -> tunnel private network route
-  # (192.168.1.119/32, apiserver, added in Zero Trust by hand) -> k3s. TLS
-  # stays end to end so the client cert kubeconfig works unchanged. TCP only
-  # while protocol is http2; UDP through this route needs quic back.
-  warpRouting:
-    enabled: true
-
   ingress:
     routes:
       # argocd, longhorn, and signoz retired: they now serve under

--- a/projects/platform/cloudflare-gateway/values.yaml
+++ b/projects/platform/cloudflare-gateway/values.yaml
@@ -74,12 +74,6 @@ tunnel:
   protocol: ""
   noAutoupdate: true
 
-  # Routes WARP-enrolled clients into the LAN ranges added under the tunnel's
-  # Private Network config in Zero Trust. Off by default; prod turns it on for
-  # kubectl access to the k3s apiserver from outside the LAN.
-  warpRouting:
-    enabled: false
-
   secret:
     type: onepassword
     onepassword:


### PR DESCRIPTION
Reverts 858499712 (#? WARP private-network routing).

Every jomcgi.dev host (public, authentik, friends, hikes) has returned empty-body 503 through Cloudflare since shortly after that commit deployed (~01:15Z; platform charts deploy on HEAD). Cache-busted requests confirm no path reaches the origin. Root cause is not yet isolated from outside the LAN (could equally be node/WAN), so this PR is STAGED, NOT AUTO-MERGED: merge it to redeploy the pre-WARP tunnel config via ArgoCD (outbound pull, works even with ingress down) if cloudflared is the culprit.

Render sanity-checked: reverted config matches the pre-change shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K