### PR TITLE
feat(embervm): node-local git mirror over smart http for hydration

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -590,7 +590,13 @@ apko.translate_lock(
     name = "embervm_runtime_pi_lock",
     lock = "//projects/embervm/runtimes/pi:apko.lock.json",
 )
-use_repo(apko, "embervm_conformance_lock", "embervm_lock", "embervm_noded_lock", "embervm_runtime_bazel_lock", "embervm_runtime_claude_lock", "embervm_runtime_k3s_agent_lock", "embervm_runtime_k3s_server_lock", "embervm_runtime_pi_lock", "embervm_runtime_postgres_lock", "embervm_runtime_python_lock", "embervm_scratch_prep_lock", "embervm_tokenbroker_lock", "embervm_xds_lock", "monolith_frontend_lock", "rootfs_builder_lock", "sandbox_elixir_lock", "sandbox_go_lock", "sandbox_javascript_lock", "sandbox_ocaml_lock", "sandbox_python_lock", "sandbox_rust_lock", "semgrep_guest_lock", "shotter_lock", "whatsapp_lock")
+
+apko.translate_lock(
+    name = "embervm_mirror_lock",
+    lock = "//projects/embervm/mirror/image:apko.lock.json",
+)
+
+use_repo(apko, "embervm_conformance_lock", "embervm_mirror_lock", "embervm_lock", "embervm_noded_lock", "embervm_runtime_bazel_lock", "embervm_runtime_claude_lock", "embervm_runtime_k3s_agent_lock", "embervm_runtime_k3s_server_lock", "embervm_runtime_pi_lock", "embervm_runtime_postgres_lock", "embervm_runtime_python_lock", "embervm_scratch_prep_lock", "embervm_tokenbroker_lock", "embervm_xds_lock", "monolith_frontend_lock", "rootfs_builder_lock", "sandbox_elixir_lock", "sandbox_go_lock", "sandbox_javascript_lock", "sandbox_ocaml_lock", "sandbox_python_lock", "sandbox_rust_lock", "semgrep_guest_lock", "shotter_lock", "whatsapp_lock")
 
 # Download multiarch archives (binaries from zip files)
 multiarch_http_archive = use_repo_rule("//bazel/tools/http:multiarch_http_archive.bzl", "multiarch_http_archive")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -590,13 +590,11 @@ apko.translate_lock(
     name = "embervm_runtime_pi_lock",
     lock = "//projects/embervm/runtimes/pi:apko.lock.json",
 )
-
 apko.translate_lock(
     name = "embervm_mirror_lock",
     lock = "//projects/embervm/mirror/image:apko.lock.json",
 )
-
-use_repo(apko, "embervm_conformance_lock", "embervm_mirror_lock", "embervm_lock", "embervm_noded_lock", "embervm_runtime_bazel_lock", "embervm_runtime_claude_lock", "embervm_runtime_k3s_agent_lock", "embervm_runtime_k3s_server_lock", "embervm_runtime_pi_lock", "embervm_runtime_postgres_lock", "embervm_runtime_python_lock", "embervm_scratch_prep_lock", "embervm_tokenbroker_lock", "embervm_xds_lock", "monolith_frontend_lock", "rootfs_builder_lock", "sandbox_elixir_lock", "sandbox_go_lock", "sandbox_javascript_lock", "sandbox_ocaml_lock", "sandbox_python_lock", "sandbox_rust_lock", "semgrep_guest_lock", "shotter_lock", "whatsapp_lock")
+use_repo(apko, "embervm_conformance_lock", "embervm_lock", "embervm_mirror_lock", "embervm_noded_lock", "embervm_runtime_bazel_lock", "embervm_runtime_claude_lock", "embervm_runtime_k3s_agent_lock", "embervm_runtime_k3s_server_lock", "embervm_runtime_pi_lock", "embervm_runtime_postgres_lock", "embervm_runtime_python_lock", "embervm_scratch_prep_lock", "embervm_tokenbroker_lock", "embervm_xds_lock", "monolith_frontend_lock", "rootfs_builder_lock", "sandbox_elixir_lock", "sandbox_go_lock", "sandbox_javascript_lock", "sandbox_ocaml_lock", "sandbox_python_lock", "sandbox_rust_lock", "semgrep_guest_lock", "shotter_lock", "whatsapp_lock")
 
 # Download multiarch archives (binaries from zip files)
 multiarch_http_archive = use_repo_rule("//bazel/tools/http:multiarch_http_archive.bzl", "multiarch_http_archive")

