### PR TITLE
fix(embervm): stop the bank dial fail-open destroying sessions, and self-heal the spec_trace seq

### DIFF
--- a/projects/embervm/conformance/scenarios.go
+++ b/projects/embervm/conformance/scenarios.go
@@ -338,7 +338,7 @@ func runS2(ctx context.Context, cfg config, client *controlPlaneClient) s2Result
 		return s2Result{verdict: scenarioVerdict{Verdict: verdictFail, Detail: "idle bank wait interrupted: " + err.Error()}, liveDelay: liveDelay}
 	}
 	if _, err := waitForSessionState(ctx, client, session, bankedSessionStates); err != nil {
-		return s2Result{verdict: scenarioVerdict{Verdict: verdictVacuous, Detail: "bank never observed"}, liveDelay: liveDelay}
+		return s2Result{verdict: scenarioVerdict{Verdict: verdictVacuous, Detail: "bank never observed: " + err.Error()}, liveDelay: liveDelay}
 	}
 
 	invokePath := "/v1/sessions/" + url.PathEscape(session.ID) + "/invoke"

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -325,6 +325,10 @@ defmodule Embervm.SessionManager do
       # process, which stops on admission) so three strikes across bank attempts fails
       # the session. Cleared on a successful bank or a successful invoke-driven relight.
       bank_failures: %{},
+      # session_id -> placed instance dial. The capacity table is eventually
+      # consistent, so keep the dial that actually created or restarted the VM for
+      # bank and destroy when its live-vm fact is temporarily absent.
+      session_dials: %{},
       # Snapshot-disk low watermark (bytes): when a node's snapshot_disk_free_bytes
       # is below this, disk-pressure eviction fires. nil = eviction disabled.
       disk_low_watermark_bytes: Keyword.get(opts, :disk_low_watermark_bytes, nil),
@@ -476,7 +480,9 @@ defmodule Embervm.SessionManager do
     # the session process's own FIFO parks the caller. So we reply the pid to the
     # caller path via a spawned forwarder, keeping the manager responsive. Simpler:
     # forward synchronously from a short task so the manager is not the bottleneck.
-    case resolve_route(state, session_id) do
+    {route, state} = resolve_route(state, session_id)
+
+    case route do
       {:live, pid} ->
         # Forward off the manager so a long guest round-trip does not serialize other
         # sessions' routing through this one GenServer.
@@ -503,7 +509,7 @@ defmodule Embervm.SessionManager do
   def handle_call({:destroy, session_id}, _from, state) do
     case SessionStore.get(state.session_store, session_id) do
       {:ok, %{state: session_state}} when session_state in [:expired, :evicted, :destroyed, :failed] ->
-        {:reply, {:ok, :already_terminal}, state}
+        {:reply, {:ok, :already_terminal}, clear_session_tracking(state, session_id)}
 
       {:ok, %{state: :destroying}} ->
         {:reply, {:ok, :destroying}, state}
@@ -917,7 +923,7 @@ defmodule Embervm.SessionManager do
             state
           end
 
-        result =
+        {result, state} =
           case outcome do
             {:ok, vm_id, restored} ->
               register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id, lineage_id, restore_lineage, restored)
@@ -937,7 +943,7 @@ defmodule Embervm.SessionManager do
                 _ = retire_session_volume(state, %{volume_node_id: node_id, workload: workload, lineage_id: restore_lineage})
               end
 
-              {:error, {:denied, reason}}
+              {{:error, {:denied, reason}}, state}
           end
 
         GenServer.reply(from, result)
@@ -1186,17 +1192,19 @@ defmodule Embervm.SessionManager do
     # node_id is the K8s node where the VM primed/started; SessionStore carries it into session_created.
     case SessionStore.create(state.session_store, attrs) do
       {:ok, %{session_id: session_id} = created} ->
+        state = remember_session_dial(state, session_id, node_id, dial_id)
+
         case start_session_process(state, session_id, workload, principal, entry, node_id, vm_id, dial_id) do
           {:ok, _pid} ->
-            {:ok, Map.put(created, :restored, restored)}
+            {{:ok, Map.put(created, :restored, restored)}, state}
 
           {:error, reason} ->
             Logger.error("embervm session: process start failed for #{session_id}: #{inspect(reason)}")
-            {:error, {:denied, :process_start_failed}}
+            {{:error, {:denied, :process_start_failed}}, state}
         end
 
       {:error, reason} ->
-        {:error, {:denied, {:store, reason}}}
+        {{:error, {:denied, {:store, reason}}}, state}
     end
   end
 
@@ -1262,22 +1270,27 @@ defmodule Embervm.SessionManager do
   # A catalog miss (workload deleted) is surfaced so the caller can fail the session
   # rather than start a process with no config.
   defp start_session_from_row(state, session, node_id, vm_id, dial_id, extra_opts \\ []) do
+    state = remember_session_dial(state, session.session_id, node_id, dial_id)
+
     case fetch_session_workload(state, session.workload) do
       {:ok, entry} ->
-        start_session_process(
-          state,
-          session.session_id,
-          session.workload,
-          session.principal,
-          entry,
-          node_id,
-          vm_id,
-          dial_id,
-          extra_opts
-        )
+        result =
+          start_session_process(
+            state,
+            session.session_id,
+            session.workload,
+            session.principal,
+            entry,
+            node_id,
+            vm_id,
+            dial_id,
+            extra_opts
+          )
+
+        {result, state}
 
       {:error, reason} ->
-        {:error, {:no_catalog_entry, reason}}
+        {{:error, {:no_catalog_entry, reason}}, state}
     end
   end
 
@@ -1292,14 +1305,14 @@ defmodule Embervm.SessionManager do
       {:ok, %{state: st, expires_at: exp} = session}
       when st in [:running, :banked, :parked] and is_integer(exp) ->
         if exp <= state.clock.() do
-          _ = expire_session(state, session)
-          {:error, {:gone, "expired"}}
+          state = expire_session(state, session)
+          {{:error, {:gone, "expired"}}, state}
         else
