### PR TITLE
chore(embervm): re-key ping to image-lane-4 after the overnight brick rolls

### DIFF
--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1887,7 +1887,7 @@ pingWorkload:
   nodeLocalWake: true
   # Base-signature re-key for the ping workload (see the template's
   # EMBER_BASE_EPOCH). Inert to the guest; bumping it forces a rebuild.
-  baseEpoch: "image-lane-3"
+  baseEpoch: "image-lane-4"
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/ping
     tag: latest


### PR DESCRIPTION
Follow-up to #5225 for the #5180 drill. The image-lane serving-images registration is still BuildBase-time and in-memory (#5221 gap 1): the overnight brick restarts wiped every entry #5225's rebuild created, so wakes 502 with "no serving image provisioned" again this morning (verified 14:47Z, all five attempts, on brick-2gi-node-1).

One more re-key forces the rebuild that repopulates inventory on the current pods so today's end-to-end drill can run. The durable fix (persist a runtime-ref marker per base bundle and re-seed it at boot) lands via #5221.