--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -32,6 +32,7 @@ multirun(
         "//projects/embervm/chart:chart.push",
         "//projects/embervm/conformance:image.push",
         "//projects/embervm/image:image.push",
+        "//projects/embervm/mirror/image:image.push",
         "//projects/embervm/noded/image:image.push",
         "//projects/embervm/runtimes/bazel:image.push",
         "//projects/embervm/runtimes/claude:image.push",

--- a/bazel/images/digests/BUILD
+++ b/bazel/images/digests/BUILD
@@ -14,6 +14,7 @@ oci_digest_manifest(
         "//bazel/tools/image:image.info": "//bazel/tools/image:image.push",
         "//projects/embervm/conformance:image.info": "//projects/embervm/conformance:image.push",
         "//projects/embervm/image:image.info": "//projects/embervm/image:image.push",
+        "//projects/embervm/mirror/image:image.info": "//projects/embervm/mirror/image:image.push",
         "//projects/embervm/noded/image:image.info": "//projects/embervm/noded/image:image.push",
         "//projects/embervm/runtimes/bazel:image.info": "//projects/embervm/runtimes/bazel:image.push",
         "//projects/embervm/runtimes/claude:image.info": "//projects/embervm/runtimes/claude:image.push",

--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -39,6 +39,10 @@ helm_chart(
         # The egress-proxy sidecar (ADR 023). Pinned from its
         # .info so the sidecar the daemon tunnels to is the digest CI built.
         "egress.image": "//projects/firecracker/substrate/egress-proxy:image.info",
+        # The node-local git mirror sidecar (#4473). Distinct FLAT top-level key
+        # (D14a.6), pinned from its .info so every brick serves the digest CI
+        # built. Reached only through the egress lane's reserved host.
+        "gitMirror.image": "//projects/embervm/mirror/image:image.info",
         # Issue #4055: the runtime-claude base image, a session-class guest that
         # runs the Claude Code CLI headlessly under a vsock shim so monolith can
         # expose agent sessions as MCP tools. Distinct FLAT top-level key (D14a.6),

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -502,6 +502,14 @@ containers:
       {{- end }}
       {{- end }}
       {{- end }}
+      {{- if and $ctx.Values.egress.enabled $ctx.Values.gitMirror.enabled }}
+      # Node-local git mirror lane (#4473): connections the guests address to
+      # the reserved host are tunnelled straight to the co-located mirror
+      # sidecar's loopback listener below instead of being resolved as an
+      # ordinary destination. Unset (gitMirror disabled) keeps the seam dead.
+      - name: EGRESS_GIT_MIRROR_ADDR
+        value: "127.0.0.1:{{ $ctx.Values.gitMirror.port }}"
+      {{- end }}
     {{- if $ctx.Values.egress.ca.enabled }}
     volumeMounts:
       - name: egress-ca
@@ -510,6 +518,57 @@ containers:
     {{- end }}
     resources:
       {{- toYaml $ctx.Values.egress.resources | nindent 6 }}
+{{- end }}
+{{- if and $ctx.Values.egress.enabled $ctx.Values.gitMirror.enabled }}
+  # Node-local git mirror sidecar (#4473). Mirrors the configured repos from
+  # GitHub on an interval and serves them over git smart http on the pod
+  # LOOPBACK, so session guests hydrate node-local with no GitHub dependency
+  # and no credential anywhere on the clone path. Loopback-only is load
+  # bearing twice over: nothing in the cluster can dial it directly (the ONLY
+  # consumer is the egress-proxy above via its reserved-host seam), and a
+  # loopback listener is unreachable by kubelet probes, so there are none; the
+  # shim's github fallback covers a dead or warming mirror instead.
+  # nosemgrep: require-readiness-probe
+  - name: git-mirror
+    image: "{{ $ctx.Values.gitMirror.image.repository }}@{{ $ctx.Values.gitMirror.image.digest }}"
+    imagePullPolicy: {{ $ctx.Values.noded.image.pullPolicy | default "IfNotPresent" }}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 65532
+      runAsGroup: 65532
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+    env:
+      - name: EMBERVM_MIRROR_LISTEN
+        value: "127.0.0.1:{{ $ctx.Values.gitMirror.port }}"
+      - name: EMBERVM_MIRROR_ROOT
+        value: /var/lib/git-mirror/mirrors
+      # An empty list makes the server exit non-zero rather than serve a
+      # mirror that can never answer a clone, so the misconfiguration is loud.
+      - name: EMBERVM_MIRROR_REPOS
+        value: {{ join "," $ctx.Values.gitMirror.repos | quote }}
+      - name: EMBERVM_MIRROR_REFRESH_INTERVAL
+        value: "{{ $ctx.Values.gitMirror.refreshIntervalSeconds }}s"
+      {{- if and $ctx.Values.gitMirror.githubToken $ctx.Values.gitMirror.githubToken.secretRef.name }}
+      # Optional read token for private repos. Lives only in this container,
+      # travels per-invocation as extraheader argv inside the sidecar (never
+      # written to disk, never in a guest), and is optional so a not-yet-synced
+      # 1Password item degrades to anonymous mirroring of public repos.
+      - name: EMBERVM_MIRROR_GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: {{ $ctx.Values.gitMirror.githubToken.secretRef.name | quote }}
+            key: {{ $ctx.Values.gitMirror.githubToken.secretRef.key | quote }}
+            optional: true
+      {{- end }}
+    resources:
+      {{- toYaml $ctx.Values.gitMirror.resources | nindent 6 }}
+    volumeMounts:
+      - name: git-mirror-mirrors
+        mountPath: /var/lib/git-mirror/mirrors
 {{- end }}
 volumes:
 {{- if and $ctx.Values.egress.enabled $ctx.Values.egress.ca.enabled }}
@@ -530,6 +589,15 @@ volumes:
       # cleartext lane, so a guest loses https:// credential injection rather
       # than all egress.
       optional: true
+{{- end }}
+{{- if and $ctx.Values.egress.enabled $ctx.Values.gitMirror.enabled }}
+  # The bare mirror clones. Per-node and disposable by design: an emptyDir on
+  # the node disk, sized so a runaway refresh is evicted rather than filling
+  # the node. Losing it costs one re-clone per repo, not data: the mirror is a
+  # cache of upstream, never a source of record.
+  - name: git-mirror-mirrors
+    emptyDir:
+      sizeLimit: {{ $ctx.Values.gitMirror.diskSizeLimit | quote }}
 {{- end }}
   - name: dev-kvm
     hostPath:

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1709,6 +1709,49 @@ egress:
     limits:
       memory: 64Mi
 
+# Node-local git mirror sidecar (#4473). When enabled alongside egress, every
+# noded pod runs a small server that mirrors a fixed repo list from GitHub and
+# serves it over git smart http on the POD LOOPBACK only. Guests hydrate from
+# it through the egress lane's reserved host (git-mirror.egress.internal),
+# which restores node-local session hydration (~1.3s class) and takes GitHub's
+# rate limit off the session-create path with NO credential on the clone path.
+#
+# Reachability is deliberately narrower than the retired central mirror: the
+# listener binds loopback inside the noded pod, so nothing in the cluster can
+# dial it directly and no allowlist entry is spent; the reserved host is
+# answered by the co-located egress-proxy before routing or never.
+gitMirror:
+  enabled: false
+  # Requires egress.enabled: the mirror is reached THROUGH the egress lane,
+  # and its env is rendered into the egress-proxy container below.
+  port: 9419
+  # Any port except 9418 would work; 9419 reads as git-adjacent and keeps the
+  # guest-side half-close suppression (scoped to :9418) out of these tunnels.
+  refreshIntervalSeconds: 60
+  # Repos mirrored on every FC node, "owner/name". Keep this list short: each
+  # entry is cloned onto every node's disk and re-fetched every interval.
+  repos: []
+  # Optional read token for private repos (1Password operator syncs it). The
+  # token lives in this container only, rides per-invocation extraheader argv
+  # (never written to disk), and is optional: public repos need nothing, and
+  # guests fall back to their credentialed GitHub path when a repo is absent.
+  githubToken:
+    secretRef:
+      name: ""
+      key: ""
+  # Bazel-pinned at chart-build from the mirror image .info provider
+  # (chart/BUILD `images`).
+  image: {}
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      memory: 256Mi
+  # Ceiling for the bare clones (emptyDir sizeLimit). The mirror is a cache,
+  # so hitting the ceiling evicts pod-local state rather than filling the node.
+  diskSizeLimit: 10Gi
+
 # The claude-runtime session workload (issue #4055): voice-drivable Claude Code
 # agent sessions. Same frozen guest contract as every other guest (vsock 1027,
 # /shim/ready), but the invoke path is /shim/turn, and the monolith addresses it

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -649,6 +649,25 @@ egress:
     name: embervm-embervm-egress
     itemPath: "vaults/k8s-homelab/items/embervm-agent-secrets"
 
+# Node-local git mirror (#4473): serve the mirrored repos over git smart http
+# from a loopback sidecar in every noded pod, and point session hydration at it
+# so the clone leaves the GitHub rate limit and the slow credentialed lane.
+# Guests reach it as http://git-mirror.egress.internal:<port> through the
+# ordinary egress lane; the reserved host is answered by the co-located
+# egress-proxy before any routing, so no allowlist entry is spent. The shim
+# falls back to its credentialed GitHub clone for repos this list does not
+# carry, so catalog drift degrades to today's path instead of failed sessions.
+gitMirror:
+  enabled: true
+  port: 9419
+  refreshIntervalSeconds: 60
+  # The MCP agent tool defaults every session to jomcgi/homelab (#4473), which
+  # is why the mirror exists; extend only as other catalogs earn their disk on
+  # every FC node (one clone per repo per node, refreshed every interval).
+  repos:
+    - jomcgi/homelab
+
+
 # Voice-drivable Claude Code agent sessions (issue #4055). The monolith addresses
 # this workload by name, so it must exist before agent_sessions can create a
 # session at all. Sizing and the node disk arithmetic are in chart/values.yaml.

--- a/projects/embervm/mirror/cmd/BUILD
+++ b/projects/embervm/mirror/cmd/BUILD
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "cmd_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/mirror/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//projects/embervm/mirror/refresh",
+        "//projects/embervm/mirror/server",
+    ],
+)
+
+go_binary(
+    name = "git-mirror",
+    embed = [":cmd_lib"],
+    visibility = ["//projects/embervm/mirror:__subpackages__"],
+)

--- a/projects/embervm/mirror/cmd/main.go
+++ b/projects/embervm/mirror/cmd/main.go
@@ -1,0 +1,131 @@
+// Command embervm-git-mirror serves a node-local git mirror over the smart
+// HTTP protocol (#4473). It runs as a sidecar container in every noded pod,
+// bound to the pod's loopback so the ONLY way in is through the co-located
+// egress-proxy's reserved mirror lane; nothing else in the cluster or on the
+// node can dial it.
+//
+// Environment:
+//
+//	EMBERVM_MIRROR_LISTEN          listen addr (default 127.0.0.1:9419)
+//	EMBERVM_MIRROR_ROOT            bare-clone root (default /var/lib/git-mirror/mirrors)
+//	EMBERVM_MIRROR_REPOS           comma-separated owner/name repos to mirror
+//	EMBERVM_MIRROR_REFRESH_INTERVAL  Go duration between fetch passes (default 60s)
+//	EMBERVM_MIRROR_GITHUB_TOKEN    optional GitHub read token (private repos)
+//	EMBERVM_MIRROR_GIT_BIN         git executable override (default "git")
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/jomcgi/homelab/projects/embervm/mirror/refresh"
+	"github.com/jomcgi/homelab/projects/embervm/mirror/server"
+)
+
+const (
+	defaultListen   = "127.0.0.1:9419"
+	defaultRoot     = "/var/lib/git-mirror/mirrors"
+	defaultInterval = 60 * time.Second
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
+
+	listen := envOr("EMBERVM_MIRROR_LISTEN", defaultListen)
+	root := envOr("EMBERVM_MIRROR_ROOT", defaultRoot)
+	repos := splitRepos(os.Getenv("EMBERVM_MIRROR_REPOS"))
+	interval, err := parseDuration(os.Getenv("EMBERVM_MIRROR_REFRESH_INTERVAL"), defaultInterval)
+	if err != nil {
+		logger.Error("mirror: invalid refresh interval", "err", err)
+		os.Exit(1)
+	}
+
+	if len(repos) == 0 {
+		// Serving an empty mirror is a misconfiguration, not a degraded state:
+		// every hydration would silently fall back to GitHub and nobody would
+		// ever notice the sidecar is dead weight.
+		logger.Error("mirror: EMBERVM_MIRROR_REPOS is empty; refusing to start")
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	refresher := refresh.New(refresh.Config{
+		Root:     root,
+		GitBin:   os.Getenv("EMBERVM_MIRROR_GIT_BIN"),
+		Repos:    repos,
+		Interval: interval,
+		Token:    os.Getenv("EMBERVM_MIRROR_GITHUB_TOKEN"),
+	}, logger)
+	go refresher.Run(ctx)
+
+	mux := server.New(root, logger).Handler()
+	httpServer := &http.Server{
+		Addr:              listen,
+		Handler:           mux,
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- httpServer.ListenAndServe()
+	}()
+	logger.Info("mirror: serving",
+		"listen", listen,
+		"root", root,
+		"repos", repos,
+		"refresh_interval", interval.String(),
+	)
+
+	select {
+	case <-ctx.Done():
+	case err := <-errCh:
+		if err != nil && err != http.ErrServerClosed {
+			logger.Error("mirror: listener failed", "err", err)
+			os.Exit(1)
+		}
+	}
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = httpServer.Shutdown(shutdownCtx)
+	stop()
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func splitRepos(raw string) []string {
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func parseDuration(raw string, fallback time.Duration) (time.Duration, error) {
+	if raw == "" {
+		return fallback, nil
+	}
+	if seconds, err := strconv.Atoi(raw); err == nil {
+		return time.Duration(seconds) * time.Second, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, err
+	}
+	return d, nil
+}

--- a/projects/embervm/mirror/image/BUILD
+++ b/projects/embervm/mirror/image/BUILD
@@ -1,0 +1,37 @@
+# gazelle:ignore
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("//bazel/tools/oci:apko_image.bzl", "apko_image")
+
+# Node-local git mirror sidecar image (#4473): the Wolfi base (git + busybox)
+# with the embervm-git-mirror Go server layered at /usr/local/bin. Runs as one
+# non-root container in every noded pod; see apko.yaml for the uid reasoning.
+#
+# amd64 only: see the `arm64` arg in apko_image.bzl and the comment in
+# apko.yaml.
+
+platform_transition_filegroup(
+    name = "git_mirror_amd64_bin",
+    srcs = ["//projects/embervm/mirror/cmd:git-mirror"],
+    target_platform = "@rules_go//go/toolchain:linux_amd64",
+)
+
+tar(
+    name = "git_mirror_tar_amd64",
+    srcs = [":git_mirror_amd64_bin"],
+    mtree = [
+        "./usr/local/bin/embervm-git-mirror type=file content=$(execpath :git_mirror_amd64_bin) mode=0755 uid=0 gid=0",
+    ],
+)
+
+apko_image(
+    name = "image",
+    # amd64 only: see the `arm64` arg in apko_image.bzl.
+    arm64 = False,
+    config = "apko.yaml",
+    contents = "@embervm_mirror_lock//:contents",
+    repository = "ghcr.io/jomcgi/homelab/projects/embervm/mirror/image",
+    tars = [
+        ":git_mirror_tar_amd64",
+    ],
+)

--- a/projects/embervm/mirror/image/apko.lock.json
+++ b/projects/embervm/mirror/image/apko.lock.json
@@ -1,0 +1,730 @@
+{
+  "version": "v1",
+  "config": {
+    "name": "projects/embervm/mirror/image/apko.yaml",
+    "checksum": "sha256-z08/JHstCi7JV5dbAh+L1mneRQ3jEsKzoduj2J5bb1w="
+  },
+  "contents": {
+    "keyring": [
+      {
+        "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "content": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA5qQUHmzqX9oa/RS3OSgL\nYTYB1mzvVmnWC0JXsAafdgRkavJ9xRhsXMKXWPKMghZw6UnkxuxQCZlB9UhaFqed\nX7SWfQ8qRgECFmdGUjoeV7P3VUkg17RU0mUKsXZZF/2mU+jCGyk5eweKcLWrk6bn\nlNNF1vBJ9EXbHdfvbQsA5GfLku5tJhqRJ4FVQAGCw+1JoSKu+o3q+6xP7z6kMfR9\ncp54FSj48rTJUibbAv+cPtZ3AnbpjdyarV7SYMfxp14Q/KR0CJYDihG3CFoU+TaM\ndr7LUrgXaYw7m7g8hA2PY1jF8aqDqVFjVu/csPKnKVQSqNHfm4C4gljwT6TDVhPe\n6xKSGKfAUNvHx2RIqSsZJCh68Af+VnfuimbHMYzGhzV4/efihpJlYsDnOXJj/PeY\nSbEIYG2yoI3AYvDFyFX2OAOtQ9d4TPs4zS4aDg4R3UseXLib46FX3ZTfIi1/W0IO\neC3AFU5mK+02jq+7swcGbgzem30dFA/B3n8NQExJjF2WlGNJxFw2WnJQqKIkIh0s\nkm5jaxJ28xYgik+bEgxy1LsilKTowdkbEPRKv36JGdap4dOEGR+LwZsM+ontF1AO\nwY6tvwtZKJWhgj7ES3BdtiC1GA2htFnP90lA7KnKbSMOxwWtSCH8spitdPdzgI8G\nSxrOb0SZs6ZFAxYYe3GlvS0CAwEAAQ==\n-----END PUBLIC KEY-----\n"
+      }
+    ],
+    "build_repositories": [],
+    "runtime_repositories": [],
+    "repositories": [
+      {
+        "name": "packages.wolfi.dev/os/x86_64",
+        "url": "https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz",
+        "architecture": "x86_64"
+      }
+    ],
+    "packages": [
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1932",
+          "checksum": "sha1-mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+        },
+        "data": {
+          "range": "bytes=1933-13952",
+          "checksum": "sha256-5jOBVeXTWJEbL+Cnxj5Nu4klEL4SEB7IDMzT96rbkkA="
+        },
+        "checksum": "Q1mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20260413-r1.apk",
+        "version": "20260413-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8322",
+          "checksum": "sha1-u3xyVyewNfx7ZzTDikWdOlY9Tt8="
+        },
+        "data": {
+          "range": "bytes=8323-137882",
+          "checksum": "sha256-FfsoSAq28t7qTE1H+hPbrozu3BjgGiACoDMkS37a2G0="
+        },
+        "checksum": "Q1u3xyVyewNfx7ZzTDikWdOlY9Tt8="
+      },
+      {
+        "name": "glibc-2.43-locale-posix",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.43-locale-posix-2.43-r15.apk",
+        "version": "2.43-r15",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-16619",
+          "checksum": "sha1-DxOjOxPCpsx0MT5D8U9saQOsOYA="
+        },
+        "data": {
+          "range": "bytes=16620-93380",
+          "checksum": "sha256-G6rVZ3oFIAcNduWGSLRGNvUAYro2cpZ5mOggPBkMQFw="
+        },
+        "checksum": "Q1DxOjOxPCpsx0MT5D8U9saQOsOYA="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-16.2.0-r0.apk",
+        "version": "16.2.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10563",
+          "checksum": "sha1-tCpwlcP4haBDjOFa3aV8fkGv0lE="
+        },
+        "data": {
+          "range": "bytes=10564-106145",
+          "checksum": "sha256-KzCw+4alCI3cqTpByvs92BsZ+aYLWTKhnzFYtTPfXTs="
+        },
+        "checksum": "Q1tCpwlcP4haBDjOFa3aV8fkGv0lE="
+      },
+      {
+        "name": "glibc-2.43",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.43-2.43-r15.apk",
+        "version": "2.43-r15",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-16849",
+          "checksum": "sha1-mDx2u0pNqoPGiFntifi77qnUoT0="
+        },
+        "data": {
+          "range": "bytes=16850-3072090",
+          "checksum": "sha256-E5pvmLndtirK4mD9BvHvYJmOJwZi+FoKqXCmpRClgJg="
+        },
+        "checksum": "Q1mDx2u0pNqoPGiFntifi77qnUoT0="
+      },
+      {
+        "name": "ld-linux-2.43",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-2.43-r15.apk",
+        "version": "2.43-r15",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-16654",
+          "checksum": "sha1-1cw5KS54Gne6L/isyDpeA+EWloE="
+        },
+        "data": {
+          "range": "bytes=16655-150852",
+          "checksum": "sha256-yJuVvAfoGyPH+vRAAF8eI8uGdBgPxJPn/UgaMO1JEUg="
+        },
+        "checksum": "Q11cw5KS54Gne6L/isyDpeA+EWloE="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.5.2-r4.apk",
+        "version": "4.5.2-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9765",
+          "checksum": "sha1-8mwy9m46Q+nYofoWKiURDdXCCBk="
+        },
+        "data": {
+          "range": "bytes=9766-107326",
+          "checksum": "sha256-CQcWRLKhYiydnvRpfxynMDvtYNe2x126F4BgtZq7+VY="
+        },
+        "checksum": "Q18mwy9m46Q+nYofoWKiURDdXCCBk="
+      },
+      {
+        "name": "libcrypt1-2.43",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.43-2.43-r15.apk",
+        "version": "2.43-r15",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-16658",
+          "checksum": "sha1-RRB87eVnaOMWrB1L+MhfId4bQZU="
+        },
+        "data": {
+          "range": "bytes=16659-18284",
+          "checksum": "sha256-SV10OI4/Z6qlthcHjn1s0y2u7xnpcaD1hKor0V+TceY="
+        },
+        "checksum": "Q1RRB87eVnaOMWrB1L+MhfId4bQZU="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.38.0-r1.apk",
+        "version": "1.38.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11081",
+          "checksum": "sha1-TEtV+ITXD1zpV5PiTldkPzlho2s="
+        },
+        "data": {
+          "range": "bytes=11082-435543",
+          "checksum": "sha256-+nZM5S8JgVBQGVLmsWGz3o+n0jkN96zHzGzYOLiuyg8="
+        },
+        "checksum": "Q1TEtV+ITXD1zpV5PiTldkPzlho2s="
+      },
+      {
+        "name": "libpcre2-8-0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.47-r0.apk",
+        "version": "10.47-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6848",
+          "checksum": "sha1-5bkXL31L9lMVsxJdyleMiTb2Esg="
+        },
+        "data": {
+          "range": "bytes=6849-307246",
+          "checksum": "sha256-LBagnNrkJtEnWnNJIYKGEllGZqRH6y5+9I9lQ05+NIs="
+        },
+        "checksum": "Q15bkXL31L9lMVsxJdyleMiTb2Esg="
+      },
+      {
+        "name": "zlib",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.2-r4.apk",
+        "version": "1.3.2-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9127",
+          "checksum": "sha1-uur/HAJCSzF/hyt+ffNYqiqGYAs="
+        },
+        "data": {
+          "range": "bytes=9128-73248",
+          "checksum": "sha256-t35y9rhtwo05Lya7W99+zKvNIDde4vCmx+XTNgozvAc="
+        },
+        "checksum": "Q1uur/HAJCSzF/hyt+ffNYqiqGYAs="
+      },
+      {
+        "name": "libexpat1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libexpat1-2.8.3-r0.apk",
+        "version": "2.8.3-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8290",
+          "checksum": "sha1-rYpLU3va57pFjMzLjqyGkCwgAnQ="
+        },
+        "data": {
+          "range": "bytes=8291-111331",
+          "checksum": "sha256-Xlpd9n5NLCqwQF1bbVZKY6Ba6LnAYhj67aa09CqnbAg="
+        },
+        "checksum": "Q1rYpLU3va57pFjMzLjqyGkCwgAnQ="
+      },
+      {
+        "name": "libbrotlicommon1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.2.0-r3.apk",
+        "version": "1.2.0-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6793",
+          "checksum": "sha1-jiywS9aIP3q1TI5UwC1zp/dsVr8="
+        },
+        "data": {
+          "range": "bytes=6794-76948",
+          "checksum": "sha256-OarefY1K7DoAVQnI+gKBLCpdMFeyGlj9gEIfBGp3Fvg="
+        },
+        "checksum": "Q1jiywS9aIP3q1TI5UwC1zp/dsVr8="
+      },
+      {
+        "name": "libbrotlidec1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.2.0-r3.apk",
+        "version": "1.2.0-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6806",
+          "checksum": "sha1-G/f4liNwY7eefOjRe3Dd3U9FM7o="
+        },
+        "data": {
+          "range": "bytes=6807-38364",
+          "checksum": "sha256-U7AnPRqeMceKaariNoQB/dP2etJh98p2RzIrSMayits="
+        },
+        "checksum": "Q1G/f4liNwY7eefOjRe3Dd3U9FM7o="
+      },
+      {
+        "name": "libverto",
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r7.apk",
+        "version": "0.3.2-r7",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7019",
+          "checksum": "sha1-sDJ1BUkf//wbO4iWftq36lU0TKw="
+        },
+        "data": {
+          "range": "bytes=7020-20251",
+          "checksum": "sha256-Z1Lrte4GAbGfrMW6bu3AKImDbo/cCeXPAl63zVvzDLU="
+        },
+        "checksum": "Q1sDJ1BUkf//wbO4iWftq36lU0TKw="
+      },
+      {
+        "name": "krb5-conf",
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-conf-1.0-r9.apk",
+        "version": "1.0-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1146",
+          "checksum": "sha1-Ra+vl5lLBEyOhG8QYdPfwg9wdgg="
+        },
+        "data": {
+          "range": "bytes=1147-2879",
+          "checksum": "sha256-sdgWS1AsGdT2maS7nI53u3Yj9gq6XjsFhKRTO6Ty4jk="
+        },
+        "checksum": "Q1Ra+vl5lLBEyOhG8QYdPfwg9wdgg="
+      },
+      {
+        "name": "keyutils-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r39.apk",
+        "version": "1.6.3-r39",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8319",
+          "checksum": "sha1-EWYvd29yrhJnDZ22Zuzjm3L+k10="
+        },
+        "data": {
+          "range": "bytes=8320-18938",
+          "checksum": "sha256-hb0G2mECwi2wIXS+5hzKAsMvIUTLzhly/xGAc9MjG/s="
+        },
+        "checksum": "Q1EWYvd29yrhJnDZ22Zuzjm3L+k10="
+      },
+      {
+        "name": "libcom_err",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcom_err-1.47.4-r1.apk",
+        "version": "1.47.4-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8252",
+          "checksum": "sha1-CMcRrPrpbLziSeZwJAsj1IggRAg="
+        },
+        "data": {
+          "range": "bytes=8253-16737",
+          "checksum": "sha256-u0G4PIicoyfgySbZKrzDrrgzWhBNmqRVcMg6zQFSSS4="
+        },
+        "checksum": "Q1CMcRrPrpbLziSeZwJAsj1IggRAg="
+      },
+      {
+        "name": "libcrypto3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.6.3-r5.apk",
+        "version": "3.6.3-r5",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11120",
+          "checksum": "sha1-Owan7JJqqV7bcXcmimjJC9Nsxpg="
+        },
+        "data": {
+          "range": "bytes=11121-2439662",
+          "checksum": "sha256-2N5XjyaMruE8xdyhMSBnEssjH98387qJARQsW9FYfVQ="
+        },
+        "checksum": "Q1Owan7JJqqV7bcXcmimjJC9Nsxpg="
+      },
+      {
+        "name": "libssl3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.6.3-r5.apk",
+        "version": "3.6.3-r5",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11129",
+          "checksum": "sha1-o3m1w5zIUp5iykPPjkz0YWnu1jw="
+        },
+        "data": {
+          "range": "bytes=11130-524661",
+          "checksum": "sha256-XLnVrVKzZsNUOxdfTFzRJl7aTCF4zrCE99jDfmCxR68="
+        },
+        "checksum": "Q1o3m1w5zIUp5iykPPjkz0YWnu1jw="
+      },
+      {
+        "name": "krb5-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.22.2-r2.apk",
+        "version": "1.22.2-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8895",
+          "checksum": "sha1-xseCtT4lsF66PC2c5G0LLMk+aq4="
+        },
+        "data": {
+          "range": "bytes=8896-1047954",
+          "checksum": "sha256-By1IkTuSdK0eqziOaHpvntsQA25M3dL+pReOZ1lKbPo="
+        },
+        "checksum": "Q1xseCtT4lsF66PC2c5G0LLMk+aq4="
+      },
+      {
+        "name": "libunistring",
+        "url": "https://packages.wolfi.dev/os/x86_64/libunistring-1.4.2-r2.apk",
+        "version": "1.4.2-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7520",
+          "checksum": "sha1-yQVDwlBj+eVaAbOLQdnJEtSg9X8="
+        },
+        "data": {
+          "range": "bytes=7521-904686",
+          "checksum": "sha256-GI6eG0zWe5m0XvD9gtqeVflLEmYFymJ721kuHiTCrjQ="
+        },
+        "checksum": "Q1yQVDwlBj+eVaAbOLQdnJEtSg9X8="
+      },
+      {
+        "name": "libidn2",
+        "url": "https://packages.wolfi.dev/os/x86_64/libidn2-2.3.8-r8.apk",
+        "version": "2.3.8-r8",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8340",
+          "checksum": "sha1-uEc4gafn6qJPsQoKgrRTB1vaXbE="
+        },
+        "data": {
+          "range": "bytes=8341-127709",
+          "checksum": "sha256-SiZiRqAA71K/o2vmoZJXPl5tLOK26vpowh0u1DIIEDs="
+        },
+        "checksum": "Q1uEc4gafn6qJPsQoKgrRTB1vaXbE="
+      },
+      {
+        "name": "nghttp3",
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp3-1.18.0-r0.apk",
+        "version": "1.18.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6985",
+          "checksum": "sha1-F5IPxGpCQOMhv/6KeXDC/VZlhF0="
+        },
+        "data": {
+          "range": "bytes=6986-108505",
+          "checksum": "sha256-iAlEdlGPtlW0sqXgmj56DzxvsPkUX1chCVoEXPlJJkI="
+        },
+        "checksum": "Q1F5IPxGpCQOMhv/6KeXDC/VZlhF0="
+      },
+      {
+        "name": "ngtcp2",
+        "url": "https://packages.wolfi.dev/os/x86_64/ngtcp2-1.25.0-r1.apk",
+        "version": "1.25.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7106",
+          "checksum": "sha1-r2/pOwGyDrRBcQFNNfVQiTxwmTY="
+        },
+        "data": {
+          "range": "bytes=7107-233126",
+          "checksum": "sha256-5rPHzafATupYO+KFDDtNaAS6VY6hUUovvh5TWrRn9x8="
+        },
+        "checksum": "Q1r2/pOwGyDrRBcQFNNfVQiTxwmTY="
+      },
+      {
+        "name": "libpsl",
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.23.3-r0.apk",
+        "version": "0.23.3-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7874",
+          "checksum": "sha1-JX7gR0k50ZAwT6m8xnvb9taqXOo="
+        },
+        "data": {
+          "range": "bytes=7875-73564",
+          "checksum": "sha256-IMEHWLMhD0rXpPnQHsX+/VLUxFVqGF0D+bCppSnEgYA="
+        },
+        "checksum": "Q1JX7gR0k50ZAwT6m8xnvb9taqXOo="
+      },
+      {
+        "name": "libnghttp2-14",
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.70.0-r2.apk",
+        "version": "1.70.0-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7811",
+          "checksum": "sha1-oQRHF/5LZECCttiyB7bVkXopPYI="
+        },
+        "data": {
+          "range": "bytes=7812-109901",
+          "checksum": "sha256-V3N73ehpJfQwWvL71PSF24KE3IpdRb9HTZFSCgr+yeM="
+        },
+        "checksum": "Q1oQRHF/5LZECCttiyB7bVkXopPYI="
+      },
+      {
+        "name": "gdbm",
+        "url": "https://packages.wolfi.dev/os/x86_64/gdbm-1.26-r5.apk",
+        "version": "1.26-r5",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7464",
+          "checksum": "sha1-m4CRD8lCkRLk/whYIwa2UQuA8uk="
+        },
+        "data": {
+          "range": "bytes=7465-274283",
+          "checksum": "sha256-0u2QmNUl9YQxfpb+TygxHhYAOi/40XsqJOfpEEkuGmE="
+        },
+        "checksum": "Q1m4CRD8lCkRLk/whYIwa2UQuA8uk="
+      },
+      {
+        "name": "sqlite-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/sqlite-libs-3.53.4-r0.apk",
+        "version": "3.53.4-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5297",
+          "checksum": "sha1-x8+xdfUz1lcwo4swX+n/QBhifHc="
+        },
+        "data": {
+          "range": "bytes=5298-978595",
+          "checksum": "sha256-YoBymbCMq42aqTuMRnLY3jUw1feoxwpptIrll5q34hM="
+        },
+        "checksum": "Q1x8+xdfUz1lcwo4swX+n/QBhifHc="
+      },
+      {
+        "name": "ncurses-terminfo-base",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.6.20260822-r0.apk",
+        "version": "6.6.20260822-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10334",
+          "checksum": "sha1-iKIY37LU1f1y7lJjAupxZWoGaMA="
+        },
+        "data": {
+          "range": "bytes=10335-118486",
+          "checksum": "sha256-6VFIz0FYDZR+HiVlJtELtmxi/FZg9QAgVfZLC6cnXDE="
+        },
+        "checksum": "Q1iKIY37LU1f1y7lJjAupxZWoGaMA="
+      },
+      {
+        "name": "ncurses",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.6.20260822-r0.apk",
+        "version": "6.6.20260822-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10474",
+          "checksum": "sha1-1/fKAErIQIutqqds8zwswQe3iMQ="
+        },
+        "data": {
+          "range": "bytes=10475-622274",
+          "checksum": "sha256-WIX8oABa2C3j9hfSA+zsfeQSaPUNGqGndKXujUpaFKE="
+        },
+        "checksum": "Q11/fKAErIQIutqqds8zwswQe3iMQ="
+      },
+      {
+        "name": "readline",
+        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.3-r2.apk",
+        "version": "8.3-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6720",
+          "checksum": "sha1-1WRlY3do45L9jnu5YAoRTSTcimY="
+        },
+        "data": {
+          "range": "bytes=6721-342785",
+          "checksum": "sha256-b8Pq+h8UH9KT10SqvwjnKyZNJ1p5qhjdXy2Yn63jtNw="
+        },
+        "checksum": "Q11WRlY3do45L9jnu5YAoRTSTcimY="
+      },
+      {
+        "name": "heimdal-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/heimdal-libs-7.8.0-r51.apk",
+        "version": "7.8.0-r51",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9136",
+          "checksum": "sha1-r9q4OvkeTlqURw1ZdYdqM2LJb+4="
+        },
+        "data": {
+          "range": "bytes=9137-1474084",
+          "checksum": "sha256-UIQDEybAlELRbwYzMxY55JzmDqYOUS2Uk2xQXMKIW8s="
+        },
+        "checksum": "Q1r9q4OvkeTlqURw1ZdYdqM2LJb+4="
+      },
+      {
+        "name": "cyrus-sasl-heimdal-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/cyrus-sasl-heimdal-libs-2.1.28-r54.apk",
+        "version": "2.1.28-r54",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10521",
+          "checksum": "sha1-pxMdknpbKHP0//I2ps885ZNaajY="
+        },
+        "data": {
+          "range": "bytes=10522-217336",
+          "checksum": "sha256-SaD3M1tquLyiTz+HEyQEct1spbdWEGEkRvTndhZQyVE="
+        },
+        "checksum": "Q1pxMdknpbKHP0//I2ps885ZNaajY="
+      },
+      {
+        "name": "libldap-2.7",
+        "url": "https://packages.wolfi.dev/os/x86_64/libldap-2.7-2.7.0-r0.apk",
+        "version": "2.7.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-14116",
+          "checksum": "sha1-XJMgJZVe8HSU6exqz2Zbhcu8aMg="
+        },
+        "data": {
+          "range": "bytes=14117-267149",
+          "checksum": "sha256-fI2nPiNuYhFL3R2YJrT5FeiLjp0gM8MkHDC4WDC9vPM="
+        },
+        "checksum": "Q1XJMgJZVe8HSU6exqz2Zbhcu8aMg="
+      },
+      {
+        "name": "libcurl-openssl4",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.21.0-r2.apk",
+        "version": "8.21.0-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12863",
+          "checksum": "sha1-h42nTQ9mtkeiZ21B0cetPcbgO24="
+        },
+        "data": {
+          "range": "bytes=12864-579080",
+          "checksum": "sha256-rQ9vApIzjG1LHyfW8yHyMXLpCXax2F4xnHsAgqncnns="
+        },
+        "checksum": "Q1h42nTQ9mtkeiZ21B0cetPcbgO24="
+      },
+      {
+        "name": "git",
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.55.0-r4.apk",
+        "version": "2.55.0-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8596",
+          "checksum": "sha1-m5iqPzPggZn/SxFmGCMhO07SYSY="
+        },
+        "data": {
+          "range": "bytes=8597-9774543",
+          "checksum": "sha256-UwJ6vOT1zKhqd61gt67HfislDBSi4xnYpbRDk4kXyVY="
+        },
+        "checksum": "Q1m5iqPzPggZn/SxFmGCMhO07SYSY="
+      }
+    ]
+  }
+}