-          resolve_non_expired(state, session_id)
+          {resolve_non_expired(state, session_id), state}
         end
 
       _ ->
-        resolve_non_expired(state, session_id)
+        {resolve_non_expired(state, session_id), state}
     end
   end
 
@@ -1593,10 +1606,10 @@ defmodule Embervm.SessionManager do
     workload = session.workload
     parent_base_ref = session.base_snapshot_ref
     generation = (session.generation || 0) + 1
-    # Dial the OWNING instance running this live vm_id, not the node-name alias
-    # (co-location made it point at an arbitrary sibling brick). Resolved on the owner
-    # so the worker reads a settled key; fail-open to node_id.
-    dial_key = Embervm.WakeInstance.dial_for_session_vm(state.capacity_table, node_id, vm_id)
+    # dial_for_session_vm fails open to node_id on a miss. As restore_then_prime
+    # does for volume ownership, detect that sentinel exactly and fall back to the
+    # instance dial retained when this VM was placed or restarted.
+    dial_key = session_dial(state, session_id, node_id, vm_id)
 
     spawn(fn ->
       # A lifecycle span (Task 9). Idle-bank has no caller trace, so it is a root
@@ -1645,7 +1658,9 @@ defmodule Embervm.SessionManager do
       # adoption reaps it; drain any mid-bank parked callers gone. Never resurrect
       # the session.
       {:ok, %{state: st}} when st in [:destroying, :expired, :evicted, :destroyed, :failed] ->
-        drain_relight_waiters(state, session_id, {:error, {:gone, to_string(st)}})
+        state
+        |> clear_session_tracking(session_id)
+        |> drain_relight_waiters(session_id, {:error, {:gone, to_string(st)}})
 
       _ ->
         finish_bank_active(state, session_id, node_id, outcome)
@@ -1697,43 +1712,54 @@ defmodule Embervm.SessionManager do
     end
   end
 
-  # A bank failed: ETS back to running, count the strike. Three strikes fail the
-  # session + destroy its VM; under the limit, restart a session process so the live
-  # VM keeps serving and its idle timer will retry the bank.
+  # A bank failed: ETS back to running. A dial-resolution miss is retryable
+  # infrastructure and does not count as a strike. Other failures preserve the
+  # three-strike policy. Under the limit, restart a session process so the live VM
+  # keeps serving and its idle timer will retry the bank.
   defp handle_bank_failure(state, session_id, reason) do
     _ = SessionStore.mark(state.session_store, session_id, :bank_abort)
-    failures = Map.get(state.bank_failures, session_id, 0) + 1
-    Logger.warning("embervm session bank failed", session_id: session_id, reason: inspect(reason), consecutive: failures)
 
-    if failures >= @bank_fail_limit do
-      state = clear_bank_failures(state, session_id)
-
-      case SessionStore.get(state.session_store, session_id) do
-        {:ok, session} ->
-          destroying? =
-            session.state == :destroying or
-              MapSet.member?(state.destroy_inflight, session_id)
-
-          state =
-            if destroying? do
-              state
-            else
-              fail_session_and_destroy(state, session)
-            end
-
-          # Any mid-bank parked callers: the session is failed now, or its destroy
-          # worker already owns teardown.
-          gone_state = if destroying?, do: "destroying", else: "failed"
-          drain_relight_waiters(state, session_id, {:error, {:gone, gone_state}})
-
-        :error ->
-          state
-      end
-    else
-      state = %{state | bank_failures: Map.put(state.bank_failures, session_id, failures)}
+    if bank_dial_miss?(reason) do
+      Logger.warning("embervm session bank failed", session_id: session_id, reason: inspect(reason))
       restart_running_process(state, session_id)
+    else
+      failures = Map.get(state.bank_failures, session_id, 0) + 1
+      Logger.warning("embervm session bank failed", session_id: session_id, reason: inspect(reason), consecutive: failures)
+
+      if failures >= @bank_fail_limit do
+        state = clear_bank_failures(state, session_id)
+
+        case SessionStore.get(state.session_store, session_id) do
+          {:ok, session} ->
+            destroying? =
+              session.state == :destroying or
+                MapSet.member?(state.destroy_inflight, session_id)
+
+            state =
+              if destroying? do
+                state
+              else
+                fail_session_and_destroy(state, session)
+              end
+
+            # Any mid-bank parked callers: the session is failed now, or its destroy
+            # worker already owns teardown.
+            gone_state = if destroying?, do: "destroying", else: "failed"
+            drain_relight_waiters(state, session_id, {:error, {:gone, gone_state}})
+
+          :error ->
+            clear_session_tracking(state, session_id)
+        end
+      else
+        state = %{state | bank_failures: Map.put(state.bank_failures, session_id, failures)}
+        restart_running_process(state, session_id)
+      end
     end
   end
+
+  defp bank_dial_miss?({:error, :unknown_node}), do: true
+  defp bank_dial_miss?({:error, {:error, :unknown_node}}), do: true
+  defp bank_dial_miss?(_reason), do: false
 
   # Restart a session process for a running session that lost its process (a failed
   # bank: the process stopped on admission but the VM is still live). Idempotent: a
@@ -1749,8 +1775,8 @@ defmodule Embervm.SessionManager do
           [] ->
             # Resolve the co-located instance still running this live vm_id so the
             # restarted process's per-invoke dial targets the owner, not the alias.
-            dial_id = Embervm.WakeInstance.dial_for_session_vm(state.capacity_table, node_id, vm_id)
-            _ = start_session_from_row(state, session, node_id, vm_id, dial_id)
+            dial_id = session_dial(state, session_id, node_id, vm_id)
+            {_result, state} = start_session_from_row(state, session, node_id, vm_id, dial_id)
             state
         end
 
@@ -1762,11 +1788,32 @@ defmodule Embervm.SessionManager do
   defp fail_session_and_destroy(state, session) do
     _ = destroy_vm(state, session)
     fail_session(state, session.session_id, :failed, "bank_failed_three_strikes")
-    state
   end
 
   defp clear_bank_failures(state, session_id) do
     %{state | bank_failures: Map.delete(state.bank_failures, session_id)}
+  end
+
+  defp clear_session_tracking(state, session_id) do
+    %{
+      state
+      | bank_failures: Map.delete(state.bank_failures, session_id),
+        session_dials: Map.delete(state.session_dials, session_id)
+    }
+  end
+
+  defp remember_session_dial(state, session_id, node_id, dial_id)
+       when is_binary(dial_id) and dial_id != node_id do
+    %{state | session_dials: Map.put(state.session_dials, session_id, dial_id)}
+  end
+
+  defp remember_session_dial(state, _session_id, _node_id, _dial_id), do: state
+
+  defp session_dial(state, session_id, node_id, vm_id) do
+    case Embervm.WakeInstance.dial_for_session_vm(state.capacity_table, node_id, vm_id) do
+      ^node_id -> Map.get(state.session_dials, session_id, node_id)
+      resolved -> resolved
+    end
   end
 
   # A node is at its bank cap when the count of in-flight banks on it reaches the
@@ -1984,18 +2031,21 @@ defmodule Embervm.SessionManager do
     owner = self()
     failure_fun = fn reason -> send(owner, {:rejoin_assign_failed, session_id, reason}) end
 
-    case start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id,
-           dial_id, [rejoin_failure_fun: failure_fun]) do
+    {start_result, state} =
+      start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id,
+        dial_id, [rejoin_failure_fun: failure_fun])
+
+    case start_result do
       {:ok, pid} ->
         case SessionStore.transition(state.session_store, session_id, :rejoin_ready, :session_rejoined,
                %{volume_node_id: session.volume_node_id}, %{node_id: node_id, vm_id: vm_id}) do
           {:ok, _} -> drain_relight_into_process(state, session_id, pid)
           {:error, reason} ->
