### PR TITLE
fix(embervm): make noded blessing enforcement unconditional

### DIFF
--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -362,15 +362,6 @@ containers:
             name: {{ include "embervm.store.credentialsSecretName" $ctx }}
             key: {{ $ctx.Values.noded.store.credentials.secretAccessKeyKey }}
       {{- end }}
-      # R7 (ADR embervm/011, standing decision 4): the control plane becomes
-      # the sole issuer of volume generations. false accepts a legacy
-      # blessed_generation == 0 self-bump (the default, so this PR can land
-      # both sides in one chart version without a wedge); true rejects an
-      # unblessed writable attach FAILED_PRECONDITION. The CP and noded ship
-      # from this ONE chart, so flipping this true here lands in the same
-      # version the control plane starts blessing (never a mixed state).
-      - name: EMBERVM_NODED_REQUIRE_BLESSING
-        value: {{ $ctx.Values.noded.requireBlessing | quote }}
       - name: EMBERVM_NODED_REQUIRE_RESTORE_CAPABILITY
         value: {{ $ctx.Values.noded.requireRestoreCapability | quote }}
       # Artifact-decoupling Phase 2: the node-side image identity table that

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1355,13 +1355,10 @@ noded:
         # generated Secret name to <embervm.fullname>-store.
         itemPath: ""
 
-  # R7 (ADR embervm/011, standing decision 4): the control plane becomes the
-  # sole issuer of volume generations. true rejects a writable attach carrying
-  # blessed_generation == 0 (a legacy self-bump) FAILED_PRECONDITION; this chart
-  # deploys BOTH the control plane and noded, so setting this true here lands
-  # in the exact version the control plane starts blessing, never a mixed
-  # CP/noded state.
-  requireBlessing: true
+  # R7 (ADR embervm/011, standing decision 4): the control plane is the sole
+  # issuer of volume generations. noded rejects an unblessed writable attach
+  # (blessed_generation == 0) FAILED_PRECONDITION unconditionally; the
+  # EMBERVM_NODED_REQUIRE_BLESSING rollout gate was collapsed in #4950.
 
   # EMBERVM_NODED_REQUIRE_RESTORE_CAPABILITY. Phase 1 validates restore
   # capabilities with enforcement inert. Arm only after the control plane