--- a/projects/embervm/mirror/image/apko.yaml
+++ b/projects/embervm/mirror/image/apko.yaml
@@ -1,0 +1,49 @@
+# Node-local git mirror sidecar image (#4473): a Wolfi userland with git plus
+# the embervm-git-mirror Go server layered at /usr/local/bin. One container in
+# every noded pod, bound to the pod loopback so the egress-proxy's reserved
+# mirror lane is the only way in.
+#
+# AMD64-ONLY (arm64 = False in BUILD): every cluster node is amd64, matching
+# the xds sibling image's reasoning. The lock therefore pins x86_64 packages.
+#
+# Non-root uid 65532: a plain network server with no privileged needs. git is
+# exec'd for upload-pack serving and mirror refreshes; nothing else is needed,
+# busybox rides along only for in-pod debugging, matching the xds image.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - ca-certificates-bundle
+    - git
+    - busybox
+
+archs:
+  - x86_64
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  # HOME must be writable: git wants one for its (here empty) global config,
+  # and the refresher keeps it credential-free by design.
+  HOME: /tmp
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+paths:
+  - path: /var/lib/git-mirror/mirrors
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+
+entrypoint:
+  command: /usr/local/bin/embervm-git-mirror

--- a/projects/embervm/mirror/refresh/BUILD
+++ b/projects/embervm/mirror/refresh/BUILD
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "refresh",
+    srcs = ["refresher.go"],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/mirror/refresh",
+    visibility = ["//projects/embervm/mirror:__subpackages__"],
+)
+
+go_test(
+    name = "refresh_test",
+    srcs = ["refresher_test.go"],
+    embed = [":refresh"],
+)

