### PR TITLE
fix(monolith): stop reporting advisory health components as failing

### DIFF
--- a/projects/monolith/frontend/src/routes/public/health/+server.js
+++ b/projects/monolith/frontend/src/routes/public/health/+server.js
@@ -14,6 +14,12 @@ const API_BASE = process.env.API_BASE || "http://localhost:8000";
 // keeping the /api surface off the browser. Success is edge-cached for 60s
 // (HEALTH_CACHE_CONTROL) to cap origin load at ~1 req/min; the 503 path sets no
 // cache header so failures are never cached and an outage surfaces within a cycle.
+//
+// The backend distinguishes two kinds of health component: fatal (which cause
+// 503) and advisory (which are reported as degraded on a 200 response). This
+// proxy must preserve that distinction: the frontend never lists advisory
+// component names under failing, and it exposes degraded on both 200 and 503
+// paths so the advisory signal is visible and correctly labelled.
 export async function GET({ fetch }) {
   let res;
   try {
@@ -28,12 +34,19 @@ export async function GET({ fetch }) {
   }
 
   if (!res.ok) {
-    // Expose component names for attribution, never internal detail strings.
+    // Expose component names for attribution (fatal ones only), never internal
+    // detail strings. Advisory components are listed separately under degraded.
     let failing = [];
+    let degraded = [];
     try {
       const body = await res.json();
+      // Guard the shape once: a non-array degraded (an older backend, a
+      // mangled body) would otherwise become a Set of its characters and
+      // start matching single-letter component names.
+      degraded = Array.isArray(body?.degraded) ? body.degraded : [];
+      const advisoryNames = new Set(degraded);
       failing = Object.entries(body?.components ?? {})
-        .filter(([, c]) => !c?.ok)
+        .filter(([name, c]) => !c?.ok && !advisoryNames.has(name))
         .map(([name]) => name)
         .sort();
     } catch {
@@ -44,6 +57,7 @@ export async function GET({ fetch }) {
         status: "unhealthy",
         backendStatus: res.status,
         ...(failing.length ? { failing } : {}),
+        ...(degraded.length ? { degraded } : {}),
       },
       { status: 503 },
     );

--- a/projects/monolith/frontend/src/routes/public/health/server.test.js
+++ b/projects/monolith/frontend/src/routes/public/health/server.test.js
@@ -71,6 +71,76 @@ describe("/public/health GET", () => {
     expect(JSON.stringify(body)).not.toContain("secret");
   });
 
+  it("excludes advisory components from failing on 503", async () => {
+    // Regression test for the bug: cd is advisory (in degraded array)
+    // so it must not appear in failing.
+    const fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        status: "unhealthy",
+        components: {
+          a: { ok: false, detail: "fatal" },
+          cd: { ok: false, detail: "advisory chart lag" },
+        },
+        degraded: ["cd"],
+      }),
+    });
+
+    const res = await GET({ fetch });
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.failing).toEqual(["a"]);
+    expect(body.degraded).toEqual(["cd"]);
+    expect(JSON.stringify(body)).not.toContain("fatal");
+    expect(JSON.stringify(body)).not.toContain("advisory chart lag");
+  });
+
+  it("omits failing key when only advisory components are not ok", async () => {
+    // When all not-ok components are advisory, failing should not be present.
+    const fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        status: "unhealthy",
+        components: {
+          cd: { ok: false, detail: "advisory chart lag" },
+        },
+        degraded: ["cd"],
+      }),
+    });
+
+    const res = await GET({ fetch });
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.failing).toBeUndefined();
+    expect(body.degraded).toEqual(["cd"]);
+  });
+
+  it("handles 503 with no degraded key (older backend)", async () => {
+    // Graceful fallback when backend does not include degraded array.
+    const fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        status: "unhealthy",
+        components: {
+          a: { ok: false, detail: "fatal error" },
+        },
+      }),
+    });
+
+    const res = await GET({ fetch });
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.failing).toEqual(["a"]);
+    expect(body.degraded).toBeUndefined();
+    expect(JSON.stringify(body)).not.toContain("fatal error");
+  });
+
   it("omits failing names when the backend body is not parseable", async () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: false,


### PR DESCRIPTION
## The bug

`https://jomcgi.dev/health` listed ADVISORY components under `failing`, as if they were causes of the outage. During today's Cloudflare tunnel incident it returned:

```json
{"status":"unhealthy","backendStatus":503,"failing":["cd","ember_pages","ember_qwen"]}
```

`cd` is advisory. `home/module.py` registers it under `register_health_advisory` with an explicit comment: "Production being behind on a chart, or a mid-flight deploy, is not the public site being down... Nothing pages on cd now, it is a payload signal." Listing it under `failing` contradicts that and points whoever is reading the endpoint mid-incident at a chart-lag signal that was never a cause. That is exactly what happened today.

The backend gets the split right and populates `degraded` independently of the 200/503 status. The SvelteKit proxy threw it away, filtering `components` on `!c.ok` alone.

## The fix

`failing` now contains only components that are both not-ok **and** not advisory, and `degraded` is passed through on the 503 path as well as the 200 path, so the advisory signal stays visible and correctly labelled.

Component **names** only, never the backend's `detail` strings: the existing privacy test is untouched and still passes. The cache-header behaviour is unchanged (success edge-cached, failures never cached). A non-array or missing `degraded` falls back to the previous behaviour rather than crashing, guarded once so a stray string cannot become a `Set` of its own characters and start matching single-letter component names.

## Tests

Three added on top of the four existing:

- 503 with `components: {a, cd}` and `degraded: ["cd"]` yields `failing: ["a"]`, `degraded: ["cd"]` (the regression)
- 503 where the only not-ok component is advisory omits `failing` entirely
- 503 with no `degraded` key behaves as before

## Verification

`ci` green. `Executed 2 out of 760 tests: 760 tests pass.`

Note the affected-target probe falls back to `//...` here because `+server.js` breaks Bazel's query parser (`syntax error at '+ server.js'`). Pre-existing, not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaA2SsVAWiexez2NPepNmo