--- a/projects/embervm/control/lib/embervm/stateful_store.ex
+++ b/projects/embervm/control/lib/embervm/stateful_store.ex
@@ -79,7 +79,7 @@ defmodule Embervm.StatefulStore do
   A volume is QUARANTINED when a node reports its generation has moved PAST
   the last value this control plane blessed, with `generation_blessed: false`
   on the wire (a self-bump the daemon made outside the blessing ledger, e.g. a
-  legacy noded that has not yet enabled `EMBERVM_NODED_REQUIRE_BLESSING`, or a
+  node-local activator whose blessing lease was absent or exhausted, or a
   split-brain write). `upsert_volume/3` re-derives `quarantined` in the
   blessing table on every node refresh that carries a `generation_blessed`
   fact: true when the reported generation exceeds `blessed_generation` AND the

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -418,14 +418,6 @@ type Config struct {
 	// encrypted objects. Env EMBERVM_NODED_STORE_ENCRYPT. Default false.
 	StoreEncrypt bool
 
-	// RequireBlessing rejects any writable stateful attach (FRESH/RELIGHT/COLD)
-	// carrying blessed_generation == 0 with FAILED_PRECONDITION, once the
-	// control plane has started issuing blessed generations (R7, ADR
-	// embervm/011, standing decision 4). Defaults false so a rollout can land
-	// the control-plane side first; the chart flips this true in the SAME
-	// version so a mixed CP/noded state cannot outlive the roll. Env
-	// EMBERVM_NODED_REQUIRE_BLESSING.
-	RequireBlessing bool
 	// RequireRestoreCapability refuses an enveloped artifact restore unless its
 	// request carries a valid, tuple-scoped capability. This is a two-phase
 	// rollout: validation ships everywhere with enforcement OFF, then enforcement
@@ -505,7 +497,6 @@ func Load() (Config, error) {
 		StoreAccessKeyID:     os.Getenv("EMBERVM_NODED_STORE_ACCESS_KEY_ID"),
 		StoreSecretAccessKey: os.Getenv("EMBERVM_NODED_STORE_SECRET_ACCESS_KEY"),
 
-		RequireBlessing:          boolDefault("EMBERVM_NODED_REQUIRE_BLESSING", false),
 		RequireRestoreCapability: boolDefault("EMBERVM_NODED_REQUIRE_RESTORE_CAPABILITY", false),
 	}
 	if c.AdmissionModel != "observed" && c.AdmissionModel != "reserved" {

--- a/projects/embervm/noded/config/config_test.go
+++ b/projects/embervm/noded/config/config_test.go
@@ -404,9 +404,6 @@ func TestLoadDefaults(t *testing.T) {
 	if c.GroupUnhealthyThreshold != 3 {
 		t.Errorf("GroupUnhealthyThreshold = %d, want 3", c.GroupUnhealthyThreshold)
 	}
-	if c.RequireBlessing {
-		t.Error("RequireBlessing should default false so a rollout can land the control-plane side first")
-	}
 	if c.StoreEncrypt {
 		t.Error("StoreEncrypt should default false for the two-phase rollout")
 	}
@@ -427,20 +424,6 @@ func TestLoadDiffBankingOverride(t *testing.T) {
 	}
 	if got, want := strings.Join(c.DiffBankingWorkloads, ","), "sandbox-session,another-session"; got != want {
 		t.Errorf("DiffBankingWorkloads = %q, want %q", got, want)
-	}
-}
-
-// TestLoadRequireBlessingOverride proves EMBERVM_NODED_REQUIRE_BLESSING is
-// parsed as a bool (R7, ADR embervm/011): the chart flips this true in the
-// same version the control plane starts blessing.
-func TestLoadRequireBlessingOverride(t *testing.T) {
-	t.Setenv("EMBERVM_NODED_REQUIRE_BLESSING", "true")
-	c, err := Load()
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if !c.RequireBlessing {
-		t.Error("RequireBlessing should be true when EMBERVM_NODED_REQUIRE_BLESSING=true")
 	}
 }
 

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -98,10 +98,11 @@ func (s *Server) startStateful(ctx context.Context, req *nodev1.StartStatefulReq
 // attachGeneration resolves the generation a writable attach records. A nonzero
 // blessedGeneration on the request is recorded via volume.Manager.RecordBlessed
 // (the control-plane-issued value, never invented here). Zero means the lease
-// lane for a trusted node-local activator and, while
-// s.cfg.RequireBlessing is false, the legacy RPC path. The activator follows
-// the same self-bump discipline as checkpoint auto-abort when its lease is
-// absent or exhausted and relies on the physical volume attach fence.
+// lane for a trusted node-local activator; any other unblessed writable attach
+// is refused FAILED_PRECONDITION (R7, ADR embervm/011, standing decision 4:
+// the control plane is the sole issuer of volume generations). The activator
+// follows the same self-bump discipline as checkpoint auto-abort when its lease
+// is absent or exhausted and relies on the physical volume attach fence.
 func (s *Server) attachGeneration(workload string, blessedGeneration uint64, activatorOrigin bool) (uint64, error) {
 	if blessedGeneration > 0 {
 		gen, err := s.volumes.RecordBlessed(workload, blessedGeneration)
@@ -130,9 +131,11 @@ func (s *Server) attachGeneration(workload string, blessedGeneration uint64, act
 			s.logger.Warn("blessing lease exhausted for workload, falling back to unblessable self-bump", "workload", workload)
 		}
 	}
-	if s.cfg.RequireBlessing && !activatorOrigin {
-		return 0, status.Errorf(codes.FailedPrecondition, "noded: writable attach for %q requires a blessed_generation (EMBERVM_NODED_REQUIRE_BLESSING is set)", workload)
+	if !activatorOrigin {
+		return 0, status.Errorf(codes.FailedPrecondition, "noded: writable attach for %q requires a blessed_generation", workload)
 	}
+	// Only the activator's lease-exhaustion fallback reaches this legacy
+	// self-bump; every RPC caller must carry a blessed_generation.
 	gen, err := s.volumes.BumpGeneration(workload)
 	if err != nil {
 		return 0, status.Errorf(codes.Internal, "noded: bump generation for %q: %v", workload, err)

--- a/projects/embervm/noded/server/stateful_test.go
+++ b/projects/embervm/noded/server/stateful_test.go
@@ -295,17 +295,20 @@ func newStatefulTestServer(t *testing.T) (*Server, *fakeServingNet, *fakeStatefu
 }
 
 // startFreshStateful is a helper that FRESH-boots a stateful VM (creating the
-// volume) against a ready loopback TCP endpoint.
+// volume) against a ready loopback TCP endpoint. It carries the blessed
+// generation the control plane would issue for a fresh volume (ledger 0, so 1):
+// noded rejects an unblessed writable attach unconditionally (#4950).
 func startFreshStateful(t *testing.T, s *Server, port uint32, workload string) *nodev1.StartStatefulResponse {
 	t.Helper()
 	resp, err := s.StartStateful(context.Background(), &nodev1.StartStatefulRequest{
-		Trace:           &nodev1.Trace{Workload: workload},
-		Mode:            nodev1.StartStatefulMode_START_STATEFUL_MODE_FRESH,
-		BootImageRef:    "img-a",
-		Port:            port,
-		VolumeSizeBytes: 1 << 20,
-		VolumeMount:     "/var/lib/postgresql/data",
-		CreateIfMissing: true,
+		Trace:             &nodev1.Trace{Workload: workload},
+		Mode:              nodev1.StartStatefulMode_START_STATEFUL_MODE_FRESH,
+		BootImageRef:      "img-a",
+		Port:              port,
+		VolumeSizeBytes:   1 << 20,
+		VolumeMount:       "/var/lib/postgresql/data",
+		CreateIfMissing:   true,
+		BlessedGeneration: 1,
 	})
 	if err != nil {
 		t.Fatalf("StartStateful(fresh): %v", err)
@@ -364,7 +367,7 @@ func TestStartStatefulFreshCreatesVolumeAndBoots(t *testing.T) {
 		t.Error("StartStateful returned no vm_id")
 	}
 	if resp.GetGeneration() != 1 {
-		t.Errorf("generation = %d want 1 (first FRESH attach bumps from 0)", resp.GetGeneration())
+		t.Errorf("generation = %d want 1 (the CP-issued first blessed generation)", resp.GetGeneration())
 	}
 	if resp.GetWasRelight() {
 		t.Error("a FRESH boot must not report was_relight")
@@ -441,13 +444,14 @@ func TestStartStatefulGenerationBumpedBeforeBootAndNotRolledBackOnFailure(t *tes
 	fsd.failClaim = status.Error(codes.Internal, "boom")
 
 	_, err := s.StartStateful(context.Background(), &nodev1.StartStatefulRequest{
-		Trace:           &nodev1.Trace{Workload: "wl-state"},
-		Mode:            nodev1.StartStatefulMode_START_STATEFUL_MODE_FRESH,
-		BootImageRef:    "img-a",
-		Port:            port,
-		VolumeSizeBytes: 1 << 20,
-		VolumeMount:     "/data",
-		CreateIfMissing: true,
+		Trace:             &nodev1.Trace{Workload: "wl-state"},
+		Mode:              nodev1.StartStatefulMode_START_STATEFUL_MODE_FRESH,
+		BootImageRef:      "img-a",
+		Port:              port,
+		VolumeSizeBytes:   1 << 20,
+		VolumeMount:       "/data",
+		CreateIfMissing:   true,
+		BlessedGeneration: 1,
 	})
 	if status.Code(err) != codes.FailedPrecondition {
 		t.Fatalf("boot failure: got %v want FailedPrecondition", err)
@@ -457,7 +461,7 @@ func TestStartStatefulGenerationBumpedBeforeBootAndNotRolledBackOnFailure(t *tes
 		t.Fatalf("Generation after failed boot: %v", gerr)
 	}
 	if gen != 1 {
-		t.Errorf("generation after a failed boot = %d want 1 (bump is never rolled back)", gen)
+		t.Errorf("generation after a failed boot = %d want 1 (the record is never rolled back)", gen)
 	}
 	// The failed attach must have released the lock so a retry is possible.
 	if s.volumes.IsAttached("wl-state") {
@@ -498,14 +502,13 @@ func TestStartStatefulBlessedGenerationRecordedVerbatim(t *testing.T) {
 	}
 }
 
-// TestStartStatefulUnblessedRejectedWhenRequireBlessingSet proves that once
-// the daemon's EMBERVM_NODED_REQUIRE_BLESSING flag is on, a writable attach
-// carrying blessed_generation == 0 is refused FAILED_PRECONDITION rather than
-// falling back to a legacy self-bump.
-func TestStartStatefulUnblessedRejectedWhenRequireBlessingSet(t *testing.T) {
+// TestStartStatefulUnblessedRejected proves a writable attach carrying
+// blessed_generation == 0 is refused FAILED_PRECONDITION rather than falling
+// back to a legacy self-bump. The EMBERVM_NODED_REQUIRE_BLESSING rollout gate
+// was collapsed in #4950: this is unconditional, no config knob.
+func TestStartStatefulUnblessedRejected(t *testing.T) {
 	port := tcpHealthServer(t)
 	s, _, _ := newStatefulTestServer(t)
-	s.cfg.RequireBlessing = true
 
 	_, err := s.StartStateful(context.Background(), &nodev1.StartStatefulRequest{
 		Trace:           &nodev1.Trace{Workload: "wl-state"},
@@ -517,23 +520,16 @@ func TestStartStatefulUnblessedRejectedWhenRequireBlessingSet(t *testing.T) {
 		CreateIfMissing: true,
 	})
 	if status.Code(err) != codes.FailedPrecondition {
-		t.Fatalf("unblessed attach with RequireBlessing set: got %v want FailedPrecondition", err)
+		t.Fatalf("unblessed attach: got %v want FailedPrecondition", err)
 	}
-}
-
-// TestStartStatefulUnblessedAllowedWhenRequireBlessingUnset proves the legacy
-// self-bump lane still works while RequireBlessing is false (the default
-// during a rollout where the control plane has not yet started blessing).
-func TestStartStatefulUnblessedAllowedWhenRequireBlessingUnset(t *testing.T) {
-	port := tcpHealthServer(t)
-	s, _, _ := newStatefulTestServer(t)
-
-	resp := startFreshStateful(t, s, port, "wl-state")
-	if resp.GetGeneration() != 1 {
-		t.Errorf("generation = %d want 1 (legacy self-bump)", resp.GetGeneration())
+	// The refusal must be fail-closed BEFORE any ledger write: an unblessed
+	// attach never advances (or blesses) the generation.
+	gen, gerr := s.volumes.Generation("wl-state")
+	if gerr != nil {
+		t.Fatalf("Generation after refused unblessed attach: %v", gerr)
 	}
-	if s.volumes.GenerationBlessed("wl-state") {
-		t.Error("a legacy self-bumped attach must not read as blessed")
+	if gen != 0 {
+		t.Errorf("generation after refused unblessed attach = %d want 0 (no self-bump)", gen)
 	}
 }
 
@@ -562,6 +558,7 @@ func TestStartStatefulRelightMatchedGeneration(t *testing.T) {
 		RelightSnapshotRef: bankResp.GetSnapshotRef(),
 		Port:               port,
 		VolumeMount:        "/data",
+		BlessedGeneration:  2,
 	})
 	if err != nil {
 		t.Fatalf("StartStateful(relight): %v", err)
@@ -573,7 +570,7 @@ func TestStartStatefulRelightMatchedGeneration(t *testing.T) {
 		t.Errorf("cold_boot_reason = %q want empty for a matched relight", relit.GetColdBootReason())
 	}
 	if relit.GetGeneration() != 2 {
-		t.Errorf("relight generation = %d want 2 (bumped again on resume)", relit.GetGeneration())
+		t.Errorf("relight generation = %d want 2 (the CP-issued next generation, recorded on resume)", relit.GetGeneration())
 	}
 	_ = fsd
 }
@@ -600,7 +597,7 @@ func TestStartStatefulRelightGenerationMismatchFallsBackAndEvicts(t *testing.T) 
 	// COLD boot + destroy (no bank), so the bundle is now stale.
 	cold, err := s.StartStateful(context.Background(), &nodev1.StartStatefulRequest{
 		Trace: &nodev1.Trace{Workload: "wl-state"}, Mode: nodev1.StartStatefulMode_START_STATEFUL_MODE_COLD,
-		BootImageRef: "img-a", Port: port, VolumeMount: "/data",
+		BootImageRef: "img-a", Port: port, VolumeMount: "/data", BlessedGeneration: 2,
 	})
 	if err != nil {
 		t.Fatalf("cold boot to advance generation: %v", err)
@@ -618,6 +615,7 @@ func TestStartStatefulRelightGenerationMismatchFallsBackAndEvicts(t *testing.T) 
 		RelightSnapshotRef: staleRef,
 		Port:               port,
 		VolumeMount:        "/data",
+		BlessedGeneration:  3,
 	})
 	if err != nil {
 		t.Fatalf("StartStateful(relight, mismatched): %v", err)
@@ -658,6 +656,7 @@ func TestStartStatefulRelightNoBundleFallsBack(t *testing.T) {
 		RelightSnapshotRef: "ghost-ref",
 		Port:               port,
 		VolumeMount:        "/data",
+		BlessedGeneration:  2,
 	})
 	if err != nil {
 		t.Fatalf("StartStateful(relight, no bundle): %v", err)
@@ -702,10 +701,12 @@ func TestStartStatefulRelightLedgerUnreadableEvictsBundle(t *testing.T) {
 		RelightSnapshotRef: staleRef,
 		Port:               port,
 		VolumeMount:        "/data",
+		BlessedGeneration:  2,
 	})
-	// A genuinely corrupted ledger cannot be bumped even for the cold-boot
-	// fallback, so the call fails; the important assertion is what happened
-	// BEFORE that failure (the stale bundle was evicted), not the outer error.
+	// A genuinely corrupted ledger cannot be recorded even for the cold-boot
+	// fallback (RecordBlessed must read the ledger first), so the call fails;
+	// the important assertion is what happened BEFORE that failure (the stale
+	// bundle was evicted), not the outer error.
 	if err == nil {
 		t.Fatal("StartStateful against a corrupted ledger should fail (fail-closed)")
 	}
@@ -733,7 +734,7 @@ func TestStopStatefulBankEvictsPriorBundle(t *testing.T) {
 
 	cold, err := s.StartStateful(context.Background(), &nodev1.StartStatefulRequest{
 		Trace: &nodev1.Trace{Workload: "wl-state"}, Mode: nodev1.StartStatefulMode_START_STATEFUL_MODE_COLD,
-		BootImageRef: "img-a", Port: port, VolumeMount: "/data",
+		BootImageRef: "img-a", Port: port, VolumeMount: "/data", BlessedGeneration: 2,
 	})
 	if err != nil {
 		t.Fatalf("cold boot: %v", err)
@@ -925,6 +926,7 @@ func TestStatefulResolveCommit(t *testing.T) {
 	relit, err := s.StartStateful(context.Background(), &nodev1.StartStatefulRequest{
 		Trace: &nodev1.Trace{Workload: "wl-state"}, Mode: nodev1.StartStatefulMode_START_STATEFUL_MODE_RELIGHT,
 		BootImageRef: "img-a", RelightSnapshotRef: resp.GetSnapshotRef(), Port: port, VolumeMount: "/data",
+		BlessedGeneration: 2,
 	})
 	if err != nil {
 		t.Fatalf("relight off committed bundle: %v", err)
@@ -1169,6 +1171,7 @@ func TestStartStatefulRelightRepinsTapIP(t *testing.T) {
 	relit, err := s.StartStateful(context.Background(), &nodev1.StartStatefulRequest{
 		Trace: &nodev1.Trace{Workload: "wl-state"}, Mode: nodev1.StartStatefulMode_START_STATEFUL_MODE_RELIGHT,
 		BootImageRef: "img-a", RelightSnapshotRef: bankResp.GetSnapshotRef(), Port: port, VolumeMount: "/data",
+		BlessedGeneration: 2,
 	})
 	if err != nil {
 		t.Fatalf("StartStateful(relight): %v", err)

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -895,9 +895,10 @@ message StartStatefulRequest {
   map<string, string> mmds_env = 10;
   // blessed_generation is the volume generation the control plane issued for
   // THIS writable attach (R7, ADR embervm/011, standing decision 4). The daemon
-  // records it and reports it back, it never invents one. 0 means legacy
-  // self-bump, accepted only until noded's EMBERVM_NODED_REQUIRE_BLESSING flag
-  // is set, after which 0 is rejected.
+  // records it and reports it back, it never invents one. 0 is refused
+  // FAILED_PRECONDITION (the control plane is the sole issuer of generations;
+  // only the node-local activator's blessing lease may advance a generation
+  // without one).
   uint64 blessed_generation = 11;
   // volume_device is the host block-device path (e.g. /dev/longhorn/<name>) the
   // control plane resolved for this workload's Longhorn-native volume (R7,


### PR DESCRIPTION
Closes #4950.

Prod and dev both run `EMBERVM_NODED_REQUIRE_BLESSING=true`, so the permissive branch was dead outside unit tests. Collapse the gate:

- config field + env parse removed; `attachGeneration` refuses any non-activator unblessed writable attach FAILED_PRECONDITION unconditionally (activator blessing-lease lane and exhaustion fallback stay, ADR embervm/037)
- chart stops rendering the env var; values key removed from both deploy values
- tests: false-branch allow test deleted, reject test inverted to the unconditional behaviour with a fail-closed ledger assertion

Verified: go vet + targeted go tests green; 6 pre-existing macOS-environmental failures baseline-proven identical on unchanged code; helm render diff is a pure 9x deletion of the env block, nothing else changes in a 12k-line render; `ci` green (171 pass, 10 executed).

Implemented by ox-alpha via opencode, reviewed on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K