--- a/projects/embervm/mirror/refresh/refresher.go
+++ b/projects/embervm/mirror/refresh/refresher.go
@@ -1,0 +1,225 @@
+// Package refresh keeps a mirrors root warm: one bare clone per configured
+// GitHub repository under <root>/<owner>/<repo>.git, re-fetched on an interval
+// so session hydration reads a fresh-to-one-tick-old copy of upstream instead
+// of GitHub itself (#4473).
+//
+// Layout and refspec mirror the retired central mirror's contract: heads and
+// tags only, never refs/pull/*, pruned so deleted upstream branches disappear
+// here too. The optional token exists for private repos; it travels per
+// invocation as an extraheader argument and is never written to disk or logs.
+package refresh
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	defaultGitBin = "git"
+	githubURLBase = "https://github.com/"
+)
+
+// Config is one Refresher's inputs. Repos are "owner/name" strings.
+type Config struct {
+	Root     string
+	GitBin   string
+	Repos    []string
+	Interval time.Duration
+	// Token is an optional GitHub read credential for private repos.
+	Token string
+	// UpstreamBase defaults to GitHub; tests point it at a local fixture path.
+	UpstreamBase string
+}
+
+// Refresher runs the fetch loop over a Config.
+type Refresher struct {
+	cfg    Config
+	logger *slog.Logger
+}
+
+// New builds a Refresher. Interval must be positive; GitBin defaults to "git"
+// and UpstreamBase to GitHub.
+func New(cfg Config, logger *slog.Logger) *Refresher {
+	if cfg.GitBin == "" {
+		cfg.GitBin = defaultGitBin
+	}
+	if cfg.UpstreamBase == "" {
+		cfg.UpstreamBase = githubURLBase
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Refresher{cfg: cfg, logger: logger}
+}
+
+// Run blocks until ctx is done, syncing every repo immediately and then once
+// per interval. A failing repo logs and retries next tick; it never stops the
+// loop, because a partial mirror serving its good repos beats no mirror.
+func (r *Refresher) Run(ctx context.Context) {
+	r.syncAll(ctx)
+	ticker := time.NewTicker(r.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.syncAll(ctx)
+		}
+	}
+}
+
+func (r *Refresher) syncAll(ctx context.Context) {
+	for _, repo := range r.cfg.Repos {
+		if err := r.syncRepo(ctx, repo); err != nil {
+			r.logger.Error("mirror: refresh failed", "repo", repo, "err", err)
+		}
+	}
+	r.logger.Info("mirror: refresh pass complete", "repos", len(r.cfg.Repos))
+}
+
+// RepoDir is where repo's bare clone lives (or will live).
+func (r *Refresher) RepoDir(repo string) string {
+	return filepath.Join(r.cfg.Root, repo+".git")
+}
+
+func (r *Refresher) syncRepo(ctx context.Context, repo string) error {
+	if !validRepoName(repo) {
+		return fmt.Errorf("invalid repo %q", repo)
+	}
+	dir := r.RepoDir(repo)
+	exists, err := r.isBareRepo(dir)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if err := r.initialClone(ctx, repo, dir); err != nil {
+			return err
+		}
+	}
+	return r.fetch(ctx, repo, dir)
+}
+
+// initialClone creates the bare skeleton and pulls heads+tags the first time.
+// It deliberately avoids `git clone --mirror`: that would also drag GitHub's
+// refs/pull/* into every node's disk for content nobody clones.
+func (r *Refresher) initialClone(ctx context.Context, repo, dir string) error {
+	if out, err := r.git(ctx,
+		"-c", "gc.auto=0",
+		"init",
+		"--bare",
+		"--initial-branch=main",
+		dir,
+	); err != nil {
+		return fmt.Errorf("init %s: %w: %s", dir, err, out)
+	}
+	if out, err := r.git(ctx,
+		"-C", dir,
+		"remote", "add", "origin", r.cfg.UpstreamBase+repo+".git",
+	); err != nil {
+		return fmt.Errorf("remote add %s: %w: %s", repo, err, out)
+	}
+	// Partial-clone support advertised by this repo forever, matching the
+	// retired mirror ("Enable partial/shallow clones"). Belt-and-braces with
+	// the -c the server passes on every request.
+	if _, err := r.git(ctx,
+		"-C", dir,
+		"config", "uploadpack.allowFilter", "true",
+	); err != nil {
+		return fmt.Errorf("config %s: %w", repo, err)
+	}
+	if err := r.fetch(ctx, repo, dir); err != nil {
+		return err
+	}
+	r.pointHeadAtDefault(ctx, dir)
+	return nil
+}
+
+func (r *Refresher) fetch(ctx context.Context, repo, dir string) error {
+	out, err := r.git(ctx,
+		"-C", dir,
+		"-c", "gc.auto=0",
+		"fetch",
+		"--prune",
+		"--force",
+		"origin",
+		"+refs/heads/*:refs/heads/*",
+		"+refs/tags/*:refs/tags/*",
+	)
+	if err != nil {
+		return fmt.Errorf("fetch %s: %w: %s", repo, err, out)
+	}
+	return nil
+}
+
+// pointHeadAtDefault aims the bare clone's HEAD at upstream's default branch,
+// best-effort: a clone without --branch resolves HEAD, so a dangling HEAD
+// would fail exactly those hydrations. Failures log and move on because a
+// stale HEAD self-corrects on the next pass and hydration mostly pins --branch.
+func (r *Refresher) pointHeadAtDefault(ctx context.Context, dir string) {
+	out, err := r.git(ctx, "-C", dir, "ls-remote", "--symref", "origin", "HEAD")
+	if err != nil {
+		r.logger.Warn("mirror: could not read upstream HEAD", "dir", dir, "err", err)
+		return
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		ref, found := strings.CutPrefix(line, "ref: ")
+		if !found {
+			continue
+		}
+		target, ok := strings.CutPrefix(ref, "refs/heads/")
+		fields := strings.Fields(target)
+		if ok && len(fields) > 0 {
+			if _, err := r.git(ctx, "-C", dir, "symbolic-ref", "HEAD", "refs/heads/"+fields[0]); err != nil {
+				r.logger.Warn("mirror: could not set HEAD", "dir", dir, "err", err)
+			}
+		}
+		return
+	}
+}
+
+// authArgs renders the per-invocation credential for private repos. It rides
+// argv only: nothing lands in the repo config, on disk, or in any log line.
+// With no token the clone stays anonymous (public repos need nothing).
+func authArgs(token string) []string {
+	if token == "" {
+		return nil
+	}
+	basic := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token))
+	return []string{
+		"-c", "http.https://github.com/.extraheader=Authorization: Basic " + basic,
+	}
+}
+
+func validRepoName(repo string) bool {
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok || owner == "" || name == "" {
+		return false
+	}
+	return !strings.ContainsAny(owner, "./ \t\n") && !strings.ContainsAny(name, "./ \t\n")
+}
+
+func (r *Refresher) isBareRepo(dir string) (bool, error) {
+	out, err := r.git(context.Background(), "-C", dir, "rev-parse", "--is-bare-repository")
+	if err != nil {
+		// rev-parse fails outside any repository, which here means
+		// not-initialized-yet rather than an operational failure.
+		return false, nil
+	}
+	return strings.TrimSpace(string(out)) == "true", nil
+}
+
+// git runs one git invocation with this refresher's binary plus the shared
+// auth extraheader when a token is configured.
+func (r *Refresher) git(ctx context.Context, args ...string) ([]byte, error) {
+	argv := append([]string{r.cfg.GitBin}, authArgs(r.cfg.Token)...)
+	argv = append(argv, args...)
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	return cmd.CombinedOutput()
+}

--- a/projects/embervm/mirror/refresh/refresher_test.go
+++ b/projects/embervm/mirror/refresh/refresher_test.go
@@ -1,0 +1,133 @@
+package refresh
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	path, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("git not on PATH: %v", err)
+	}
+	cmd := exec.Command(path, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v: %s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+func commitFile(t *testing.T, work, name, content, message string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(work, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, work, "add", name)
+	git(t, work, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-m", message)
+}
+
+// fixtureUpstream creates an upstream "remote" shaped exactly as the refresher
+// addresses GitHub: <base>/<owner>/<name>.git holding one branch main.
+func fixtureUpstream(t *testing.T) (base string, work string) {
+	t.Helper()
+	tmp := t.TempDir()
+	work = filepath.Join(tmp, "work")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git(t, work, "init", "-b", "main", ".")
+	commitFile(t, work, "hello.txt", "first\n", "first")
+	base = filepath.Join(tmp, "upstream") + string(filepath.Separator)
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git(t, work, "clone", "--bare", ".", filepath.Join(base, "owner", "name.git"))
+	return base, work
+}
+
+func newTestRefresher(t *testing.T, base string) *Refresher {
+	t.Helper()
+	path, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("git not on PATH: %v", err)
+	}
+	return New(Config{
+		Root:         filepath.Join(t.TempDir(), "mirrors"),
+		GitBin:       path,
+		Repos:        []string{"owner/name"},
+		Interval:     time.Hour,
+		UpstreamBase: base,
+	}, nil)
+}
+
+func TestSyncRepoInitialCloneAndRefresh(t *testing.T) {
+	base, work := fixtureUpstream(t)
+	r := newTestRefresher(t, base)
+
+	dir := r.RepoDir("owner/name")
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("mirror exists before first sync: %v", err)
+	}
+
+	r.syncRepo(t.Context(), "owner/name")
+
+	out := git(t, dir, "rev-parse", "--is-bare-repository")
+	if strings.TrimSpace(out) != "true" {
+		t.Errorf("mirror is not a bare repository: %s", out)
+	}
+	out = git(t, dir, "rev-list", "--count", "refs/heads/main")
+	if strings.TrimSpace(out) != "1" {
+		t.Errorf("main commit count = %s, want 1", out)
+	}
+
+	// The filter config is load-bearing: without it guests cannot hydrate
+	// with --filter=blob:none (#4473).
+	out = git(t, dir, "config", "--get", "uploadpack.allowFilter")
+	if strings.TrimSpace(out) != "true" {
+		t.Errorf("uploadpack.allowFilter = %q, want true", out)
+	}
+	// HEAD points at the upstream default branch so a plain clone resolves.
+	out = git(t, dir, "symbolic-ref", "HEAD")
+	if strings.TrimSpace(out) != "refs/heads/main" {
+		t.Errorf("HEAD = %q, want refs/heads/main", out)
+	}
+
+	// A second upstream commit appears after the next pass: the mirror moves
+	// with upstream within one interval. The work repo pushes into the bare
+	// stand-in remote, exactly what a real GitHub push does.
+	commitFile(t, work, "hello.txt", "second\n", "second")
+	git(t, work, "push", filepath.Join(base, "owner", "name.git"), "main")
+	r.syncRepo(t.Context(), "owner/name")
+
+	out = strings.TrimSpace(git(t, dir, "rev-parse", "refs/heads/main"))
+	want := strings.TrimSpace(git(t, work, "rev-parse", "refs/heads/main"))
+	if out != want {
+		t.Errorf("mirror main = %s, want upstream %s", out, want)
+	}
+}
+
+func TestSyncRepoRejectsInvalidNames(t *testing.T) {
+	base, _ := fixtureUpstream(t)
+	r := newTestRefresher(t, base)
+	for _, repo := range []string{"norepo", "../escape", "", "a/b/c"} {
+		if err := r.syncRepo(t.Context(), repo); err == nil {
+			t.Errorf("syncRepo(%q) succeeded, want rejection", repo)
+		}
+	}
+}
+
+func TestAuthArgsEmptyTokenIsNil(t *testing.T) {
+	if got := authArgs(""); got != nil {
+		t.Errorf("authArgs(\"\") = %v, want nil", got)
+	}
+	if got := authArgs("tok"); len(got) != 2 || !strings.Contains(got[1], "Basic ") {
+		t.Errorf("authArgs(tok) = %v, want one -c pair carrying Basic auth", got)
+	}
+}

