### PR TITLE
feat(monolith): ember reads as a landing page, accordion rows carry the depth

### DIFF
--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -92,7 +92,6 @@
     }, POLL_MS);
     return () => clearInterval(poll);
   });
-
 </script>
 
 <svelte:head>
@@ -502,8 +501,8 @@ serving                            → plain HTTP, straight into the VM</pre>
 
     <footer class="foot">
       <span
-        >Elixir/OTP control plane · Go node daemon · 10 of 12 roadmap
-        milestones shipped</span
+        >Elixir/OTP control plane · Go node daemon · 10 of 12 roadmap milestones
+        shipped</span
       >
       <span class="foot-links">
         <a href="https://github.com/jomcgi/homelab/tree/main/projects/embervm"

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -256,7 +256,16 @@ serving                            → plain HTTP, straight into the VM</pre>
       <h2 class="h2" id="arch">
         <a class="anchor" href="#arch">How it works</a>
       </h2>
-      <div class="arch">
+      <p class="body">
+        An <b>Elixir control plane</b> manages Firecracker VM lifecycle on
+        Kubernetes; a Go daemon on each node owns the machines.
+        <b>Serving requests never touch the control plane</b>: the edge routes
+        through a node-local Envoy straight into the VM, so the control plane
+        can restart mid-request and traffic notices nothing.
+      </p>
+      <details class="fold">
+        <summary><span class="fold-label">the moving parts</span></summary>
+        <div class="arch">
         <svg
           viewBox="0 0 720 300"
           role="img"
@@ -434,13 +443,8 @@ serving                            → plain HTTP, straight into the VM</pre>
           <span><i class="swatch sw-xds"></i> configuration, ahead of time</span
           >
         </div>
-      </div>
-      <p class="arch-punch">
-        <b>Serving requests never touch the control plane.</b> The edge routes to
-        a node-local Envoy the control plane has already programmed, and the connection
-        goes straight into the VM. The control plane can restart mid-request; serving
-        traffic notices nothing.
-      </p>
+        </div>
+      </details>
       <div class="iso">
         <p>
           <b
@@ -901,6 +905,60 @@ serving                            → plain HTTP, straight into the VM</pre>
     border-bottom-color: var(--em-ember-deep);
   }
 
+  /* ---------- diagram fold: same disclosure language as the class rows ---- */
+  .fold {
+    border-top: 1px solid var(--eml-line-strong);
+    border-bottom: 1px solid var(--em-line);
+    margin-bottom: 16px;
+  }
+
+  .fold summary {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 18px;
+    align-items: center;
+    padding: 12px 4px;
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .fold summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .fold-label {
+    font-family: var(--em-mono);
+    font-size: 12.5px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--em-faint);
+  }
+
+  .fold summary::after {
+    content: "+";
+    font-family: var(--em-mono);
+    font-size: 15px;
+    line-height: 1;
+    color: var(--em-faint);
+    justify-self: end;
+  }
+
+  .fold[open] summary::after {
+    transform: rotate(45deg);
+  }
+
+  .fold summary:hover .fold-label {
+    color: var(--em-muted);
+  }
+
+  .fold summary:focus-visible {
+    outline: 2px solid var(--em-ember-deep);
+    outline-offset: 3px;
+  }
+
+  .fold .arch {
+    margin-bottom: 14px;
+  }
+
   /* ---------- architecture ---------- */
   .arch {
     background: var(--eml-panel-warm);
@@ -1057,17 +1115,6 @@ serving                            → plain HTTP, straight into the VM</pre>
     border-top-style: dashed;
   }
 