-            _ = destroy_vm(state, %{node_id: node_id, vm_id: vm_id})
+            _ = destroy_vm(state, %{session_id: session_id, node_id: node_id, vm_id: vm_id})
             drain_relight_waiters(state, session_id, {:error, reason})
         end
       {:error, reason} ->
-        _ = destroy_vm(state, %{node_id: node_id, vm_id: vm_id})
+        _ = destroy_vm(state, %{session_id: session_id, node_id: node_id, vm_id: vm_id})
         drain_relight_waiters(state, session_id, {:error, reason})
     end
   end
@@ -2422,7 +2472,10 @@ defmodule Embervm.SessionManager do
 
         state = clear_bank_failures(state, session_id)
 
-        case start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id, dial_id) do
+        {start_result, state} =
+          start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id, dial_id)
+
+        case start_result do
           {:ok, pid} ->
             Logger.info("embervm session relit",
               session_id: session_id,
@@ -2433,13 +2486,13 @@ defmodule Embervm.SessionManager do
             drain_relight_into_process(state, session_id, pid)
 
           {:error, reason} ->
-            fail_session(state, session_id, :failed, "relit process start failed: #{inspect(reason)}")
+            state = fail_session(state, session_id, :failed, "relit process start failed: #{inspect(reason)}")
             drain_relight_waiters(state, session_id, {:error, :failed})
         end
 
       {:error, :snapshot_lost} ->
         session = get_session!(state, session_id)
-        fail_session(state, session_id, :snapshot_lost, "snapshot_lost")
+        state = fail_session(state, session_id, :snapshot_lost, "snapshot_lost")
         _ = evict_snapshot(state, session)
         drain_relight_waiters(state, session_id, {:error, {:gone, "snapshot_lost"}})
 
@@ -2724,7 +2777,7 @@ defmodule Embervm.SessionManager do
       workload: session.workload
     )
 
-    state
+    if match?({:ok, _}, reply), do: clear_session_tracking(state, session.session_id), else: state
   end
 
   # Direction 2: a node reports a live session VM whose session_id no CP row matches.
@@ -2978,7 +3031,7 @@ defmodule Embervm.SessionManager do
            %{}
          ) do
       {:ok, _} ->
-        state
+        clear_session_tracking(state, session.session_id)
 
       {:error, err} ->
         if MapSet.member?(state.logged_unapplicable, session.session_id) do
@@ -3012,7 +3065,10 @@ defmodule Embervm.SessionManager do
         state
 
       [] ->
-        case start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id, dial_id) do
+        {start_result, state} =
+          start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id, dial_id)
+
+        case start_result do
           {:ok, _pid} ->
             Logger.info("embervm session adopted (live)", session_id: session.session_id, node_id: node_id)
             state
@@ -3238,7 +3294,7 @@ defmodule Embervm.SessionManager do
 
     retire_session_volume(state, session)
 
-    _ =
+    reply =
       SessionStore.transition(
         state.session_store,
         session.session_id,
@@ -3254,7 +3310,7 @@ defmodule Embervm.SessionManager do
       principal: session.principal
     )
 
-    state
+    if match?({:ok, _}, reply), do: clear_session_tracking(state, session.session_id), else: state
   end
 
   # Banked/parked-TTL GC (#4305): a banked or parked session untouched
@@ -3341,7 +3397,7 @@ defmodule Embervm.SessionManager do
   defp evict_banked(state, session, reason) do
     _ = evict_snapshot(state, session)
 
-    _ =
+    reply =
       SessionStore.transition(
         state.session_store,
         session.session_id,
@@ -3358,7 +3414,7 @@ defmodule Embervm.SessionManager do
       reason: reason
     )
 
-    state
+    if match?({:ok, _}, reply), do: clear_session_tracking(state, session.session_id), else: state
   end
 
   # Evict a parked session: skips stop_session_process (park already tore down
@@ -3371,7 +3427,7 @@ defmodule Embervm.SessionManager do
     _ = evict_snapshot(state, session)
     retire_session_volume(state, session)
 
-    _ =
+    reply =
       SessionStore.transition(
         state.session_store,
         session.session_id,
@@ -3388,7 +3444,7 @@ defmodule Embervm.SessionManager do
       reason: reason
     )
 
