### PR TITLE
fix(embervm): render EMBERVM_PLACEMENT_RETRY and EMBERVM_ASYNC_LIFECYCLE_WRITES from chart values

### DIFF
--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -193,6 +193,34 @@ semgrep_test(
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
 
+# Pins the two ADR-014-style control-plane gates (#5230) to their chart keys:
+# EMBERVM_PLACEMENT_RETRY (dispatcher.placementRetry) and
+# EMBERVM_ASYNC_LIFECYCLE_WRITES (asyncLifecycleWrites) must always render,
+# defaulting "false" and flipping via --set alone. See
+# chart_control_env_gate_test.py.
+py_test(
+    name = "chart_control_env_gate_test",
+    srcs = ["chart_control_env_gate_test.py"],
+    data = [
+        "Chart.yaml",
+        "values.yaml",
+        "@multitool//tools/helm",
+    ] + glob([
+        "templates/**/*",
+        "crds/**/*",
+    ]),
+    env = {
+        "HELM_BIN": "$(rootpath @multitool//tools/helm)",
+    },
+    deps = ["@pip//pytest"],
+)
+
+semgrep_test(
+    name = "chart_control_env_gate_test_semgrep_test",
+    srcs = ["chart_control_env_gate_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
 semgrep_test(
     name = "noded_networkpolicy_test_semgrep_test",
     srcs = ["noded_networkpolicy_test.py"],

--- a/projects/embervm/chart/chart_control_env_gate_test.py
+++ b/projects/embervm/chart/chart_control_env_gate_test.py
@@ -1,0 +1,72 @@
+"""Render-test the control-plane feature-gate env wiring (issue #5230).
+
+EMBERVM_PLACEMENT_RETRY and EMBERVM_ASYNC_LIFECYCLE_WRITES are read by the
+control plane but were rendered by no template, so their docstrings'
+"flips via a values-only deploy" claim described unreachable configuration.
+This pins both env vars to their chart keys: rendered "false" by default
+(the code's OFF default) and "true" when the key is set.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ENV = re.compile(r'^\s*- name: (\S+)\n\s+value: "?([^"\n]+)"?', re.MULTILINE)
+_GATES = ("EMBERVM_PLACEMENT_RETRY", "EMBERVM_ASYNC_LIFECYCLE_WRITES")
+
+
+def _chart_dir() -> Path:
+    chart = Path(__file__).resolve().parent
+    if (chart / "Chart.yaml").exists():
+        return chart
+    raise RuntimeError("Could not find chart Chart.yaml")
+
+
+def _render_gate_values(sets: list[str]) -> dict[str, str]:
+    helm_bin = os.environ.get("HELM_BIN", "helm")
+    result = subprocess.run(
+        [
+            helm_bin,
+            "template",
+            "gate-env-test",
+            str(_chart_dir()),
+            *[arg for pair in sets for arg in ("--set", pair)],
+            "--show-only",
+            "templates/deployment.yaml",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"helm template failed: {result.stderr}")
+
+    env = dict(_ENV.findall(result.stdout))
+    missing = [name for name in _GATES if name not in env]
+    assert not missing, f"gates not always rendered: {missing}"
+    return {name: env[name] for name in _GATES}
+
+
+def test_gates_default_off() -> None:
+    assert _render_gate_values([]) == {
+        "EMBERVM_PLACEMENT_RETRY": "false",
+        "EMBERVM_ASYNC_LIFECYCLE_WRITES": "false",
+    }
+
+
+@pytest.mark.parametrize(
+    ("key", "env_name"),
+    [
+        ("dispatcher.placementRetry", "EMBERVM_PLACEMENT_RETRY"),
+        ("asyncLifecycleWrites", "EMBERVM_ASYNC_LIFECYCLE_WRITES"),
+    ],
+)
+def test_gate_flips_via_its_chart_key(key: str, env_name: str) -> None:
+    rendered = _render_gate_values([f"{key}=true"])
+    assert rendered[env_name] == "true"
+    other = next(name for name in _GATES if name != env_name)
+    assert rendered[other] == "false", f"{key} must not move {other}"

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -119,6 +119,14 @@ spec:
             # node-confirmed path executes anywhere.
             - name: EMBERVM_NODE_CONFIRMED_DESTROY
               value: {{ if .Values.nodeConfirmedDestroy }}"true"{{ else }}"false"{{ end }}
+            # Async lifecycle op-log appends (ADR embervm/014 decision 2,
+            # GitHub issue #5230): true defers the boot/wake lifecycle appends
+            # (:assigned/:started, session_created/session_relit) to
+            # Embervm.AsyncWriter off the hot path; false (the default) keeps
+            # today's write-through ordering. Rendered beside its sibling gate
+            # above so both ADR-014 ordering gates flip via values only.
+            - name: EMBERVM_ASYNC_LIFECYCLE_WRITES
+              value: {{ if .Values.asyncLifecycleWrites }}"true"{{ else }}"false"{{ end }}
             # SpecTrace gate for spec validation (GitHub issue #4770):
             # the debug-gated, spec-shaped trace reads once at boot.
             # OFF means no process, no connection, no sweep.
@@ -260,6 +268,12 @@ spec:
             - name: EMBERVM_PRINCIPAL_SHARE_FRACTION
               value: {{ .Values.dispatcher.principalShareFraction | quote }}
             {{- end }}
+            # Placement reject/retry gate (GitHub issue #5230): true lets the
+            # dispatcher walk remaining candidates after a rejection; false
+            # (the default) stops at the first failed candidate. Read by
+            # Embervm.Scheduler.Retry.enabled?/0.
+            - name: EMBERVM_PLACEMENT_RETRY
+              value: {{ if .Values.dispatcher.placementRetry }}"true"{{ else }}"false"{{ end }}
             # Session invoke wall-clock watchdog margin (#4434): last-resort kill
             # of a SessionAssign worker that outlived the server-enforced deadline.
             - name: EMBERVM_SESSION_INVOKE_WATCHDOG_MARGIN_MS

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -169,6 +169,19 @@ opLog:
 # until dev has exercised it under the conformance harness.
 nodeConfirmedDestroy: false
 
+# Async lifecycle op-log appends (ADR embervm/014 decision 2, GitHub issue
+# #5230). Read once at boot by Embervm.Application.async_lifecycle_writes_enabled/0
+# (control/lib/embervm/application.ex) as EMBERVM_ASYNC_LIFECYCLE_WRITES. False
+# (the default) keeps today's write-through ordering: the boot/wake lifecycle
+# appends (:assigned/:started on dispatch, session_created/session_relit on
+# session boot/wake) block the hot-path caller before the instance is handed
+# back. True defers those four appends to Embervm.AsyncWriter after in-memory
+# state advances (a lost write is repaired by adoption backfill); metering,
+# :submitted, destruction, and bank ops are never deferred regardless. This key
+# exists so the gate flips via a values-only deploy, the same surface its
+# sibling nodeConfirmedDestroy above has had all along.
+asyncLifecycleWrites: false
+
 # existing op_log_mod/0 selection and avoids inventing a second switch.
 specTrace:
   # Default OFF in production. ON in dev for local spec validation.
@@ -250,6 +263,14 @@ dispatcher:
   # cap / active-principals (min 1), so under contention no principal starves
   # the others. Set a fraction in (0, 1] to fix each principal's share instead.
   principalShareFraction: ""
+  # Placement reject/retry gate (GitHub issue #5230). Read by
+  # Embervm.Scheduler.Retry.enabled?/0 (control/lib/embervm/scheduler/retry.ex)
+  # as EMBERVM_PLACEMENT_RETRY. False (the default) keeps today's
+  # single-attempt placement: the first candidate rejection ends the attempt.
+  # True lets the placement walk its remaining candidates after a rejection
+  # (reject/retry policy). Mirrors the env-gate convention of the ADR-014
+  # changes so it flips via a values-only deploy, no code change.
+  placementRetry: false
 
 # Session-process tuning (control-plane env).
 session:

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -1017,7 +1017,9 @@ defmodule Embervm.Application do
   # (RPC already succeeded), taking the durable write off the hot path; a lost write
   # (CP crash before the async append) is repaired by the adoption backfill. Metering,
   # :submitted, destruction, and bank ops are NEVER deferred. Wired here so it flips
-  # via a deploy values env change, no code change. Nothing sets it on in this PR.
+  # via a deploy values env change, no code change: the chart's `asyncLifecycleWrites`
+  # key (chart/values.yaml) renders this variable in deployment.yaml. Nothing sets
+  # it on in this PR.
   defp async_lifecycle_writes_enabled do
     case trimmed_env("EMBERVM_ASYNC_LIFECYCLE_WRITES") do
       v when v in ["1", "true", "TRUE", "True"] -> true

--- a/projects/embervm/control/lib/embervm/scheduler/retry.ex
+++ b/projects/embervm/control/lib/embervm/scheduler/retry.ex
@@ -182,7 +182,9 @@ defmodule Embervm.Scheduler.Retry do
   Whether the reject/retry policy is enabled, from `EMBERVM_PLACEMENT_RETRY`
   (default OFF). UNSET or "0"/"false"/"" keeps today's single-attempt behaviour;
   "1"/"true" turns on multi-candidate retry. Mirrors the env-gate convention of
-  the other ADR-014 changes so it flips via a values-only deploy, no code change.
+  the other ADR-014 changes: the chart key `dispatcher.placementRetry`
+  (chart/values.yaml) renders this variable in deployment.yaml, so it flips via
+  a values-only deploy, no code change.
   """
   @spec enabled?() :: boolean()
   def enabled? do


### PR DESCRIPTION
Closes #5230.

Both env gates are read by the control plane but rendered by no template, so the docstrings' "flips via a values-only deploy" claim was unreachable. Wired like their ADR-014 siblings:

- `dispatcher.placementRetry` (default false) renders `EMBERVM_PLACEMENT_RETRY`
- `asyncLifecycleWrites` (default false) renders `EMBERVM_ASYNC_LIFECYCLE_WRITES` beside `nodeConfirmedDestroy`
- deploy values untouched (arming is a separate decision); docstrings now name the keys
- new render test (3 cases) pins default-false, set-true, and placement

Verified: helm renders pasted in the worktree report (defaults false, `--set` flips both), render pytest 3 passed, `ci` green incl. full ExUnit (1445 tests, 0 failures).

Implemented by ox-alpha via opencode, reviewed on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K