### PR TITLE
feat(embervm): idempotent session creation with a client-supplied key

### DIFF
--- a/projects/embervm/control/lib/embervm/op_log/postgres.ex
+++ b/projects/embervm/control/lib/embervm/op_log/postgres.ex
@@ -141,6 +141,7 @@ defmodule Embervm.OpLog.Postgres do
     CREATE TABLE IF NOT EXISTS sessions (
       session_id TEXT PRIMARY KEY,
       lineage_id TEXT,
+      idempotency_key TEXT,
       tenant TEXT NOT NULL,
       principal TEXT,
       workload TEXT,
@@ -167,6 +168,20 @@ defmodule Embervm.OpLog.Postgres do
     # reads those back as session_id, exactly what lineage_id always equalled
     # for them since there is no adoption yet to make the two diverge.
     "ALTER TABLE sessions ADD COLUMN IF NOT EXISTS lineage_id TEXT",
+    # #4919: the create-dedupe binding column plus its partial unique index (one
+    # session per principal per key, terminal rows included: reuse after destroy
+    # conflicts). The enforcement itself is an explicit pre-check inside the
+    # append transaction (see project/3 for :session_created) so the caller gets
+    # the holder's id back and the failed append rolls back whole; this index is
+    # the durable backstop. The binding lives as long as its session row does:
+    # retention compaction of a terminal session frees the key. The index sits
+    # AFTER the ALTER here so the column exists on upgraded DBs too.
+    "ALTER TABLE sessions ADD COLUMN IF NOT EXISTS idempotency_key TEXT",
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS sessions_idem_idx
+      ON sessions(principal, idempotency_key)
+      WHERE idempotency_key IS NOT NULL
+    """,
     """
     CREATE TABLE IF NOT EXISTS serving_instances (
       instance_id TEXT PRIMARY KEY,
@@ -795,6 +810,28 @@ defmodule Embervm.OpLog.Postgres do
   defp project(conn, %Op{kind: :session_created} = op, _seq) do
     payload = op.payload
 
+    # #4919: enforce the per-principal create-key binding inside the append
+    # transaction (Postgrex.transaction serializes this projection against the
+    # row it reads), mirroring Embervm.OpLog.SQLite. A collision errors the
+    # whole append (Postgrex.rollback discards the ops row too) and names the
+    # EXISTING holder, terminal holders included. A holder equal to this op's
+    # own session_id is the adopt-and-backfill repair racing a late-draining
+    # original append, which ON CONFLICT DO NOTHING used to absorb benignly.
+    idempotency_key = Map.get(payload, :idempotency_key)
+
+    case existing_session_for_idempotency_key(conn, op.principal, idempotency_key) do
+      {:ok, nil} ->
+        do_insert_session_created(conn, op, payload, idempotency_key)
+
+      {:ok, holder} when holder == op.session_id ->
+        :ok
+
+      {:ok, holder} ->
+        {:error, {:duplicate_session_idempotency_key, holder}}
+    end
+  end
+
+  defp do_insert_session_created(conn, op, payload, idempotency_key) do
     # ON CONFLICT DO NOTHING: idempotent on session_id so the adopt-and-backfill
     # repair can re-append session_created for a lost async write without a clash
     # (mirrors the SQLite backend's INSERT OR IGNORE), ADR embervm/014 decision 2.
@@ -803,8 +840,8 @@ defmodule Embervm.OpLog.Postgres do
       (session_id, tenant, principal, workload, state, node_id, volume_node_id,
        base_snapshot_ref, base_digest, generation, snapshot_ref, snapshot_size_bytes,
        token_sha256, created_at, last_invoke_at, expires_at, updated_at, terminal_reason,
-       lineage_id)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 0, NULL, NULL, $10, $11, NULL, $12, $13, NULL, $14)
+       lineage_id, idempotency_key)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 0, NULL, NULL, $10, $11, NULL, $12, $13, NULL, $14, $15)
     ON CONFLICT (session_id) DO NOTHING
     """
 
@@ -825,8 +862,25 @@ defmodule Embervm.OpLog.Postgres do
       # #4306 slice 1: do_create always sends lineage_id now (= session_id this
       # slice); the default here is belt-and-suspenders for an op written by
       # code that predates this field.
-      Map.get(payload, :lineage_id, op.session_id)
+      Map.get(payload, :lineage_id, op.session_id),
+      idempotency_key
     ])
+  end
+
+  # The session_id currently bound to (principal, idempotency_key), or nil.
+  # nil key (an unkeyed create) always reads as unbound. Sees TERMINAL rows on
+  # purpose: reuse-after-destroy must conflict, not rebind (#4919).
+  defp existing_session_for_idempotency_key(_conn, _principal, nil), do: {:ok, nil}
+
+  defp existing_session_for_idempotency_key(conn, principal, idempotency_key) do
+    case Postgrex.query(conn, "SELECT session_id FROM sessions WHERE principal=$1 AND idempotency_key=$2", [
+           principal,
+           idempotency_key
+         ]) do
+      {:ok, %Postgrex.Result{rows: []}} -> {:ok, nil}
+      {:ok, %Postgrex.Result{rows: [[existing]]}} -> {:ok, existing}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   defp project(conn, %Op{kind: :session_invoked} = op, _seq) do
@@ -1824,7 +1878,7 @@ defmodule Embervm.OpLog.Postgres do
     SELECT session_id, tenant, principal, workload, state, node_id, volume_node_id,
            base_snapshot_ref, base_digest, generation, snapshot_ref, snapshot_size_bytes,
            token_sha256, created_at, last_invoke_at, expires_at, updated_at, terminal_reason,
-           COALESCE(lineage_id, session_id)
+           COALESCE(lineage_id, session_id), idempotency_key
     FROM sessions
     """
 
@@ -1835,26 +1889,27 @@ defmodule Embervm.OpLog.Postgres do
   end
 
   defp row_to_session([
-         session_id,
-         tenant,
-         principal,
-         workload,
-         state,
-         node_id,
-         volume_node_id,
-         base_snapshot_ref,
-         base_digest,
-         generation,
-         snapshot_ref,
-         snapshot_size_bytes,
-         token_sha256,
-         created_at,
-         last_invoke_at,
-         expires_at,
-         updated_at,
-         terminal_reason,
-         lineage_id
-       ]) do
+          session_id,
+          tenant,
+          principal,
+          workload,
+          state,
+          node_id,
+          volume_node_id,
+          base_snapshot_ref,
+          base_digest,
+          generation,
+          snapshot_ref,
+          snapshot_size_bytes,
+          token_sha256,
+          created_at,
+          last_invoke_at,
+          expires_at,
+          updated_at,
+          terminal_reason,
+          lineage_id,
+          idempotency_key
+        ]) do
     %{
       session_id: session_id,
       tenant: tenant,
@@ -1874,7 +1929,8 @@ defmodule Embervm.OpLog.Postgres do
       expires_at: expires_at,
       updated_at: updated_at,
       terminal_reason: terminal_reason,
-      lineage_id: lineage_id
+      lineage_id: lineage_id,
+      idempotency_key: idempotency_key
     }
   end
 

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -207,6 +207,7 @@ defmodule Embervm.OpLog.SQLite do
     CREATE TABLE IF NOT EXISTS sessions (
       session_id TEXT PRIMARY KEY,
       lineage_id TEXT,
+      idempotency_key TEXT,
       tenant TEXT NOT NULL,
       principal TEXT,
       workload TEXT,
@@ -956,6 +957,32 @@ defmodule Embervm.OpLog.SQLite do
   defp project(conn, %Op{kind: :session_created} = op, _seq) do
     payload = op.payload
 
+    # #4919: enforce the per-principal create-key binding INSIDE the append
+    # transaction (BEGIN IMMEDIATE serializes writers, so check-then-insert is
+    # atomic here), the session-side mirror of :submitted's task dedupe. A
+    # collision returns the EXISTING holder's id and errors the whole append,
+    # so do_append rolls back the ops row too: no trace of the losing create
+    # survives, and the unique index stays a pure backstop. Terminal holders
+    # conflict as well (a reused key after destroy never silently mints a fresh
+    # session); retention compaction freeing the row is what frees the key.
+    # A holder EQUAL to this op's own session_id is not a collision: it is the
+    # adopt-and-backfill repair racing a late-draining original append, which
+    # INSERT OR IGNORE alone used to absorb as a benign no-op.
+    idempotency_key = Map.get(payload, :idempotency_key)
+
+    case existing_session_for_idempotency_key(conn, op.principal, idempotency_key) do
+      {:ok, nil} ->
+        do_insert_session_created(conn, op, payload, idempotency_key)
+
+      {:ok, holder} when holder == op.session_id ->
+        :ok
+
+      {:ok, holder} ->
+        {:error, {:duplicate_session_idempotency_key, holder}}
+    end
+  end
+
+  defp do_insert_session_created(conn, op, payload, idempotency_key) do
     # INSERT OR IGNORE: idempotent on session_id so the adopt-and-backfill repair
     # (session_manager Direction-2, ADR embervm/014) can re-append session_created
     # for a lost async write without a primary-key clash if the original append
@@ -966,8 +993,8 @@ defmodule Embervm.OpLog.SQLite do
       (session_id, tenant, principal, workload, state, node_id, volume_node_id,
        base_snapshot_ref, base_digest, generation, snapshot_ref, snapshot_size_bytes,
        token_sha256, created_at, last_invoke_at, expires_at, updated_at, terminal_reason,
-       lineage_id)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL, ?, ?, NULL, ?, ?, NULL, ?)
+       lineage_id, idempotency_key)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL, ?, ?, NULL, ?, ?, NULL, ?, ?)
     """
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
@@ -992,11 +1019,34 @@ defmodule Embervm.OpLog.SQLite do
              # #4306 slice 1: do_create always sends lineage_id now (= session_id
              # this slice); the default here is belt-and-suspenders for an op
              # written by code that predates this field.
-             Map.get(payload, :lineage_id, op.session_id)
+             Map.get(payload, :lineage_id, op.session_id),
+             idempotency_key
            ]),
          :done <- Sqlite3.step(conn, stmt),
          :ok <- Sqlite3.release(conn, stmt) do
       :ok
+    end
+  end
+
+  # The session_id currently bound to (principal, idempotency_key), or nil.
+  # nil key (an unkeyed create) always reads as unbound. Sees TERMINAL rows on
+  # purpose: reuse-after-destroy must conflict, not rebind (#4919).
+  defp existing_session_for_idempotency_key(_conn, _principal, nil), do: {:ok, nil}
+
+  defp existing_session_for_idempotency_key(conn, principal, idempotency_key) do
+    sql = "SELECT session_id FROM sessions WHERE principal=? AND idempotency_key=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [principal, idempotency_key]) do
+      case Sqlite3.step(conn, stmt) do
+        {:row, [existing]} ->
+          :ok = Sqlite3.release(conn, stmt)
+          {:ok, existing}
+
+        :done ->
+          :ok = Sqlite3.release(conn, stmt)
+          {:ok, nil}
+      end
     end
   end
 
@@ -2482,7 +2532,7 @@ defmodule Embervm.OpLog.SQLite do
     SELECT session_id, tenant, principal, workload, state, node_id, volume_node_id,
            base_snapshot_ref, base_digest, generation, snapshot_ref, snapshot_size_bytes,
            token_sha256, created_at, last_invoke_at, expires_at, updated_at, terminal_reason,
-           COALESCE(lineage_id, session_id)
+           COALESCE(lineage_id, session_id), idempotency_key
     FROM sessions
     """
 