-    state
+    if match?({:ok, _}, reply), do: clear_session_tracking(state, session.session_id), else: state
   end
 
   # -- snapshot eviction RPC -------------------------------------------------
@@ -3484,11 +3540,11 @@ defmodule Embervm.SessionManager do
            %{}
          ) do
       {:ok, _} ->
-        :ok
+        clear_session_tracking(state, session_id)
 
       {:error, err} ->
         Logger.warning("embervm session fail transition failed", session_id: session_id, error: inspect(err))
-        :error
+        state
     end
   end
 
@@ -3580,7 +3636,7 @@ defmodule Embervm.SessionManager do
         case SessionStore.get(state.session_store, session_id) do
           {:ok, %{state: session_state}}
           when session_state in [:expired, :evicted, :destroyed, :failed] ->
-            state
+            clear_session_tracking(state, session_id)
 
           {:ok, %{state: :destroying} = session} ->
             finish_destroying_session(state, session, confirmed, resumed)
@@ -3645,7 +3701,7 @@ defmodule Embervm.SessionManager do
           principal: session.principal
         )
 
-        state
+        if match?({:ok, _}, reply), do: clear_session_tracking(state, session.session_id), else: state
       end
     else
       Logger.warning("embervm session teardown unconfirmed, left destroying",
@@ -3744,6 +3800,7 @@ defmodule Embervm.SessionManager do
         principal: session.principal
       )
 
+      state = if match?({:ok, _}, reply), do: clear_session_tracking(state, session.session_id), else: state
       {reply, state}
     else
       Logger.warning("embervm session teardown unconfirmed, left destroying",
@@ -3815,6 +3872,7 @@ defmodule Embervm.SessionManager do
         principal: session.principal
       )
 
+      state = if match?({:ok, _}, reply), do: clear_session_tracking(state, session.session_id), else: state
       {reply, state}
     else
       # 3b. Unconfirmed: leave the session in destroying. The reconcile loop
@@ -3869,10 +3927,11 @@ defmodule Embervm.SessionManager do
   # unconfirmed). A dial failure, an RPC error, or a raised/thrown fault all read as
   # unconfirmed (false), keeping the session in destroying under the node-confirmed
   # gate; the legacy path discards this and proceeds as today.
-  defp destroy_vm(state, %{node_id: node_id, vm_id: vm_id})
+  defp destroy_vm(state, %{session_id: session_id, node_id: node_id, vm_id: vm_id})
        when is_binary(node_id) and is_binary(vm_id) do
-    # Dial the OWNING instance running this live vm_id, not the node-name alias.
-    dial_key = Embervm.WakeInstance.dial_for_session_vm(state.capacity_table, node_id, vm_id)
+    # Match the bank path: prefer current ownership, then the placed dial retained
+    # by the manager, and only then preserve the legacy bare-node fallback.
+    dial_key = session_dial(state, session_id, node_id, vm_id)
 
     case safe_channel(state.channel_fun, dial_key) do
       {:ok, channel} ->
@@ -3899,6 +3958,11 @@ defmodule Embervm.SessionManager do
       {:error, _} ->
         false
     end
+  end
+
+  defp destroy_vm(state, %{node_id: node_id, vm_id: vm_id} = session)
+       when is_binary(node_id) and is_binary(vm_id) do
+    destroy_vm(state, Map.put(session, :session_id, nil))
   end
 
   defp destroy_vm(_state, _session), do: false

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -1807,7 +1807,12 @@ defmodule Embervm.SessionManager do
     %{state | session_dials: Map.put(state.session_dials, session_id, dial_id)}
   end
 
-  defp remember_session_dial(state, _session_id, _node_id, _dial_id), do: state
+  # A re-placement whose dial resolved to the bare node name must CLEAR any
+  # previous placement's instance dial: leaving it would misroute the next bank
+  # or destroy to the old brick, the same class the sentinel check avoids.
+  defp remember_session_dial(state, session_id, _node_id, _dial_id) do
+    %{state | session_dials: Map.delete(state.session_dials, session_id)}
+  end
 
   defp session_dial(state, session_id, node_id, vm_id) do
     case Embervm.WakeInstance.dial_for_session_vm(state.capacity_table, node_id, vm_id) do
@@ -2698,7 +2703,7 @@ defmodule Embervm.SessionManager do
       # lingering process first (a same-CP retry after a failed RPC), then re-issue
       # the Destroy; a CP-crash re-drive has no process, so this is a no-op there.
       Map.has_key?(live_vms, sid) ->
-        dial_key = Embervm.WakeInstance.dial_for_session_vm(state.capacity_table, session.node_id, session.vm_id)
+        dial_key = session_dial(state, sid, session.node_id, session.vm_id)
 
         if node_reporting?(state, dial_key) do
           emit_redrive_intent.()
@@ -2844,6 +2849,7 @@ defmodule Embervm.SessionManager do
       :orphan ->
         confirmed =
           destroy_vm(state, %{
+            session_id: v.session_id,
             node_id: fact.configured_id,
             vm_id: v.vm_id
           })

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -96,6 +96,12 @@ defmodule Embervm.SessionManager do
   # that cannot bank must not squat live capacity forever.
   @bank_fail_limit 3
 
+  # Bank retries on dial-resolution miss (capacity-table miss, dial fell back to node_id).
+  # At 20s idle-bank cadence, this is roughly ten minutes. Comfortably outlasts a control-plane
+  # restart plus fleet re-registration (transient cause), while terminalizing a genuinely dead
+  # instance long before the six-hour session lifetime (maxLifetimeSeconds 21600).
+  @bank_dial_miss_limit 30
+
   # NodeCapacity.updated_at is stamped from a monotonic clock. Keep its freshness
   # gate in that domain instead of comparing it with session row wall-clock times.
   @fleet_freshness_window_ms 120_000
@@ -321,10 +327,13 @@ defmodule Embervm.SessionManager do
       # GenServer call wrote synchronously, not an inference over another
       # structure's shape.
       inflight_restore_lineages: MapSet.new(),
