### PR TITLE
fix(embervm): PUT /serial rate limiter is a flat token bucket on n v1.16

### DIFF
--- a/projects/embervm/noded/fcvm/driver/serial.go
+++ b/projects/embervm/noded/fcvm/driver/serial.go
@@ -85,13 +85,16 @@ func (d *Driver) prepareSerialOutput(threadID string) (string, error) {
 // burst for boot-time kernel spew, then 64 KiB/s sustained. Once the bucket
 // empties Firecracker drops further UART bytes, so a flooding guest loses
 // middle output but the most recent console lines keep flowing.
-func serialRateLimiter() *fcclient.RateLimiter {
-	return &fcclient.RateLimiter{
-		Bandwidth: &fcclient.TokenBucket{
-			Size:         serialBurstBytes + serialBandwidthBytesPerSec,
-			OneTimeBurst: serialBurstBytes,
-			RefillTime:   serialBandwidthRefillMs,
-		},
+//
+// n v1.16.1's PUT /serial takes the limiter as a FLAT token bucket
+// ({size, refill_time, one_time_burst}), not the drive/net {bandwidth: ...}
+// wrapper: the fleet answered our first wrapped body with SerdeJson "missing
+// field `size`" pointing at the end of the bandwidth object.
+func serialRateLimiter() *fcclient.TokenBucket {
+	return &fcclient.TokenBucket{
+		Size:         serialBurstBytes + serialBandwidthBytesPerSec,
+		OneTimeBurst: serialBurstBytes,
+		RefillTime:   serialBandwidthRefillMs,
 	}
 }
 

--- a/projects/embervm/noded/fcvm/driver/serial_test.go
+++ b/projects/embervm/noded/fcvm/driver/serial_test.go
@@ -70,16 +70,18 @@ func TestColdBootPrecreatesSinkAndIssuesPutSerialBeforeStart(t *testing.T) {
 	if !ok {
 		t.Fatalf("rate_limiter missing from body: %v", bodies[0])
 	}
-	bw, ok := rl["bandwidth"].(map[string]any)
-	if !ok {
-		t.Fatalf("bandwidth missing from rate limiter: %v", rl)
-	}
+	// n v1.16.1's serial dialect takes the token bucket FLAT under
+	// rate_limiter; the drive/net {bandwidth: ...} wrapper is rejected with
+	// SerdeJson "missing field `size`" (observed live on the dev fleet).
 	wantSize := float64(serialBurstBytes + serialBandwidthBytesPerSec)
-	if bw["size"] != wantSize ||
-		bw["one_time_burst"] != float64(serialBurstBytes) ||
-		bw["refill_time"] != float64(serialBandwidthRefillMs) {
-		t.Fatalf("bandwidth token bucket = %v, want size/burst/refill %v/%d/%d",
-			bw, wantSize, serialBurstBytes, serialBandwidthRefillMs)
+	if rl["size"] != wantSize ||
+		rl["one_time_burst"] != float64(serialBurstBytes) ||
+		rl["refill_time"] != float64(serialBandwidthRefillMs) {
+		t.Fatalf("rate limiter token bucket = %v, want size/burst/refill %v/%d/%d",
+			rl, wantSize, serialBurstBytes, serialBandwidthRefillMs)
+	}
+	if _, wrapped := rl["bandwidth"]; wrapped {
+		t.Fatalf("rate_limiter must be a flat token bucket, got wrapper: %v", rl)
 	}
 }
 

--- a/projects/embervm/noded/fcvm/fcclient/client.go
+++ b/projects/embervm/noded/fcvm/fcclient/client.go
@@ -122,30 +122,27 @@ type SnapshotLoad struct {
 // TokenBucket is one half of a Firecracker RateLimiter: `size` tokens are
 // available immediately and refilled to full every `refill_time` milliseconds,
 // so size/refill_time is the sustained rate, with an optional initial
-// one_time_burst on top of the first bucket.
+// one_time_burst on top of the first bucket. On PUT /serial this type appears
+// DIRECTLY under rate_limiter (no bandwidth/ops wrapper in that dialect).
 type TokenBucket struct {
 	Size         int64 `json:"size"`
 	OneTimeBurst int64 `json:"one_time_burst,omitempty"`
 	RefillTime   int64 `json:"refill_time"`
 }
 
-// RateLimiter is a Firecracker token-bucket rate limiter over bandwidth (bytes)
-// and/or ops (I/O operation count). Each half is optional.
-type RateLimiter struct {
-	Bandwidth *TokenBucket `json:"bandwidth,omitempty"`
-	Ops       *TokenBucket `json:"ops,omitempty"`
-}
-
 // Serial is the body of PUT /serial. Firecracker v1.14 added the endpoint with
-// serial_out_path (upstream #5350); v1.16 added the rate limiter. It redirects
-// the microVM's UART output away from the Firecracker process's inherited
-// stdio into a host file sink. Serial configuration is deliberately NOT part
-// of the snapshot state, so EVERY process that will run this microVM must
-// issue it afresh: before Start on a cold boot AND before LoadSnapshot when
-// restoring (issue #4404).
+// serial_out_path (upstream #5350); v1.16 added the rate limiter, which on this
+// dialect is a FLAT token bucket ({size, refill_time, one_time_burst}) directly
+// under rate_limiter, NOT the drive/net {bandwidth: ...} wrapper: n v1.16.1
+// answers a wrapped body with SerdeJson "missing field `size`" (the wrapper
+// object has no size of its own). It redirects the microVM's UART output away
+// from the Firecracker process's inherited stdio into a host file sink. Serial
+// configuration is deliberately NOT part of the snapshot state, so EVERY
+// process that will run this microVM must issue it afresh: before Start on a
+// cold boot AND before LoadSnapshot when restoring (issue #4404).
 type Serial struct {
 	SerialOutPath string       `json:"serial_out_path"`
-	RateLimiter   *RateLimiter `json:"rate_limiter,omitempty"`
+	RateLimiter   *TokenBucket `json:"rate_limiter,omitempty"`
 }
 
 // PutSerial points the microVM's UART at a host file sink, optionally rate

--- a/projects/embervm/noded/fcvm/fcclient/client_test.go
+++ b/projects/embervm/noded/fcvm/fcclient/client_test.go
@@ -183,15 +183,16 @@ func TestClientLoadSnapshotResume(t *testing.T) {
 }
 
 // TestClientPutSerialWireFormat pins the PUT /serial request shape (issue
-// #4404): method+path, the sink path field, and the bandwidth token bucket.
+// #4404): method+path, the sink path field, and the rate limiter as a FLAT
+// token bucket. n v1.16.1 rejects the drive/net {bandwidth: ...} wrapper with
+// SerdeJson "missing field `size`" (observed live on the dev fleet); its
+// serial limiter sits directly under rate_limiter.
 func TestClientPutSerialWireFormat(t *testing.T) {
 	fake, sock := startFakeFC(t)
 	c := New(sock)
 	serial := Serial{
 		SerialOutPath: "/disks/nvme-02/thread-t1/serial.log",
-		RateLimiter: &RateLimiter{
-			Bandwidth: &TokenBucket{Size: 1089536, OneTimeBurst: 1048576, RefillTime: 1000},
-		},
+		RateLimiter:   &TokenBucket{Size: 1089536, OneTimeBurst: 1048576, RefillTime: 1000},
 	}
 	if err := c.PutSerial(context.Background(), serial); err != nil {
 		t.Fatalf("PutSerial: %v", err)
@@ -209,19 +210,19 @@ func TestClientPutSerialWireFormat(t *testing.T) {
 	if r.Body["serial_out_path"] != serial.SerialOutPath {
 		t.Fatalf("serial_out_path = %v, want %q", r.Body["serial_out_path"], serial.SerialOutPath)
 	}
-	rl, ok := r.Body["rate_limiter"].(map[string]any)
+	tb, ok := r.Body["rate_limiter"].(map[string]any)
 	if !ok {
 		t.Fatalf("rate_limiter = %v, want object", r.Body["rate_limiter"])
 	}
-	bw, ok := rl["bandwidth"].(map[string]any)
-	if !ok {
-		t.Fatalf("bandwidth = %v, want object", rl["bandwidth"])
+	if tb["size"] != float64(1089536) || tb["one_time_burst"] != float64(1048576) || tb["refill_time"] != float64(1000) {
+		t.Fatalf("token bucket = %v", tb)
 	}
-	if bw["size"] != float64(1089536) || bw["one_time_burst"] != float64(1048576) || bw["refill_time"] != float64(1000) {
-		t.Fatalf("bandwidth bucket = %v", bw)
-	}
-	if _, present := rl["ops"]; present {
-		t.Fatalf("ops must be omitted when unset: %v", rl)
+	// The drive/net wrapper shape must stay absent: this dialect has no
+	// bandwidth/ops halves on the serial endpoint.
+	for _, banned := range []string{"bandwidth", "ops"} {
+		if _, present := tb[banned]; present {
+			t.Fatalf("%s must be omitted (flat token bucket dialect): %v", banned, tb)
+		}
 	}
 }
 


### PR DESCRIPTION
Unblocks the fleet: every snapshot restore has been failing since #4404's serial sink landed, which turned Kargo's conformance gate red (prime_failed -> session create 500 on chart 0.44.0) and blocked all promotions.

## Evidence (dev, 15:49:39Z)

```
[vm-cce3215b0b80f10c:fc_api] The API server received a Put request on "/serial" with body
  {"serial_out_path":".../serial.log","rate_limiter":{"bandwidth":{"size":1114112,"one_time_burst":1048576,"refill_time":1000}}}
[vm-cce3215b0b80f10c:fc_api] SerdeJson(Error("missing field `size`", line: 1, column: 207))
```

Column 207 is exactly where the `bandwidth` object closes: n v1.16.1 parses `rate_limiter` as a FLAT token bucket (`{size, refill_time, one_time_burst}`), not the drive/net `{bandwidth: ...}` wrapper this endpoint inherited from upstream Firecracker convention.

## Fix

- `Serial.RateLimiter` becomes `*TokenBucket` (flat); drop the now-unused `RateLimiter` type.
- Pin the flat wire shape in both the client wire-format test (with an explicit anti-wrapper assertion) and the driver cold-boot ordering test.
- Limiter semantics unchanged: same size/burst/refill values.

`ci` green locally (153 affected tests). After this merges, the next freight should pass conformance and let today's queued ping re-keys (#5257/#5260) finally reach prod.