@@ -2515,7 +2565,8 @@ defmodule Embervm.OpLog.SQLite do
          expires_at,
          updated_at,
          terminal_reason,
-         lineage_id
+         lineage_id,
+         idempotency_key
        ]} ->
         session = %{
           session_id: session_id,
@@ -2536,7 +2587,8 @@ defmodule Embervm.OpLog.SQLite do
           expires_at: expires_at,
           updated_at: updated_at,
           terminal_reason: terminal_reason,
-          lineage_id: lineage_id
+          lineage_id: lineage_id,
+          idempotency_key: idempotency_key
         }
 
         collect_sessions(conn, stmt, [session | acc])
@@ -3450,6 +3502,7 @@ defmodule Embervm.OpLog.SQLite do
     with :ok <- migrate_results_headers(conn),
          :ok <- migrate_sessions_volume_node_id(conn),
          :ok <- migrate_sessions_lineage_id(conn),
+         :ok <- migrate_sessions_idempotency_key(conn),
          :ok <- migrate_ops_session_id(conn),
          :ok <- migrate_ops_serving_instance_id(conn),
          :ok <- migrate_usage_request_count(conn),
@@ -3481,6 +3534,31 @@ defmodule Embervm.OpLog.SQLite do
       else
         Sqlite3.execute(conn, "ALTER TABLE sessions ADD COLUMN lineage_id TEXT")
       end
+    end
+  end
+
+  # #4919: the additive nullable sessions.idempotency_key column plus the
+  # partial unique index backing the create-dedupe contract (one session per
+  # principal per key, terminal rows included). Mirrors
+  # migrate_sessions_lineage_id/1 for the column; the index is created HERE
+  # rather than in @ddl because on an upgraded DB the sessions CREATE TABLE IF
+  # NOT EXISTS is a no-op and the column would not exist yet when the @ddl list
+  # runs. An upgraded DB's existing rows get idempotency_key=NULL from the
+  # ALTER, which the partial index ignores: pre-existing sessions are unkeyed,
+  # exactly what they always were.
+  defp migrate_sessions_idempotency_key(conn) do
+    with {:ok, cols} <- table_columns(conn, "sessions"),
+         :ok <-
+           add_column_if_missing(
+             conn,
+             cols,
+             "idempotency_key",
+             "ALTER TABLE sessions ADD COLUMN idempotency_key TEXT"
+           ) do
+      Sqlite3.execute(
+        conn,
+        "CREATE UNIQUE INDEX IF NOT EXISTS sessions_idem_idx ON sessions(principal, idempotency_key) WHERE idempotency_key IS NOT NULL"
+      )
     end
   end
 

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -121,6 +121,11 @@ defmodule Embervm.Router do
 
   # -- session routes (R2, front-end only; no placement logic here) ----------
 
+  # POST /v1/workloads/:name/sessions takes an optional `Idempotency-Key`
+  # header (#4919): same-key retry replays the SAME live session (200, no
+  # token), reuse after its terminal state conflicts (409), malformed keys
+  # are rejected (400). GET on this path accepts ?idempotency_key= to resolve
+  # one binding instead of paging.
   post "/v1/workloads/:name/sessions" do
     handle_create_session(conn, name)
   end
@@ -976,19 +981,28 @@ defmodule Embervm.Router do
   # body `{"restore_lineage": "<lineage-id>"}` requests a #4306 slice 3
   # cross-generation create: the new session inherits that lineage's durable
   # workspace instead of minting a fresh one (an absent/empty/malformed body
-  # is always a normal create). 201 with the token (returned ONCE) and
-  # `restored` (whether the inherited workspace was actually recovered), 429
-  # for a capacity/quota denial, 403/404/409 for a class, workload, or lineage
-  # mismatch, 500 for an internal failure.
+  # is always a normal create). An optional `Idempotency-Key` header (#4919)
+  # makes the create an UPSERT: a same-key retry answers 200 with the SAME
+  # live session's current state and NO token (the capability was returned
+  # exactly once), a same-key retry after that session went terminal is a 409
+  # conflict, and a malformed/oversized key is a 400. Keys are scoped per
+  # principal and bounded by their session row's lifetime (retention frees a
+  # terminal row's key). 201 with the token (returned ONCE) and `restored`
+  # (whether the inherited workspace was actually recovered) for a fresh
+  # create, 429 for a capacity/quota denial, 403/404/409 for a class,
+  # workload, or lineage mismatch, 500 for an internal failure.
   defp handle_create_session(conn, workload) do
     principal = conn.assigns.principal
     {restore_lineage, conn} = optional_restore_lineage(conn)
+    idempotency_key = header_value(conn, "idempotency-key")
 
     # Cold-boot persistence creates legitimately take tens of seconds; the
     # SessionManager call must not cut the claim/prime RPC at the old 5-second limit.
     result =
       try do
-        session_manager().create(session_manager_server(), workload, principal, restore_lineage)
+        session_manager().create(session_manager_server(), workload, principal, restore_lineage,
+          idempotency_key: idempotency_key
+        )
       catch
         :exit, {:timeout, _} -> :control_plane_busy
       end
@@ -996,6 +1010,20 @@ defmodule Embervm.Router do
     case result do
       :control_plane_busy ->
         send_json(conn, 503, %{error: "control plane busy", retryable: true})
+
+      # A keyed retry resolved to an EXISTING live session: 200 with its current
+      # state, deliberately WITHOUT a session_token (that capability is minted
+      # once, at the original create; replaying it would widen a bearer secret).
+      {:ok, %{replayed: true} = replay} ->
+        send_json(conn, 200, %{
+          session_id: replay.session_id,
+          lineage_id: Map.get(replay, :lineage_id, replay.session_id),
+          expires_at: replay.expires_at,
+          base_digest: replay.base_digest,
+          state: to_string(Map.get(replay, :state, :running)),
+          restored: false,
+          replayed: true
+        })
 
       {:ok, created} ->
         send_json(conn, 201, %{
@@ -1010,6 +1038,18 @@ defmodule Embervm.Router do
           base_digest: created.base_digest,
           state: to_string(Map.get(created, :state, :running)),
           restored: Map.get(created, :restored, false)
+        })
+
+      # A key whose holder is terminal (destroyed/expired/evicted/failed):
+      # the issue's rule is CONFLICT, never a silent fresh session. The old
+      # session is gone, so this is not retryable against THIS key; callers
+      # mint a new key to create again.
+      {:error, {:conflict, reason}} ->
+        send_json(conn, 409, %{
+          error: "session idempotency key already bound to a terminal session",
+          reason: to_string(reason),
+          workload: workload,
+          retryable: false
         })
 
       {:error, {:denied, reason}} ->
@@ -1053,6 +1093,17 @@ defmodule Embervm.Router do
           reason: to_string(r),
           workload: workload,
           retryable: true
+        })
+
+      # #4919: a malformed or oversized Idempotency-Key is a CLIENT bug (400,
+      # the request itself is invalid), unlike a cap denial (429, retry when
+      # capacity frees). Nothing was placed or bound.
+      :invalid_idempotency_key ->
+        send_json(conn, 400, %{
+          error: "idempotency key must be 1..200 bytes of printable ASCII",
+          reason: "invalid_idempotency_key",
+          workload: workload,
+          retryable: false
         })
 
       :unknown_workload ->
@@ -1136,20 +1187,50 @@ defmodule Embervm.Router do
     end
   end
 
-  # GET /v1/workloads/:name/sessions (management auth): paged listing.
+  # GET /v1/workloads/:name/sessions (management auth): paged listing. With an
+  # `idempotency_key` query parameter (#4919) it answers the query-by-key seam
+  # instead of paging: at most ONE session (a key binds one session per
+  # principal), scoped to the CALLER's principal, so a caller can never probe
+  # another principal's bindings by guessing keys; a mismatched workload or
+  # principal reads as an empty page rather than an error.
   defp handle_list_sessions(conn, workload) do
     limit = conn |> int_param("limit", 50) |> clamp(1, 500)
     offset = conn |> int_param("offset", 0) |> max(0)
 
-    {:ok, page} = session_store().list(session_store_server(), workload, limit: limit, offset: offset)
+    case Map.get(conn.query_params, "idempotency_key") do
+      nil ->
+        {:ok, page} = session_store().list(session_store_server(), workload, limit: limit, offset: offset)
 
-    send_json(conn, 200, %{
-      workload: workload,
-      items: Enum.map(page.items, &session_view/1),
-      total: page.total,
-      limit: page.limit,
-      offset: page.offset
-    })
+        send_json(conn, 200, %{
+          workload: workload,
+          items: Enum.map(page.items, &session_view/1),
+          total: page.total,
+          limit: page.limit,
+          offset: page.offset
+        })
+
+      "" ->
+        send_json(conn, 200, empty_session_page(workload, limit, offset))
+
+      key ->
+        items =
+          case session_store().get_by_idempotency_key(session_store_server(), conn.assigns.principal, key) do
+            {:ok, %{workload: ^workload} = session} -> [session_view(session)]
+            _ -> []
+          end
+
+        send_json(conn, 200, %{
+          workload: workload,
+          items: items,
+          total: length(items),
+          limit: limit,
+          offset: offset
+        })
+    end
+  end
+
+  defp empty_session_page(workload, limit, offset) do
+    %{workload: workload, items: [], total: 0, limit: limit, offset: offset}
   end
 
   # POST /v1/sessions/:id/invoke (SESSION TOKEN auth ONLY). The bearer token must

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -100,6 +100,11 @@ defmodule Embervm.SessionManager do
   # gate in that domain instead of comparing it with session row wall-clock times.
   @fleet_freshness_window_ms 120_000
 