-      # session_id -> consecutive bank-failure count. Lives HERE (not in the session
-      # process, which stops on admission) so three strikes across bank attempts fails
-      # the session. Cleared on a successful bank or a successful invoke-driven relight.
+      # session_id -> consecutive non-dial bank-failure count. Lives HERE (not in the
+      # session process, which stops on admission) so three strikes across bank attempts
+      # fails the session. Dial-resolution misses are tracked separately in
+      # bank_dial_misses with their own limit and do not advance this counter. Both are
+      # cleared on a successful bank or a successful invoke-driven relight.
       bank_failures: %{},
+      bank_dial_misses: %{},
       # session_id -> placed instance dial. The capacity table is eventually
       # consistent, so keep the dial that actually created or restarted the VM for
       # bank and destroy when its live-vm fact is temporarily absent.
@@ -1644,8 +1653,9 @@ defmodule Embervm.SessionManager do
   #     session_banked op (generation+1, snapshot fact), clear the failure streak,
   #     and if a mid-bank invoke parked, immediately relight it;
   #   * on failure: mark ETS `banking -[bank_abort]-> running` (the VM is still alive,
-  #     no snapshot written), count the failure, and either restart a session process
-  #     (so it can serve invokes + retry) or, at three strikes, fail + destroy the VM.
+  #     no snapshot written), count the relevant failure class, and either restart a
+  #     session process (so it can serve invokes + retry) or fail + destroy the VM when
+  #     that class reaches its limit.
   defp finish_bank(state, session_id, node_id, outcome) do
     state =
       state
@@ -1713,47 +1723,60 @@ defmodule Embervm.SessionManager do
   end
 
   # A bank failed: ETS back to running. A dial-resolution miss is retryable
-  # infrastructure and does not count as a strike. Other failures preserve the
-  # three-strike policy. Under the limit, restart a session process so the live VM
-  # keeps serving and its idle timer will retry the bank.
+  # infrastructure and has its own longer limit without counting as a strike. Other
+  # failures preserve the three-strike policy. Under the applicable limit, restart a
+  # session process so the live VM keeps serving and its idle timer will retry the bank.
   defp handle_bank_failure(state, session_id, reason) do
     _ = SessionStore.mark(state.session_store, session_id, :bank_abort)
 
     if bank_dial_miss?(reason) do
-      Logger.warning("embervm session bank failed", session_id: session_id, reason: inspect(reason))
-      restart_running_process(state, session_id)
+      misses = Map.get(state.bank_dial_misses, session_id, 0) + 1
+      Logger.warning("embervm session bank failed", session_id: session_id, reason: inspect(reason), consecutive: misses)
+
+      if misses >= @bank_dial_miss_limit do
+        state
+        |> clear_bank_failures(session_id)
+        |> terminal_bank_failure(session_id, "bank_dial_miss_limit")
+      else
+        state = %{state | bank_dial_misses: Map.put(state.bank_dial_misses, session_id, misses)}
+        restart_running_process(state, session_id)
+      end
     else
       failures = Map.get(state.bank_failures, session_id, 0) + 1
       Logger.warning("embervm session bank failed", session_id: session_id, reason: inspect(reason), consecutive: failures)
 
       if failures >= @bank_fail_limit do
-        state = clear_bank_failures(state, session_id)
-
-        case SessionStore.get(state.session_store, session_id) do
-          {:ok, session} ->
-            destroying? =
-              session.state == :destroying or
-                MapSet.member?(state.destroy_inflight, session_id)
-
-            state =
-              if destroying? do
-                state
-              else
-                fail_session_and_destroy(state, session)
-              end
-
-            # Any mid-bank parked callers: the session is failed now, or its destroy
-            # worker already owns teardown.
-            gone_state = if destroying?, do: "destroying", else: "failed"
-            drain_relight_waiters(state, session_id, {:error, {:gone, gone_state}})
-
-          :error ->
-            clear_session_tracking(state, session_id)
-        end
+        state
+        |> clear_bank_failures(session_id)
+        |> terminal_bank_failure(session_id, "bank_failed_three_strikes")
       else
         state = %{state | bank_failures: Map.put(state.bank_failures, session_id, failures)}
         restart_running_process(state, session_id)
       end
+    end
+  end
+
+  defp terminal_bank_failure(state, session_id, fail_reason) do
+    case SessionStore.get(state.session_store, session_id) do
+      {:ok, session} ->
+        destroying? =
+          session.state == :destroying or
+            MapSet.member?(state.destroy_inflight, session_id)
+
+        state =
+          if destroying? do
+            state
+          else
+            fail_session_and_destroy(state, session, fail_reason)
+          end
+
+        # Any mid-bank parked callers: the session is failed now, or its destroy
+        # worker already owns teardown.
+        gone_state = if destroying?, do: "destroying", else: "failed"
+        drain_relight_waiters(state, session_id, {:error, {:gone, gone_state}})
+
+      :error ->
+        clear_session_tracking(state, session_id)
     end
   end
 
@@ -1785,19 +1808,24 @@ defmodule Embervm.SessionManager do
     end
   end
 
-  defp fail_session_and_destroy(state, session) do
+  defp fail_session_and_destroy(state, session, fail_reason) do
     _ = destroy_vm(state, session)
-    fail_session(state, session.session_id, :failed, "bank_failed_three_strikes")
+    fail_session(state, session.session_id, :failed, fail_reason)
   end
 
   defp clear_bank_failures(state, session_id) do
-    %{state | bank_failures: Map.delete(state.bank_failures, session_id)}
+    %{
+      state
+      | bank_failures: Map.delete(state.bank_failures, session_id),
+        bank_dial_misses: Map.delete(state.bank_dial_misses, session_id)
+    }
   end
 
   defp clear_session_tracking(state, session_id) do
     %{
       state
       | bank_failures: Map.delete(state.bank_failures, session_id),
+        bank_dial_misses: Map.delete(state.bank_dial_misses, session_id),
         session_dials: Map.delete(state.session_dials, session_id)
     }
   end