-  .arch-punch {
-    margin: 14px 2px 0;
-    font-size: 15px;
-    line-height: 1.55;
-    color: var(--em-muted);
-  }
-
-  .arch-punch b {
-    color: var(--em-ink);
-  }
-
   /* ---------- isolation ---------- */
   .iso {
     display: flex;
@@ -1164,11 +1211,13 @@ serving                            → plain HTTP, straight into the VM</pre>
   /* Opening motion is opt-in: absent by default, per the reduced-motion
      opt-in shape this repo prefers for new work. */
   @media (prefers-reduced-motion: no-preference) {
-    .class summary::after {
+    .class summary::after,
+    .fold summary::after {
       transition: transform 0.18s ease;
     }
 
-    .class[open] .cmore {
+    .class[open] .cmore,
+    .fold[open] .arch {
       animation: em-reveal 0.22s ease;
     }
 

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -266,183 +266,211 @@ serving                            → plain HTTP, straight into the VM</pre>
       <details class="fold">
         <summary><span class="fold-label">the moving parts</span></summary>
         <div class="arch">
-        <svg
-          viewBox="0 0 720 300"
-          role="img"
-          aria-label="Ember architecture: callers reach the Elixir control plane, which dispatches over gRPC to the Go node daemon driving Firecracker VMs; serving traffic bypasses the control plane entirely via a node-local Envoy programmed over xDS. Snapshots and boot images are banked to S3."
-        >
-          <defs>
-            <marker
-              id="arrow-ember"
-              markerWidth="8"
-              markerHeight="8"
-              refX="7"
-              refY="4"
-              orient="auto"
+          <svg
+            viewBox="0 0 720 300"
+            role="img"
+            aria-label="Ember architecture: callers reach the Elixir control plane, which dispatches over gRPC to the Go node daemon driving Firecracker VMs; serving traffic bypasses the control plane entirely via a node-local Envoy programmed over xDS. Snapshots and boot images are banked to S3."
+          >
+            <defs>
+              <marker
+                id="arrow-ember"
+                markerWidth="8"
+                markerHeight="8"
+                refX="7"
+                refY="4"
+                orient="auto"
+              >
+                <path class="mk mk-control" d="M1,1 L7,4 L1,7" />
+              </marker>
+              <marker
+                id="arrow-frost"
+                markerWidth="8"
+                markerHeight="8"
+                refX="7"
+                refY="4"
+                orient="auto"
+              >
+                <path class="mk mk-data" d="M1,1 L7,4 L1,7" />
+              </marker>
+              <marker
+                id="arrow-amber"
+                markerWidth="8"
+                markerHeight="8"
+                refX="7"
+                refY="4"
+                orient="auto"
+              >
+                <path class="mk mk-xds" d="M1,1 L7,4 L1,7" />
+              </marker>
+              <marker
+                id="arrow-slate"
+                markerWidth="8"
+                markerHeight="8"
+                refX="7"
+                refY="4"
+                orient="auto"
+              >
+                <path class="mk mk-bank" d="M1,1 L7,4 L1,7" />
+              </marker>
+            </defs>
+
+            <rect
+              class="lane"
+              x="150"
+              y="18"
+              width="230"
+              height="264"
+              rx="10"
+            />
+            <text x="162" y="38" class="lane-label"
+              >CONTROL PLANE · ELIXIR/OTP</text
             >
-              <path class="mk mk-control" d="M1,1 L7,4 L1,7" />
-            </marker>
-            <marker
-              id="arrow-frost"
-              markerWidth="8"
-              markerHeight="8"
-              refX="7"
-              refY="4"
-              orient="auto"
+            <rect
+              class="lane"
+              x="420"
+              y="18"
+              width="286"
+              height="264"
+              rx="10"
+            />
+            <text x="432" y="38" class="lane-label">EACH FIRECRACKER NODE</text>
+
+            <rect x="14" y="74" width="100" height="44" rx="8" class="box" />
+            <text x="64" y="93" text-anchor="middle" class="node-label"
+              >caller</text
             >
-              <path class="mk mk-data" d="M1,1 L7,4 L1,7" />
-            </marker>
-            <marker
-              id="arrow-amber"
-              markerWidth="8"
-              markerHeight="8"
-              refX="7"
-              refY="4"
-              orient="auto"
+            <text x="64" y="107" text-anchor="middle" class="node-sub"
+              >task / session</text
             >
-              <path class="mk mk-xds" d="M1,1 L7,4 L1,7" />
-            </marker>
-            <marker
-              id="arrow-slate"
-              markerWidth="8"
-              markerHeight="8"
-              refX="7"
-              refY="4"
-              orient="auto"
+
+            <rect x="14" y="196" width="100" height="44" rx="8" class="box" />
+            <text x="64" y="215" text-anchor="middle" class="node-label"
+              >edge</text
             >
-              <path class="mk mk-bank" d="M1,1 L7,4 L1,7" />
-            </marker>
-          </defs>
+            <text x="64" y="229" text-anchor="middle" class="node-sub"
+              >HTTPRoute</text
+            >
 
-          <rect class="lane" x="150" y="18" width="230" height="264" rx="10" />
-          <text x="162" y="38" class="lane-label"
-            >CONTROL PLANE · ELIXIR/OTP</text
-          >
-          <rect class="lane" x="420" y="18" width="286" height="264" rx="10" />
-          <text x="432" y="38" class="lane-label">EACH FIRECRACKER NODE</text>
+            <rect x="170" y="66" width="120" height="46" rx="8" class="box" />
+            <text x="230" y="86" text-anchor="middle" class="node-label"
+              >HTTP API</text
+            >
+            <text x="230" y="101" text-anchor="middle" class="node-sub"
+              >/v1/workloads</text
+            >
 
-          <rect x="14" y="74" width="100" height="44" rx="8" class="box" />
-          <text x="64" y="93" text-anchor="middle" class="node-label"
-            >caller</text
-          >
-          <text x="64" y="107" text-anchor="middle" class="node-sub"
-            >task / session</text
-          >
+            <rect x="170" y="130" width="120" height="42" rx="8" class="box" />
+            <text x="230" y="149" text-anchor="middle" class="node-label"
+              >op-log</text
+            >
+            <text x="230" y="163" text-anchor="middle" class="node-sub"
+              >Postgres</text
+            >
 
-          <rect x="14" y="196" width="100" height="44" rx="8" class="box" />
-          <text x="64" y="215" text-anchor="middle" class="node-label"
-            >edge</text
-          >
-          <text x="64" y="229" text-anchor="middle" class="node-sub"
-            >HTTPRoute</text
-          >
+            <rect x="170" y="192" width="120" height="42" rx="8" class="box" />
+            <text x="230" y="211" text-anchor="middle" class="node-label"
+              >xDS publisher</text
+            >
+            <text x="230" y="225" text-anchor="middle" class="node-sub"
+              >programs Envoy</text
+            >
 
-          <rect x="170" y="66" width="120" height="46" rx="8" class="box" />
-          <text x="230" y="86" text-anchor="middle" class="node-label"
-            >HTTP API</text
-          >
-          <text x="230" y="101" text-anchor="middle" class="node-sub"
-            >/v1/workloads</text
-          >
+            <rect x="436" y="60" width="130" height="46" rx="8" class="box" />
+            <text x="501" y="80" text-anchor="middle" class="node-label"
+              >noded</text
+            >
+            <text x="501" y="95" text-anchor="middle" class="node-sub"
+              >Go daemon</text
+            >
 
-          <rect x="170" y="130" width="120" height="42" rx="8" class="box" />
-          <text x="230" y="149" text-anchor="middle" class="node-label"
-            >op-log</text
-          >
-          <text x="230" y="163" text-anchor="middle" class="node-sub"
-            >Postgres</text
-          >
+            <rect x="622" y="60" width="72" height="46" rx="8" class="box" />
+            <text x="658" y="80" text-anchor="middle" class="node-label"
+              >VM</text
+            >
+            <text x="658" y="95" text-anchor="middle" class="node-sub"
+              >vsock only</text
+            >
 
-          <rect x="170" y="192" width="120" height="42" rx="8" class="box" />
-          <text x="230" y="211" text-anchor="middle" class="node-label"
-            >xDS publisher</text
-          >
-          <text x="230" y="225" text-anchor="middle" class="node-sub"
-            >programs Envoy</text
-          >
+            <rect x="436" y="136" width="130" height="40" rx="8" class="box" />
+            <text x="501" y="154" text-anchor="middle" class="node-label"
+              >S3</text
+            >
+            <text x="501" y="168" text-anchor="middle" class="node-sub"
+              >snapshots + images</text
+            >
+            <path class="path-bank" d="M494,106 L494,132" />
+            <path class="path-bank" d="M508,132 L508,106" />
+            <text
+              x="548"
+              y="124"
+              text-anchor="middle"
+              class="edge-label el-bank">bank</text
+            >
 
-          <rect x="436" y="60" width="130" height="46" rx="8" class="box" />
-          <text x="501" y="80" text-anchor="middle" class="node-label"
-            >noded</text
-          >
-          <text x="501" y="95" text-anchor="middle" class="node-sub"
-            >Go daemon</text
-          >
+            <rect x="436" y="196" width="130" height="46" rx="8" class="box" />
+            <text x="501" y="216" text-anchor="middle" class="node-label"
+              >node Envoy</text
+            >
+            <text x="501" y="231" text-anchor="middle" class="node-sub"
+              >exact-match</text
+            >
 
-          <rect x="622" y="60" width="72" height="46" rx="8" class="box" />
-          <text x="658" y="80" text-anchor="middle" class="node-label">VM</text>
-          <text x="658" y="95" text-anchor="middle" class="node-sub"
-            >vsock only</text
-          >
+            <rect x="622" y="196" width="72" height="46" rx="8" class="box" />
+            <text x="658" y="216" text-anchor="middle" class="node-label"
+              >VM</text
+            >
+            <text x="658" y="231" text-anchor="middle" class="node-sub"
+              >tap NIC</text
+            >
 
-          <rect x="436" y="136" width="130" height="40" rx="8" class="box" />
-          <text x="501" y="154" text-anchor="middle" class="node-label">S3</text
-          >
-          <text x="501" y="168" text-anchor="middle" class="node-sub"
-            >snapshots + images</text
-          >
-          <path class="path-bank" d="M494,106 L494,132" />
-          <path class="path-bank" d="M508,132 L508,106" />
-          <text x="548" y="124" text-anchor="middle" class="edge-label el-bank"
-            >bank</text
-          >
+            <path class="path-control" d="M114,92 L166,90" />
+            <path class="path-control" d="M290,86 L432,83" />
+            <text
+              x="360"
+              y="75"
+              text-anchor="middle"
+              class="edge-label el-control">gRPC</text
+            >
+            <path class="path-control" d="M566,83 L618,83" />
+            <text
+              x="592"
+              y="76"
+              text-anchor="middle"
+              class="edge-label el-control">vsock</text
+            >
 
-          <rect x="436" y="196" width="130" height="46" rx="8" class="box" />
-          <text x="501" y="216" text-anchor="middle" class="node-label"
-            >node Envoy</text
-          >
-          <text x="501" y="231" text-anchor="middle" class="node-sub"
-            >exact-match</text
-          >
+            <path
+              class="path-data"
+              d="M114,222 C 140,222 138,262 170,262 L 350,262 C 400,262 396,222 432,222"
+            />
+            <text
+              x="260"
+              y="277"
+              text-anchor="middle"
+              class="edge-label el-data">bypasses the control plane</text
+            >
+            <path class="path-data" d="M566,219 L618,219" />
+            <text
+              x="592"
+              y="212"
+              text-anchor="middle"
+              class="edge-label el-data">DNAT</text
+            >
 
-          <rect x="622" y="196" width="72" height="46" rx="8" class="box" />
-          <text x="658" y="216" text-anchor="middle" class="node-label">VM</text
-          >
-          <text x="658" y="231" text-anchor="middle" class="node-sub"
-            >tap NIC</text
-          >
-
-          <path class="path-control" d="M114,92 L166,90" />
-          <path class="path-control" d="M290,86 L432,83" />
-          <text
-            x="360"
-            y="75"
-            text-anchor="middle"
-            class="edge-label el-control">gRPC</text
-          >
-          <path class="path-control" d="M566,83 L618,83" />
-          <text
-            x="592"
-            y="76"
-            text-anchor="middle"
-            class="edge-label el-control">vsock</text
-          >
-
-          <path
-            class="path-data"
-            d="M114,222 C 140,222 138,262 170,262 L 350,262 C 400,262 396,222 432,222"
-          />
-          <text x="260" y="277" text-anchor="middle" class="edge-label el-data"
-            >bypasses the control plane</text
-          >
-          <path class="path-data" d="M566,219 L618,219" />
-          <text x="592" y="212" text-anchor="middle" class="edge-label el-data"
-            >DNAT</text
-          >
-
-          <path class="path-xds" d="M290,213 C 340,213 380,208 432,207" />
-          <text x="360" y="199" text-anchor="middle" class="edge-label el-xds"
-            >xDS</text
-          >
-        </svg>
-        <div class="legend">
-          <span
-            ><i class="swatch sw-control"></i> control path (tasks &amp; sessions)</span
-          >
-          <span><i class="swatch sw-data"></i> serving data path</span>
-          <span><i class="swatch sw-xds"></i> configuration, ahead of time</span
-          >
-        </div>
+            <path class="path-xds" d="M290,213 C 340,213 380,208 432,207" />
+            <text x="360" y="199" text-anchor="middle" class="edge-label el-xds"
+              >xDS</text
+            >
+          </svg>
+          <div class="legend">
+            <span
+              ><i class="swatch sw-control"></i> control path (tasks &amp; sessions)</span
+            >
+            <span><i class="swatch sw-data"></i> serving data path</span>
+            <span
+              ><i class="swatch sw-xds"></i> configuration, ahead of time</span
+            >
+          </div>
         </div>
       </details>
       <div class="iso">

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -1,8 +1,9 @@
 <script>
-  // /ember: the landing page for the Ember mini-site, set as a typeset
-  // README: one column, ruled lists, an SVG architecture diagram, checkbox
-  // roadmap. Copy voice follows the project README (blunt mechanism
-  // sentences, no rhetoric). Visual language is the shared ember token
+  // /ember: the landing page for the Ember mini-site. Narrative order is
+  // what is it (masthead) -> is it useful to me (class rows) -> how does it
+  // do that (diagram + isolation) -> see it run (demo doors); depth sits
+  // behind accordion rows so the visible words stay few. Copy voice follows
+  // the project README (blunt mechanism sentences, no rhetoric). Visual language is the shared ember token
   // sheet (lib/public/ember/ember.css) plus landing-only tokens in
   // ./landing.css; hex never appears in this <style> block.
   //
@@ -92,70 +93,6 @@
     return () => clearInterval(poll);
   });
 
-  // Checkbox and name visible; the sentence sits behind the row's
-  // disclosure, and the full story stays in ARCHITECTURE.md.
-  const MILESTONES = [
-    {
-      done: true,
-      name: "R0 tasks",
-      desc: "Dispatch, fair pooling, metering, quotas.",
-    },
-    {
-      done: true,
-      name: "R1 functions",
-      desc: "Zip functions; the first public function live.",
-    },
-    {
-      done: true,
-      name: "R2 sessions",
-      desc: "Bank/relight; adoption across control-plane restarts.",
-    },
-    {
-      done: true,
-      name: "R3 serving",
-      desc: "Per-node Envoy; the control plane leaves the hot path.",
-    },
-    {
-      done: true,
-      name: "R4 stateful",
-      desc: "A database that sleeps and wakes on connect. The demo above.",
-    },
-    {
-      done: true,
-      name: "R5 composite",
-      desc: "A scratch Kubernetes cluster as one workload.",
-    },
-    {
-      done: true,
-      name: "R6 continuity",
-      desc: "Snapshots and boot images recorded to S3.",
-    },
-    {
-      done: false,
-      name: "R7 distribution",
-      desc: "A wake restores onto whichever node has room.",
-    },
-    {
-      done: true,
-      name: "R8 consumers",
-      desc: "The agent platform runs on sessions.",
-    },
-    {
-      done: false,
-      name: "R9 packaging",
-      desc: "A standalone artifact somebody else could run.",
-    },
-    {
-      done: true,
-      name: "transport auth",
-      desc: "Bearer token behind an ingress policy; mTLS is the upgrade path.",
-    },
-    {
-      done: true,
-      name: "encryption at rest",
-      desc: "Envelope encryption with capability-gated restore.",
-    },
-  ];
 </script>
 
 <svelte:head>
@@ -220,7 +157,7 @@
 
     <section>
       <h2 class="h2" id="classes">
-        <a class="anchor" href="#classes">What Ember runs</a>
+        <a class="anchor" href="#classes">What you'd run on it</a>
       </h2>
       <p class="body">
         Five classes, declared as Kubernetes custom resources, all assuming the
@@ -318,7 +255,7 @@ serving                            → plain HTTP, straight into the VM</pre>
 
     <section>
       <h2 class="h2" id="arch">
-        <a class="anchor" href="#arch">Architecture</a>
+        <a class="anchor" href="#arch">How it works</a>
       </h2>
       <div class="arch">
         <svg
@@ -505,10 +442,6 @@ serving                            → plain HTTP, straight into the VM</pre>
         goes straight into the VM. The control plane can restart mid-request; serving
         traffic notices nothing.
       </p>
-    </section>
-
-    <section>
-      <h2 class="h2" id="iso"><a class="anchor" href="#iso">Isolation</a></h2>
       <div class="iso">
         <p>
           <b
@@ -567,29 +500,10 @@ serving                            → plain HTTP, straight into the VM</pre>
       </div>
     </section>
 
-    <section>
-      <h2 class="h2" id="roadmap">
-        <a class="anchor" href="#roadmap">Roadmap</a>
-      </h2>
-      <div class="roadmap">
-        {#each MILESTONES as m (m.name)}
-          <details class="milestone" name="em-roadmap">
-            <summary>
-              <span class="cb" class:todo={!m.done}
-                >{m.done ? "[x]" : "[ ]"}</span
-              >
-              <span class="rname">{m.name}</span>
-            </summary>
-            <p class="rdesc">{m.desc}</p>
-          </details>
-        {/each}
-      </div>
-    </section>
-
     <footer class="foot">
       <span
-        >Elixir/OTP control plane · Go node daemon · Firecracker microVMs ·
-        running on this cluster</span
+        >Elixir/OTP control plane · Go node daemon · 10 of 12 roadmap
+        milestones shipped</span
       >
       <span class="foot-links">
         <a href="https://github.com/jomcgi/homelab/tree/main/projects/embervm"
@@ -874,8 +788,7 @@ serving                            → plain HTTP, straight into the VM</pre>
     overflow-x: auto;
   }
 
-  .classes code,
-  .rdesc code {
+  .classes code {
     font-family: var(--em-mono);
     font-size: 0.88em;
     background: var(--em-track);
@@ -936,8 +849,7 @@ serving                            → plain HTTP, straight into the VM</pre>
     color: var(--em-muted);
   }
 
-  .class summary::after,
-  .milestone summary::after {
+  .class summary::after {
     content: "+";
     font-family: var(--em-mono);
     font-size: 15px;
@@ -947,8 +859,7 @@ serving                            → plain HTTP, straight into the VM</pre>
     align-self: center;
   }
 
-  .class[open] summary::after,
-  .milestone[open] summary::after {
+  .class[open] summary::after {
     transform: rotate(45deg);
   }
 
@@ -956,8 +867,7 @@ serving                            → plain HTTP, straight into the VM</pre>
     color: var(--em-ink);
   }
 
-  .class summary:focus-visible,
-  .milestone summary:focus-visible {
+  .class summary:focus-visible {
     outline: 2px solid var(--em-ember-deep);
     outline-offset: 3px;
   }
@@ -1252,72 +1162,14 @@ serving                            → plain HTTP, straight into the VM</pre>
     transform: translateX(4px);
   }
 
-  /* ---------- roadmap ---------- */
-  .roadmap {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .milestone {
-    border-bottom: 1px solid var(--em-line);
-  }
-
-  .milestone:first-child {
-    border-top: 1px solid var(--eml-line-strong);
-  }
-
-  .milestone summary {
-    display: grid;
-    grid-template-columns: 26px minmax(0, 1fr) 18px;
-    gap: 14px;
-    align-items: baseline;
-    padding: 11px 4px;
-    cursor: pointer;
-    list-style: none;
-  }
-
-  .milestone summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .cb {
-    font-family: var(--em-mono);
-    font-size: 14px;
-    line-height: 1.4;
-    color: var(--em-ember-deep);
-    font-weight: 600;
-  }
-
-  .cb.todo {
-    color: var(--em-faint);
-    font-weight: 400;
-  }
-
-  .rname {
-    font-family: var(--em-mono);
-    font-size: 13px;
-    color: var(--em-ink);
-    font-weight: 600;
-  }
-
-  .rdesc {
-    font-size: 14.5px;
-    line-height: 1.5;
-    color: var(--em-muted);
-    margin: 0;
-    padding: 0 26px 11px 40px;
-  }
-
   /* Opening motion is opt-in: absent by default, per the reduced-motion
      opt-in shape this repo prefers for new work. */
   @media (prefers-reduced-motion: no-preference) {
-    .class summary::after,
-    .milestone summary::after {
+    .class summary::after {
       transition: transform 0.18s ease;
     }
 
-    .class[open] .cmore,
-    .milestone[open] .rdesc {
+    .class[open] .cmore {
       animation: em-reveal 0.22s ease;
     }
 

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -265,8 +265,7 @@
           <summary>
             <span class="cname">serving<small>always answering</small></span>
             <span class="cline"
-              >A warm HTTP endpoint; requests never touch the control
-              plane.</span
+              >A warm HTTP endpoint; requests never touch the control plane.</span
             >
           </summary>
           <div class="cmore">
@@ -300,15 +299,14 @@
           <summary>
             <span class="cname">composite<small>wakes as one</small></span>
             <span class="cline"
-              >Several VMs, one private network, banked and relit
-              together.</span
+              >Several VMs, one private network, banked and relit together.</span
             >
           </summary>
           <div class="cmore">
             <p>
               An all-or-none group. A scratch Kubernetes cluster ran as one
-              composite workload: control plane and workers woke together on
-              the first kubectl.
+              composite workload: control plane and workers woke together on the
+              first kubectl.
             </p>
           </div>
         </details>
@@ -577,7 +575,8 @@ serving                            → plain HTTP, straight into the VM</pre>
         {#each MILESTONES as m (m.name)}
           <details class="milestone" name="em-roadmap">
             <summary>
-              <span class="cb" class:todo={!m.done}>{m.done ? "[x]" : "[ ]"}</span
+              <span class="cb" class:todo={!m.done}
+                >{m.done ? "[x]" : "[ ]"}</span
               >
               <span class="rname">{m.name}</span>
             </summary>

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -92,8 +92,8 @@
     return () => clearInterval(poll);
   });
 
-  // One line per milestone; the full story lives in ARCHITECTURE.md behind
-  // the source link above.
+  // Checkbox and name visible; the sentence sits behind the row's
+  // disclosure, and the full story stays in ARCHITECTURE.md.
   const MILESTONES = [
     {
       done: true,
@@ -223,78 +223,99 @@
         <a class="anchor" href="#classes">What Ember runs</a>
       </h2>
       <p class="body">
-        Every workload is a Kubernetes custom resource, in one of five classes.
-        The three that differ by <b
-          >how much of the machine the guest may touch</b
-        >:
+        Five classes, declared as Kubernetes custom resources, all assuming the
+        guest is hostile.
       </p>
-      <dl class="classes">
-        <div class="class">
-          <dt>task<small>run once</small></dt>
-          <dd>
-            One-shot execution in a fresh or snapshot-restored VM.
-            <b>No network device at all</b>; the guest has one channel to the
-            host daemon and nothing else, then the VM is destroyed.
-          </dd>
-        </div>
-        <div class="class">
-          <dt>session<small>sleep &amp; wake</small></dt>
-          <dd>
-            A stateful sandbox that survives across invocations. Idle sessions
-            are <b>banked</b> (snapshotted to disk) and
-            <b>relit</b> (restored) on the next call, with memory, processes and open
-            files intact. Banked snapshots are offloaded to S3; a session survives
-            the node it slept on.
-          </dd>
-        </div>
-        <div class="class">
-          <dt>serving<small>always answering</small></dt>
-          <dd>
-            A warm HTTP endpoint. Requests reach the guest directly; the control
-            plane is not in the path.
-          </dd>
-        </div>
-      </dl>
-      <p class="body classes-after">
-        Stateful adds a disk that outlives the VM (the database below);
-        composite wakes several VMs as one unit.
-      </p>
+      <div class="classes">
+        <details class="class" name="em-classes">
+          <summary>
+            <span class="cname">task<small>run once</small></span>
+            <span class="cline"
+              >A fresh VM, no network device, destroyed after one job.</span
+            >
+          </summary>
+          <div class="cmore">
+            <p>
+              One-shot execution in a fresh or snapshot-restored VM. The guest
+              can reach exactly one thing: its channel to the host daemon. The
+              scan fleet runs the CI security scanner this way.
+            </p>
+          </div>
+        </details>
+        <details class="class" name="em-classes">
+          <summary>
+            <span class="cname">session<small>sleep &amp; wake</small></span>
+            <span class="cline"
+              >An agent's sandbox, banked between turns, relit with memory
+              intact.</span
+            >
+          </summary>
+          <div class="cmore">
+            <p>
+              Idle sessions are <b>banked</b> (snapshotted to disk) and
+              <b>relit</b> on the next call with memory, processes and open
+              files intact. Snapshots offload to S3, so a session survives the
+              node it slept on. Each AI agent gets its own machine to make a
+              mess in: shell, filesystem, packages,
+              <b>destroyed without ceremony</b>.
+            </p>
+          </div>
+        </details>
+        <details class="class" name="em-classes">
+          <summary>
+            <span class="cname">serving<small>always answering</small></span>
+            <span class="cline"
+              >A warm HTTP endpoint; requests never touch the control
+              plane.</span
+            >
+          </summary>
+          <div class="cmore">
+            <p>
+              Requests reach the guest directly through a node-local Envoy the
+              control plane has already programmed. An image renderer answers
+              real internet traffic this way,
+              <b>rate-limited and quota-capped</b>.
+            </p>
+          </div>
+        </details>
+        <details class="class" name="em-classes">
+          <summary>
+            <span class="cname"
+              >stateful<small>a database that sleeps</small></span
+            >
+            <span class="cline"
+              >Its disk outlives the VM; the next connection wakes it.</span
+            >
+          </summary>
+          <div class="cmore">
+            <p>
+              Postgres banked to disk the moment it goes idle.
+              <b>Zero compute while asleep</b>, and the volume on node NVMe is
+              the authoritative copy.
+              <a class="sig" href="/ember/postgres">see it live →</a>
+            </p>
+          </div>
+        </details>
+        <details class="class" name="em-classes">
+          <summary>
+            <span class="cname">composite<small>wakes as one</small></span>
+            <span class="cline"
+              >Several VMs, one private network, banked and relit
+              together.</span
+            >
+          </summary>
+          <div class="cmore">
+            <p>
+              An all-or-none group. A scratch Kubernetes cluster ran as one
+              composite workload: control plane and workers woke together on
+              the first kubectl.
+            </p>
+          </div>
+        </details>
+      </div>
       <pre class="api">POST /v1/workloads/:name/tasks     → 202 + a task_id
 POST /v1/workloads/:name/sessions  → a session_id, then /v1/sessions/:id/invoke
 serving                            → plain HTTP, straight into the VM</pre>
-    </section>
-
-    <section>
-      <h2 class="h2" id="uses">
-        <a class="anchor" href="#uses">What that lets you run</a>
-      </h2>
-      <p class="body">Every one of these assumes the guest is hostile.</p>
-      <dl class="classes">
-        <div class="class">
-          <dt>an agent's sandbox<small>session</small></dt>
-          <dd>
-            Each AI agent gets its own machine to make a mess in: shell,
-            filesystem, packages. Banked between turns, relit mid-conversation, <b
-              >destroyed without ceremony</b
-            >.
-          </dd>
-        </div>
-        <div class="class">
-          <dt>a database nobody queries at 3am<small>stateful</small></dt>
-          <dd>
-            Postgres banked to disk the moment it goes idle, woken by the next
-            connection. <b>Zero compute while asleep.</b>
-            <a class="sig" href="/ember/postgres">see it live →</a>
-          </dd>
-        </div>
-        <div class="class">
-          <dt>a public function, served warm<small>serving</small></dt>
-          <dd>
-            An image renderer answering real internet traffic from a warm
-            microVM, <b>rate-limited and quota-capped</b>.
-          </dd>
-        </div>
-      </dl>
     </section>
 
     <section>
@@ -498,20 +519,11 @@ serving                            → plain HTTP, straight into the VM</pre>
           >
         </p>
         <p>
-          The task class has <b>no network device at all</b>. The guest can
-          reach exactly one thing: its channel to the host daemon.
+          Task and session guests have <b>no network device at all</b>: one
+          channel to the host daemon.
         </p>
         <p>
           <b>Quotas fail closed.</b> A customer with quota 0 is hard-stopped at submit.
-        </p>
-        <p>
-          The spend tally fails open: a node cut off from the control plane
-          keeps running the work and keeps its own tally.
-        </p>
-        <p>
-          The one public route is scoped at <b>three independent layers</b>: the
-          edge pins host and path, Envoy exact-matches the internal authority,
-          and the guest shim reserves its own control prefix.
         </p>
       </div>
     </section>
@@ -524,10 +536,7 @@ serving                            → plain HTTP, straight into the VM</pre>
         <a class="door" href="/ember/postgres">
           <span class="k">live demo</span>
           <h3>A Postgres that sleeps</h3>
-          <p>
-            A real database banked to disk. Click connect, watch the stopwatch:
-            snapshot restore, disk to answering queries, best wake 78&nbsp;ms.
-          </p>
+          <p>Click connect, watch the stopwatch: best wake 78&nbsp;ms.</p>
           <span class="go">ember/postgres</span>
         </a>
         <a class="door" href="/ember/bazel">
@@ -542,28 +551,19 @@ serving                            → plain HTTP, straight into the VM</pre>
         <a class="door" href="/ember/firecracker">
           <span class="k">explainer</span>
           <h3>How Firecracker resumes a VM</h3>
-          <p>
-            What a microVM snapshot actually contains, and how a full machine
-            (kernel, memory, device state) comes back in ~22&nbsp;ms.
-          </p>
+          <p>What a snapshot contains; a full machine back in ~22&nbsp;ms.</p>
           <span class="go">ember/firecracker</span>
         </a>
         <a class="door" href="/ember/agents">
           <span class="k">explainer</span>
           <h3>One microVM per agent session</h3>
-          <p>
-            The agent lifecycle: restored in 2.5 ms, killed 20 s after the last
-            turn, rebuilt from S3 days later.
-          </p>
+          <p>Restored in 2.5 ms, killed 20 s after the last turn.</p>
           <span class="go">ember/agents</span>
         </a>
         <a class="door" href="/ember/semgrep">
           <span class="k">workload demo</span>
           <h3>Semgrep</h3>
-          <p>
-            The CI security scanner, warm in a microVM, scanning your snippet in
-            about a second.
-          </p>
+          <p>Warm in a microVM, scanning your snippet in about a second.</p>
           <span class="go">ember/semgrep</span>
         </a>
       </div>
@@ -575,12 +575,14 @@ serving                            → plain HTTP, straight into the VM</pre>
       </h2>
       <div class="roadmap">
         {#each MILESTONES as m (m.name)}
-          <div class="milestone">
-            <span class="cb" class:todo={!m.done}>{m.done ? "[x]" : "[ ]"}</span
-            >
-            <span class="rname">{m.name}</span>
+          <details class="milestone" name="em-roadmap">
+            <summary>
+              <span class="cb" class:todo={!m.done}>{m.done ? "[x]" : "[ ]"}</span
+              >
+              <span class="rname">{m.name}</span>
+            </summary>
             <p class="rdesc">{m.desc}</p>
-          </div>
+          </details>
         {/each}
       </div>
     </section>
@@ -883,7 +885,11 @@ serving                            → plain HTTP, straight into the VM</pre>
     color: var(--em-ink);
   }
 
-  /* ---------- ruled definition lists (classes + use cases) ---------- */
+  /* ---------- ruled class rows: one line visible, detail on demand ------
+     The picomq-style accordion, done as native <details name="em-classes">
+     so one row is open at a time with no JS; older browsers just get
+     independent toggles. The affordance is a mono plus that rotates to a
+     multiply: rotation only, per the transform-and-opacity motion rule. */
   .classes {
     display: flex;
     flex-direction: column;
@@ -892,23 +898,32 @@ serving                            → plain HTTP, straight into the VM</pre>
   }
 
   .class {
-    display: grid;
-    grid-template-columns: 210px minmax(0, 1fr);
-    gap: 18px;
-    padding: 16px 4px;
     border-bottom: 1px solid var(--em-line);
   }
 
-  .class dt {
+  .class summary {
+    display: grid;
+    grid-template-columns: 210px minmax(0, 1fr) 18px;
+    gap: 18px;
+    align-items: baseline;
+    padding: 14px 4px;
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .class summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .cname {
     font-family: var(--em-mono);
     font-size: 14px;
     font-weight: 600;
     line-height: 1.45;
     color: var(--em-ember-deep);
-    margin: 0;
   }
 
-  .class dt small {
+  .cname small {
     display: block;
     font-weight: 400;
     color: var(--em-faint);
@@ -916,14 +931,50 @@ serving                            → plain HTTP, straight into the VM</pre>
     margin-top: 5px;
   }
 
-  .class dd {
+  .cline {
+    font-size: 15px;
+    line-height: 1.55;
+    color: var(--em-muted);
+  }
+
+  .class summary::after,
+  .milestone summary::after {
+    content: "+";
+    font-family: var(--em-mono);
+    font-size: 15px;
+    line-height: 1;
+    color: var(--em-faint);
+    justify-self: end;
+    align-self: center;
+  }
+
+  .class[open] summary::after,
+  .milestone[open] summary::after {
+    transform: rotate(45deg);
+  }
+
+  .class summary:hover .cline {
+    color: var(--em-ink);
+  }
+
+  .class summary:focus-visible,
+  .milestone summary:focus-visible {
+    outline: 2px solid var(--em-ember-deep);
+    outline-offset: 3px;
+  }
+
+  .cmore {
+    padding: 0 26px 16px 228px;
+  }
+
+  .cmore p {
     margin: 0;
     font-size: 15px;
     line-height: 1.55;
     color: var(--em-muted);
   }
 
-  .class dd b {
+  .cmore b {
     color: var(--em-ink);
     font-weight: 600;
   }
@@ -1209,16 +1260,25 @@ serving                            → plain HTTP, straight into the VM</pre>
   }
 
   .milestone {
-    display: grid;
-    grid-template-columns: 26px 110px minmax(0, 1fr);
-    gap: 14px;
-    align-items: baseline;
-    padding: 11px 4px;
     border-bottom: 1px solid var(--em-line);
   }
 
   .milestone:first-child {
     border-top: 1px solid var(--eml-line-strong);
+  }
+
+  .milestone summary {
+    display: grid;
+    grid-template-columns: 26px minmax(0, 1fr) 18px;
+    gap: 14px;
+    align-items: baseline;
+    padding: 11px 4px;
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .milestone summary::-webkit-details-marker {
+    display: none;
   }
 
   .cb {
@@ -1246,6 +1306,28 @@ serving                            → plain HTTP, straight into the VM</pre>
     line-height: 1.5;
     color: var(--em-muted);
     margin: 0;
+    padding: 0 26px 11px 40px;
+  }
+
+  /* Opening motion is opt-in: absent by default, per the reduced-motion
+     opt-in shape this repo prefers for new work. */
+  @media (prefers-reduced-motion: no-preference) {
+    .class summary::after,
+    .milestone summary::after {
+      transition: transform 0.18s ease;
+    }
+
+    .class[open] .cmore,
+    .milestone[open] .rdesc {
+      animation: em-reveal 0.22s ease;
+    }
+
+    @keyframes em-reveal {
+      from {
+        opacity: 0;
+        transform: translateY(-3px);
+      }
+    }
   }
 
   /* ---------- footer ---------- */
@@ -1296,17 +1378,22 @@ serving                            → plain HTTP, straight into the VM</pre>
   }
 
   @media (max-width: 640px) {
-    .class {
-      grid-template-columns: 1fr;
-      gap: 4px;
+    .class summary {
+      grid-template-columns: minmax(0, 1fr) 18px;
+      gap: 6px 14px;
     }
 
-    .milestone {
-      grid-template-columns: 26px minmax(0, 1fr);
+    .class summary .cline {
+      grid-column: 1;
     }
 
-    .milestone .rdesc {
+    .class summary::after {
+      grid-row: 1;
       grid-column: 2;
+    }
+
+    .cmore {
+      padding-left: 4px;
     }
   }
 

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -162,7 +162,7 @@
   <title>Ember · a workload orchestrator on Firecracker microVMs</title>
   <meta
     name="description"
-    content="Ember orchestrates Firecracker microVMs for untrusted code: short-lived tasks, services that sleep as snapshots and wake, disk to answering queries in {servingWakeMs} ms, and disks that outlive their VM. Includes a live Postgres you can wake yourself."
+    content="Ember gives every job its own tiny virtual machine: run once and destroyed, slept as a snapshot and woken in {servingWakeMs} ms, or paired with a disk that outlives the VM. Includes a live Postgres you can wake yourself."
   />
 </svelte:head>
 
@@ -182,10 +182,11 @@
     <header class="masthead">
       <h1><span class="word">Ember</span></h1>
       <p class="lede">
-        Ember orchestrates <b>Firecracker microVMs</b> for untrusted code:
-        short-lived tasks, services that sleep as snapshots and wake,
-        <b>disk to answering queries in 78&nbsp;ms</b>, and disks that outlive
-        their VM. Built from scratch on this cluster.
+        Ember gives every job its own tiny virtual machine. Some run once and
+        are destroyed. Some sleep as snapshots and wake on demand,
+        <b>disk to answering queries in 78&nbsp;ms</b>. Some keep a disk that
+        outlives the VM. Built from scratch on this cluster, on
+        <b>Firecracker</b>.
       </p>
       <p class="live">
         <span class="dot {dotClass}"></span>


### PR DESCRIPTION
Second editorial pass on `/ember`, following the merged #5281. One file changed (`projects/monolith/frontend/src/routes/public/ember/+page.svelte`); tokens, palette, and fonts untouched.

**Lede** (`f7b90bb`): one sentence per VM lifetime, concrete nouns:

> Ember gives every job its own tiny virtual machine. Some run once and are destroyed. Some sleep as snapshots and wake on demand, disk to answering queries in 78 ms. Some keep a disk that outlives the VM. Built from scratch on this cluster, on Firecracker.

**Accordion cut** (`60bda8d`): visible text drops from 828 to ~470 words without losing depth. The two parallel class sections merge into one ruled accordion (native `<details name>`, one row open at a time, no JS): class name plus one line visible, full definition and use case behind the row. Isolation trims to three lines, door cards to one line. Disclosure affordance is a mono `+` rotating to `x` (transform only); reveal fade is opt-in under `prefers-reduced-motion: no-preference`.

**Landing narrative** (`efa9029`): the page now reads what is it (masthead) → is it useful to me ("What you'd run on it") → how does it do that ("How it works": diagram plus the isolation lines) → see it run (demo doors as the closing CTA). The roadmap section is gone; its signal survives as one footer line (10 of 12 milestones shipped) with the full list in `ARCHITECTURE.md` behind the masthead source link.

The page `<title>` remains unchanged (`synthetic_probe.py` SSR sentinel). Includes the format bot's `style: auto-format` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcS9EyqANPjctESssdBb1p