+  # #4919: a create idempotency key is 1..200 bytes of printable ASCII. Anything
+  # else (oversized, control characters, non-ASCII) is a client bug and is
+  # denied BEFORE any placement/capacity work, never stored, never bound.
+  @idem_key_max_bytes 200
+
   # -- Client API ------------------------------------------------------------
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -171,9 +176,47 @@ defmodule Embervm.SessionManager do
   @spec create(GenServer.server(), String.t(), String.t(), String.t() | nil) ::
           {:ok, map()} | {:error, term()}
   def create(server, workload, principal, restore_lineage) do
+    create(server, workload, principal, restore_lineage, [])
+  end
+
+  @doc """
+  Like `create/4`, with `opts` carrying the optional `:idempotency_key`
+  (#4919). A key makes the create an UPSERT for the calling workflow:
+
+    * the FIRST create with a given (principal, key) proceeds normally and
+      binds the key to the new session durably;
+    * a retry with the SAME key while that session is live returns the SAME
+      session (`{:ok, map}` with `replayed: true` and NO `token`: the
+      capability was returned exactly once, at the original create);
+    * a second create arriving while the first is still mid-flight (claim/
+      prime run outside this process) is PARKED and resolved with the same
+      replay view when the first settles, so concurrent same-key creates
+      yield exactly ONE session;
+    * reusing a key whose holder is TERMINAL (destroyed/expired/evicted/
+      failed) is `{:error, {:conflict, :session_idempotency_key_reused}}`,
+      never a silent fresh session;
+    * a malformed or oversized key (>200 bytes, or containing anything but
+      printable ASCII) is `{:error, {:denied, :invalid_idempotency_key}}`.
+
+  Enforcement of the binding itself lives in the op-log projection (a unique
+  `(principal, idempotency_key)` constraint applied inside the append
+  transaction, terminal rows included), not in check-then-create here; the
+  lookup above is the fast path, the store has the final word. A binding's
+  lifetime is its session row's lifetime: retention compaction of a terminal
+  session frees its key. Keys are scoped PER PRINCIPAL: two principals may use
+  the same key independently.
+  """
+  @spec create(GenServer.server(), String.t(), String.t(), String.t() | nil, keyword()) ::
+          {:ok, map()} | {:error, term()}
+  def create(server, workload, principal, restore_lineage, opts) do
     # Cold-boot persistence creates can legitimately take tens of seconds while
     # the manager remains responsive to other calls.
-    GenServer.call(server, {:create, workload, principal, normalize_restore_lineage(restore_lineage)}, 180_000)
+    GenServer.call(
+      server,
+      {:create, workload, principal, normalize_restore_lineage(restore_lineage),
+       normalize_idempotency_key(Keyword.get(opts, :idempotency_key))},
+      180_000
+    )
   end
 
   @doc """
@@ -301,11 +344,18 @@ defmodule Embervm.SessionManager do
       # invoke can park (relighting ledger) and be relit once the bank completes.
       banking: %{},
       # create_ref -> {from, lineage_id, workload, principal, entry, node_id,
-      # snapshot_ref, dial_id, restore_lineage}; claim/prime runs outside this
-      # process. restore_lineage is nil for a normal create (#4306 slice 3).
+      # snapshot_ref, dial_id, restore_lineage, idempotency_key}; claim/prime runs
+      # outside this process. restore_lineage is nil for a normal create (#4306
+      # slice 3); idempotency_key is nil for an unkeyed create (#4919).
       create_inflight: %{},
       create_next_ref: 0,
       create_workers: %{},
+      # #4919: {principal, key} -> create_ref for creates currently mid-flight,
+      # and {principal, key} -> [from] callers parked behind them. Claimed
+      # synchronously in handle_call (so a later same-key caller parks instead of
+      # racing), drained in finish_create with the winner's result as a replay.
+      idempotency_inflight: %{},
+      idempotency_waiters: %{},
       # session_id -> {pid, monitor_ref, timeout_ref, worker_ref, resumed}. Live
       # teardown must not run on this process because a stuck node RPC would block
       # creates, routing, sweeps, and the reconcile pass that can redrive it.
@@ -422,53 +472,138 @@ defmodule Embervm.SessionManager do
   end
 
   @impl true
-  def handle_call({:create, workload, principal, restore_lineage}, from, state) do
-    case do_create_inline(state, workload, principal, restore_lineage) do
-      {:ok,
-       %{entry: entry, node_id: node_id, dial_id: dial_id, snapshot_ref: snapshot_ref, lineage_id: lineage_id}} ->
-        ref = state.create_next_ref
-
-        state =
-          put_in(
-            state.create_inflight[ref],
-            {from, lineage_id, workload, principal, entry, node_id, snapshot_ref, dial_id, restore_lineage}
-          )
-
-        # #4306/#4313 review fix 2: mark the lineage in flight in the SAME
-        # state update, synchronously, before this handle_call returns (so
-        # the very next {:create,...} this GenServer processes, for any
-        # caller, sees it).
-        state =
-          if restore_lineage do
-            %{state | inflight_restore_lineages: MapSet.put(state.inflight_restore_lineages, restore_lineage)}
-          else
-            state
-          end
-
-        state = %{state | create_next_ref: ref + 1}
-        {state, worker} =
-          spawn_create_worker(
-            state,
-            ref,
-            node_id,
-            dial_id,
-            workload,
-            snapshot_ref,
-            entry,
-            lineage_id,
-            restore_lineage,
-            principal
-          )
-
-        {:noreply, put_in(state.create_workers[ref], worker)}
-
-      {:error, {:denied, reason}} = error_result ->
-        # Bind the FULL {:error, {:denied, _}} tuple: binding the inner term
-        # replied {:denied, reason} and every denial test failed on the shape.
+  def handle_call({:create, workload, principal, restore_lineage, idempotency_key}, from, state) do
+    cond do
+      # A present-but-malformed key is a client bug: deny before anything runs.
+      idempotency_key != nil and not valid_idempotency_key?(idempotency_key) ->
+        reason = :invalid_idempotency_key
         audit_denial(state, principal, workload, reason)
-        log_create_result(error_result, workload, principal)
-        {:reply, error_result, state}
+        log_create_result({:error, {:denied, reason}}, workload, principal)
+        {:reply, {:error, {:denied, reason}}, state}
+
+      # Same-key retry against an already-bound session: replay the live holder,
+      # conflict on a terminal one (reuse after destroy is never a fresh create).
+      idempotency_key != nil ->
+        case idempotency_lookup(state, principal, idempotency_key) do
+          {:replay, session} ->
+            {:reply, {:ok, replay_view(session)}, state}
+
+          {:conflict, _terminal} ->
+            {:reply, {:error, {:conflict, :session_idempotency_key_reused}}, state}
+
+          :unbound ->
+            create_unbound(state, from, workload, principal, restore_lineage, idempotency_key)
+        end
+
+      true ->
+        create_unbound(state, from, workload, principal, restore_lineage, nil)
     end
+  end
+
+  # The tail of {:create, ...} for a key that is not yet bound (or was never
+  # supplied): the ordinary inline fast path, plus the in-flight parking that
+  # makes concurrent same-key creates resolve to ONE session. do_create_inline
+  # runs synchronously here; if it admits the create, its worker (claim/prime)
+  # runs OUTSIDE this process, so a second same-key caller arriving before
+  # finish_create parks on {principal, key} instead of racing a duplicate.
+  defp create_unbound(state, from, workload, principal, restore_lineage, idempotency_key) do
+    waiter_key = {principal, idempotency_key}
+
+    if idempotency_key != nil and Map.has_key?(state.idempotency_inflight, waiter_key) do
+      # The first same-key create has not settled yet. Park this caller; it is
+      # replied when finish_create drains the key (same result shape, replay view).
+      waiters = Map.get(state.idempotency_waiters, waiter_key, [])
+      {:noreply, %{state | idempotency_waiters: Map.put(state.idempotency_waiters, waiter_key, [from | waiters])}}
+    else
+      case do_create_inline(state, workload, principal, restore_lineage) do
+        {:ok,
+         %{entry: entry, node_id: node_id, dial_id: dial_id, snapshot_ref: snapshot_ref, lineage_id: lineage_id}} ->
+          ref = state.create_next_ref
+
+          state =
+            put_in(
+              state.create_inflight[ref],
+              {from, lineage_id, workload, principal, entry, node_id, snapshot_ref, dial_id, restore_lineage,
+               idempotency_key}
+            )
+
+          # #4306/#4313 review fix 2: mark the lineage in flight in the SAME
+          # state update, synchronously, before this handle_call returns (so
+          # the very next {:create,...} this GenServer processes, for any
+          # caller, sees it).
+          state =
+            if restore_lineage do
+              %{state | inflight_restore_lineages: MapSet.put(state.inflight_restore_lineages, restore_lineage)}
+            else
+              state
+            end
+
+          # #4919: claim the key in the SAME synchronous update, so any later
+          # same-key create sees it parked rather than racing a duplicate.
+          state =
+            if idempotency_key do
+              %{
+                state
+                | idempotency_inflight: Map.put(state.idempotency_inflight, waiter_key, ref),
+                  idempotency_waiters: Map.put(state.idempotency_waiters, waiter_key, [])
+              }
+            else
+              state
+            end
+
+          state = %{state | create_next_ref: ref + 1}
+
+          {state, worker} =
+            spawn_create_worker(
+              state,
+              ref,
+              node_id,
+              dial_id,
+              workload,
+              snapshot_ref,
+              entry,
+              lineage_id,
+              restore_lineage,
+              principal
+            )
+
+          {:noreply, put_in(state.create_workers[ref], worker)}
+
+        {:error, {:denied, reason}} = error_result ->
+          # Bind the FULL {:error, {:denied, _}} tuple: binding the inner term
+          # replied {:denied, reason} and every denial test failed on the shape.
+          audit_denial(state, principal, workload, reason)
+          log_create_result(error_result, workload, principal)
+          {:reply, error_result, state}
+      end
+    end
+  end
+
+  # The durable hot-set lookup behind a keyed retry: `{:replay, session}` for a
+  # live holder, `{:conflict, session}` for a terminal one (the issue's rule:
+  # reuse after destroy conflicts), `:unbound` to proceed with a normal create.
+  defp idempotency_lookup(state, principal, key) do
+    case SessionStore.get_by_idempotency_key(state.session_store, principal, key) do
+      {:ok, %{state: session_state} = session} ->
+        if SessionState.terminal?(session_state), do: {:conflict, session}, else: {:replay, session}
+
+      :error ->
+        :unbound
+    end
+  end
+
+  # The replay body of a same-key retry: the SAME session's current identity,
+  # no token (the capability was minted once, at the original create).
+  defp replay_view(session) do
+    %{
+      session_id: session.session_id,
+      lineage_id: session.lineage_id || session.session_id,
+      expires_at: session.expires_at,
+      base_digest: session.base_digest,
+      state: session.state,
+      restored: false,
+      replayed: true
+    }
   end
 
   def handle_call({:route_invoke, session_id, req}, from, state) do
@@ -901,7 +1036,8 @@ defmodule Embervm.SessionManager do
       {nil, _} ->
         state
 
-      {{from, lineage_id, workload, principal, entry, node_id, _snapshot_ref, dial_id, restore_lineage}, inflight} ->
+      {{from, lineage_id, workload, principal, entry, node_id, _snapshot_ref, dial_id, restore_lineage,
+        idempotency_key}, inflight} ->
         cleanup_create_worker(Map.get(state.create_workers, ref))
 
         state = %{state | create_inflight: inflight, create_workers: Map.delete(state.create_workers, ref)}
@@ -920,7 +1056,7 @@ defmodule Embervm.SessionManager do
         result =
           case outcome do
             {:ok, vm_id, restored} ->
-              register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id, lineage_id, restore_lineage, restored)
+              register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id, lineage_id, restore_lineage, restored, idempotency_key)
 
             {:error, reason} ->
               audit_denial(state, principal, workload, reason)
@@ -941,10 +1077,36 @@ defmodule Embervm.SessionManager do
           end
 
         GenServer.reply(from, result)
+
+        # #4919: drain callers parked on this key with the SAME outcome, shaped
+        # as a replay for a success (they never receive the capability token:
+        # exactly one create response ever carries it). A failed winner replies
+        # its failure to every waiter; each client simply retries.
+        waiter_key = {principal, idempotency_key}
+        {waiters, waiters_map} = Map.pop(state.idempotency_waiters, waiter_key, [])
+
+        state = %{
+          state
+          | idempotency_inflight: Map.delete(state.idempotency_inflight, waiter_key),
+            idempotency_waiters: waiters_map
+        }
+
+        Enum.each(waiters, fn waiter ->
+          GenServer.reply(waiter, idempotent_waiter_result(result))
+        end)
+
         log_create_result(result, workload, principal)
         state
     end
   end
+
+  # A parked same-key caller's view of the winning create: identical identity,
+  # replayed: true, and NO token (the capability was returned exactly once).
+  defp idempotent_waiter_result({:ok, created}) do
+    {:ok, created |> Map.delete(:token) |> Map.put(:replayed, true)}
+  end
+
+  defp idempotent_waiter_result(other), do: other
 
   defp cleanup_create_worker({pid, monitor_ref, timeout_ref}) do
     Process.cancel_timer(timeout_ref)
@@ -1075,6 +1237,19 @@ defmodule Embervm.SessionManager do
   defp normalize_restore_lineage(lineage) when is_binary(lineage) and lineage != "", do: lineage
   defp normalize_restore_lineage(_other), do: nil
 
+  # #4919: absent, empty, or non-string mean "no key"; a present key is carried
+  # verbatim (format validation is the server-side gate below, so a malformed
+  # key is a structured denial rather than a silently unkeyed create).
+  defp normalize_idempotency_key(key) when is_binary(key) and key != "", do: key
+  defp normalize_idempotency_key(_other), do: nil
+
+  defp valid_idempotency_key?(key) when is_binary(key) do
+    byte_size(key) <= @idem_key_max_bytes and
+      Enum.all?(:binary.bin_to_list(key), fn b -> b >= 0x20 and b <= 0x7E end)
+  end
+
+  defp valid_idempotency_key?(_other), do: false
+
   defp prime(state, node_id, workload, snapshot_ref, entry, lineage_id) do
     # A prime failure is NOT a capacity problem, and reporting it as one cost a
     # whole debugging cycle: the persistence flip denied every create with
@@ -1150,7 +1325,7 @@ defmodule Embervm.SessionManager do
   # PR-4 rebinds). If the process fails to start, the durable session is orphaned as
   # a live-but-unrouted row; PR-4 adoption rebinds it from NodeStatus, so we surface
   # the create as failed rather than leave the caller a token to a dead process.
-  defp register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id, lineage_id, restore_lineage, restored) do
+  defp register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id, lineage_id, restore_lineage, restored, idempotency_key \\ nil) do
     attrs = %{
       tenant: state.tenant,
       principal: principal,
@@ -1180,7 +1355,8 @@ defmodule Embervm.SessionManager do
       volume_node_id: if(persistence_enabled_workload?(entry), do: node_id, else: nil),
       base_snapshot_ref: Map.get(entry, :image_ref),
       base_digest: base_digest(entry),
-      expires_at: state.clock.() + entry.session.max_lifetime_seconds * 1000
+      expires_at: state.clock.() + entry.session.max_lifetime_seconds * 1000,
+      idempotency_key: idempotency_key
     }
 
     # node_id is the K8s node where the VM primed/started; SessionStore carries it into session_created.
@@ -1195,8 +1371,30 @@ defmodule Embervm.SessionManager do
             {:error, {:denied, :process_start_failed}}
         end
 
+      # #4919 defense in depth: this manager's own fast path already serializes
+      # same-key creates, so reaching the store-level duplicate means another
+      # writer bound the key first (a restart race, or a second manager against
+      # one op-log). Resolve the holder to exactly what the fast path would have
+      # answered: replay the live winner, conflict on a terminal one.
+      {:error, {:duplicate_session_idempotency_key, holder}} ->
+        resolve_lost_key_race(state, holder)
+
       {:error, reason} ->
         {:error, {:denied, {:store, reason}}}
+    end
+  end
+
+  defp resolve_lost_key_race(state, holder) do
+    case SessionStore.get(state.session_store, holder) do
+      {:ok, %{state: session_state} = winner} ->
+        if SessionState.terminal?(session_state) do
+          {:error, {:conflict, :session_idempotency_key_reused}}
+        else
+          {:ok, replay_view(winner)}
+        end
+
+      :error ->
+        {:error, {:denied, {:store, {:duplicate_session_idempotency_key, holder}}}}
     end
   end
 

--- a/projects/embervm/control/lib/embervm/session_store.ex
+++ b/projects/embervm/control/lib/embervm/session_store.ex
@@ -43,6 +43,12 @@ defmodule Embervm.SessionStore do
 
   @sessions_table :embervm_sessions
   @residency_table :embervm_session_residency
+  # #4919: {{principal, idempotency_key} -> session_id}. The hot-set side of the
+  # create-dedupe contract; the AUTHORITATIVE enforcement lives in the op-log
+  # projection's unique (principal, idempotency_key) constraint. Rebuilt from the
+  # durable rows on init, so a restart recovers every binding whose session row
+  # survived (retention compaction of a terminal row frees its key).
+  @idem_table :embervm_session_idempotency
 
   # The live (non-terminal) session states, for residency and other non-terminal
   # checks; the per-workload COUNTS bucket a subset of these into `:banked`
@@ -74,11 +80,12 @@ defmodule Embervm.SessionStore do
   restoring create (#4306 slice 3, `session_manager.ex`'s `register_and_start`)
   passes an EXISTING lineage_id explicitly and `session_id` absent, so a fresh
   session_id is minted while lineage_id stays pinned to the inherited value,
-  the one place the two diverge. Appends `session_created` (write-through),
-  inserts the ETS hot-set row in `:running` (the create claimed a live VM),
-  records the residency fact, and returns `{:ok, %{session_id, lineage_id,
-  token, expires_at, base_digest, ...}}`. The plaintext token is returned ONLY
-  here and never stored.
+  the one place the two diverge. `idempotency_key` (#4919) is optional and
+  carried into the durable row + its per-principal uniqueness binding. Appends
+  `session_created` (write-through), inserts the ETS hot-set row in `:running`
+  (the create claimed a live VM), records the residency fact, and returns
+  `{:ok, %{session_id, lineage_id, token, expires_at, base_digest, ...}}`. The
+  plaintext token is returned ONLY here and never stored.
   """
   @spec create(GenServer.server(), map()) :: {:ok, map()} | {:error, term()}
   def create(store \\ __MODULE__, attrs) do