--- a/projects/embervm/control/lib/embervm/spec_trace.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace.ex
@@ -271,8 +271,26 @@ defmodule Embervm.SpecTrace.Writer do
   # the exit is caught here, so a stall costs counted drops and nothing else.
   defp flush(state) do
     case state.store_mod.write(state.store, Enum.reverse(state.records)) do
-      :ok -> schedule_flush(%{state | records: []})
-      {:error, reason} -> Embervm.SpecTrace.note_drop(); Logger.warning("embervm spec_trace store write failed", reason: inspect(reason)); schedule_flush(%{state | records: []})
+      :ok ->
+        schedule_flush(%{state | records: []})
+
+      {:error, reason} ->
+        Embervm.SpecTrace.note_drop()
+
+        if seq_collision?(reason) do
+          old_seq = state.seq
+          new_seq = max(old_seq, safe_max_seq(state.store_mod, state.store))
+
+          Logger.warning("embervm spec_trace seq collided, fast-forwarded",
+            old_seq: old_seq,
+            new_seq: new_seq
+          )
+
+          schedule_flush(%{state | seq: new_seq, records: []})
+        else
+          Logger.warning("embervm spec_trace store write failed", reason: inspect(reason))
+          schedule_flush(%{state | records: []})
+        end
     end
   catch
     :exit, reason ->
@@ -282,6 +300,10 @@ defmodule Embervm.SpecTrace.Writer do
   rescue
     error -> Embervm.SpecTrace.note_drop(); Logger.warning("embervm spec_trace store write failed", error: inspect(error)); schedule_flush(%{state | records: []})
   end
+
+  defp seq_collision?(%Postgrex.Error{postgres: %{code: :unique_violation}}), do: true
+  defp seq_collision?(reason), do: inspect(reason) =~ "UNIQUE constraint failed"
+
   defp schedule_flush(state), do: (Process.send_after(self(), :flush, state.flush_ms); state)
 
   defp stringify(value) when is_atom(value), do: Atom.to_string(value)

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -18,6 +18,8 @@ defmodule Embervm.SessionManagerTest do
   alias Embervm.OpLog.SQLite
   alias Embervm.Node.V1.{BankResponse, GuestResponse, PrimeResponse, RelightResponse, SessionAssignResponse, UsageStats}
 
+  @bank_dial_miss_limit 30
+
   defmodule OpLogRecorder do
     def append(agent, op) do
       Agent.update(agent, &[op | &1])
@@ -507,6 +509,89 @@ defmodule Embervm.SessionManagerTest do
     assert :sys.get_state(ctx.mgr).bank_failures == %{}
     refute_received :destroyed_after_dial_miss
     assert [{_pid, _}] = Registry.lookup(ctx.registry, created.session_id)
+  end
+
+  test "bank dial misses beyond the limit fail the session and attempt destroy" do
+    parent = self()
+    {:ok, dial_attempts} = Agent.start_link(fn -> 0 end)
+
+    ctx =
+      start_stack(
+        channel_fun: fn _dial_key ->
+          attempt = Agent.get_and_update(dial_attempts, fn count -> {count + 1, count + 1} end)
+
+          if attempt <= @bank_dial_miss_limit do
+            {:error, :unknown_node}
+          else
+            {:ok, :ch}
+          end
+        end,
+        destroy_fun: fn _ch, vm_id ->
+          send(parent, {:destroyed_after_dial_miss_limit, vm_id})
+          {:ok, %{teardown_confirmed: true}}
+        end
+      )
+
+    put_session_workload(ctx, "wl-bank-dial-miss-limit")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-bank-dial-miss-limit", "p1")
+
+    for _miss <- 1..(@bank_dial_miss_limit - 1) do
+      assert :ok = SessionManager.bank(ctx.mgr, created.session_id)
+      assert wait_for_state(ctx, created.session_id, :running).state == :running
+    end
+
+    state = :sys.get_state(ctx.mgr)
+    assert state.bank_dial_misses[created.session_id] == @bank_dial_miss_limit - 1
+    assert state.bank_failures == %{}
+
+    assert :ok = SessionManager.bank(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :failed).state == :failed
+    assert_receive {:destroyed_after_dial_miss_limit, vm_id}
+    assert is_binary(vm_id)
+
+    state = :sys.get_state(ctx.mgr)
+    refute Map.has_key?(state.bank_failures, created.session_id)
+    refute Map.has_key?(state.bank_dial_misses, created.session_id)
+
+    {:ok, ops} = SQLite.read_from(ctx.op_log, 0)
+    failed_op = Enum.find(ops, &(&1.session_id == created.session_id and &1.kind == :session_failed))
+    assert failed_op.payload["detail"] == "bank_dial_miss_limit"
+  end
+
+  test "bank dial misses under the limit stay running without striking" do
+    {:ok, remaining_misses} = Agent.start_link(fn -> @bank_dial_miss_limit - 1 end)
+
+    ctx =
+      start_stack(
+        channel_fun: fn _dial_key ->
+          Agent.get_and_update(remaining_misses, fn
+            remaining when remaining > 0 ->
+              {{:error, :unknown_node}, remaining - 1}
+
+            remaining ->
+              {{:ok, :ch}, remaining}
+          end)
+        end
+      )
+
+    put_session_workload(ctx, "wl-bank-dial-miss-under-limit")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-bank-dial-miss-under-limit", "p1")
+
+    for _miss <- 1..(@bank_dial_miss_limit - 1) do
+      assert :ok = SessionManager.bank(ctx.mgr, created.session_id)
+      assert wait_for_state(ctx, created.session_id, :running).state == :running
+    end
+
+    state = :sys.get_state(ctx.mgr)
+    assert state.bank_dial_misses[created.session_id] == @bank_dial_miss_limit - 1
+    assert state.bank_failures == %{}
+
+    assert :ok = SessionManager.bank(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :banked).state == :banked
+
+    state = :sys.get_state(ctx.mgr)
+    refute Map.has_key?(state.bank_dial_misses, created.session_id)
+    refute Map.has_key?(state.bank_failures, created.session_id)
   end
 
   test "three non-dial bank failures still fail and destroy the session" do

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -458,6 +458,110 @@ defmodule Embervm.SessionManagerTest do
     refute "node-4/small" in keys
   end
 
