### PR TITLE
fix(monolith): repair the hourly homelab changelog broken by the org move

### DIFF
--- a/projects/monolith/chat/changelog.py
+++ b/projects/monolith/chat/changelog.py
@@ -174,7 +174,9 @@ async def run_changelog_iteration(
 
     since = datetime.now(timezone.utc) - timedelta(hours=config.interval_hours)
 
-    async with httpx.AsyncClient(timeout=httpx.Timeout(600.0)) as client:
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(600.0), follow_redirects=True
+    ) as client:
         commits = await _fetch_commits_since(
             client, config.github_repo, github_token, since
         )
@@ -281,7 +283,9 @@ async def run_changelog_for_config(
         return
 
     since = datetime.now(timezone.utc) - timedelta(hours=config.interval_hours)
-    async with httpx.AsyncClient(timeout=httpx.Timeout(600.0)) as client:
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(600.0), follow_redirects=True
+    ) as client:
         commits = await _fetch_commits_since(
             client, config.github_repo, github_token, since
         )

--- a/projects/monolith/chat/changelog_fetch_test.py
+++ b/projects/monolith/chat/changelog_fetch_test.py
@@ -125,3 +125,57 @@ class TestFetchCommitsSince:
 
         params = client.get.call_args[1]["params"]
         assert params["per_page"] == 100
+
+
+class TestRedirectFollowing:
+    """The repo moved orgs, so GitHub answers the old slug with a 301.
+
+    These use a real httpx.AsyncClient over MockTransport rather than the
+    AsyncMock above. A mocked client cannot exercise redirect handling at all,
+    which is why the org move broke the hourly changelog job in production
+    while this suite stayed green.
+    """
+
+    @staticmethod
+    def _transport(commits):
+        def handle(request: httpx.Request) -> httpx.Response:
+            if "/repos/jomcgi/homelab/" in str(request.url):
+                return httpx.Response(
+                    301,
+                    headers={
+                        "Location": "https://api.github.com/repos/jomcgi-org/homelab/commits"
+                    },
+                    json={"message": "Moved Permanently"},
+                )
+            return httpx.Response(200, json=commits)
+
+        return httpx.MockTransport(handle)
+
+    @pytest.mark.asyncio
+    async def test_follows_the_org_move_redirect(self):
+        """With follow_redirects the 301 resolves to the real commit list."""
+        commits = [{"sha": "abc123", "commit": {"message": "feat: new thing"}}]
+        async with httpx.AsyncClient(
+            transport=self._transport(commits), follow_redirects=True
+        ) as client:
+            result = await _fetch_commits_since(
+                client, "jomcgi/homelab", "token", datetime.now(timezone.utc)
+            )
+        assert result == commits
+
+    @pytest.mark.asyncio
+    async def test_without_following_the_redirect_raises(self):
+        """Pin the production failure mode.
+
+        raise_for_status() returns early only on is_success, so a 301 raises
+        HTTPStatusError rather than passing a redirect body downstream. That
+        exception is what exited the hourly job with code 1.
+        """
+        async with httpx.AsyncClient(
+            transport=self._transport([]), follow_redirects=False
+        ) as client:
+            with pytest.raises(httpx.HTTPStatusError) as excinfo:
+                await _fetch_commits_since(
+                    client, "jomcgi/homelab", "token", datetime.now(timezone.utc)
+                )
+        assert excinfo.value.response.status_code == 301

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -169,7 +169,7 @@ chat:
   changelogs:
     - name: "homelab"
       channelId: "1491186550472708117"
-      githubRepo: "jomcgi/homelab"
+      githubRepo: "jomcgi-org/homelab"
       prompt: "professional"
       embedTitle: "Joe - Homelab"
       embedColor: "0x2ECC71"


### PR DESCRIPTION
chat-changelog-homelab has failed every hour for hours with `main: Error (exit code 1)`. The cause is a stale repository slug in config, not in code: `projects/monolith/deploy/values.yaml` still named `jomcgi/homelab`, the pre-move owner.

## Chain

1. `githubRepo: "jomcgi/homelab"` is the pre-org-move slug.
2. GitHub answers it with `301` to `jomcgi-org/homelab`.
3. `httpx.AsyncClient` defaults to `follow_redirects=False`, and `raise_for_status()` returns early only on `is_success`, so the 301 raises `HTTPStatusError`.
4. That propagates out of the job, exit 1.

`chat-changelog-colin-homelab` (`ColinCee/homelab`) and `chat-changelog-loom` (`weave-hand/loom`) point at repos that never moved, which is why only this one entry failed.

Verified against the live API: the old slug returns `301` with `Location: .../repos/jomcgi-org/homelab/...`, the new slug and both sibling repos return `200`.

## Changes

- Correct the slug to `jomcgi-org/homelab`.
- Add `follow_redirects=True` to both `AsyncClient` constructions in `chat/changelog.py`, matching the hardening #5270 applied to the GitHub call sites in code.

Either change alone fixes the symptom. They are kept together because they fail differently: the slug fix is exact but goes stale again on the next move, and the redirect fix degrades any future move into a redirect rather than an outage. The two land safely in either deploy order, since the corrected slug returns `200` under the old code and the old slug is followed under the new code.

## Why #5270 did not catch it

That PR swept GitHub call sites in code. This slug is a *value*, delivered through the `$values` git ref rather than baked into the image, so a call-site sweep could not reach it.

## Tests

The existing suite injects an `AsyncMock(spec=httpx.AsyncClient)`, so no test in it could observe redirect behaviour at all: the seam that broke is the client construction, which nothing reached. That is why this was green in CI while failing hourly in production.

The new tests drive a real `AsyncClient` over `httpx.MockTransport`, one asserting the org-move redirect is followed and one pinning the 301 failure mode. Confirmed the second one fails against the unfixed code path before being corrected to assert the real exception.

`ci test`: `Executed 1 out of 360 tests: 360 tests pass.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaA2SsVAWiexez2NPepNmo