@@ -255,6 +262,18 @@ defmodule Embervm.SessionStore do
   end
 
   @doc """
+  The session currently bound to (principal, idempotency_key) by its create,
+  any state (terminal included: reuse-after-destroy must CONFLICT, not
+  rebind), or `:error` when unbound. #4919's query-by-key seam: a workflow
+  tick looks its deterministic key up here before creating, so the spawn is an
+  upsert and a crash between spawn and record recovers the existing session.
+  """
+  @spec get_by_idempotency_key(GenServer.server(), String.t(), String.t()) :: {:ok, map()} | :error
+  def get_by_idempotency_key(store \\ __MODULE__, principal, key) do
+    GenServer.call(store, {:get_by_idempotency_key, principal, key})
+  end
+
+  @doc """
   Pages sessions for `workload`, newest-created first, by `:limit` (default 50)
   and `:offset` (default 0). A full ETS scan (bounded, listing is rare), never
   the op-log; serves `GET /v1/workloads/{name}/sessions`.
@@ -291,6 +310,7 @@ defmodule Embervm.SessionStore do
 
     sessions = :ets.new(@sessions_table, [:set, :private])
     residency = :ets.new(@residency_table, [:set, :private])
+    idem = :ets.new(@idem_table, [:set, :private])
 
     state = %{
       op_log: op_log,
@@ -302,6 +322,7 @@ defmodule Embervm.SessionStore do
       async_lifecycle_writes: async_lifecycle_writes,
       sessions: sessions,
       residency: residency,
+      idem: idem,
       # workload -> %{live, banked}, kept in step with the hot set on every write.
       counts: %{}
     }
@@ -325,6 +346,7 @@ defmodule Embervm.SessionStore do
           Enum.reduce(rows, state, fn row, acc ->
             session = row_to_session(row)
             :ets.insert(acc.sessions, {session.session_id, session})
+            index_idempotency(acc, session)
             bump_counts(acc, nil, session.state, session.workload)
           end)
 
@@ -333,6 +355,17 @@ defmodule Embervm.SessionStore do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  # The (principal, key) -> session_id hot-set binding. Rows with no principal
+  # or no key are unindexed (a keyed create always carries a principal).
+  defp index_idempotency(_state, %{idempotency_key: key}) when not is_binary(key) or key == "", do: :ok
+
+  defp index_idempotency(_state, %{principal: principal}) when not is_binary(principal), do: :ok
+
+  defp index_idempotency(state, session) do
+    :ets.insert(state.idem, {{session.principal, session.idempotency_key}, session.session_id})
+    :ok
   end
 
   defp row_to_session(row) do
@@ -360,7 +393,8 @@ defmodule Embervm.SessionStore do
       last_invoke_at: row.last_invoke_at,
       expires_at: row.expires_at,
       updated_at: row.updated_at,
-      terminal_reason: row.terminal_reason
+      terminal_reason: row.terminal_reason,
+      idempotency_key: Map.get(row, :idempotency_key)
     }
   end
 
@@ -464,6 +498,16 @@ defmodule Embervm.SessionStore do
     {:reply, reply, state}
   end
 
+  def handle_call({:get_by_idempotency_key, principal, key}, _from, state) do
+    reply =
+      case :ets.lookup(state.idem, {principal, key}) do
+        [{{^principal, ^key}, session_id}] -> get_view(state, session_id)
+        [] -> :error
+      end
+
+    {:reply, reply, state}
+  end
+
   def handle_call({:backfill_created, session_id}, _from, state) do
     case fetch(state, session_id) do
       {:ok, session} ->
@@ -486,7 +530,11 @@ defmodule Embervm.SessionStore do
             token_sha256: session.token_sha256,
             expires_at: session.expires_at,
             state: to_string(session.state),
-            lineage_id: session.lineage_id
+            lineage_id: session.lineage_id,
+            # #4919: the re-driven op carries the same binding key as the row it
+            # reconstructs, so a duplicate-key pre-check that resolves back to
+            # THIS session stays the benign no-op INSERT OR IGNORE already was.
+            idempotency_key: Map.get(session, :idempotency_key)
           }
         }
 
@@ -565,6 +613,10 @@ defmodule Embervm.SessionStore do
     # a rejoined volume. Groundwork only: this slice never diverges the two.
     lineage_id = Map.get(attrs, :lineage_id) || session_id
     {token, token_sha256} = SessionId.mint_token()
+    # #4919: the caller-supplied dedupe key (nil for an unkeyed create). The
+    # op-log projection enforces its uniqueness per principal; this module only
+    # carries it durably and indexes the hot set.
+    idempotency_key = normalize_key(Map.get(attrs, :idempotency_key))
 
     payload = %{
       node_id: Map.get(attrs, :node_id),
@@ -577,7 +629,8 @@ defmodule Embervm.SessionStore do
       # The durable projection defaults session_created to "running" (the create
       # already claimed a live VM); recorded explicitly for clarity.
       state: "running",
-      lineage_id: lineage_id
+      lineage_id: lineage_id,
+      idempotency_key: idempotency_key
     }
 
     op = %Op{
@@ -610,7 +663,8 @@ defmodule Embervm.SessionStore do
       last_invoke_at: nil,
       expires_at: Map.get(attrs, :expires_at),
       updated_at: ts,
-      terminal_reason: nil
+      terminal_reason: nil,
+      idempotency_key: idempotency_key
     }
 
     reply = %{
@@ -649,13 +703,23 @@ defmodule Embervm.SessionStore do
       case state.op_log_mod.append(state.op_log, op) do
         {:ok, _seq} ->
           insert_created_session(state, session)
+          index_idempotency(state, session)
           {:reply, {:ok, reply}, bump_counts(state, nil, :running, session.workload)}
 
         {:error, _reason} = error ->
+          # The durable append failed (a duplicate idempotency key among other
+          # reasons): ETS is untouched, so no hot-set row or binding exists for a
+          # session the log rejected. The caller surfaces the store reason.
           {:reply, error, state}
       end
     end
   end
+
+  # Absent/empty means "no key" (matching the router's header tolerance); a
+  # present key is carried verbatim. FORMAT validation is the SessionManager's
+  # job (it maps malformed input to a structured denial before anything runs).
+  defp normalize_key(key) when is_binary(key) and key != "", do: key
+  defp normalize_key(_other), do: nil
 
   # The ETS side of a create: the hot-set row + its residency fact. Shared by the
   # write-through and async paths so both land the identical in-memory state; only

--- a/projects/embervm/control/test/embervm/op_log/postgres_live_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/postgres_live_test.exs
@@ -156,6 +156,28 @@ defmodule Embervm.OpLog.PostgresLiveTest do
     assert {:ok, nil} = Postgres.load_request(server, "missing")
   end
 
+  # #4919: the session-side mirror of the tasks table's duplicate-idempotency-key
+  # transactional rollback, unique per principal.
+  test "a duplicate (principal, idempotency_key) session_created rolls back and names the holder", %{
+    server: server
+  } do
+    append(server, :session_created, 300,
+      tenant: "t1", principal: "p9", workload: "wl-session", session_id: "sess-k1",
+      payload: %{state: "running", node_id: "node-1", base_snapshot_ref: "base", base_digest: "digest",
+        token_sha256: "token-1", expires_at: 999, idempotency_key: "dup"}
+    )
+
+    assert {:error, {:duplicate_session_idempotency_key, "sess-k1"}} =
+             append(server, :session_created, 310,
+               tenant: "t1", principal: "p9", workload: "wl-session", session_id: "sess-k2",
+               payload: %{state: "running", node_id: "node-1", base_snapshot_ref: "base", base_digest: "digest",
+                 token_sha256: "token-2", expires_at: 999, idempotency_key: "dup"}
+             )
+
+    # The failed append left no row (and no ops trace): the transaction rolled back.
+    assert {:ok, [%{session_id: "sess-k1", idempotency_key: "dup"}]} = Postgres.load_sessions(server)
+  end
+
   test "list_usage returns accumulated task metering", %{server: server} do
     for {task_id, ts, cpu_ms} <- [{"usage-1", 5 * 86_400_000, 2_000}, {"usage-2", 5 * 86_400_000 + 1, 1_000}] do
       append(server, :submitted, ts, tenant: "t1", principal: "p1", workload: "wl-usage", task_id: task_id)

--- a/projects/embervm/control/test/embervm/op_log/session_projection_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/session_projection_test.exs
@@ -338,4 +338,93 @@ defmodule Embervm.OpLog.SessionProjectionTest do
 
     :ok = GenServer.stop(server)
   end
+
+  # -- idempotency-key binding (#4919) ----------------------------------------
+
+  test "a duplicate (principal, idempotency_key) session_created rolls the WHOLE append back", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("s-k1", "p1", 100, %{idempotency_key: "dup"}))
+
+    # Same key, same principal, different session: the append must fail with the
+    # EXISTING session id, and the failed op must leave no trace (the ops row is
+    # rolled back with the projection write, the pinned transactional semantics).
+    assert {:error, {:duplicate_session_idempotency_key, "s-k1"}} =
+             SQLite.append(server, created_op("s-k2", "p1", 200, %{idempotency_key: "dup"}))
+
+    {:ok, ops} = SQLite.read_from(server, 0)
+    refute Enum.any?(ops, &(&1.session_id == "s-k2"))
+    refute Map.has_key?(session_by_id(server), "s-k2")
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "the same key under a DIFFERENT principal is a distinct binding", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("s-pa", "pA", 100, %{idempotency_key: "shared"}))
+    {:ok, _} = SQLite.append(server, created_op("s-pb", "pB", 110, %{idempotency_key: "shared"}))
+
+    ids = session_by_id(server) |> Map.keys() |> Enum.sort()
+    assert ids == ["s-pa", "s-pb"]
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "a terminal session keeps its binding until retention compaction frees the key", %{path: path} do
+    server = start_server(path, retention_ms: 500)
+
+    {:ok, _} = SQLite.append(server, created_op("s-gone", "p1", 100, %{idempotency_key: "freed"}))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :session_destroyed,
+        tenant: "t1",
+        principal: "p1",
+        workload: "sandbox-session",
+        session_id: "s-gone",
+        ts: 200,
+        payload: %{reason: "destroyed"}
+      })
+
+    # While the row survives (terminal or not), the binding still conflicts.
+    assert {:error, {:duplicate_session_idempotency_key, "s-gone"}} =
+             SQLite.append(server, created_op("s-new", "p1", 300, %{idempotency_key: "freed"}))
+
+    # Retention prunes the terminal row past its window; only then does a fresh
+    # create under the same key succeed (the documented bounded lifetime).
+    {:ok, res} = SQLite.compact(server, 200 + 501)
+    assert res.sessions_compacted == 1
+
+    {:ok, _} = SQLite.append(server, created_op("s-fresh", "p1", 800, %{idempotency_key: "freed"}))
+    assert Map.has_key?(session_by_id(server), "s-fresh")
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "the binding is enforced again after a kill/restart (rebuild keeps it)", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("s-durable", "p1", 100, %{idempotency_key: "durable"}))
+    :ok = GenServer.stop(server)
+
+    server2 = start_server(path)
+
+    assert {:error, {:duplicate_session_idempotency_key, "s-durable"}} =
+             SQLite.append(server2, created_op("s-other", "p1", 200, %{idempotency_key: "durable"}))
+
+    :ok = GenServer.stop(server2)
+  end
+
+  test "load_sessions carries idempotency_key through the rebuild rows", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("s-carry", "p1", 100, %{idempotency_key: "carry-me"}))
+
+    {:ok, [row]} = SQLite.load_sessions(server)
+    assert row.session_id == "s-carry"
+    assert row.idempotency_key == "carry-me"
+
+    :ok = GenServer.stop(server)
+  end
 end

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -60,7 +60,10 @@ defmodule Embervm.RouterTest do
   # can drive the HTTP surface, and especially the SESSION-TOKEN auth boundary,
   # without a live daemon or the supervised SessionManager.
   defmodule FakeSessionManager do
-    def create(_srv, "wl-ok", _principal, _restore_lineage),
+    # The 5th arg is the create-call opts (the #4919 idempotency key rides in as
+    # idempotency_key: <header value or nil>); every clause below ignores it
+    # unless it exists to prove header threading.
+    def create(_srv, "wl-ok", _principal, _restore_lineage, _opts),
       do:
         {:ok,
          %{
@@ -73,9 +76,9 @@ defmodule Embervm.RouterTest do
            restored: false
          }}
 
-    def create(_srv, "wl-cap", _principal, _restore_lineage), do: {:error, {:denied, :session_cap}}
-    def create(_srv, "wl-vmcap", _principal, _restore_lineage), do: {:error, {:denied, :workload_cap}}
-    def create(_srv, "wl-task", _principal, _restore_lineage), do: {:error, {:denied, :not_session_class}}
+    def create(_srv, "wl-cap", _principal, _restore_lineage, _opts), do: {:error, {:denied, :session_cap}}
+    def create(_srv, "wl-vmcap", _principal, _restore_lineage, _opts), do: {:error, {:denied, :workload_cap}}
+    def create(_srv, "wl-task", _principal, _restore_lineage, _opts), do: {:error, {:denied, :not_session_class}}
 
     # #4306 slice 3: restore_lineage-carrying creates. wl-restore-ok only
     # returns restored: true when it actually RECEIVED restore_lineage (a
@@ -83,7 +86,7 @@ defmodule Embervm.RouterTest do
     # rather than the fake just always answering true. lineage_id echoes the
     # RECEIVED restore_lineage (item B): the response must expose the same
     # inherited lineage handle the caller sent, not the fresh session_id.
-    def create(_srv, "wl-restore-ok", _principal, restore_lineage) when is_binary(restore_lineage) and restore_lineage != "",
+    def create(_srv, "wl-restore-ok", _principal, restore_lineage, _opts) when is_binary(restore_lineage) and restore_lineage != "",
       do:
         {:ok,
          %{
@@ -96,16 +99,44 @@ defmodule Embervm.RouterTest do
            restored: true
          }}
 
-    def create(_srv, "wl-unknown-lineage", _principal, _restore_lineage), do: {:error, {:denied, :unknown_lineage}}
-    def create(_srv, "wl-lineage-workload-mismatch", _principal, _restore_lineage), do: {:error, {:denied, :lineage_workload_mismatch}}
-    def create(_srv, "wl-lineage-principal-mismatch", _principal, _restore_lineage), do: {:error, {:denied, :lineage_principal_mismatch}}
-    def create(_srv, "wl-lineage-live-heir", _principal, _restore_lineage), do: {:error, {:denied, :lineage_live_heir}}
+    def create(_srv, "wl-unknown-lineage", _principal, _restore_lineage, _opts), do: {:error, {:denied, :unknown_lineage}}
+    def create(_srv, "wl-lineage-workload-mismatch", _principal, _restore_lineage, _opts), do: {:error, {:denied, :lineage_workload_mismatch}}
+    def create(_srv, "wl-lineage-principal-mismatch", _principal, _restore_lineage, _opts), do: {:error, {:denied, :lineage_principal_mismatch}}
+    def create(_srv, "wl-lineage-live-heir", _principal, _restore_lineage, _opts), do: {:error, {:denied, :lineage_live_heir}}
 
     # #4306/#4313 review fix 2: TOCTOU guard denial.
-    def create(_srv, "wl-lineage-restore-in-flight", _principal, _restore_lineage),
+    def create(_srv, "wl-lineage-restore-in-flight", _principal, _restore_lineage, _opts),
       do: {:error, {:denied, :lineage_restore_in_flight}}
 
-    def create(_srv, _wl, _principal, _restore_lineage), do: {:error, {:denied, :unknown_workload}}
+    # #4919: the replay/conflict/invalid-key response shapes, plus wl-idem-echo,
+    # which answers successfully ONLY when the router threaded the exact
+    # Idempotency-Key header value through, proving the hop.
+    def create(_srv, "wl-idem-echo", _principal, _restore_lineage, opts) do
+      case Keyword.get(opts, :idempotency_key) do
+        "thread-me" ->
+          {:ok,
+           %{
+             session_id: "s-replayed",
+             lineage_id: "s-replayed",
+             expires_at: 9_000_000,
+             base_digest: "sha256:x",
+             state: :running,
+             restored: false,
+             replayed: true
+           }}
+
+        _ ->
+          {:error, {:denied, :unknown_workload}}
+      end
+    end
+
+    def create(_srv, "wl-idem-conflict", _principal, _restore_lineage, _opts),
+      do: {:error, {:conflict, :session_idempotency_key_reused}}
+
+    def create(_srv, "wl-idem-invalid", _principal, _restore_lineage, _opts),
+      do: {:error, {:denied, :invalid_idempotency_key}}
+
+    def create(_srv, _wl, _principal, _restore_lineage, _opts), do: {:error, {:denied, :unknown_workload}}
 
     def invoke(_srv, "s-live", _req), do: {:ok, %{status_code: 200, headers: %{"content-type" => "text/plain"}, body: "echoed"}}
     def invoke(_srv, "s-queue", _req), do: {:error, :queue_full}
@@ -120,7 +151,7 @@ defmodule Embervm.RouterTest do
   end
 
   defmodule TimeoutSessionManager do
-    def create(server, _workload, _principal, _restore_lineage) do
+    def create(server, _workload, _principal, _restore_lineage, _opts) do
       timeout = Application.fetch_env!(:embervm, :session_create_call_timeout_ms)
       GenServer.call(server, :create, timeout)
     end
@@ -156,6 +187,26 @@ defmodule Embervm.RouterTest do
       do: {:ok, %{items: [], total: 0, limit: 50, offset: 0}}
 
     def list(_srv, _wl, _opts), do: {:ok, %{items: [], total: 0, limit: 50, offset: 0}}
+
+    # #4919 query-by-key: one known binding for the list-by-key request test.
+    def get_by_idempotency_key(_srv, _principal, "find-me"),
+      do:
+        {:ok,
+         %{
+           session_id: "s-live",
+           workload: "wl-ok",
+           principal: "p",
+           state: :running,
+           generation: 0,
+           base_digest: "sha256:x",
+           created_at: 1,
+           last_invoke_at: nil,
+           expires_at: 9_000_000,
+           updated_at: 1,
+           terminal_reason: nil
+         }}
+
+    def get_by_idempotency_key(_srv, _principal, _key), do: :error
 
     def all(_srv) do
       [
@@ -1127,6 +1178,73 @@ defmodule Embervm.RouterTest do
     assert json(resp.body)["restored"] == false
   end
 
+  # -- Idempotency-Key on session create (#4919) ------------------------------
+
+  test "POST .../sessions threads the Idempotency-Key header through and answers a replay with 200 and no token" do
+    with_session_fakes()
+
+    resp =
+      req(
+        :post,
+        "/v1/workloads/wl-idem-echo/sessions",
+        auth("good") ++ [{"idempotency-key", "thread-me"}]
+      )
+
+    assert resp.status == 200
+    body = json(resp.body)
+    assert body["session_id"] == "s-replayed"
+    # The capability token was returned ONCE (at the original create); a replay
+    # view carries the session's current state but never a fresh token.
+    refute Map.has_key?(body, "session_token")
+    assert body["replayed"] == true
+  end
+
+  test "POST .../sessions without the header passes no idempotency key (normal create path)" do
+    with_session_fakes()
+
+    # wl-idem-echo only succeeds when the exact key arrives, so a bare request
+    # proves the router forwards an ABSENT key as absent, not as some default.
+    resp = req(:post, "/v1/workloads/wl-idem-echo/sessions", auth("good"))
+    assert resp.status == 404
+    assert json(resp.body)["reason"] == "unknown_workload"
+  end
+
+  test "POST .../sessions with a reused-after-destroy key is a non-retryable 409 conflict" do
+    with_session_fakes()
+
+    resp =
+      req(
+        :post,
+        "/v1/workloads/wl-idem-conflict/sessions",
+        auth("good") ++ [{"idempotency-key", "dead/run"}]
+      )
+
+    assert resp.status == 409
+    body = json(resp.body)
+    assert body["reason"] == "session_idempotency_key_reused"
+    assert body["retryable"] == false
+  end
+
+  test "POST .../sessions with an oversized key is a 400" do
+    with_session_fakes()
+
+    # An oversized key travels fine over HTTP and must be denied BY THE CONTROL
+    # PLANE (400), not by an HTTP client. Control-character keys never reach the
+    # router over HTTP/1 (the client refuses them first), so byte-level
+    # malformedness is pinned in SessionCreateIdempotencyTest against the
+    # manager directly.
+    oversized =
+      req(
+        :post,
+        "/v1/workloads/wl-idem-invalid/sessions",
+        auth("good") ++ [{"idempotency-key", String.duplicate("k", 201)}]
+      )
+
+    assert oversized.status == 400
+    assert json(oversized.body)["reason"] == "invalid_idempotency_key"
+    assert json(oversized.body)["retryable"] == false
+  end
+
   test "an empty or malformed restore_lineage body is treated as a normal create, not an error" do
     with_session_fakes()
 
@@ -1274,6 +1392,21 @@ defmodule Embervm.RouterTest do
     body = json(resp.body)
     assert body["workload"] == "wl-ok"
     assert body["items"] == []
+  end
+
+  test "GET /v1/workloads/:name/sessions?idempotency_key= resolves one session by key (#4919)" do
+    with_session_fakes()
+
+    hit = req(:get, "/v1/workloads/wl-ok/sessions?idempotency_key=find-me", auth("good"))
+    assert hit.status == 200
+    body = json(hit.body)
+    assert body["total"] == 1
+    assert [%{"session_id" => "s-live"}] = body["items"]
+
+    miss = req(:get, "/v1/workloads/wl-ok/sessions?idempotency_key=never-seen", auth("good"))
+    assert miss.status == 200
+    assert json(miss.body)["total"] == 0
+    assert json(miss.body)["items"] == []
   end
 
   # -- activator (R3, Task 8) ------------------------------------------------

--- a/projects/embervm/control/test/embervm/session_create_idempotency_test.exs
+++ b/projects/embervm/control/test/embervm/session_create_idempotency_test.exs
@@ -1,0 +1,411 @@
+defmodule Embervm.SessionCreateIdempotencyTest do
+  @moduledoc """
+  #4919 acceptance: idempotent session creation with a client-supplied key.
+
+  Covers the four required behaviours plus the store-level contract:
+
+    * a same-key retry returns the SAME live session (no duplicate row, no
+      second token, no capacity consumed);
+    * two concurrent same-key creates (the second parked behind the first's
+      in-flight create) resolve to exactly ONE durable session;
+    * reusing a key after its session is DESTROYED is a conflict, never a
+      silent fresh session;
+    * malformed and oversized keys are rejected before anything is placed;
+    * different keys and an absent key behave exactly like today;
+    * the binding is scoped per principal and survives a store rebuild from
+      the durable op-log projection.
+
+  The harness is the session_manager_test stack idiom: a real unnamed SQLite
+  op-log + real SessionStore give the real FSM and durable projection, with
+  fake daemon seams; unique ETS tables keep tests isolated.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Embervm.{NodeCapacity, SessionManager, SessionStore, WorkloadCatalog}
+  alias Embervm.Node.V1.PrimeResponse
+  alias Embervm.OpLog.SQLite
+
+  setup do
+    %{ctx: start_stack()}
+  end
+
+  # -- harness ---------------------------------------------------------------
+
+  defp start_stack(opts \\ []) do
+    suffix = System.unique_integer([:positive])
+    cap_table = :"icap_#{suffix}"
+    cat_table = :"icat_#{suffix}"
+
+    NodeCapacity.create(cap_table)
+    WorkloadCatalog.create(cat_table)
+
+    path = Path.join(System.tmp_dir!(), "embervm_session_idem_test_#{suffix}.db")
+    on_exit(fn -> File.rm_rf!(path) end)
+
+    {:ok, op_log} = SQLite.start_link(name: nil, path: path)
+    {:ok, writer} = Embervm.AsyncWriter.start_link(name: nil)
+    {:ok, store} = SessionStore.start_link(name: nil, op_log: op_log, async_writer: writer)
+
+    registry = :"ireg_#{suffix}"
+    {:ok, _} = Registry.start_link(keys: :unique, name: registry)
+    {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+    claim_fun =
+      Keyword.get(opts, :claim_fun, fn _dispatcher, _node, _workload -> {:ok, "vm-#{suffix}"} end)
+
+    {:ok, mgr} =
+      SessionManager.start_link(
+        name: nil,
+        session_store: store,
+        supervisor: sup,
+        registry: registry,
+        capacity_table: cap_table,
+        catalog_table: cat_table,
+        clock: fn -> 5_000_000 end,
+        monotonic_clock: fn -> -800_000 end,
+        channel_fun: fn _node -> {:ok, :fake_channel} end,
+        claim_fun: claim_fun,
+        prime_fun: fn _ch, _req -> {:ok, %PrimeResponse{vm_id: "vm-primed-#{suffix}"}} end,
+        bank_fun: fn _ch, req -> {:ok, %{snapshot_ref: "snap-#{req.session_id}", size_bytes: 1_000}} end,
+        relight_fun: fn _ch, _req -> {:ok, %{vm_id: "vm-relit"}} end,
+        evict_fun: fn _ch, _req -> {:ok, %{}} end,
+        evict_artifact_fun: fn _ch, _req -> {:ok, %{}} end,
+        restore_artifact_fun: fn _ch, _req -> {:error, %GRPC.RPCError{status: 5}} end,
+        archive_volume_fun: fn _ch, _req -> {:ok, %{skipped: false}} end,
+        retire_volume_fun: fn _ch, _req -> {:ok, %{}} end,
+        delete_session_volume_fun: fn _ch, _req -> {:ok, %{}} end,
+        session_opts: [
+          channel_fun: fn _node -> {:ok, :ch} end,
+          assign_fun: fn _ch, req ->
+            {:ok,
+             %Embervm.Node.V1.SessionAssignResponse{
+               response: %Embervm.Node.V1.GuestResponse{status_code: 200, headers: %{}, body: req.request.body},
+               usage: nil,
+               suspect: false
+             }}
+          end,
+          destroy_fun: fn _ch, _vm -> {:ok, %{teardown_confirmed: true}} end,
+          invalidate_fun: fn _node, _ch -> :ok end
+        ],
+        async_writer: writer,
+        op_log: op_log,
+        op_log_mod: SQLite
+      )
+
+    ctx = %{
+      mgr: mgr,
+      store: store,
+      op_log: op_log,
+      cap_table: cap_table,
+      cat_table: cat_table,
+      registry: registry,
+      sup: sup,
+      path: path
+    }
+
+    put_session_workload(ctx, "wl-idem")
+    ctx
+  end
+
+  defp put_session_workload(ctx, wl) do
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      node_id: "node-4",
+      pod_uid: "pod-node-4",
+      configured_id: "node-4",
+      workloads: %{
+        wl => %{
+          free_primed_slots: 1,
+          snapshot_ref: "snap-#{wl}",
+          base_state: :BASE_BUILD_STATE_READY,
+          primed_vm_ids: []
+        }
+      },
+      live_vms: 0,
+      max_live_vms: 8,
+      draining: false,
+      store_reachable: true,
+      updated_at: 5_000_000
+    })
+
+    WorkloadCatalog.upsert(ctx.cat_table, wl, %{
+      name: wl,
+      namespace: "embervm",
+      class: "session",
+      image_ref: "img@sha256:abc",
+      invoke_path: "/",
+      timeout_ms: 90_000,
+      cap: 8,
+      floor: 1,
+      session: %{
+        idle_bank_seconds: 300,
+        max_lifetime_seconds: 3600,
+        banked_ttl_seconds: 3600,
+        max_sessions: 16,
+        invoke_queue_cap: 4
+      },
+      mem_mib: nil,
+      persistence: nil
+    })
+  end
+
+  defp eventually(fun), do: eventually(fun, 200)
+
+  defp eventually(_fun, 0), do: flunk("condition not met in time")
+
+  defp eventually(fun, n) do
+    if fun.(), do: :ok, else: (Process.sleep(10) && eventually(fun, n - 1))
+  end
+
+  defp created_ops(op_log) do
+    {:ok, ops} = SQLite.read_from(op_log, 0)
+    Enum.filter(ops, &(&1.kind == :session_created))
+  end
+
+  defp destroy_and_settle(ctx, session_id) do
+    {:ok, _} = SessionManager.destroy(ctx.mgr, session_id)
+    eventually(fn ->
+      match?({:ok, %{state: :destroyed}}, SessionStore.get(ctx.store, session_id))
+    end)
+  end
+
+  # -- same-key retry --------------------------------------------------------
+
+  test "a same-key retry returns the SAME live session without minting a duplicate", %{ctx: ctx} do
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil, idempotency_key: "run/42/step")
+
+    assert %{session_id: session_id, token: token} = created
+    refute Map.get(created, :replayed)
+
+    {:ok, replay} = SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil, idempotency_key: "run/42/step")
+
+    # The SAME session, its current state, no fresh capability token.
+    assert replay.session_id == session_id
+    assert replay.replayed == true
+    refute Map.has_key?(replay, :token)
+    assert token != nil
+
+    # Exactly one durable session and one create op; the retry consumed nothing.
+    assert %{live: 1, banked: 0} = SessionStore.counts(ctx.store, "wl-idem")
+    assert length(created_ops(ctx.op_log)) == 1
+  end
+
+  test "the store resolves a session by (principal, key), scoped to that principal", %{ctx: ctx} do
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil, idempotency_key: "scope-key")
+
+    assert {:ok, %{session_id: session_id}} =
+             SessionStore.get_by_idempotency_key(ctx.store, "principal-a", "scope-key")
+
+    assert session_id == created.session_id
+    # A different principal's binding is invisible: keys are unique PER PRINCIPAL.
+    assert :error = SessionStore.get_by_idempotency_key(ctx.store, "principal-b", "scope-key")
+    assert :error = SessionStore.get_by_idempotency_key(ctx.store, "principal-a", "other-key")
+  end
+
+  # -- concurrency -----------------------------------------------------------
+
+  test "two concurrent same-key creates yield exactly one session", %{ctx: ctx} do
+    # Re-stack with a claim gate so create A is provably mid-worker when B lands.
+    GenServer.stop(ctx.mgr)
+    test_pid = self()
+
+    {:ok, mgr2} =
+      SessionManager.start_link(
+        name: nil,
+        session_store: ctx.store,
+        supervisor: ctx.sup,
+        registry: ctx.registry,
+        capacity_table: ctx.cap_table,
+        catalog_table: ctx.cat_table,
+        clock: fn -> 5_000_000 end,
+        monotonic_clock: fn -> -800_000 end,
+        channel_fun: fn _node -> {:ok, :fake_channel} end,
+        claim_fun: fn _d, _n, _w ->
+          # Signal ENTRY (with this worker's pid so the test can release it)
+          # then hold the create mid-worker until the test sends :go HERE.
+          send(test_pid, {:claim_entered, self()})
+
+          receive do
+            :go -> {:ok, "vm-gated"}
+          end
+        end,
+        prime_fun: fn _ch, _req -> {:ok, %PrimeResponse{vm_id: "vm-primed"}} end,
+        bank_fun: fn _ch, req -> {:ok, %{snapshot_ref: "snap-#{req.session_id}", size_bytes: 1_000}} end,
+        relight_fun: fn _ch, _req -> {:ok, %{vm_id: "vm-relit"}} end,
+        evict_fun: fn _ch, _req -> {:ok, %{}} end,
+        evict_artifact_fun: fn _ch, _req -> {:ok, %{}} end,
+        restore_artifact_fun: fn _ch, _req -> {:error, %GRPC.RPCError{status: 5}} end,
+        archive_volume_fun: fn _ch, _req -> {:ok, %{skipped: false}} end,
+        retire_volume_fun: fn _ch, _req -> {:ok, %{}} end,
+        delete_session_volume_fun: fn _ch, _req -> {:ok, %{}} end,
+        session_opts: [
+          channel_fun: fn _node -> {:ok, :ch} end,
+          assign_fun: fn _ch, req ->
+            {:ok,
+             %Embervm.Node.V1.SessionAssignResponse{
+               response: %Embervm.Node.V1.GuestResponse{status_code: 200, headers: %{}, body: req.request.body},
+               usage: nil,
+               suspect: false
+             }}
+          end,
+          destroy_fun: fn _ch, _vm -> {:ok, %{teardown_confirmed: true}} end,
+          invalidate_fun: fn _node, _ch -> :ok end
+        ],
+        async_writer: Embervm.AsyncWriter,
+        op_log: ctx.op_log,
+        op_log_mod: SQLite
+      )
+
+    task_a =
+      Task.async(fn -> SessionManager.create(mgr2, "wl-idem", "principal-a", nil, idempotency_key: "conc") end)
+
+    # Deterministic overlap: A is inside its worker (in-flight registered) before
+    # B arrives, and A cannot SETTLE until the test releases its worker, so B can
+    # only park behind it (or, in the degenerate race where :go lands first,
+    # replay the finished winner: the same session either way).
+    assert_receive {:claim_entered, worker_a}, 2_000
+
+    task_b =
+      Task.async(fn -> SessionManager.create(mgr2, "wl-idem", "principal-a", nil, idempotency_key: "conc") end)
+
+    Process.sleep(20)
+    send(worker_a, :go)
+
+    {:ok, res_a} = Task.await(task_a)
+    {:ok, res_b} = Task.await(task_b)
+
+    assert res_a.session_id == res_b.session_id
+
+    # Exactly ONE response carries the capability token; the other is a replay view.
+    tokens = [Map.get(res_a, :token), Map.get(res_b, :token)]
+    assert Enum.count(tokens, &is_binary/1) == 1
+    replays = [Map.get(res_a, :replayed), Map.get(res_b, :replayed)]
+    assert Enum.count(replays, & &1) == 1
+
+    assert %{live: 1} = SessionStore.counts(ctx.store, "wl-idem")
+    assert length(created_ops(ctx.op_log)) == 1
+  end
+
+  test "concurrent same-key creates from DIFFERENT principals are independent", %{ctx: ctx} do
+    {:ok, a} = SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil, idempotency_key: "shared")
+    {:ok, b} = SessionManager.create(ctx.mgr, "wl-idem", "principal-b", nil, idempotency_key: "shared")
+
+    refute a.session_id == b.session_id
+    assert %{live: 2} = SessionStore.counts(ctx.store, "wl-idem")
+  end
+
+  # -- reuse after destroy ---------------------------------------------------
+
+  test "reusing a key after its session is destroyed CONFLICTS instead of silently creating", %{ctx: ctx} do
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil, idempotency_key: "dead/run")
+    destroy_and_settle(ctx, created.session_id)
+
+    assert {:error, {:conflict, :session_idempotency_key_reused}} =
+             SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil, idempotency_key: "dead/run")
+
+    # Still exactly one row (terminal), no second session ever minted.
+    assert length(created_ops(ctx.op_log)) == 1
+    assert %{live: 0, banked: 0} = SessionStore.counts(ctx.store, "wl-idem")
+  end
+
+  test "the binding survives a store rebuild from the durable projection", %{ctx: ctx} do
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil, idempotency_key: "restart-k")
+
+    GenServer.stop(ctx.mgr)
+    GenServer.stop(ctx.store)
+
+    {:ok, writer} = Embervm.AsyncWriter.start_link(name: nil)
+    {:ok, store} = SessionStore.start_link(name: nil, op_log: ctx.op_log, async_writer: writer)
+
+    {:ok, mgr} =
+      SessionManager.start_link(
+        name: nil,
+        session_store: store,
+        supervisor: ctx.sup,
+        registry: ctx.registry,
+        capacity_table: ctx.cap_table,
+        catalog_table: ctx.cat_table,
+        clock: fn -> 5_000_000 end,
+        monotonic_clock: fn -> -800_000 end,
+        channel_fun: fn _node -> {:ok, :fake_channel} end,
+        claim_fun: fn _d, _n, _w -> {:ok, "vm-x"} end,
+        prime_fun: fn _ch, _req -> {:ok, %PrimeResponse{vm_id: "vm-primed"}} end,
+        bank_fun: fn _ch, req -> {:ok, %{snapshot_ref: "snap-#{req.session_id}", size_bytes: 1_000}} end,
+        relight_fun: fn _ch, _req -> {:ok, %{vm_id: "vm-relit"}} end,
+        evict_fun: fn _ch, _req -> {:ok, %{}} end,
+        evict_artifact_fun: fn _ch, _req -> {:ok, %{}} end,
+        restore_artifact_fun: fn _ch, _req -> {:error, %GRPC.RPCError{status: 5}} end,
+        archive_volume_fun: fn _ch, _req -> {:ok, %{skipped: false}} end,
+        retire_volume_fun: fn _ch, _req -> {:ok, %{}} end,
+        delete_session_volume_fun: fn _ch, _req -> {:ok, %{}} end,
+        session_opts: [
+          channel_fun: fn _node -> {:ok, :ch} end,
+          assign_fun: fn _ch, req ->
+            {:ok,
+             %Embervm.Node.V1.SessionAssignResponse{
+               response: %Embervm.Node.V1.GuestResponse{status_code: 200, headers: %{}, body: req.request.body},
+               usage: nil,
+               suspect: false
+             }}
+          end,
+          destroy_fun: fn _ch, _vm -> {:ok, %{teardown_confirmed: true}} end,
+          invalidate_fun: fn _node, _ch -> :ok end
+        ],
+        async_writer: writer,
+        op_log: ctx.op_log,
+        op_log_mod: SQLite
+      )
+
+    # Rebuild recovered the index: the same key still resolves to the SAME session.
+    {:ok, replay} = SessionManager.create(mgr, "wl-idem", "principal-a", nil, idempotency_key: "restart-k")
+    assert replay.session_id == created.session_id
+    assert replay.replayed == true
+    assert length(created_ops(ctx.op_log)) == 1
+  end
+
+  # -- malformed / oversized keys ---------------------------------------------
+
+  test "oversized keys are rejected before anything is placed", %{ctx: ctx} do
+    oversized = String.duplicate("k", 201)
+
+    assert {:error, {:denied, :invalid_idempotency_key}} =
+             SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil, idempotency_key: oversized)
+
+    assert %{live: 0} = SessionStore.counts(ctx.store, "wl-idem")
+    assert created_ops(ctx.op_log) == []
+  end
+
+  test "malformed keys (non-printable, non-ASCII) are rejected", %{ctx: ctx} do
+    for bad <- ["has\0nul", "cl\xc3\xa9", "\u0007bell"] do
+      assert {:error, {:denied, :invalid_idempotency_key}} =
+               SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil, idempotency_key: bad),
+             "expected #{inspect(bad)} to be rejected"
+    end
+
+    assert created_ops(ctx.op_log) == []
+  end
+
+  # -- unchanged behaviour ----------------------------------------------------
+
+  test "different keys and an absent key behave as today (fresh sessions)", %{ctx: ctx} do
+    {:ok, a} = SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil, idempotency_key: "k1")
+    {:ok, b} = SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil, idempotency_key: "k2")
+    {:ok, c} = SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil)
+
+    ids = [a.session_id, b.session_id, c.session_id]
+    assert length(Enum.uniq(ids)) == 3
+
+    for res <- [a, b, c] do
+      assert is_binary(Map.fetch!(res, :token))
+      refute Map.get(res, :replayed)
+    end
+
+    assert %{live: 3} = SessionStore.counts(ctx.store, "wl-idem")
+
+    # An empty header normalizes to ABSENT (no key), matching the
+    # restore_lineage tolerance idiom: it is a normal create, not an error.
+    {:ok, d} = SessionManager.create(ctx.mgr, "wl-idem", "principal-a", nil, idempotency_key: "")
+    refute Map.get(d, :replayed)
+    assert %{live: 4} = SessionStore.counts(ctx.store, "wl-idem")
+  end
+end