+  test "bank uses the placed instance dial when the capacity fact misses the VM" do
+    parent = self()
+
+    ctx =
+      start_stack(
+        channel_fun: fn dial_key ->
+          send(parent, {:bank_dialed, dial_key})
+          {:ok, :ch}
+        end,
+        claim_fun: fake_claim_fun("vm-bank-stored-dial")
+      )
+
+    put_session_workload(ctx, "wl-bank-stored-dial")
+    NodeCapacity.drop(ctx.cap_table, "node-4")
+    put_brick(ctx, "wl-bank-stored-dial", "bank-owner", [])
+
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-bank-stored-dial", "p1")
+    assert :sys.get_state(ctx.mgr).session_dials[created.session_id] == "node-4/bank-owner"
+
+    NodeCapacity.drop(ctx.cap_table, {"node-4", "bank-owner"})
+    assert :ok = SessionManager.bank(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :banked).state == :banked
+    assert_receive {:bank_dialed, "node-4/bank-owner"}
+  end
+
+  test "a bank dial miss returns to running without counting a strike" do
+    parent = self()
+
+    ctx =
+      start_stack(
+        channel_fun: fn dial_key ->
+          send(parent, {:bank_dialed, dial_key})
+          {:error, :unknown_node}
+        end,
+        destroy_fun: fn _ch, _vm ->
+          send(parent, :destroyed_after_dial_miss)
+          {:ok, %{teardown_confirmed: true}}
+        end
+      )
+
+    put_session_workload(ctx, "wl-bank-dial-miss")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-bank-dial-miss", "p1")
+
+    assert :ok = SessionManager.bank(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :running).state == :running
+    assert_receive {:bank_dialed, "node-4"}
+    assert :sys.get_state(ctx.mgr).bank_failures == %{}
+    refute_received :destroyed_after_dial_miss
+    assert [{_pid, _}] = Registry.lookup(ctx.registry, created.session_id)
+  end
+
+  test "three non-dial bank failures still fail and destroy the session" do
+    parent = self()
+
+    ctx =
+      start_stack(
+        bank_fun: fn _ch, _req -> {:error, :boom} end,
+        destroy_fun: fn _ch, vm_id ->
+          send(parent, {:destroyed_after_bank_failures, vm_id})
+          {:ok, %{teardown_confirmed: true}}
+        end
+      )
+
+    put_session_workload(ctx, "wl-bank-three-strikes")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-bank-three-strikes", "p1")
+
+    for failure <- 1..2 do
+      assert :ok = SessionManager.bank(ctx.mgr, created.session_id)
+      assert wait_for_state(ctx, created.session_id, :running).state == :running
+      assert :sys.get_state(ctx.mgr).bank_failures[created.session_id] == failure
+    end
+
+    assert :ok = SessionManager.bank(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :failed).state == :failed
+    assert_receive {:destroyed_after_bank_failures, vm_id}
+    assert is_binary(vm_id)
+    refute Map.has_key?(:sys.get_state(ctx.mgr).bank_failures, created.session_id)
+  end
+
+  test "destroy uses the placed instance dial when the capacity fact misses the VM" do
+    parent = self()
+
+    ctx =
+      start_stack(
+        channel_fun: fn dial_key ->
+          send(parent, {:destroy_dialed, dial_key})
+          {:ok, :ch}
+        end,
+        claim_fun: fake_claim_fun("vm-destroy-stored-dial")
+      )
+
+    put_session_workload(ctx, "wl-destroy-stored-dial")
+    NodeCapacity.drop(ctx.cap_table, "node-4")
+    put_brick(ctx, "wl-destroy-stored-dial", "destroy-owner", [])
+
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-destroy-stored-dial", "p1")
+    NodeCapacity.drop(ctx.cap_table, {"node-4", "destroy-owner"})
+
+    assert {:ok, :destroying} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :destroyed).state == :destroyed
+    assert_receive {:destroy_dialed, "node-4/destroy-owner"}
+    refute Map.has_key?(:sys.get_state(ctx.mgr).session_dials, created.session_id)
+  end
+
   test "create happy path: claims a primed VM, mints a token, starts a live session" do
     ctx = start_stack()
     put_session_workload(ctx, "wl-a")

--- a/projects/embervm/control/test/embervm/spec_trace_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace_test.exs
@@ -4,6 +4,24 @@ defmodule Embervm.SpecTraceTest do
   alias Embervm.SpecTrace
   alias Embervm.SpecTrace.Store.SQLite
 
+  defmodule SeqStore do
+    def start_link(state), do: Agent.start_link(fn -> state end)
+
+    def max_seq(store) do
+      Agent.get_and_update(store, fn %{max_seqs: [max_seq | rest]} = state ->
+        {max_seq, %{state | max_seqs: rest}}
+      end)
+    end
+
+    def write(store, records) do
+      Agent.get_and_update(store, fn %{write_replies: [reply | rest]} = state ->
+        {reply, %{state | write_replies: rest, writes: state.writes ++ [records]}}
+      end)
+    end
+
+    def state(store), do: Agent.get(store, & &1)
+  end
+
   setup do
     System.put_env("EMBERVM_SPEC_TRACE", "on")
     SpecTrace.configure()
@@ -121,6 +139,55 @@ defmodule Embervm.SpecTraceTest do
     assert seqs == Enum.uniq(seqs), "duplicate seq values: #{inspect(seqs)}"
   end
 