--- a/projects/embervm/mirror/server/BUILD
+++ b/projects/embervm/mirror/server/BUILD
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "server",
+    srcs = ["server.go"],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/mirror/server",
+    visibility = ["//projects/embervm/mirror:__subpackages__"],
+)
+
+go_test(
+    name = "server_test",
+    srcs = ["server_test.go"],
+    embed = [":server"],
+)

--- a/projects/embervm/mirror/server/server.go
+++ b/projects/embervm/mirror/server/server.go
@@ -1,0 +1,308 @@
+// Package server serves bare git mirrors over the smart HTTP protocol so a
+// session guest can hydrate its workspace from a node-local copy instead of
+// cloning GitHub through the credential-injecting egress lane (#4473).
+//
+// Only git-upload-pack is served, anonymous and read-only. There is no
+// receive-pack: the claude runtime's hydration path never pushes to the
+// mirror, and a read-only surface is the whole posture (ADR agents/050 kept
+// scratch-ref pushes on the retired central mirror; nothing consumes them on
+// this node-local one).
+//
+// The wire shape is the standard git smart-http contract:
+//
+//	GET  /<owner>/<repo>.git/info/refs?service=git-upload-pack
+//	     -> application/x-git-upload-pack-advertisement
+//	POST /<owner>/<repo>.git/git-upload-pack
+//	     -> application/x-git-upload-pack-result
+//
+// backed by `git upload-pack` subprocesses against the on-disk bare clones,
+// which keeps every protocol decision (v0/v2 negotiation, pack generation,
+// blob filters) inside git rather than reimplemented here.
+package server
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultGitBin is the git binary used unless WithGitBin overrides it.
+const DefaultGitBin = "git"
+
+const (
+	contentTypeAdvertisement = "application/x-git-upload-pack-advertisement"
+	contentTypeRequest       = "application/x-git-upload-pack-request"
+	contentTypeResult        = "application/x-git-upload-pack-result"
+	serviceUploadPack        = "git-upload-pack"
+)
+
+// Server serves one mirrors root over git smart-http. It is safe for
+// concurrent use: every request runs its own short-lived git subprocess.
+type Server struct {
+	// root holds one bare clone per mirrored repository, laid out as
+	// <root>/<owner>/<repo>.git exactly as the URL path names them.
+	root string
+	// gitBin is the git executable. Overridable for tests.
+	gitBin string
+	logger *slog.Logger
+}
+
+// New builds a Server serving the bare clones under root.
+func New(root string, logger *slog.Logger) *Server {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Server{root: root, gitBin: DefaultGitBin, logger: logger}
+}
+
+// WithGitBin overrides the git executable. Production leaves the default;
+// tests pin the host git explicitly so the suite does not depend on PATH.
+func (s *Server) WithGitBin(gitBin string) *Server {
+	s.gitBin = gitBin
+	return s
+}
+
+// Handler returns the http.Handler serving the mirror. /healthz answers 200 so
+// an in-pod probe has something cheap to hit; everything else is the git
+// smart-http surface.
+func (s *Server) Handler() http.Handler {
+	return http.HandlerFunc(s.serveHTTP)
+}
+
+func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/healthz" {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok\n")
+		return
+	}
+	repoDir, action, ok := resolveRepoPath(s.root, r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	// An unmaterialized mirror (not yet cloned by the refresher, or a repo
+	// that never existed) is a plain 404 for every action.
+	if _, err := os.Stat(repoDir); err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	switch action {
+	case "info/refs":
+		s.serveInfoRefs(w, r, repoDir)
+	case "git-upload-pack":
+		s.serveUploadPack(w, r, repoDir)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// resolveRepoPath maps "/<owner>/<repo>.git/<action>" onto
+// <root>/<owner>/<repo>.git and returns the action suffix. The mapping is
+// strict: exactly two non-empty path segments before the action, no dot-dot,
+// no hidden segments, because the repo dir is joined onto root verbatim.
+func resolveRepoPath(root, requestPath string) (repoDir, action string, ok bool) {
+	trimmed := strings.TrimPrefix(requestPath, "/")
+	owner, rest, found := strings.Cut(trimmed, "/")
+	if !found {
+		return "", "", false
+	}
+	name, action, found := strings.Cut(rest, "/")
+	if !found {
+		return "", "", false
+	}
+	for _, seg := range []string{owner, name} {
+		if seg == "" || seg == "." || seg == ".." || strings.HasPrefix(seg, ".") {
+			return "", "", false
+		}
+	}
+	// GitHub's git endpoints are addressed with the .git suffix and the mirror
+	// layout uses it too; requiring it here keeps plain directory names from
+	// being served by accident.
+	if !strings.HasSuffix(name, ".git") || name == ".git" {
+		return "", "", false
+	}
+	action = strings.TrimSuffix(action, "/")
+	return filepath.Join(root, owner, name), action, true
+}
+
+// serveInfoRefs answers the ref discovery request. Only upload-pack is
+// offered: discovery for any other service (receive-pack) is a 404, so the
+// mirror never even advertises a write side.
+func (s *Server) serveInfoRefs(w http.ResponseWriter, r *http.Request, repoDir string) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", http.MethodGet+", "+http.MethodHead)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if service := r.URL.Query().Get("service"); service != serviceUploadPack {
+		s.logger.Warn("mirror: refused non-upload-pack ref discovery", "service", service)
+		http.NotFound(w, r)
+		return
+	}
+	out, err := s.runUploadPack(r.Context(), repoDir, "--http-backend-info-refs", nil, protocolEnv(r))
+	if err != nil {
+		s.logger.Error("mirror: ref discovery failed", "err", err)
+		http.Error(w, "ref discovery failed", http.StatusInternalServerError)
+		return
+	}
+	body := append(serviceHeader(serviceUploadPack), out...)
+	w.Header().Set("Content-Type", contentTypeAdvertisement)
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Content-Length", fmt.Sprint(len(body)))
+	if r.Method == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	_, _ = w.Write(body)
+}
+
+// serveUploadPack answers the stateless RPC POST by piping the request body
+// through `git upload-pack --stateless-rpc` and streaming the pack back.
+func (s *Server) serveUploadPack(w http.ResponseWriter, r *http.Request, repoDir string) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// The client content type is application/x-git-upload-pack-request;
+	// anything else is not speaking the protocol at this endpoint.
+	if ct := r.Header.Get("Content-Type"); !hasContentTypePrefix(ct, contentTypeRequest) {
+		s.logger.Warn("mirror: refused upload-pack POST with unexpected content type", "content_type", ct)
+		http.NotFound(w, r)
+		return
+	}
+	body, err := decodeMaybeGzip(r)
+	if err != nil {
+		http.Error(w, "unreadable request body", http.StatusBadRequest)
+		return
+	}
+	pr, pw := io.Pipe()
+	cmdDone := make(chan error, 1)
+	go func() {
+		err := s.uploadPack(r.Context(), repoDir, "--stateless-rpc", body, pw, protocolEnv(r))
+		_ = pw.CloseWithError(err)
+		cmdDone <- err
+	}()
+	w.Header().Set("Content-Type", contentTypeResult)
+	w.Header().Set("Cache-Control", "no-cache")
+	flusher, _ := w.(http.Flusher)
+	w.WriteHeader(http.StatusOK)
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := pr.Read(buf)
+		if n > 0 {
+			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
+				// Client hung up; the request context cancels the subprocess.
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if readErr != nil {
+			break
+		}
+	}
+	if err := <-cmdDone; err != nil {
+		// The response headers are already gone, so the truncated body is all
+		// the client sees; log for the operator instead.
+		s.logger.Error("mirror: upload-pack rpc failed", "err", err)
+	}
+}
+
+func hasContentTypePrefix(ct, want string) bool {
+	return ct == want || strings.HasPrefix(ct, want+";")
+}
+
+// decodeMaybeGzip unwraps a gzip request body. git compresses large
+// upload-pack requests with Content-Encoding: gzip.
+func decodeMaybeGzip(r *http.Request) (io.Reader, error) {
+	if r.Header.Get("Content-Encoding") != "gzip" {
+		return r.Body, nil
+	}
+	return gzip.NewReader(r.Body)
+}
+
+// serviceHeader renders the pkt-line "# service=<name>" banner every smart-http
+// discovery response starts with, followed by the flush-pkt delimiter.
+func serviceHeader(service string) []byte {
+	line := fmt.Sprintf("# service=%s\n", service)
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%04x%s", len(line)+4, line)
+	b.WriteString("0000")
+	return b.Bytes()
+}
+
+// protocolEnv extracts the wire protocol version the client negotiated. Passing
+// it through lets v2 clients stay on v2; absent or malformed values fall back
+// to git's own default rather than being trusted blindly.
+func protocolEnv(r *http.Request) string {
+	for _, part := range strings.Split(r.Header.Get("Git-Protocol"), ":") {
+		version, ok := strings.CutPrefix(part, "version=")
+		if ok && isDigits(version) {
+			return "GIT_PROTOCOL=" + part
+		}
+	}
+	return ""
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// runUploadPack runs one buffered upload-pack invocation (ref discovery).
+func (s *Server) runUploadPack(ctx context.Context, repoDir, mode string, stdin io.Reader, protocol string) ([]byte, error) {
+	var out bytes.Buffer
+	if err := s.uploadPack(ctx, repoDir, mode, stdin, &out, protocol); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+// uploadPack execs one `git upload-pack <mode> .` against repoDir. mode is
+// --http-backend-info-refs for discovery or --stateless-rpc for the RPC POST.
+//
+// uploadpack.allowFilter here (not only in the repo config) is what makes
+// --filter=blob:none clones work no matter how the bare clone was produced:
+// partial clone support is the entire point of the mirror (#4473). A minimal
+// environment keeps the guest-facing surface independent of whatever leaks in;
+// GIT_PROTOCOL is appended only when the client sent a parseable version.
+func (s *Server) uploadPack(ctx context.Context, repoDir, mode string, stdin io.Reader, stdout io.Writer, protocol string) error {
+	cmd := exec.CommandContext(ctx, s.gitBin,
+		"-c", "uploadpack.allowFilter=true",
+		"upload-pack", mode, ".",
+	)
+	cmd.Dir = repoDir
+	env := []string{"PATH=/usr/local/bin:/usr/bin:/bin"}
+	if protocol != "" {
+		env = append(env, protocol)
+	}
+	cmd.Env = env
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	stderrBuf := &bytes.Buffer{}
+	cmd.Stderr = stderrBuf
+	if err := cmd.Run(); err != nil {
+		if stderrText := strings.TrimSpace(stderrBuf.String()); stderrText != "" {
+			return fmt.Errorf("upload-pack %s: %w: %s", mode, err, stderrText)
+		}
+		return fmt.Errorf("upload-pack %s: %w", mode, err)
+	}
+	return nil
+}

--- a/projects/embervm/mirror/server/server_test.go
+++ b/projects/embervm/mirror/server/server_test.go
@@ -1,0 +1,229 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// git runs a git command in dir and fails t on error.
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(gitBin(t), args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v: %s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+func gitBin(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("git not on PATH: %v", err)
+	}
+	return path
+}
+
+// fixtureMirror builds one bare mirror of a two-commit repo under
+// root/owner/repo.git and returns the file content the second commit carries,
+// so the clone smoke can assert real data crossed the wire.
+func fixtureMirror(t *testing.T, root string) string {
+	t.Helper()
+	work := t.TempDir()
+	git(t, work, "init", "-b", "main", ".")
+	write := func(name, content, message string) {
+		if err := os.WriteFile(filepath.Join(work, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git(t, work, "add", name)
+		git(t, work, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-m", message)
+	}
+	write("hello.txt", "hi from the fixture\n", "first")
+	write("hello.txt", "second revision\n", "second")
+	mirrorDir := filepath.Join(root, "owner", "repo.git")
+	if err := os.MkdirAll(filepath.Dir(mirrorDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git(t, work, "clone", "--bare", ".", mirrorDir)
+	return "second revision\n"
+}
+
+func newTestServer(t *testing.T) (*Server, http.Handler) {
+	t.Helper()
+	root := t.TempDir()
+	s := New(root, nil)
+	s.gitBin = gitBin(t)
+	return s, s.Handler()
+}
+
+func TestResolveRepoPath(t *testing.T) {
+	cases := []struct {
+		name       string
+		path       string
+		wantRepo   string
+		wantAction string
+		wantOK     bool
+	}{
+		{"happy path", "/owner/repo.git/info/refs", filepath.Join("/r", "owner", "repo.git"), "info/refs", true},
+		{"upload-pack action", "/owner/repo.git/git-upload-pack", filepath.Join("/r", "owner", "repo.git"), "git-upload-pack", true},
+		{"trailing slash", "/owner/repo.git/info/refs/", filepath.Join("/r", "owner", "repo.git"), "info/refs", true},
+		{"missing action", "/owner/repo.git", "", "", false},
+		{"single segment", "/repo.git", "", "", false},
+		{"no dot git", "/owner/repo/info/refs", "", "", false},
+		{"dotdot owner", "/../repo.git/info/refs", "", "", false},
+		{"dotdot name", "/owner/../info/refs", "", "", false},
+		{"hidden segment", "/.hidden/repo.git/info/refs", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, action, ok := resolveRepoPath("/r", tc.path)
+			if ok != tc.wantOK || repo != tc.wantRepo || action != tc.wantAction {
+				t.Errorf("resolveRepoPath(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.path, repo, action, ok, tc.wantRepo, tc.wantAction, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestInfoRefsAdvertisement(t *testing.T) {
+	root := t.TempDir()
+	fixtureMirror(t, root)
+	s := New(root, nil).WithGitBin(gitBin(t))
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/owner/repo.git/info/refs?service=git-upload-pack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body := new(bytes.Buffer)
+	if _, err := body.ReadFrom(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+
+	const wantHeader = "001e# service=git-upload-pack\n0000"
+	if got := body.String(); !strings.HasPrefix(got, wantHeader) {
+		t.Errorf("advertisement prefix = %q, want %q", got[:minInt(len(got), len(wantHeader))], wantHeader)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != contentTypeAdvertisement {
+		t.Errorf("content type = %q, want %q", ct, contentTypeAdvertisement)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("cache-control = %q, want no-cache", cc)
+	}
+	// The filter capability is what makes guest --filter=blob:none hydration
+	// possible at all (#4473): the server must advertise it on every mirror.
+	if !strings.Contains(body.String(), "filter") {
+		t.Errorf("advertisement does not advertise the filter capability:\n%s", body.String())
+	}
+	if !strings.Contains(body.String(), "HEAD") {
+		t.Errorf("advertisement missing refs:\n%s", body.String())
+	}
+}
+
+func minInt(a, b int) int {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+func TestInfoRefsRejectsOtherServices(t *testing.T) {
+	_, handler := newTestServer(t)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/owner/repo.git/info/refs?service=git-receive-pack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("receive-pack discovery status = %d, want 404 (mirror must not advertise a write side)", resp.StatusCode)
+	}
+}
+
+func TestUploadPackRejectsWrongContentType(t *testing.T) {
+	_, handler := newTestServer(t)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/owner/repo.git/git-upload-pack", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("wrong content-type status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestUnknownRepoIs404(t *testing.T) {
+	_, handler := newTestServer(t)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/ghost/nothing.git/info/refs?service=git-upload-pack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("unknown repo status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestRealGitCloneSmoke is the end-to-end guard: an actual `git clone` (the
+// exact shape hydration uses, --single-branch --filter=blob:none) succeeds
+// against the served fixture and checks out the fixture's content.
+func TestRealGitCloneSmoke(t *testing.T) {
+	root := t.TempDir()
+	wantContent := fixtureMirror(t, root)
+	s := New(root, nil).WithGitBin(gitBin(t))
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	dst := filepath.Join(t.TempDir(), "checkout")
+	git(t, t.TempDir(), "clone",
+		"--single-branch",
+		"--filter=blob:none",
+		srv.URL+"/owner/repo.git",
+		dst,
+	)
+	content, err := os.ReadFile(filepath.Join(dst, "hello.txt"))
+	if err != nil {
+		t.Fatalf("cloned checkout missing hello.txt: %v", err)
+	}
+	if string(content) != wantContent {
+		t.Errorf("cloned hello.txt = %q, want %q", content, wantContent)
+	}
+	// Full history survived the partial clone: both commits present.
+	logOut := git(t, dst, "rev-list", "--count", "HEAD")
+	if strings.TrimSpace(logOut) != "2" {
+		t.Errorf("commit count = %s, want 2 (blob:none keeps history)", logOut)
+	}
+}
+
+func TestHealthz(t *testing.T) {
+	_, handler := newTestServer(t)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("healthz status = %d, want 200", resp.StatusCode)
+	}
+}

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -31,6 +31,16 @@ VSOCK_EGRESS_PORT = 1025
 # after the request and FC hybrid vsock kills the in-flight response on any
 # shutdown. See VsockEgressForwarder._forward.
 GIT_DAEMON_PORT = "9418"
+# Node-local hydration source (#4473). The noded pod runs a git-mirror sidecar
+# serving bare clones over smart http on its LOOPBACK, and the egress-proxy
+# tunnels the reserved host below straight to it, so the only thing a guest
+# needs is this URL through the ordinary lane proxy. The port is deliberately
+# NOT GIT_DAEMON_PORT: the half-close suppression that wedged connection #2 on
+# git:// is scoped to :9418, so smart-http's sequential connections here tear
+# down normally and blob:none lazy fetches are safe again. Setting
+# EMBER_GIT_MIRROR_URL empty disables the mirror attempt entirely.
+MIRROR_URL_ENV = "EMBER_GIT_MIRROR_URL"
+DEFAULT_MIRROR_URL = "http://git-mirror.egress.internal:9419"
 EGRESS_VSOCK_CONNECT_TIMEOUT_SECONDS = 5.0
 EGRESS_VSOCK_CONNECT_ATTEMPTS = 3
 EGRESS_VSOCK_CONNECT_BACKOFF_SECONDS = 0.2
@@ -547,9 +557,11 @@ SANDBOX_PROMPT = (
     "is present and git log, git blame and git bisect all work. File contents "
     "are fetched on demand, so an operation touching many old revisions pauses "
     "while blobs download rather than failing.\n"
-    "- origin points at GitHub over https. Pushes go to the real repository, so "
-    "treat any push as publishing. The proxy attaches the credential on the way "
-    "out; you hold none.\n"
+    "- The checkout was cloned from a read-only node-local mirror, so "
+    "origin does not accept pushes (#4473). To publish work, add GitHub as "
+    "a remote (`git remote add github https://github.com/OWNER/REPO.git`) "
+    "and push there; the proxy attaches the credential on the way out, so "
+    "you still hold none.\n"
     "- Your git identity is already configured. Do not set user.name or "
     "user.email.\n"
     "- All network egress is proxied. The public internet is reachable and "
@@ -607,6 +619,26 @@ def _github_basic_optin():
     """
     token = os.environ.get(GH_TOKEN_ENV, "")
     return base64.b64encode(("x-access-token:%s" % token).encode()).decode()
+
+
+def _clone_sources(repo):
+    """Ordered (source, url, credential_optin) attempts for workspace hydration.
+
+    Mirror first (#4473): node-local, no credential anywhere on the path, and
+    full history plus lazy blobs because the mirror advertises the filter
+    capability. GitHub direct second: it keeps unmirrored repos and private
+    repos hydrating exactly as today, which is what bounds #4473's two caveats
+    (up-to-one-refresh-interval staleness, token-scoped mirroring) to staleness
+    on catalogued repos instead of breakage on everything else. The github
+    entry carries the Basic opt-in header; the mirror entry deliberately
+    carries nothing.
+    """
+    sources = []
+    mirror_base = os.environ.get(MIRROR_URL_ENV, DEFAULT_MIRROR_URL).strip().rstrip("/")
+    if mirror_base:
+        sources.append(("mirror", "%s/%s.git" % (mirror_base, repo), False))
+    sources.append(("github", "https://github.com/%s.git" % repo, True))
+    return sources
 
 
 # The egress CA the sidecar mints MITM leaves from, and the reserved preamble
@@ -3538,128 +3570,158 @@ class ProcessManager:
             # A durable volume can contain a partial clone from a prior failure.
             shutil.rmtree(checkout_dir, ignore_errors=True)
         _ensure_cli_dir(self.workspace)
-        # Hydrate from GitHub over https, not from the git-mirror over git://.
+        # Hydrate from the node-local git mirror over http (#4473), falling
+        # back to GitHub direct over https.
         #
-        # The mirror was chosen (ADR agents/050) because it needs no credential
-        # and is node-local. What disqualified it is the transport: #4389 stopped
-        # propagating half-close onto the vsock leg, and that suppression is
-        # scoped to the git-daemon port
-        # (shim.py: half_close_upstream = not host_port.endswith(":9418")), so a
-        # git:// tunnel never closes and a SECOND lane connection while it lingers
-        # wedges (#4417). That is what forced --depth=1: a blob filter defers
-        # blobs, and checkout then lazy-fetches them on exactly that second
-        # connection. Shallow-but-complete was the only single-connection shape.
+        # The mirror was dropped once (ADR agents/050 -> #4470) because of its
+        # transport: #4389 stopped propagating half-close onto the vsock leg,
+        # and that suppression is scoped to the git-daemon port
+        # (shim.py: half_close_upstream = not host_port.endswith(":9418")), so
+        # a git:// tunnel never closes and a SECOND lane connection while it
+        # lingers wedges (#4417). That forced --depth=1, because a blob filter
+        # defers blobs and checkout lazy-fetches them on exactly that second
+        # connection.
         #
-        # Over :443 the tunnel tears down normally, which is why sequential CLI
-        # HTTPS and gh both work today. So the filter becomes usable, and with it
-        # FULL HISTORY: --filter=blob:none keeps every commit and tree and defers
-        # only file contents, so git log, blame and bisect all work and blobs
-        # arrive on demand. --depth=1 is therefore gone, not merely relaxed.
+        # The fix is the transport, not the mirror. Smart http on :9419 (any
+        # non-9418 port) tears its tunnels down normally, which is why
+        # sequential CLI HTTPS and gh already work on this lane, so the two
+        # sequential connections a partial clone needs are safe again. With the
+        # filter usable, FULL HISTORY returns: --filter=blob:none keeps every
+        # commit and tree and defers only file contents, so git log, blame and
+        # bisect all work and blobs arrive on demand. --depth=1 stays gone.
         #
-        # No credential enters the guest. github.com is a credentialed egressTo
-        # host (deploy/values.yaml): the sidecar terminates the guest's TLS with a
-        # leaf minted from the egress CA, sets Authorization itself using Basic
-        # (git-receive-pack 401s on Bearer), and originates fresh verified TLS. A
-        # guest already reaches github.com this way for gh and for push, so
-        # sourcing the clone here grants nothing it did not already hold. It also
-        # fixes private repos, which the mirror non-fatally SKIPS when it has no
-        # read token of its own.
+        # No credential is on the mirror path at all. The sidecar answers the
+        # reserved host with anonymous read-only upload-pack; nothing here
+        # sends an Authorization header toward it, so there is nothing to
+        # inject, discard, or leak. The github fallback keeps today's shape:
+        # github.com is a credentialed egressTo host (deploy/values.yaml), the
+        # sidecar sets Authorization itself using Basic (git-receive-pack 401s
+        # on Bearer), and originates fresh verified TLS. That fallback is also
+        # what bounds the mirror's caveats (#4473): staleness up to one refresh
+        # interval and repos the mirror has no token for degrade to today's
+        # path instead of failed sessions.
         #
         # http.proxy rather than HTTPS_PROXY: apply_egress_ca_trust() runs before
         # this and exports GIT_SSL_CAINFO into os.environ, but the proxy URL is
         # only ever built inside the per-adapter CLI spawn envs, which this
         # subprocess does not inherit. Passing it as git config keeps the setting
-        # on this one clone instead of leaking proxy env into every child.
+        # on this one clone instead of leaking proxy env into every child. Both
+        # sources ride the same lane proxy; only the destination differs.
         egress_port = os.environ.get(EGRESS_PORT_ENV, str(DEFAULT_EGRESS_PORT))
-        clone_command = [
-            "git",
-            "clone",
-            "--progress",
-            "--branch",
-            branch,
-            "--config",
-            "http.proxy=http://%s:%s" % (EGRESS_LOCALHOST, egress_port),
-            # The LOGIN GATE DUMMY that opts this clone into credential
-            # injection, derived from the same GH_TOKEN gh already presents
-            # rather than defined here.
-            #
-            # The sidecar's injection is PRESENCE-KEYED: it replaces an
-            # Authorization header the guest already sent and DISCARDS whatever
-            # value was in it (egress-proxy injectRequest: `requested :=
-            # len(req.Header.Values(sec.Header)) > 0 || sec.injectAlwaysPath(...)`
-            # then `if !requested { return false }`). The header is an opt-in
-            # switch, never a credential, which is what stops a prompt-injected
-            # guest from authenticating as anyone else.
-            #
-            # git sends no Authorization on its first request, so nothing was
-            # injected and github.com answered 401, which git surfaces as
-            # "could not read Username for 'https://github.com'" once it falls
-            # through to an interactive prompt. gh never hit this because it
-            # always sends its own dummy. Reusing GH_TOKEN keeps the value where
-            # guest env is defined (guest-init setDefaultEnv, alongside
-            # CLAUDE_CODE_OAUTH_TOKEN) instead of adding a second, credential
-            # shaped literal to this file.
-            #
-            # injectAlwaysPaths cannot cover this instead: it is an EXACT match
-            # on req.URL.Path, and git's paths are per repository
-            # (/owner/repo.git/info/refs, /owner/repo.git/git-upload-pack), so it
-            # would have to enumerate every repo anyone might ever select.
-            #
-            # x-access-token:<token> is the Basic shape GitHub's git endpoint
-            # expects. Scoped to github.com by URL so it is never presented
-            # anywhere else, and written into the clone's config so the lazy blob
-            # fetches --filter=blob:none defers carry it too.
-            "--config",
-            "http.https://github.com/.extraHeader=Authorization: Basic %s"
-            % _github_basic_optin(),
-            "--single-branch",
-            "--filter=blob:none",
-            "https://github.com/%s.git" % repo,
-            checkout_dir,
-        ]
-        try:
-            clone_start = _turn_timing_now()
-            result = subprocess.run(
-                clone_command,
-                capture_output=True,
-                timeout=GIT_CLONE_TIMEOUT_SECONDS,
-                **_cli_privilege_kwargs(),
-            )
-            _emit_elapsed("hydration_clone", clone_start)
-            if result.returncode != 0:
-                stderr = result.stderr
-                if isinstance(stderr, bytes):
-                    stderr = stderr.decode("utf-8", "replace")
-                stderr = (stderr or "").strip()
-                raise RuntimeError(
-                    "git command failed with exit code %s%s"
-                    % (result.returncode, ": " + stderr if stderr else "")
+        failure = None
+        failure_source = None
+        for source, url, credential_optin in _clone_sources(repo):
+            if failure is not None:
+                sys.stderr.write(
+                    "ember-claude-shim: %s hydration clone failed (%s); "
+                    "falling back to %s\n"
+                    % (
+                        failure_source,
+                        str(failure).strip()[:200] or "no detail",
+                        source,
+                    )
                 )
-            validation = subprocess.run(
-                ["git", "-C", checkout_dir, "rev-parse", "--verify", "HEAD"],
-                capture_output=True,
-                timeout=5,
-                **_cli_privilege_kwargs(),
-            )
-            if validation.returncode != 0:
-                raise RuntimeError("cloned directory validation failed: HEAD not found")
-        except subprocess.TimeoutExpired as exc:
-            _write_hydration_diagnostics(exc, checkout_dir)
-            shutil.rmtree(checkout_dir, ignore_errors=True)
-            self._hydration_error = str(exc)
+                sys.stderr.flush()
+            clone_command = [
+                "git",
+                "clone",
+                "--progress",
+                "--branch",
+                branch,
+                "--config",
+                "http.proxy=http://%s:%s" % (EGRESS_LOCALHOST, egress_port),
+            ]
+            if credential_optin:
+                # The LOGIN GATE DUMMY that opts this clone into credential
+                # injection, derived from the same GH_TOKEN gh already presents
+                # rather than defined here.
+                #
+                # The sidecar's injection is PRESENCE-KEYED: it replaces an
+                # Authorization header the guest already sent and DISCARDS whatever
+                # value was in it (egress-proxy injectRequest: `requested :=
+                # len(req.Header.Values(sec.Header)) > 0 || sec.injectAlwaysPath(...)`
+                # then `if !requested { return false }`). The header is an opt-in
+                # switch, never a credential, which is what stops a prompt-injected
+                # guest from authenticating as anyone else.
+                #
+                # git sends no Authorization on its first request, so nothing was
+                # injected and github.com answered 401, which git surfaces as
+                # "could not read Username for 'https://github.com'" once it falls
+                # through to an interactive prompt. gh never hit this because it
+                # always sends its own dummy. Reusing GH_TOKEN keeps the value where
+                # guest env is defined (guest-init setDefaultEnv, alongside
+                # CLAUDE_CODE_OAUTH_TOKEN) instead of adding a second, credential
+                # shaped literal to this file.
+                #
+                # injectAlwaysPaths cannot cover this instead: it is an EXACT match
+                # on req.URL.Path, and git's paths are per repository
+                # (/owner/repo.git/info/refs, /owner/repo.git/git-upload-pack), so it
+                # would have to enumerate every repo anyone might ever select.
+                #
+                # x-access-token:<token> is the Basic shape GitHub's git endpoint
+                # expects. Scoped to github.com by URL so it is never presented
+                # anywhere else, and written into the clone's config so the lazy blob
+                # fetches --filter=blob:none defers carry it too.
+                clone_command += [
+                    "--config",
+                    "http.https://github.com/.extraHeader=Authorization: Basic %s"
+                    % _github_basic_optin(),
+                ]
+            clone_command += [
+                "--single-branch",
+                "--filter=blob:none",
+                url,
+                checkout_dir,
+            ]
+            try:
+                clone_start = _turn_timing_now()
+                result = subprocess.run(
+                    clone_command,
+                    capture_output=True,
+                    timeout=GIT_CLONE_TIMEOUT_SECONDS,
+                    **_cli_privilege_kwargs(),
+                )
+                _emit_elapsed(
+                    "hydration_clone",
+                    clone_start,
+                    status="ok:%s" % source
+                    if result.returncode == 0
+                    else "failed:%s" % source,
+                )
+                if result.returncode != 0:
+                    stderr = result.stderr
+                    if isinstance(stderr, bytes):
+                        stderr = stderr.decode("utf-8", "replace")
+                    stderr = (stderr or "").strip()
+                    raise RuntimeError(
+                        "git command failed with exit code %s%s"
+                        % (result.returncode, ": " + stderr if stderr else "")
+                    )
+                validation = subprocess.run(
+                    ["git", "-C", checkout_dir, "rev-parse", "--verify", "HEAD"],
+                    capture_output=True,
+                    timeout=5,
+                    **_cli_privilege_kwargs(),
+                )
+                if validation.returncode != 0:
+                    raise RuntimeError(
+                        "cloned directory validation failed: HEAD not found"
+                    )
+                failure = None
+                break
+            except Exception as exc:
+                failure = exc
+                failure_source = source
+                # A partial clone from a failed attempt must not survive: the
+                # next attempt (or the retry on a later turn) starts clean.
+                shutil.rmtree(checkout_dir, ignore_errors=True)
+        if failure is not None:
+            if isinstance(failure, subprocess.TimeoutExpired):
+                _write_hydration_diagnostics(failure, checkout_dir)
+            self._hydration_error = str(failure)
             sys.stderr.write(
                 "ember-claude-shim: workspace hydration failed for %s@%s: %s\n"
-                % (repo, branch, exc)
-            )
-            sys.stderr.flush()
-            return
-        except Exception as exc:
-            _write_hydration_diagnostics(exc, checkout_dir)
-            shutil.rmtree(checkout_dir, ignore_errors=True)
-            self._hydration_error = str(exc)
-            sys.stderr.write(
-                "ember-claude-shim: workspace hydration failed for %s@%s: %s\n"
-                % (repo, branch, exc)
+                % (repo, branch, failure)
             )
             sys.stderr.flush()
             return

--- a/projects/embervm/runtimes/claude/shim_hydration_test.py
+++ b/projects/embervm/runtimes/claude/shim_hydration_test.py
@@ -163,7 +163,9 @@ def test_failed_hydration_retries_on_next_turn_and_succeeds(
     def fake_run(command, **_kwargs):
         if command[1] == "clone":
             clone_calls.append(command)
-            if len(clone_calls) == 1:
+            # Both the mirror attempt and the github fallback fail on the
+            # first turn; the retry on turn two succeeds on the mirror.
+            if len(clone_calls) <= 2:
                 raise subprocess.TimeoutExpired("git", shim.GIT_CLONE_TIMEOUT_SECONDS)
         return _GitProcess()
 
@@ -174,9 +176,13 @@ def test_failed_hydration_retries_on_next_turn_and_succeeds(
 
     assert first["workspace_hydration"]["failed"]
     assert second["workspace_hydration"] == "ok"
-    assert len(clone_calls) == 2
+    assert len(clone_calls) == 3
+    assert clone_calls[0][-2].startswith(shim.DEFAULT_MIRROR_URL)
+    assert clone_calls[1][-2] == "https://github.com/owner/repo.git"
     assert manager.claude.workspace == os.path.join(manager.workspace, "src")
-    assert "retrying workspace hydration" in capsys.readouterr().err
+    captured = capsys.readouterr().err
+    assert "retrying workspace hydration" in captured
+    assert "falling back to github" in captured
 
 
 def test_hydration_failure_is_capped_and_keeps_reporting(manager, monkeypatch):
@@ -195,7 +201,9 @@ def test_hydration_failure_is_capped_and_keeps_reporting(manager, monkeypatch):
         for _ in range(shim.HYDRATION_ATTEMPT_CAP + 1)
     ]
 
-    assert len(clone_calls) == shim.HYDRATION_ATTEMPT_CAP
+    # Every capped hydration turn burns BOTH sources (mirror, then github
+    # fallback) before reporting failure.
+    assert len(clone_calls) == 2 * shim.HYDRATION_ATTEMPT_CAP
     assert manager._hydration_attempts == shim.HYDRATION_ATTEMPT_CAP
     assert all(record["workspace_hydration"]["failed"] for record in records)
 
@@ -213,28 +221,55 @@ def test_git_command_shape(manager, monkeypatch):
 
     manager.turn("first", repo="owner/repo", branch="main")
     checkout_dir = os.path.join(manager.workspace, "src")
-    assert commands == [
-        [
-            "git",
-            "clone",
-            "--progress",
-            "--branch",
-            "main",
-            "--config",
-            "http.proxy=http://127.0.0.1:1024",
-            "--config",
-            "http.https://github.com/.extraHeader=Authorization: Basic %s"
-            % shim._github_basic_optin(),
-            "--single-branch",
-            "--filter=blob:none",
-            "https://github.com/owner/repo.git",
-            checkout_dir,
-        ],
+    # Mirror first (#4473): node-local smart http on the reserved host, no
+    # credential anywhere on the command.
+    assert commands[0] == [
+        "git",
+        "clone",
+        "--progress",
+        "--branch",
+        "main",
+        "--config",
+        "http.proxy=http://127.0.0.1:1024",
+        "--single-branch",
+        "--filter=blob:none",
+        "%s/owner/repo.git" % shim.DEFAULT_MIRROR_URL,
+        checkout_dir,
     ]
 
 
-def test_git_clone_regression_guards(manager, monkeypatch):
-    """Verify critical clone command properties to prevent regressions."""
+def test_mirror_clone_failure_falls_back_to_github(manager, monkeypatch):
+    """An unmirrored repo degrades to today's credentialed GitHub clone."""
+    processes = [
+        _GitProcess(returncode=128, stderr_text="fatal: repository not found"),
+        _GitProcess(),
+        _GitProcess(),
+    ]
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "clone":
+            commands.append(command)
+        return processes.pop(0)
+
+    monkeypatch.setattr(shim.subprocess, "run", fake_run)
+
+    record = manager.turn("first", repo="owner/repo", branch="main")
+
+    assert record["workspace_hydration"] == "ok"
+    checkout_dir = os.path.join(manager.workspace, "src")
+    assert len(commands) == 2
+    fallback = commands[1]
+    assert fallback[-2] == "https://github.com/owner/repo.git"
+    assert (
+        "http.https://github.com/.extraHeader=Authorization: Basic %s"
+        % shim._github_basic_optin()
+    ) in fallback
+    assert "http.proxy=http://127.0.0.1:1024" in fallback
+
+
+def test_mirror_disabled_by_empty_env(manager, monkeypatch):
+    monkeypatch.setenv(shim.MIRROR_URL_ENV, "")
     processes = [_GitProcess(), _GitProcess()]
     commands = []
 
@@ -248,35 +283,84 @@ def test_git_clone_regression_guards(manager, monkeypatch):
     manager.turn("first", repo="owner/repo", branch="main")
 
     assert len(commands) == 1
-    command = commands[0]
+    assert commands[0][-2] == "https://github.com/owner/repo.git"
 
-    # Regression guard: --depth=1 must be ABSENT. It was the workaround for
-    # #4417 while hydration ran over git:// (:9418, the one port whose tunnels
-    # deliberately never close). Over https the tunnel closes normally, and the
-    # whole point of the move is that history is present.
-    assert "--depth=1" not in command, "clone command must not be shallow"
 
-    # Regression guard: the blob filter is what makes full history affordable.
-    # Dropping it turns hydration into a full-content clone of all history.
-    assert "--filter=blob:none" in command, "clone command missing --filter=blob:none"
+def test_clone_sources_order_and_optin():
+    sources = shim._clone_sources("owner/repo")
+    assert [name for name, _url, _optin in sources] == ["mirror", "github"]
+    assert sources[0][1] == "%s/owner/repo.git" % shim.DEFAULT_MIRROR_URL
+    assert sources[0][2] is False, "the mirror path must carry no credential opt-in"
+    assert sources[1][1] == "https://github.com/owner/repo.git"
+    assert sources[1][2] is True
 
-    # Regression guard: https to GitHub, never git://. A git:// URL would put
-    # hydration back on the port whose lingering tunnels wedge connection #2,
-    # and would also lose the sidecar's credential injection (it can only set a
-    # header on bytes it can read, which requires the TLS-MITM lane).
-    url = command[-2]
-    assert url.startswith("https://github.com/"), "clone must use https to GitHub"
-    assert not any(arg.startswith("git://") for arg in command), (
-        "clone command must not use the git:// transport"
+
+def test_git_clone_regression_guards(manager, monkeypatch):
+    """Verify critical clone command properties to prevent regressions."""
+    processes = [
+        # Mirror attempt fails so the github fallback attempt also runs and
+        # both command shapes land under guard.
+        _GitProcess(returncode=128, stderr_text="not mirrored"),
+        _GitProcess(),  # github clone
+        _GitProcess(),  # rev-parse validation
+    ]
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "clone":
+            commands.append(command)
+        return processes.pop(0)
+
+    monkeypatch.setattr(shim.subprocess, "run", fake_run)
+
+    manager.turn("first", repo="owner/repo", branch="main")
+
+    assert len(commands) == 2
+    mirror_command, github_command = commands
+
+    for name, command in (("mirror", mirror_command), ("github", github_command)):
+        # Regression guard: --depth=1 must be ABSENT. It was the workaround for
+        # #4417 while hydration ran over git:// (:9418, the one port whose
+        # tunnels deliberately never close). Over http(s) the tunnel closes
+        # normally, and the whole point of the move is that history is present.
+        assert "--depth=1" not in command, "%s clone must not be shallow" % name
+
+        # Regression guard: the blob filter is what makes full history
+        # affordable. Dropping it turns hydration into a full-content clone of
+        # all history.
+        assert "--filter=blob:none" in command, (
+            "%s clone missing --filter=blob:none" % name
+        )
+
+        # Verify load-bearing flags remain. http.proxy, not core.gitProxy: the
+        # helper is a git:// proxy and does nothing for an https remote, and
+        # this subprocess does not inherit the CLI spawn env that carries
+        # HTTPS_PROXY. Both sources ride the same lane proxy.
+        assert "--single-branch" in command, "%s clone missing --single-branch" % name
+        assert any(arg.startswith("http.proxy=") for arg in command), (
+            "%s clone missing http.proxy config" % name
+        )
+        assert not any(arg.startswith("git://") for arg in command), (
+            "%s clone must not use the git:// transport" % name
+        )
+
+    # The mirror URL is the reserved host on a NON-9418 port (#4473): the port
+    # is what keeps half-close propagation (and with it the #4417 wedge)
+    # away from these tunnels.
+    mirror_url = mirror_command[-2]
+    assert mirror_url == "%s/owner/repo.git" % shim.DEFAULT_MIRROR_URL
+    assert not shim.DEFAULT_MIRROR_URL.endswith(":" + shim.GIT_DAEMON_PORT)
+
+    # The mirror attempt carries NO credential opt-in: anonymous read-only is
+    # the whole posture. Only the github fallback carries it.
+    assert not any("extraHeader" in arg for arg in mirror_command), (
+        "mirror clone must not send an Authorization opt-in"
     )
-
-    # Verify load-bearing flags remain. http.proxy, not core.gitProxy: the
-    # helper is a git:// proxy and does nothing for an https remote, and this
-    # subprocess does not inherit the CLI spawn env that carries HTTPS_PROXY.
-    assert "--single-branch" in command, "clone command missing --single-branch"
-    assert any(arg.startswith("http.proxy=") for arg in command), (
-        "clone command missing http.proxy config"
+    assert any("extraHeader" in arg for arg in github_command), (
+        "github fallback lost its credential opt-in"
     )
+    url = github_command[-2]
+    assert url.startswith("https://github.com/"), "fallback must use https to GitHub"
 
 
 def test_cli_cwd_set_to_checkout(manager, monkeypatch):
@@ -326,12 +410,9 @@ def test_hydration_works_for_non_default_branch(manager, monkeypatch):
         "develop",
         "--config",
         "http.proxy=http://127.0.0.1:1024",
-        "--config",
-        "http.https://github.com/.extraHeader=Authorization: Basic %s"
-        % shim._github_basic_optin(),
         "--single-branch",
         "--filter=blob:none",
-        "https://github.com/owner/repo.git",
+        "%s/owner/repo.git" % shim.DEFAULT_MIRROR_URL,
         checkout_dir,
     ]
     assert manager._checkout_dir == checkout_dir
@@ -404,7 +485,7 @@ def test_hydration_timing_reports_clone_and_existing_status(
         for line in first_lines
     )
     assert any(
-        line.startswith("ember-claude-shim: turn-timing phase=hydration_clone ms=")
+        line.startswith("ember-claude-shim: turn-timing phase=hydration_clone ")
         and line.rsplit("ms=", 1)[1].isdigit()
         for line in first_lines
     )
@@ -538,7 +619,7 @@ def test_no_progress_push_without_a_token(manager, monkeypatch):
 def test_clone_sends_an_authorization_header_to_opt_into_injection(
     manager, monkeypatch
 ):
-    """Regression for a live 401: the clone MUST present Authorization.
+    """Regression for a live 401: the GITHUB clone MUST present Authorization.
 
     The egress sidecar's injection is presence-keyed. It replaces a header the
     guest already sent and discards the value (injectRequest: `requested :=
@@ -550,22 +631,32 @@ def test_clone_sends_an_authorization_header_to_opt_into_injection(
 
     injectAlwaysPaths cannot substitute: it is an exact match on req.URL.Path and
     git's paths are per repository, so it would have to enumerate every repo.
+
+    Since #4473 the first attempt targets the mirror (no credential at all);
+    this guard pins the github FALLBACK attempt, which is where the opt-in
+    belongs.
     """
     monkeypatch.setenv("GH_TOKEN", "dummy-from-guest-env")
+    processes = [
+        _GitProcess(returncode=128, stderr_text="not mirrored"),
+        _GitProcess(),
+        _GitProcess(),
+    ]
     commands = []
 
     def fake_run(command, **_kwargs):
         if command[1] == "clone":
             commands.append(command)
-        return _GitProcess()
+        return processes.pop(0)
 
     monkeypatch.setattr(shim.subprocess, "run", fake_run)
     manager.turn("first", repo="owner/repo", branch="main")
 
+    assert len(commands) == 2, "the mirror attempt must fail over to github"
     configs = [
-        arg for arg in commands[0] if arg.startswith("http.") and "extraHeader" in arg
+        arg for arg in commands[1] if arg.startswith("http.") and "extraHeader" in arg
     ]
-    assert len(configs) == 1, "clone must set exactly one extraHeader"
+    assert len(configs) == 1, "github fallback must set exactly one extraHeader"
     config = configs[0]
 
     # Scoped by URL, so the opt-in is never presented to any other host.

--- a/projects/firecracker/substrate/egress-proxy/cmd/main.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/main.go
@@ -50,6 +50,10 @@
 //   - EGRESS_MAX_CONNS: maximum concurrent guest connections (default 256).
 //   - EGRESS_SECRETS: the credential catalog; enables the plaintext inject lane.
 //   - EGRESS_CA_CERT_FILE / EGRESS_CA_KEY_FILE: optional, adds the TLS-MITM lane.
+//   - EGRESS_GIT_MIRROR_ADDR: optional node-local git mirror (#4473). When set,
+//     connections addressed to the reserved mirrorHost name are tunnelled
+//     straight to this loopback address instead of being resolved and
+//     classified as a normal destination.
 package main
 
 import (
@@ -133,8 +137,12 @@ func main() {
 		secrets:              secrets,
 		brokerURL:            brokerURL,
 		minter:               minter,
+		mirrorAddr:           os.Getenv("EGRESS_GIT_MIRROR_ADDR"),
 		logger:               logger,
 		conns:                make(chan struct{}, maxConns),
+	}
+	if p.mirrorAddr != "" {
+		logger.Info("git mirror lane enabled", "reserved_host", mirrorReservedHost, "dial", p.mirrorAddr)
 	}
 
 	ln, err := net.Listen("tcp", listen)
@@ -173,6 +181,15 @@ const defaultListenAddr = "127.0.0.1:8888"
 // destination or escape the node.
 const caFetchHost = "ca.egress.internal"
 
+// mirrorReservedHost is the reserved preamble name for the node-local git
+// mirror (#4473). Like caFetchHost it is never resolved and never classified:
+// when EGRESS_GIT_MIRROR_ADDR is configured, connections addressed here are
+// tunnelled straight to that loopback listener in the same pod. The name does
+// not exist in any DNS the sidecar can reach, so with the address unset (or on
+// any pod without a mirror) the request falls through to route(), fails to
+// resolve, and is denied: fail-closed by construction.
+const mirrorReservedHost = "git-mirror.egress.internal"
+
 // proxy holds the split-horizon posture, the secret catalog, and the CA minter.
 type proxy struct {
 	// externalAllow permits public (non-internal) destinations.
@@ -195,7 +212,10 @@ type proxy struct {
 	// minter mints leaf certs from the egress CA for TLS termination; nil disables
 	// the TLS-MITM lane (the plaintext inject lane does not need it).
 	minter *caMinter
-	logger *slog.Logger
+	// mirrorAddr is the loopback git-mirror listener behind mirrorReservedHost;
+	// empty disables the mirror seam entirely.
+	mirrorAddr string
+	logger     *slog.Logger
 	// conns bounds concurrent guest connections. A nil channel leaves the proxy
 	// unlimited for tests and other direct construction sites.
 	conns         chan struct{}
@@ -279,6 +299,35 @@ func (p *proxy) handle(client net.Conn) {
 			return
 		}
 		p.logger.Info("egress: served CA certificate to guest")
+		return
+	}
+
+	// Node-local git mirror lane (#4473). The reserved host is answered before
+	// routing for the same reason caFetchHost is: it must never resolve or be
+	// classified as a normal destination. What it reaches is the co-located
+	// mirror sidecar's loopback listener, anonymous and read-only upload-pack,
+	// so a guest naming this host gains nothing it could not get from the
+	// public internet except locality: no credential is injected here and none
+	// would help. With mirrorAddr unset the branch is dead and the name falls
+	// through to route(), which cannot resolve it and denies.
+	if p.mirrorAddr != "" && strings.EqualFold(host, mirrorReservedHost) {
+		p.logger.Info("egress allowed (git-mirror)", "dest", dest, "dial", p.mirrorAddr)
+		_ = client.SetReadDeadline(time.Time{})
+		up, err := net.DialTimeout("tcp", p.mirrorAddr, dialTimeout)
+		if err != nil {
+			p.logger.Error("egress git-mirror dial failed", "dial", p.mirrorAddr, "err", err)
+			return
+		}
+		// Git's protocol is request/response in small messages; same Nagle
+		// reasoning as every other upstream in this file.
+		if tcpConn, ok := up.(*net.TCPConn); ok {
+			_ = tcpConn.SetNoDelay(true)
+		}
+		defer up.Close()
+		done := make(chan struct{}, 2)
+		go func() { _, _ = io.Copy(up, newOriginFormReader(br)); done <- struct{}{} }()
+		go func() { _, _ = io.Copy(client, up); done <- struct{}{} }()
+		<-done
 		return
 	}
 

--- a/projects/firecracker/substrate/egress-proxy/cmd/main_test.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/main_test.go
@@ -363,3 +363,117 @@ func TestMaxConnsFromEnv(t *testing.T) {
 		})
 	}
 }
+
+// echoUpstream accepts one connection and echoes every byte back until the
+// peer hangs up, standing in for the git-mirror sidecar's loopback listener.
+func echoUpstream(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				_, _ = io.Copy(conn, conn)
+				_ = conn.Close()
+			}()
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// driveHandle writes input into one end of a real TCP connection handled by
+// p.handle, half-closes so the tunnels see EOF, and returns everything that
+// comes back before the connection closes. A real socket rather than net.Pipe
+// because the pump under test relies on a genuine half-close.
+func driveHandle(t *testing.T, p *proxy, input string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	client, dialErr := net.Dial("tcp", ln.Addr().String())
+	if dialErr != nil {
+		t.Fatal(dialErr)
+	}
+	defer client.Close()
+
+	serverConn, acceptErr := ln.Accept()
+	if acceptErr != nil {
+		t.Fatal(acceptErr)
+	}
+	go p.handle(serverConn)
+
+	if _, err := io.WriteString(client, input); err != nil {
+		t.Fatal(err)
+	}
+	// No half-close here: the first-direction-wins pump would tear down the
+	// response mid-flight, which is exactly the truncation real clients avoid
+	// by keeping their side open until the response ends. A read deadline
+	// bounds the wait instead.
+	if err := client.SetReadDeadline(time.Now().Add(1500 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	var got bytes.Buffer
+	buf := make([]byte, 512)
+	for {
+		n, err := client.Read(buf)
+		if n > 0 {
+			got.Write(buf[:n])
+		}
+		if err != nil {
+			break
+		}
+	}
+	_ = serverConn.Close()
+	return got.String()
+}
+
+func TestMirrorReservedHostTunnelsToLocalSidecar(t *testing.T) {
+	addr := echoUpstream(t)
+	p := &proxy{
+		mirrorAddr: addr,
+		lookupIP: func(string) ([]net.IP, error) {
+			// Must never be consulted: the reserved host is answered before
+			// routing, not resolved.
+			t.Error("lookupIP called for reserved mirror host")
+			return nil, net.UnknownNetworkError("unreachable")
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	for _, preamble := range []string{
+		"git-mirror.egress.internal:9419\n",
+		"GIT-MIRROR.EGRESS.INTERNAL:80\n",
+	} {
+		got := driveHandle(t, p, preamble+"GET /owner/repo.git/info/refs HTTP/1.1\r\n\r\n")
+		if !strings.Contains(got, "GET /owner/repo.git/info/refs") {
+			t.Errorf("preamble %q: mirrored payload = %q, want the echoed request", preamble, got)
+		}
+	}
+}
+
+func TestMirrorLaneFailClosedWhenUnset(t *testing.T) {
+	p := &proxy{
+		// No mirrorAddr: the reserved host must fall through to routing,
+		// where its name cannot resolve, and be denied (connection closed
+		// with nothing dialled).
+		lookupIP: func(host string) ([]net.IP, error) {
+			return nil, &net.DNSError{Name: host, Err: "no such host"}
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	upstreamAddr := echoUpstream(t)
+	_ = upstreamAddr // nothing may dial it; the deny path is local
+	got := driveHandle(t, p, "git-mirror.egress.internal:9419\nGET / HTTP/1.1\r\n\r\n")
+	if got != "" {
+		t.Errorf("disabled mirror lane answered %q, want silence + close", got)
+	}
+}


### PR DESCRIPTION
Closes #4473.

Serves the git mirror over smart http and points session hydration at it, taking the clone off GitHub's rate limit and the ~9x-slower credentialed egress lane:

- new `embervm-git-mirror` sidecar (Go server + refresh loop): anonymous read-only upload-pack from bare clones, filter capability always advertised so guests keep `--filter=blob:none`
- egress-proxy gains a reserved-host seam (`git-mirror.egress.internal` -> co-located loopback), fail-closed when unset, mirroring the caFetchHost pattern; scoped away from the port-9418 half-close suppression (#4417)
- shim hydration tries the mirror credential-free first, falls back to the credentialed github.com clone for unmirrored/private repos
- chart: `gitMirror` values block gated on egress.enabled, image pinned via the images map; prod values arm it for jomcgi/homelab
- amd64 apko image (wolfi git, uid 65532), lock bootstrapped two-pass under podman

Verified locally: go vet/test green incl. a real `git clone --filter=blob:none` smoke against the served fixture; shim pytest 25/25 + full runtime suite (2 macOS-only AF_VSOCK failures baseline-proven pre-existing); helm renders on/off/prod all checked; lock checksum verified. CI must prove: rules_apko lock resolution + image build/push and digest pin (called out in the worktree report). `ci` green (763 targets, full ExUnit 1500/0).

Implemented by ox-alpha via opencode, reviewed on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K