### PR TITLE
fix(embervm): let Bank adopt a primed session VM that never served a turn

### DIFF
--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1316,17 +1316,17 @@ func (s *Server) slotsExhausted() bool {
 // ---- Session verbs (R2) ----------------------------------------------------
 
 // adoptPrimedSession promotes a primed VM from the task registry into the session
-// registry on a session's FIRST invoke. The session-create path primes/claims the
-// VM through the shared warm pool (Prime always lands it in the task registry), so
-// something has to move it into the session registry before SessionAssign can serve
-// it; doing that lazily on first invoke (rather than via a separate create-time
-// verb) keeps create a single round-trip and mirrors how Relight registers a relit
-// VM. It returns the new session entry with the in-flight guard ALREADY held (so a
-// racing second SessionAssign gets rejected until this one finishes), or (nil,false)
-// when vmID is not a primed task VM (unknown, already assigned/adopted, destroyed),
-// which SessionAssign maps to FAILED_PRECONDITION. The physical VM is already a
-// session-base VM (restored from the session workload's base, running the persistent
-// kernel); only its registry bookkeeping changes.
+// registry on a session's FIRST operation. The session-create path primes/claims
+// the VM through the shared warm pool (Prime always lands it in the task registry),
+// so something has to move it into the session registry before SessionAssign can
+// serve it or Bank can snapshot it; doing that lazily on first use (rather than via
+// a separate create-time verb) keeps create a single round-trip and mirrors how
+// Relight registers a relit VM. It returns the new session entry with the in-flight
+// guard ALREADY held (so a racing operation gets rejected until this one finishes),
+// or (nil,false) when vmID is not a primed task VM (unknown, already
+// assigned/adopted, destroyed), which the caller maps to FAILED_PRECONDITION. The
+// physical VM is already a session-base VM (restored from the session workload's
+// base, running the persistent kernel); only its registry bookkeeping changes.
 func (s *Server) adoptPrimedSession(vmID, sessionID, workload string) (*sessionEntry, bool) {
 	ve, ok := s.vms.claimForSession(vmID, workload)
 	if !ok {
@@ -1344,7 +1344,7 @@ func (s *Server) adoptPrimedSession(vmID, sessionID, workload string) (*sessionE
 		// collide on the same unix socket, and dropping the cancel would leak the
 		// goroutine past the session's teardown.
 		egressCancel: ve.egressCancel,
-		inFlight:     true, // held for the SessionAssign that triggered this adoption
+		inFlight:     true, // held for the operation that triggered this adoption
 	}
 	s.sessionVMs.add(se)
 	s.signalChange() // the VM moved primed -> session-live; refresh NodeStatus
@@ -1460,7 +1460,17 @@ func (s *Server) Bank(ctx context.Context, req *nodev1.BankRequest) (*nodev1.Ban
 	// VM, and while the guard is held no new SessionAssign can start.
 	e, ok := s.sessionVMs.beginInFlight(vmID)
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "noded: session vm %q not bankable (unknown, task-class, or a call is already in flight)", vmID)
+		// Not (yet) in the session registry. A freshly CREATED session's VM was
+		// primed/claimed through the shared warm pool, so it still lives in the task
+		// registry until its first invoke. An idle Bank can precede that invoke, so
+		// adopt the VM into the session registry now. adoptPrimedSession returns with
+		// the in-flight guard already held; Bank must not acquire it again, and its
+		// existing success and failure paths both remove the guarded entry.
+		adopted, ok2 := s.adoptPrimedSession(vmID, req.GetSessionId(), req.GetTrace().GetWorkload())
+		if !ok2 {
+			return nil, status.Errorf(codes.FailedPrecondition, "noded: session vm %q not bankable (unknown, task-class, or a call is already in flight)", vmID)
+		}
+		e = adopted
 	}
 	// The Bank destroys the VM either way: on success the entry is removed and the
 	// paused VM reaped below; on failure SnapshotSession has already torn the VM

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -71,6 +71,8 @@ type fakeDriver struct {
 	restoreMarkers             map[string]string // threadID -> marker
 	sessionsDir                string
 	snapshotSessions           int
+	snapshotSessionStarted     chan struct{}
+	blockSnapshotSession       <-chan struct{}
 	restoreSessions            int
 	lastRestoreTrackDirtyPages bool
 	removeSessions             int
@@ -155,8 +157,21 @@ func (f *fakeDriver) SnapshotBase(_ context.Context, _ substrate.Handle, baseKey
 // the server calls Release, so it does not touch f.live here.
 func (f *fakeDriver) SnapshotSession(_ context.Context, _ substrate.Handle, snapshotRef string) (substrate.SnapshotRef, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.snapshotSessions++
+	started := f.snapshotSessionStarted
+	blocked := f.blockSnapshotSession
+	f.mu.Unlock()
+	if started != nil {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+	}
+	if blocked != nil {
+		<-blocked
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.failSnapshotSession != nil {
 		// Mirror the real driver: a bank error tears the VM down (Release), so the
 		// live count drops even though no bundle is produced.
@@ -170,6 +185,12 @@ func (f *fakeDriver) SnapshotSession(_ context.Context, _ substrate.Handle, snap
 	}
 	f.sessionBundles[snapshotRef] = f.nextBankMarker
 	return substrate.SnapshotRef{ID: snapshotRef, Node: "node-4", Arch: "amd64", SizeBytes: 8192}, nil
+}
+
+func (f *fakeDriver) snapshotSessionCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.snapshotSessions
 }
 
 // RestoreSession relights a fake VM from a banked bundle: the ref must have been
@@ -1962,6 +1983,219 @@ func TestSessionInFlightGuard(t *testing.T) {
 	close(gate) // release the first
 	if err := <-firstDone; err != nil {
 		t.Fatalf("first SessionAssign: %v", err)
+	}
+}
+
+// TestBankAdoptsPrimedVM is the create-to-idle-bank regression: a freshly
+// created session can be banked before its first invoke, while its VM is still
+// in the task registry. Bank adopts it, snapshots it, and tears it down.
+func TestBankAdoptsPrimedVM(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &fakeTransport{}
+	client, srv := newSessionTestServer(t, drv, tr, 8)
+	seedBase(srv, "session__bank01", "sandbox-session")
+	ctx := context.Background()
+
+	pr, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "session__bank01"})
+	if err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	vmID := pr.GetVmId()
+	if primed, _ := srv.vms.capacity(); !contains(primed["sandbox-session"], vmID) {
+		t.Fatalf("primed VM %q not in the task registry before Bank", vmID)
+	}
+
+	resp, err := client.Bank(ctx, &nodev1.BankRequest{
+		VmId:      vmID,
+		SessionId: "s-idle-bank",
+		Trace:     &nodev1.Trace{Workload: "sandbox-session"},
+	})
+	if err != nil {
+		t.Fatalf("Bank primed VM: %v", err)
+	}
+	if resp.GetSnapshotRef() == "" || resp.GetSizeBytes() == 0 {
+		t.Fatalf("Bank resp = %+v, want a ref and non-zero size", resp)
+	}
+	if primed, _ := srv.vms.capacity(); contains(primed["sandbox-session"], vmID) {
+		t.Errorf("banked VM %q still in the task registry", vmID)
+	}
+	if ids := sessionVMIDs(srv.nodeStatus()); len(ids) != 0 {
+		t.Errorf("session_vms = %v, want empty after adopted Bank", ids)
+	}
+	if got := drv.snapshotSessionCount(); got != 1 {
+		t.Errorf("SnapshotSession calls = %d, want 1", got)
+	}
+	if _, releases, removeBundles, _ := drv.counts(); releases != 1 || removeBundles != 1 {
+		t.Errorf("adopted Bank teardown: releases=%d removeBundles=%d, want 1/1", releases, removeBundles)
+	}
+}
+
+func TestBankAdoptWorkloadMismatchRejected(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &fakeTransport{}
+	client, srv := newSessionTestServer(t, drv, tr, 8)
+	seedBase(srv, "other__bank01", "other-workload")
+	ctx := context.Background()
+
+	pr, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "other__bank01"})
+	if err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	_, err = client.Bank(ctx, &nodev1.BankRequest{
+		VmId:      pr.GetVmId(),
+		SessionId: "s-bank-mismatch",
+		Trace:     &nodev1.Trace{Workload: "sandbox-session"},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("code = %v, want FailedPrecondition (workload mismatch)", status.Code(err))
+	}
+	if primed, _ := srv.vms.capacity(); !contains(primed["other-workload"], pr.GetVmId()) {
+		t.Errorf("mismatched-workload primed VM was consumed by a failed Bank adopt")
+	}
+	if got := drv.snapshotSessionCount(); got != 0 {
+		t.Errorf("refused Bank snapshotted %d times, want 0", got)
+	}
+}
+
+func TestBankUnknownVMStillRejected(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &fakeTransport{}
+	client, _ := newSessionTestServer(t, drv, tr, 8)
+
+	_, err := client.Bank(context.Background(), &nodev1.BankRequest{
+		VmId:      "vm-nope",
+		SessionId: "s-nope",
+		Trace:     &nodev1.Trace{Workload: "sandbox-session"},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("code = %v, want FailedPrecondition", status.Code(err))
+	}
+	want := `noded: session vm "vm-nope" not bankable (unknown, task-class, or a call is already in flight)`
+	if got := status.Convert(err).Message(); got != want {
+		t.Fatalf("message = %q, want %q", got, want)
+	}
+	if got := drv.snapshotSessionCount(); got != 0 {
+		t.Errorf("unknown Bank snapshotted %d times, want 0", got)
+	}
+}
+
+func TestBankAlreadyAdoptedVMStillSucceeds(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &fakeTransport{}
+	client, srv := newSessionTestServer(t, drv, tr, 8)
+	vmID := primeSessionVM(t, srv, drv, "s-adopted", "echo", "sref-adopted", "")
+
+	resp, err := client.Bank(context.Background(), &nodev1.BankRequest{
+		VmId:      vmID,
+		SessionId: "s-adopted",
+		Trace:     &nodev1.Trace{Workload: "echo"},
+	})
+	if err != nil {
+		t.Fatalf("Bank already-adopted VM: %v", err)
+	}
+	if resp.GetSnapshotRef() == "" || resp.GetSizeBytes() == 0 {
+		t.Fatalf("Bank resp = %+v, want a ref and non-zero size", resp)
+	}
+	if got := drv.snapshotSessionCount(); got != 1 {
+		t.Errorf("SnapshotSession calls = %d, want 1", got)
+	}
+}
+
+func TestBankAdoptedVMInFlightGuardRefusesConcurrentBank(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	defer unblock()
+	drv := &fakeDriver{snapshotSessionStarted: started, blockSnapshotSession: release}
+	tr := &fakeTransport{}
+	client, srv := newSessionTestServer(t, drv, tr, 8)
+	seedBase(srv, "session__guard01", "sandbox-session")
+	ctx := context.Background()
+
+	pr, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "session__guard01"})
+	if err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := client.Bank(ctx, &nodev1.BankRequest{
+			VmId:      pr.GetVmId(),
+			SessionId: "s-bank-guard",
+			Trace:     &nodev1.Trace{Workload: "sandbox-session"},
+		})
+		firstDone <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first Bank never entered SnapshotSession")
+	}
+	_, err = client.Bank(ctx, &nodev1.BankRequest{
+		VmId:      pr.GetVmId(),
+		SessionId: "s-bank-guard",
+		Trace:     &nodev1.Trace{Workload: "sandbox-session"},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("concurrent Bank code = %v, want FailedPrecondition", status.Code(err))
+	}
+	if got := drv.snapshotSessionCount(); got != 1 {
+		t.Errorf("SnapshotSession calls = %d, want 1 while first Bank holds the guard", got)
+	}
+
+	unblock()
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first Bank: %v", err)
+	}
+}
+
+func TestBankAdoptedSnapshotFailureRemovesEntryAndCancelsEgress(t *testing.T) {
+	drv := &fakeDriver{failSnapshotSession: context.Canceled}
+	tr := &fakeTransport{}
+	client, srv := newSessionTestServer(t, drv, tr, 8)
+	seedBase(srv, "session__failure01", "sandbox-session")
+	ctx := context.Background()
+
+	pr, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "session__failure01"})
+	if err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	vmID := pr.GetVmId()
+	egressCanceled := make(chan struct{}, 1)
+	srv.vms.mu.Lock()
+	srv.vms.vms[vmID].egressCancel = func() {
+		select {
+		case egressCanceled <- struct{}{}:
+		default:
+		}
+	}
+	srv.vms.mu.Unlock()
+
+	_, err = client.Bank(ctx, &nodev1.BankRequest{
+		VmId:      vmID,
+		SessionId: "s-bank-failure",
+		Trace:     &nodev1.Trace{Workload: "sandbox-session"},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("failed adopted Bank error = %v, want FailedPrecondition", err)
+	}
+	select {
+	case <-egressCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("failed adopted Bank did not cancel the inherited egress forwarder")
+	}
+	if primed, _ := srv.vms.capacity(); contains(primed["sandbox-session"], vmID) {
+		t.Errorf("failed adopted Bank left VM %q in the task registry", vmID)
+	}
+	if ids := sessionVMIDs(srv.nodeStatus()); len(ids) != 0 {
+		t.Errorf("session_vms = %v, want empty after failed adopted Bank", ids)
+	}
+	if drv.LiveCount() != 0 {
+		t.Errorf("LiveCount after failed adopted Bank = %d, want 0", drv.LiveCount())
+	}
+	if _, ok := srv.sessionVMs.beginInFlight(vmID); ok {
+		t.Fatal("failed adopted Bank left a session registry entry or in-flight guard")
 	}
 }
 