--- a/projects/embervm/docs/api.yaml
+++ b/projects/embervm/docs/api.yaml
@@ -125,16 +125,54 @@ paths:
         Assigns a primed pristine VM from the pool (principal-bound at claim) and
         returns a per-session capability token EXACTLY ONCE. The invocation
         front-end never computes placement; the control plane owns node choice.
+        An optional Idempotency-Key makes the create an upsert (#4919): the
+        first create binds the key to the new session per principal; a retry
+        with the same key answers 200 with the SAME live session's current state
+        and NO token (the capability was returned once, at the original create);
+        a key whose session went terminal answers 409 rather than silently
+        minting a fresh session. Keys are 1..200 bytes of printable ASCII,
+        scoped per principal, and their binding lives as long as the session's
+        durable row (retention of a terminal session eventually frees its key).
       parameters:
         - { name: name, in: path, required: true, schema: { type: string } }
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema: { type: string, minLength: 1, maxLength: 200 }
+          description: >-
+            Client-supplied dedupe key, unique per principal (two principals may
+            reuse one key independently). Deterministic workflow keys such as
+            swarm/{run_id}/{node_id} make a retried step's create an upsert and
+            let a crash between spawn and record recover the existing session;
+            GET ?idempotency_key= queries the binding directly.
       responses:
         "201":
           description: Session created. The session_token is returned only here.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/SessionCreated" }
+        "200":
+          description: >-
+            Same-key retry against an existing LIVE session (idempotent replay).
+            Carries the session's current identity and replayed: true, never a
+            session_token.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SessionReplayed" }
+        "400":
+          description: Malformed or oversized Idempotency-Key (>200 bytes or non-printable ASCII).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "403": { description: Workload is not class session, or the caller is not allow-listed. }
         "404": { description: Unknown workload. }
+        "409":
+          description: >-
+            The Idempotency-Key is bound to a TERMINAL session (destroyed,
+            expired, evicted, failed). Mint a new key to create again.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "429":
           description: >-
             Create denied: session cap (live+banked+parked >= maxSessions), workload
@@ -149,9 +187,17 @@ paths:
         - { name: name, in: path, required: true, schema: { type: string } }
         - { name: limit, in: query, schema: { type: integer, default: 50, minimum: 1, maximum: 500 } }
         - { name: offset, in: query, schema: { type: integer, default: 0, minimum: 0 } }
+        - name: idempotency_key
+          in: query
+          required: false
+          schema: { type: string }
+          description: >-
+            Query by create key instead of paging: resolves the single session
+            bound to (your principal, this key), empty page when unbound. Scoped
+            to the caller's principal; another principal's bindings are invisible.
       responses:
         "200":
-          description: Session page.
+          description: Session page (a single-item page when idempotency_key is present).
           content:
             application/json:
               schema: { $ref: "#/components/schemas/SessionPage" }
@@ -268,6 +314,20 @@ components:
         expires_at: { type: integer, description: "Max-lifetime deadline, epoch ms." }
         base_digest: { type: string, description: The birth base the session is pinned to. }
         state: { type: string, enum: [running] }
+    SessionReplayed:
+      type: object
+      description: >-
+        The response body of a same-key idempotent retry (#4919): the existing
+        session's current state. No session_token field exists here by design;
+        the capability was returned once, on the original 201.
+      properties:
+        session_id: { type: string }
+        lineage_id: { type: string }
+        expires_at: { type: integer, description: epoch ms }
+        base_digest: { type: string }
+        state: { type: string, description: The session's current FSM state (e.g. running). }
+        restored: { type: boolean, enum: [false] }
+        replayed: { type: boolean, enum: [true] }
     SessionView:
       type: object
       properties:


### PR DESCRIPTION
Closes #4919.

Optional `Idempotency-Key` on `POST /v1/workloads/{name}/sessions` makes session create an upsert, so a retried DBOS step (or any at-least-once caller) can no longer mint duplicate sessions:

- same-key retry against a live holder replays the SAME session (200, capability token returned exactly once); concurrent same-key creates park and resolve to the winner; reuse after the holder went terminal conflicts (compaction frees the key); malformed/oversized keys 400 before anything runs
- enforcement lives in the op-log projection, not check-then-create: both backends gain `sessions.idempotency_key` plus a unique partial `(principal, idempotency_key)` index, collision rolls back the whole append; the self-holder no-op preserves adopt-and-backfill's ON CONFLICT DO NOTHING contract
- SessionStore indexes the key in ETS, rebuilds from the projection on boot; docs/api.yaml documents the header

Verified locally with the full pinned-toolchain replication (incl. the fake noded and live Postgres 18): new tests 23/0, affected suites green after one test fix, full suite 1465 tests with 1 pre-existing RouterTest flake (baseline-proven on clean main). `ci` green (149 affected targets); the ExUnit genrule runs in pr-checks/queue rather than the local affected set.

Implemented by ox-alpha via opencode, reviewed on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K