### PR TITLE
chore(platform): drop the tunnel's dead per-hostname ingress routing

### DIFF
--- a/projects/platform/cloudflare-gateway/templates/tunnel-configmap.yaml
+++ b/projects/platform/cloudflare-gateway/templates/tunnel-configmap.yaml
@@ -13,12 +13,12 @@ data:
     {{- end }}
     no-autoupdate: {{ .Values.tunnel.noAutoupdate }}
     ingress:
-    {{- range .Values.tunnel.ingress.routes }}
-    - hostname: {{ .hostname }}
-      service: {{ .service }}
-      {{- if .originRequest }}
-      originRequest:
-        {{- toYaml .originRequest | nindent 8 }}
-      {{- end }}
-    {{- end }}
+    {{- /*
+      Every hostname falls through to catchAll, which hands traffic to the
+      cloudflare-ingress Envoy gateway. Per-hostname routes here would bypass
+      that gateway, and nothing needs to, so the tunnel does no host routing.
+      Kept as a template comment: anything inside the config.yaml literal
+      changes the ConfigMap checksum and rolls cloudflared, which is a brief
+      total ingress outage.
+    */}}
     - service: {{ .Values.tunnel.ingress.catchAll.service }}

--- a/projects/platform/cloudflare-gateway/values-prod.yaml
+++ b/projects/platform/cloudflare-gateway/values-prod.yaml
@@ -38,11 +38,10 @@ tunnel:
   protocol: http2
 
   ingress:
-    routes:
-      # argocd, longhorn, and signoz retired: they now serve under
-      # private.jomcgi.dev/app/<app> via the cloudflare-ingress gateway
-      # (HTTPRoutes in each chart). Their old subdomains fall through to
-      # catchAll, which has no matching gateway route, so they stop resolving.
+    # argocd, longhorn, and signoz retired: they now serve under
+    # private.jomcgi.dev/app/<app> via the cloudflare-ingress gateway
+    # (HTTPRoutes in each chart). Their old subdomains fall through to
+    # catchAll, which has no matching gateway route, so they stop resolving.
     catchAll:
       service: http://cloudflare-ingress.envoy-gateway-system.svc.cluster.local:80
 

--- a/projects/platform/cloudflare-gateway/values.yaml
+++ b/projects/platform/cloudflare-gateway/values.yaml
@@ -82,7 +82,6 @@ tunnel:
       credentialsJson: ""
 
   ingress:
-    routes: []
     catchAll:
       service: http_status:404
 


### PR DESCRIPTION
cloudflared has done no host routing since argocd, longhorn and signoz moved to `private.jomcgi.dev/app/<app>` behind the cloudflare-ingress gateway. This removes the machinery that used to do it.

## Evidence it is dead

- `values.yaml`: `tunnel.ingress.routes: []`
- `values-prod.yaml`: `routes:` with only a comment beneath it, so the key is null
- No other values file in the repo sets `routes` (checked repo-wide)

So `{{- range .Values.tunnel.ingress.routes }}` in `tunnel-configmap.yaml` has been iterating an empty collection. Every hostname reaches the gateway through `catchAll`.

Dead templating is worse than absent templating here: `routes` reads as the place tunnel host routing is configured, when the live answer is that there is none and the gateway owns it.

## What is preserved

The retirement rationale for argocd/longhorn/signoz moves onto `catchAll`, where it describes the mechanism that is actually live rather than the one being deleted.

The note explaining why per-host routes would be wrong goes in the template as a **Helm** comment, not a YAML one. Anything inside the `config.yaml` literal changes the ConfigMap checksum and rolls cloudflared, which is a brief total ingress outage. I hit exactly that on the first attempt: a three-line YAML comment produced a checksum change in the render. Worth knowing for anyone editing this file.

## Verification

Rendered the chart with both values files before and after:

```
helm template cf-gw projects/platform/cloudflare-gateway/ \
  -f .../values.yaml -f .../values-prod.yaml
```

Output is **byte-for-byte identical**. No ConfigMap checksum moves, nothing restarts.

`ci test` reports `no Bazel targets affected` because none of these three files is referenced by any Bazel rule, so it is not evidence either way. The render diff is the real check.

## Trade-off

This deletes the only per-hostname bypass of the Envoy gateway. Nothing needs one today. If something later does (a raw TCP service, or one that must not traverse Envoy), restoring the range block is a small revert of this commit.

Note `projects/platform/*` deploys on HEAD, so this lands on merge with no chart bump. Since the render is unchanged, the merge is a no-op at the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaA2SsVAWiexez2NPepNmo
