### PR TITLE
feat(embervm): make image-lane serving registrations survive a daemon restart

### DIFF
--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1887,7 +1887,7 @@ pingWorkload:
   nodeLocalWake: true
   # Base-signature re-key for the ping workload (see the template's
   # EMBER_BASE_EPOCH). Inert to the guest; bumping it forces a rebuild.
-  baseEpoch: "image-lane-4"
+  baseEpoch: "image-lane-5"
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/ping
     tag: latest

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -617,7 +617,10 @@ func (d *Driver) baseMemfile(key string) string  { return filepath.Join(d.baseDi
 // the memory snapshot. handler.zip is the verified zip bytes noded holds, attached as a
 // read-only drive on a serving cold boot; runtime.ref records the runtime image whose
 // rootfs is drive 1 so a startup rescan can rebuild the serving-images inventory without
-// a control-plane round-trip.
+// a control-plane round-trip. An IMAGE-lane serving base (ADR embervm/038) has no
+// handler.zip: its runtime.ref alone marks the bundle as serving, and the rescan
+// re-seeds it as a handler-less inventory entry so the registration survives a daemon
+// restart (#5221).
 func (d *Driver) baseHandlerZip(key string) string {
 	return filepath.Join(d.baseDir(key), "handler.zip")
 }
@@ -675,6 +678,21 @@ func (d *Driver) WriteServingHandlerArtifact(baseKey, runtimeImageRef string, zi
 	return path, int64(len(zip)), nil
 }
 
+// WriteServingImageMarker persists ONLY the runtime-ref sidecar for an IMAGE-lane
+// serving base (ADR embervm/038): the bundle has no handler.zip, so the marker is
+// what makes the serving-images registration durable. The startup rescan treats
+// bases/<key>/runtime.ref without handler.zip as a handler-less inventory entry,
+// so the entry survives a daemon restart (#5221), exactly like its zip-lane twin.
+func (d *Driver) WriteServingImageMarker(baseKey, runtimeImageRef string) error {
+	if err := os.MkdirAll(d.baseDir(baseKey), 0o750); err != nil {
+		return fmt.Errorf("driver: mkdir base bundle for serving marker: %w", err)
+	}
+	if err := os.WriteFile(d.baseHandlerRuntimeRef(baseKey), []byte(runtimeImageRef), 0o640); err != nil {
+		return fmt.Errorf("driver: write serving image runtime ref sidecar: %w", err)
+	}
+	return nil
+}
+
 // ServingHandlerArtifactPath returns a base's handler-artifact path and whether it
 // exists on disk.
 func (d *Driver) ServingHandlerArtifactPath(baseKey string) (string, bool) {
@@ -685,13 +703,16 @@ func (d *Driver) ServingHandlerArtifactPath(baseKey string) (string, bool) {
 	return path, true
 }
 
-// ScanServingHandlerArtifacts globs bases/*/handler.zip on startup and returns each
-// discovered artifact with its base key, path, size, and runtime ref (from the
+// ScanServingHandlerArtifacts globs the base bundles on startup and returns each
+// discovered serving entry with its base key, path, size, and runtime ref (from the
 // runtime.ref sidecar), so the daemon re-seeds its serving-images inventory after a
-// restart. A base dir with a memory snapshot but no handler.zip (a task/session-only
-// base) is skipped; a handler.zip without a readable sidecar is skipped with no error
-// (it will be rebuilt on the next BuildBase), keeping the rescan best-effort like the
-// banked-snapshot rescan.
+// restart. Two shapes come back: a ZIP-lane artifact (handler.zip + runtime.ref,
+// Path set, SizeBytes exact) and an IMAGE-lane marker (runtime.ref alone per ADR
+// embervm/038, Path "" and SizeBytes 0; #5221). A bundle dir with neither file (a
+// task/session-only base) is skipped; either file without its counterpart is
+// handled: zip-without-ref and ref-without-zip each yield their shape above. A
+// malformed sidecar is skipped with no error (it will be rebuilt on the next
+// BuildBase), keeping the rescan best-effort like the banked-snapshot rescan.
 func (d *Driver) ScanServingHandlerArtifacts() []substrate.ServingHandlerArtifact {
 	basesDir := filepath.Join(d.cfg.SnapshotRoot, "bases")
 	entries, err := os.ReadDir(basesDir)
@@ -705,13 +726,23 @@ func (d *Driver) ScanServingHandlerArtifacts() []substrate.ServingHandlerArtifac
 		}
 		baseKey := e.Name()
 		zipPath := d.baseHandlerZip(baseKey)
-		fi, err := os.Stat(zipPath)
-		if err != nil {
-			continue // not a serving base (no handler artifact)
-		}
 		runtimeRef, rerr := os.ReadFile(d.baseHandlerRuntimeRef(baseKey))
 		if rerr != nil {
-			continue // artifact without a runtime sidecar: skip, BuildBase rebuilds it
+			continue // not a serving base (no runtime sidecar): skip, BuildBase rebuilds it
+		}
+		fi, err := os.Stat(zipPath)
+		if err != nil {
+			// runtime.ref without handler.zip: an IMAGE-lane serving base
+			// (ADR embervm/038). Re-seed it as a HANDLER-LESS inventory entry:
+			// Path "" and SizeBytes 0 tell startServingFresh to boot the image
+			// entrypoint with no artifact drive.
+			out = append(out, substrate.ServingHandlerArtifact{
+				BaseKey:         baseKey,
+				Path:            "",
+				RuntimeImageRef: strings.TrimSpace(string(runtimeRef)),
+				SizeBytes:       0,
+			})
+			continue
 		}
 		// Exact zip length from the sidecar (the on-disk file is sector-padded, so
 		// its size is >= the real zip; the guest must read only the payload). Fall

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -1468,6 +1468,35 @@ func TestWriteAndScanServingHandlerArtifact(t *testing.T) {
 	}
 }
 
+// TestWriteAndScanServingImageMarker proves the IMAGE-lane durability shape
+// (#5221): WriteServingImageMarker persists ONLY the runtime-ref sidecar (no
+// handler.zip), and the startup rescan re-discovers the base as a HANDLER-LESS
+// inventory entry (Path "", SizeBytes 0) whose fresh boot runs the image
+// entrypoint with no artifact drive (ADR embervm/038). A bundle with neither file
+// stays invisible to the rescan.
+func TestWriteAndScanServingImageMarker(t *testing.T) {
+	d := testDriver(t)
+	if err := d.WriteServingImageMarker("ping__abc", "sha256:439160ce"); err != nil {
+		t.Fatalf("WriteServingImageMarker: %v", err)
+	}
+	// The marker must be runtime.ref alone: no handler.zip may exist beside it.
+	if _, err := os.Stat(d.baseHandlerZip("ping__abc")); !os.IsNotExist(err) {
+		t.Fatalf("handler.zip must not exist for an image-lane marker, stat err = %v", err)
+	}
+	// A task/session-only bundle dir (no serving files at all) stays skipped.
+	if err := os.MkdirAll(filepath.Join(d.cfg.SnapshotRoot, "bases", "task__xyz"), 0o750); err != nil {
+		t.Fatalf("mkdir task bundle: %v", err)
+	}
+	got := d.ScanServingHandlerArtifacts()
+	if len(got) != 1 {
+		t.Fatalf("rescan found %d entries want 1 (marker yes, bare dir no)", len(got))
+	}
+	a := got[0]
+	if a.BaseKey != "ping__abc" || a.Path != "" || a.RuntimeImageRef != "sha256:439160ce" || a.SizeBytes != 0 {
+		t.Fatalf("rescanned marker mismatch: %+v", a)
+	}
+}
+
 // TestServingSnapshotRoundTrip banks a serving VM (writing the pinned-IP sidecar),
 // reads the pin back, restores from the bundle, and evicts it, mirroring the session
 // round-trip test but asserting the D-R3.4.1 IP pin is persisted and recovered.

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -835,6 +835,18 @@ func (s *Server) driveBuild(ctx context.Context, req *nodev1.BuildBaseRequest, b
 			}
 			simg.handlerPath = path
 			simg.sizeBytes = artifactBytes
+		} else {
+			// Image lane: persist the runtime-ref MARKER so this registration is
+			// durable (#5221). Without it the inventory entry lived only in
+			// memory and every daemon restart silently un-wakeable the workload:
+			// the rescan re-seeds zip-lane artifacts from disk but had nothing to
+			// find for a handler-less base. A marker write failure fails the
+			// build for the same reason as its zip-lane twin above.
+			if werr := s.servingDriver.WriteServingImageMarker(baseKey, imageDigest); werr != nil {
+				s.bases.failBuild(baseKey, werr.Error())
+				s.signalChange()
+				return nil, status.Errorf(codes.FailedPrecondition, "noded: write serving image marker for %q: %v", baseKey, werr)
+			}
 		}
 		s.servingImage.add(simg)
 		servingImageRef = baseKey

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -1375,6 +1375,75 @@ func TestBuildBaseServingRegistersImage(t *testing.T) {
 		if resp.GetServingImageRef() != got.baseKey {
 			t.Errorf("serving_image_ref = %q, want %q", resp.GetServingImageRef(), got.baseKey)
 		}
+		// The registration must be DURABLE (#5221): the image-lane branch writes a
+		// runtime-ref marker (no handler.zip) the startup rescan can re-seed.
+		scan := fsd.ScanServingHandlerArtifacts()
+		if len(scan) != 1 {
+			t.Fatalf("rescan entries = %d, want 1", len(scan))
+		}
+		if scan[0].BaseKey != got.baseKey || scan[0].Path != "" || scan[0].RuntimeImageRef != "runtime-python:1" || scan[0].SizeBytes != 0 {
+			t.Errorf("rescanned marker mismatch: %+v", scan[0])
+		}
+	})
+
+	t.Run("image-lane registration survives a daemon restart", func(t *testing.T) {
+		s, _, fsd, _ := newServer()
+		resp, err := s.BuildBase(ctx, &nodev1.BuildBaseRequest{
+			Trace:            &nodev1.Trace{Workload: "serving-image-lane"},
+			ImageRef:         "runtime-python:1",
+			WorkloadRevision: "r1",
+			ReadyPath:        "/shim/ready",
+			Resources:        &nodev1.ResourceSpec{Vcpus: 1, MemMib: 512},
+			Serving:          true,
+		})
+		if err != nil {
+			t.Fatalf("BuildBase serving image lane: %v", err)
+		}
+		// A restarted daemon re-seeds its inventory from the driver's disk rescan;
+		// the marker must come back as a wakeable handler-less entry keyed by
+		// workload (recovered from the base-key prefix), not vanish like an
+		// in-memory-only registration.
+		restarted := New(Options{
+			Config: config.Config{
+				Arch: "amd64", Node: "node-4", SnapshotRoot: t.TempDir(),
+				BootReadyTimeout:    time.Second,
+				ArchiveFetchTimeout: 30 * time.Second,
+				ArchiveMaxBytes:     512 << 20,
+				Images:              map[string]config.Image{"runtime-python:1": {RootfsPath: "/runtime.ext4"}},
+			},
+			Driver:         &fakeDriver{},
+			ServingDriver:  fsd,
+			Transport:      &fakeTransport{},
+			NewBuildDriver: func(BuildDriverSpec) BuildDriver { return &fakeDriver{} },
+			Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		})
+		images := restarted.servingImage.snapshot()
+		if len(images) != 1 {
+			t.Fatalf("post-restart inventory entries = %d, want 1", len(images))
+		}
+		got := images[0]
+		if got.workload != "serving-image-lane" || got.baseKey != resp.GetSnapshotRef() || got.handlerPath != "" || got.runtimeImageRef != "runtime-python:1" {
+			t.Errorf("post-restart inventory mismatch: %+v", got)
+		}
+	})
+
+	t.Run("image marker write failure fails build", func(t *testing.T) {
+		s, _, fsd, _ := newServer()
+		fsd.failHandlerWrite = context.Canceled
+		_, err := s.BuildBase(ctx, &nodev1.BuildBaseRequest{
+			Trace:            &nodev1.Trace{Workload: "serving-image-lane"},
+			ImageRef:         "runtime-python:1",
+			WorkloadRevision: "r1",
+			ReadyPath:        "/shim/ready",
+			Resources:        &nodev1.ResourceSpec{Vcpus: 1, MemMib: 512},
+			Serving:          true,
+		})
+		if status.Code(err) != codes.FailedPrecondition {
+			t.Fatalf("marker write failure code = %v, want FailedPrecondition", status.Code(err))
+		}
+		if got := len(s.servingImage.snapshot()); got != 0 {
+			t.Errorf("serving image inventory entries = %d, want 0 after failed marker write", got)
+		}
 	})
 
 	t.Run("zip artifact write failure fails build", func(t *testing.T) {

--- a/projects/embervm/noded/server/serving_registry.go
+++ b/projects/embervm/noded/server/serving_registry.go
@@ -92,6 +92,12 @@ type servingDriver interface {
 	// The exact length is returned so noded reports it and the guest reads only the
 	// payload, not the block device's sector padding.
 	WriteServingHandlerArtifact(baseKey, runtimeImageRef string, zip []byte) (path string, sizeBytes int64, err error)
+	// WriteServingImageMarker persists ONLY the runtime-ref sidecar for an IMAGE-lane
+	// serving base (ADR embervm/038: no handler archive exists). The marker is what
+	// makes the serving-images registration durable: the startup rescan treats
+	// bases/<baseKey>/runtime.ref without handler.zip as a handler-less inventory
+	// entry, so the registration survives a daemon restart (#5221). Idempotent.
+	WriteServingImageMarker(baseKey, runtimeImageRef string) error
 	// ServingHandlerArtifactPath returns the host path of a base's handler artifact
 	// and whether it exists on disk. Used by the startup rescan to re-discover serving
 	// images and by startServingFresh to resolve the drive to attach.

--- a/projects/embervm/noded/server/serving_test.go
+++ b/projects/embervm/noded/server/serving_test.go
@@ -201,6 +201,19 @@ func (f *fakeServingDriver) WriteServingHandlerArtifact(baseKey, runtimeImageRef
 	return path, int64(len(zip)), nil
 }
 
+// WriteServingImageMarker records ONLY the runtime ref for an image-lane base key
+// (no handler artifact), mirroring the real driver's runtime.ref-only sidecar.
+func (f *fakeServingDriver) WriteServingImageMarker(baseKey, runtimeImageRef string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failHandlerWrite != nil {
+		return f.failHandlerWrite
+	}
+	delete(f.handlers, baseKey)
+	f.handlerRuntimeRefs[baseKey] = runtimeImageRef
+	return nil
+}
+
 func (f *fakeServingDriver) handlerArtifactWriteCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -215,13 +228,20 @@ func (f *fakeServingDriver) ServingHandlerArtifactPath(baseKey string) (string, 
 	return p, ok
 }
 
-// ScanServingHandlerArtifacts returns the recorded artifacts as a startup-rescan would.
+// ScanServingHandlerArtifacts returns the recorded artifacts as a startup-rescan
+// would: zip-lane bases carry their artifact path; image-lane markers (runtime ref
+// with no handler zip) come back as handler-less entries.
 func (f *fakeServingDriver) ScanServingHandlerArtifacts() []substrate.ServingHandlerArtifact {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	out := make([]substrate.ServingHandlerArtifact, 0, len(f.handlers))
+	out := make([]substrate.ServingHandlerArtifact, 0, len(f.handlers)+len(f.handlerRuntimeRefs))
 	for k, p := range f.handlers {
 		out = append(out, substrate.ServingHandlerArtifact{BaseKey: k, Path: p, RuntimeImageRef: f.handlerRuntimeRefs[k]})
+	}
+	for k, r := range f.handlerRuntimeRefs {
+		if _, hasZip := f.handlers[k]; !hasZip {
+			out = append(out, substrate.ServingHandlerArtifact{BaseKey: k, Path: "", RuntimeImageRef: r})
+		}
 	}
 	return out
 }

--- a/projects/embervm/noded/substrate/substrate.go
+++ b/projects/embervm/noded/substrate/substrate.go
@@ -164,23 +164,28 @@ type SnapshotRef struct {
 	Base bool
 }
 
-// ServingHandlerArtifact is one discovered cold-boot handler artifact on disk (a
-// serving base's handler.zip plus its runtime-ref sidecar), returned by the driver's
-// startup rescan so the server re-seeds its serving-images inventory after a restart
-// (D-R3.11.2). It sits in substrate because both the driver (which owns the on-disk
-// base-bundle layout it globs) and the server (which consumes the rescan through the
-// servingDriver seam) name it, and neither may import the other.
+// ServingHandlerArtifact is one discovered serving-images entry on disk, returned
+// by the driver's startup rescan so the server re-seeds its serving-images
+// inventory after a restart (D-R3.11.2). It sits in substrate because both the
+// driver (which owns the on-disk base-bundle layout it globs) and the server
+// (which consumes the rescan through the servingDriver seam) name it, and neither
+// may import the other. Two shapes: a ZIP-lane handler artifact (handler.zip plus
+// its runtime-ref sidecar; Path set, SizeBytes exact) and an IMAGE-lane marker
+// (runtime.ref alone per ADR embervm/038; Path "" and SizeBytes 0, a HANDLER-LESS
+// entry whose fresh boot runs the image entrypoint with no artifact drive).
 type ServingHandlerArtifact struct {
 	// BaseKey is the serving base key (== the serving image ref the control plane
 	// places on), recovered from the bundle dir name.
 	BaseKey string
-	// Path is the host path of the handler.zip artifact (the cold-boot drive 2).
+	// Path is the host path of the handler.zip artifact (the cold-boot drive 2),
+	// or "" for an IMAGE-lane marker entry (no artifact drive exists).
 	Path string
 	// RuntimeImageRef is the runtime image whose rootfs is drive 1, read from the
 	// runtime.ref sidecar the write records so the rescan needs no control-plane call.
 	RuntimeImageRef string
 	// SizeBytes is the exact zip length (the EOCD-padding defence), read from the
-	// artifact file so the guest reads only the payload, not the block padding.
+	// artifact file so the guest reads only the payload, not the block padding;
+	// always 0 for an IMAGE-lane marker entry.
 	SizeBytes int64
 }
 


### PR DESCRIPTION
Addresses gap 1 of #5221 (boot-time backfill of image-lane inventory entries). Found this morning: after the overnight brick rolls, ping woke 502 again on all five attempts because #5225's registrations lived only in the pre-roll pods' memory.

## The hole

An IMAGE-lane serving base registers its inventory entry at BuildBase time and nowhere else. The zip lane never had this problem: its startup rescan re-seeds every `bases/<key>/handler.zip` bundle from disk. An image-lane base writes no handler.zip, so the rescan had nothing to find and every daemon restart silently un-wakeable'd the workload until something forced another rebuild.

## The fix

Give the image lane the same durability with a runtime-ref-only marker:

- `Driver.WriteServingImageMarker` persists ONLY `bases/<key>/runtime.ref` into the bundle dir.
- `BuildBase`'s image-lane branch writes it with the same contract as its zip-lane twin: write failure fails the build (`FailedPrecondition`) rather than reporting READY on an un-wakeable base.
- `ScanServingHandlerArtifacts` now returns two shapes: zip+ref (artifact entry, unchanged) and ref-alone (HANDLER-LESS entry, `Path ""`, `SizeBytes 0`). A bundle with neither file stays invisible, so task/session bases are unaffected. The existing boot re-seed in `NewServer` picks marker entries up with no change there; `startServingFresh` already boots `Path ""` entries from the image entrypoint.

## Tests

- Driver round-trip: marker write leaves no handler.zip; rescan yields exactly one handler-less entry; a bare task-bundle dir stays skipped.
- Server: image-lane BuildBase records a scannable marker; a restarted `New(Options{ServingDriver: fsd})` re-seeds the wakeable entry keyed by workload from the base-key prefix; marker-write failure fails the build with an empty inventory.
- Epoch bumped to `image-lane-5`: bases built before this binary carry no marker, so one rebuild is what makes ping restart-durable.

`ci` green locally (153 affected tests). Gap 2 of #5221 (single-endpoint activator selection) remains open.