### PR DESCRIPTION
Fixes #5293.

`adoptPrimedSession` promotes a session VM from noded's task registry into the session registry, and its only caller was `SessionAssign`. A session created and then left to idle without ever being invoked therefore never left the task registry, so its idle bank was refused as an unknown `vm_id` even though the VM was booted and healthy one registry over.

That made conformance S2 permanently vacuous ("bank never observed"), which cascaded into S3 vacuous and S4 fail, holding the Kargo dev to prod gate red and prod pinned at chart 0.41.7.

Banking a never-invoked idle session is required behavior rather than an edge case: `piRuntimeWorkload` is documented as ADR 027's `memory:true` quadrant where "an idle session banks a memory snapshot and relights from it", and S2 exercises exactly that path.

## Change

`Bank` gets the same adopt fallback `SessionAssign` already carries. `BankRequest` already supplies `session_id` and `trace.workload`, so there is no proto change. A genuinely unknown, task-class, or in-flight `vm_id` still fails `FAILED_PRECONDITION` with the same message.

`adoptPrimedSession`'s doc comment moves from "FIRST invoke" to "FIRST operation", since a bank can now be that first operation.

## Verification

The regression test was falsified rather than assumed. With the test file unchanged and ONLY the `Bank` hunk reverted:

```
server_test.go:2014: Bank primed VM: rpc error: code = FailedPrecondition
  desc = noded: session vm "vm-vm-a0cb5ae158b8ba47" not bankable
         (unknown, task-class, or a call is already in flight)
Executed 1 out of 137 tests: 136 tests pass and 1 fails remotely.
```

That is the same error observed live in `embervm-dev`. With the fix restored, `Executed 3 out of 137 tests: 137 tests pass`.

Six tests added: adoption on bank, workload mismatch still rejected, unknown vm_id still rejected, the already-adopted path unregressed, the in-flight guard on an adopted entry, and snapshot failure on an adopted entry removing the registry entry and cancelling the inherited egress forwarder.

## Note on the in-flight guard

`adoptPrimedSession` returns with `inFlight` ALREADY held, so `Bank` does not reacquire it. Bank's existing success and failure paths both remove the guarded entry, and the failure path still cancels the egress forwarder inherited from Prime, so the adopted path leaks neither the guard nor the forwarder goroutine.

## Not this

Not #5265, which fixed the bank dial fail-open and the `spec_trace` seq collision. Both are confirmed working live: the session now bounds its retries and terminalizes with the reason carried into the verdict instead of hanging. This is the distinct bug that was underneath.