+  test "writer fast-forwards after a SQLite seq collision" do
+    {writer, store} =
+      start_seq_writer(
+        {:error, "UNIQUE constraint failed: spec_trace.seq"},
+        :sqlite_collision_store,
+        :sqlite_collision_writer
+      )
+
+    :ok = SpecTrace.drain(writer)
+    SpecTrace.emit(:spec_trace_test, :consume_drop, %{})
+    send(writer, {:emit, :adoption, :prime, %{vm_id: "vm-after"}, 10, 20})
+    :ok = SpecTrace.drain(writer)
+
+    state = SeqStore.state(store)
+    assert [failed_batch, [%{"seq" => 501}]] = state.writes
+    assert [%{"action" => "preamble"}] = failed_batch
+    assert state.max_seqs == []
+  end
+
+  test "writer fast-forwards after a Postgrex unique violation" do
+    error = %Postgrex.Error{postgres: %{code: :unique_violation}}
+    {writer, store} = start_seq_writer({:error, error}, :postgres_collision_store, :postgres_collision_writer)
+
+    :ok = SpecTrace.drain(writer)
+    SpecTrace.emit(:spec_trace_test, :consume_drop, %{})
+    send(writer, {:emit, :adoption, :prime, %{vm_id: "vm-after"}, 10, 20})
+    :ok = SpecTrace.drain(writer)
+
+    state = SeqStore.state(store)
+    assert [failed_batch, [%{"seq" => 501}]] = state.writes
+    assert [%{"action" => "preamble"}] = failed_batch
+    assert state.max_seqs == []
+  end
+
+  test "writer does not fast-forward after a non-collision write error" do
+    {writer, store} =
+      start_seq_writer({:error, :store_down}, :ordinary_error_store, :ordinary_error_writer)
+
+    :ok = SpecTrace.drain(writer)
+    SpecTrace.emit(:spec_trace_test, :consume_drop, %{})
+    send(writer, {:emit, :adoption, :prime, %{vm_id: "vm-after"}, 10, 20})
+    :ok = SpecTrace.drain(writer)
+
+    state = SeqStore.state(store)
+    assert [failed_batch, [%{"seq" => 2}]] = state.writes
+    assert [%{"action" => "preamble"}] = failed_batch
+    assert state.max_seqs == [500]
+  end
+
   # Emissions follow the SCOPED writer, so one test's trace cannot contain
   # another's records.
   #
@@ -199,5 +266,26 @@ defmodule Embervm.SpecTraceTest do
     assert {:ok, %{deleted: 1, done: false}} = SQLite.sweep(store, now_ms: 100, ttl_ms: 1, batch_size: 1)
     assert {:ok, %{deleted: 1, done: false}} = SQLite.sweep(store, now_ms: 100, ttl_ms: 1, batch_size: 1)
     assert {:ok, %{deleted: 1, done: true}} = SQLite.sweep(store, now_ms: 100, ttl_ms: 1, batch_size: 1)
+  end
+
+  defp start_seq_writer(first_write_reply, store_id, writer_id) do
+    store =
+      start_supervised!(
+        %{
+          id: store_id,
+          start:
+            {SeqStore, :start_link,
+             [%{max_seqs: [0, 500], write_replies: [first_write_reply, :ok], writes: []}]}
+        }
+      )
+
+    writer =
+      start_supervised!(
+        {SpecTrace.Writer,
+         name: nil, store_mod: SeqStore, store: store, batch_size: 100, flush_ms: 60_000},
+        id: writer_id
+      )
+
+    {writer, store}
   end
 end


### PR DESCRIPTION
Fixes the two control-plane defects holding the #5224 conformance gate red and prod embervm at chart 0.41.7. Full diagnosis with live log evidence on the issues.

## What was wrong

**#5249, the bank/destroy dial.** `spawn_bank_worker` and `destroy_vm` resolved their gRPC dial via `dial_for_session_vm`, which fails open to the bare node name on a capacity-table miss. The bare node name is never a dial key, so every idle bank in dev got `{:error, :unknown_node}`, three strikes destroyed a healthy session 60s after first idle, and the destroy mis-dialed the same way so the VM leaked, poisoning the node-scoped live-VM count every subsequent conformance run read.

**#5253, the spec_trace seq.** The writer seeds its seq from `safe_max_seq`, which rescues any boot-time store error to 0. With the Postgres store coming up late under `:rest_for_one`, the writer resumed at 0 under a table whose max was far ahead and collided on the primary key on every flush, recording nothing for hours while reading as enabled. That kept conformance S4 at coverage=0.

## The fix

- A manager-state `session_dials` map keeps the placed instance dial from create/restart; bank and destroy prefer capacity-table ownership, then the stored dial, and only then the legacy bare-node fallback. Cleared on every terminal transition; a re-placement that resolves to the bare node clears the stale entry.
- A dial-resolution miss no longer counts as a bank strike (it never reached the node), but is bounded by its own counter (`@bank_dial_miss_limit 30`, roughly ten minutes at the 20s idle cadence) so a session on a genuinely dead instance still terminalizes, with fail reason `bank_dial_miss_limit`.
- The spec_trace writer detects a seq unique-collision (both store shapes), re-queries `max_seq`, and fast-forwards, making the rescue-to-0 boot state self-heal within one flush interval.
- The conformance S2 vacuous verdict now carries the poll error instead of discarding it (the live incident hid "session entered terminal state" behind "bank never observed" for a full diagnosis round).

## Verification

- `ci` green; the embervm CP ExUnit genrule executed remotely against the final branch: `1485 tests, 0 failures, 21 skipped` (judged by the genrule's own line, as required).
- New tests: bank dials the stored instance dial on a table miss; a dial miss does not strike and does not destroy; the dial-miss limit terminalizes; a successful bank resets the counter; three real strikes still destroy; spec_trace fast-forward for both error shapes; a non-collision error does not fast-forward.
- Opus review completed; all five findings addressed in commits 414b66284 and 0509d61b3.

After merge: chart publish rolls dev via Kargo, the conformance gate re-runs on the new version, and S2/S4 tell us whether the dev session lane clears or the next layer surfaces.

Closes #5249. Closes #5253. Refs #5224, #4949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iHVK9WyNFFjUkhn8q4s49
