### PR TITLE
feat(monolith): ember landing goes picomq-minimal

### DIFF
--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -1,9 +1,9 @@
 <script>
-  // /ember: the landing page for the Ember mini-site. Narrative order is
-  // what is it (masthead) -> is it useful to me (class rows) -> how does it
-  // do that (diagram + isolation) -> see it run (demo doors); depth sits
-  // behind accordion rows so the visible words stay few. Copy voice follows
-  // the project README (blunt mechanism sentences, no rhetoric). Visual language is the shared ember token
+  // /ember: the landing page for the Ember mini-site, picomq-shaped: a
+  // hero with the live status line and two CTAs, then one label-only
+  // accordion (the five classes, isolation, the moving parts). All depth
+  // sits behind the rows or in ARCHITECTURE.md. Copy voice follows the
+  // project README (blunt mechanism sentences, no rhetoric). Visual language is the shared ember token
   // sheet (lib/public/ember/ember.css) plus landing-only tokens in
   // ./landing.css; hex never appears in this <style> block.
   //
@@ -118,11 +118,9 @@
     <header class="masthead">
       <h1><span class="word">Ember</span></h1>
       <p class="lede">
-        Ember gives every job its own tiny virtual machine. Some run once and
-        are destroyed. Some sleep as snapshots and wake on demand,
-        <b>disk to answering queries in 78&nbsp;ms</b>. Some keep a disk that
-        outlives the VM. Built from scratch on this cluster, on
-        <b>Firecracker</b>.
+        Every job gets its own tiny virtual machine. Idle ones sleep as
+        snapshots; <b>disk to answering queries in 78&nbsp;ms</b>. Built from
+        scratch on this cluster.
       </p>
       <p class="live">
         <span class="dot {dotClass}"></span>
@@ -152,120 +150,105 @@
           >source</a
         >
       </p>
+      <p class="ctas">
+        <a class="cta cta-primary" href="/ember/postgres">wake the database</a>
+        <a
+          class="cta"
+          href="https://github.com/jomcgi/homelab/blob/main/projects/embervm/ARCHITECTURE.md"
+          >read the docs</a
+        >
+      </p>
     </header>
 
     <section>
       <h2 class="h2" id="classes">
-        <a class="anchor" href="#classes">What you'd run on it</a>
+        <a class="anchor" href="#classes">What it runs</a>
       </h2>
-      <p class="body">
-        Five classes, declared as Kubernetes custom resources, all assuming the
-        guest is hostile.
-      </p>
       <div class="classes">
         <details class="class" name="em-classes">
           <summary>
-            <span class="cname">task<small>run once</small></span>
-            <span class="cline"
-              >A fresh VM, no network device, destroyed after one job.</span
-            >
+            <span class="cname">task</span>
+            <span class="ctag">run once</span>
           </summary>
           <div class="cmore">
             <p>
-              One-shot execution in a fresh or snapshot-restored VM. The guest
-              can reach exactly one thing: its channel to the host daemon. The
-              scan fleet runs the CI security scanner this way.
+              A fresh VM per job, <b>no network device</b>, destroyed after. The guest reaches exactly one thing: its channel to the host daemon.
+            </p>
+            <p class="sigs"><a class="sig" href="/ember/semgrep">semgrep, live →</a> <a class="sig" href="/ember/bazel">a frozen Bazel brain, live →</a></p>
+          </div>
+        </details>
+        <details class="class" name="em-classes">
+          <summary>
+            <span class="cname">session</span>
+            <span class="ctag">sleep &amp; wake</span>
+          </summary>
+          <div class="cmore">
+            <p>
+              An agent's sandbox. <b>Banked</b> between turns, <b>relit</b> with memory, processes and open files intact; snapshots offload to S3, so a session survives its node.
+            </p>
+            <p class="sigs"><a class="sig" href="/ember/agents">one microVM per agent →</a></p>
+          </div>
+        </details>
+        <details class="class" name="em-classes">
+          <summary>
+            <span class="cname">serving</span>
+            <span class="ctag">always answering</span>
+          </summary>
+          <div class="cmore">
+            <p>
+              A warm HTTP endpoint. Requests go through a node-local Envoy straight into the VM; <b>the control plane can restart mid-request</b> and traffic notices nothing.
             </p>
           </div>
         </details>
         <details class="class" name="em-classes">
           <summary>
-            <span class="cname">session<small>sleep &amp; wake</small></span>
-            <span class="cline"
-              >An agent's sandbox, banked between turns, relit with memory
-              intact.</span
-            >
+            <span class="cname">stateful</span>
+            <span class="ctag">a database that sleeps</span>
           </summary>
           <div class="cmore">
             <p>
-              Idle sessions are <b>banked</b> (snapshotted to disk) and
-              <b>relit</b> on the next call with memory, processes and open
-              files intact. Snapshots offload to S3, so a session survives the
-              node it slept on. Each AI agent gets its own machine to make a
-              mess in: shell, filesystem, packages,
-              <b>destroyed without ceremony</b>.
+              Postgres banked to disk when idle, woken by the next connection. <b>Zero compute while asleep</b>, and the disk outlives the VM.
+            </p>
+            <p class="sigs"><a class="sig" href="/ember/postgres">wake it yourself →</a></p>
+          </div>
+        </details>
+        <details class="class" name="em-classes">
+          <summary>
+            <span class="cname">composite</span>
+            <span class="ctag">wakes as one</span>
+          </summary>
+          <div class="cmore">
+            <p>
+              Several VMs, one private network, banked and relit as a unit. A scratch Kubernetes cluster ran as one workload.
             </p>
           </div>
         </details>
         <details class="class" name="em-classes">
           <summary>
-            <span class="cname">serving<small>always answering</small></span>
-            <span class="cline"
-              >A warm HTTP endpoint; requests never touch the control plane.</span
-            >
+            <span class="cname">isolation</span>
+            <span class="ctag">hostile by default</span>
           </summary>
           <div class="cmore">
             <p>
-              Requests reach the guest directly through a node-local Envoy the
-              control plane has already programmed. An image renderer answers
-              real internet traffic this way,
-              <b>rate-limited and quota-capped</b>.
+              <b>No VM, and nothing it was restored from, is ever shared between two customers.</b> Task and session guests have no network device at all. Quotas fail closed: quota 0 is a hard stop at submit.
             </p>
           </div>
         </details>
         <details class="class" name="em-classes">
           <summary>
-            <span class="cname"
-              >stateful<small>a database that sleeps</small></span
-            >
-            <span class="cline"
-              >Its disk outlives the VM; the next connection wakes it.</span
-            >
+            <span class="cname">the moving parts</span>
+            <span class="ctag">how it fits together</span>
           </summary>
           <div class="cmore">
             <p>
-              Postgres banked to disk the moment it goes idle.
-              <b>Zero compute while asleep</b>, and the volume on node NVMe is
-              the authoritative copy.
-              <a class="sig" href="/ember/postgres">see it live →</a>
+              An <b>Elixir control plane</b> manages Firecracker VM lifecycle
+              on Kubernetes; a Go daemon on each node owns the machines.
+              Workloads are declared as Kubernetes custom resources.
             </p>
-          </div>
-        </details>
-        <details class="class" name="em-classes">
-          <summary>
-            <span class="cname">composite<small>wakes as one</small></span>
-            <span class="cline"
-              >Several VMs, one private network, banked and relit together.</span
-            >
-          </summary>
-          <div class="cmore">
-            <p>
-              An all-or-none group. A scratch Kubernetes cluster ran as one
-              composite workload: control plane and workers woke together on the
-              first kubectl.
-            </p>
-          </div>
-        </details>
-      </div>
-      <pre class="api">POST /v1/workloads/:name/tasks     → 202 + a task_id
+            <pre class="api">POST /v1/workloads/:name/tasks     → 202 + a task_id
 POST /v1/workloads/:name/sessions  → a session_id, then /v1/sessions/:id/invoke
 serving                            → plain HTTP, straight into the VM</pre>
-    </section>
-
-    <section>
-      <h2 class="h2" id="arch">
-        <a class="anchor" href="#arch">How it works</a>
-      </h2>
-      <p class="body">
-        An <b>Elixir control plane</b> manages Firecracker VM lifecycle on
-        Kubernetes; a Go daemon on each node owns the machines.
-        <b>Serving requests never touch the control plane</b>: the edge routes
-        through a node-local Envoy straight into the VM, so the control plane
-        can restart mid-request and traffic notices nothing.
-      </p>
-      <details class="fold">
-        <summary><span class="fold-label">the moving parts</span></summary>
-        <div class="arch">
+            <div class="arch">
           <svg
             viewBox="0 0 720 300"
             role="img"
@@ -472,69 +455,19 @@ serving                            → plain HTTP, straight into the VM</pre>
             >
           </div>
         </div>
-      </details>
-      <div class="iso">
-        <p>
-          <b
-            >No VM, and nothing it was restored from, is ever shared between two
-            customers.</b
-          >
-        </p>
-        <p>
-          Task and session guests have <b>no network device at all</b>: one
-          channel to the host daemon.
-        </p>
-        <p>
-          <b>Quotas fail closed.</b> A customer with quota 0 is hard-stopped at submit.
-        </p>
-      </div>
-    </section>
-
-    <section>
-      <h2 class="h2" id="live-exhibits">
-        <a class="anchor" href="#live-exhibits">See it run</a>
-      </h2>
-      <div class="doors">
-        <a class="door" href="/ember/postgres">
-          <span class="k">live demo</span>
-          <h3>A Postgres that sleeps</h3>
-          <p>Click connect, watch the stopwatch: best wake 78&nbsp;ms.</p>
-          <span class="go">ember/postgres</span>
-        </a>
-        <a class="door" href="/ember/bazel">
-          <span class="k">live demo</span>
-          <h3>Query a frozen Bazel brain</h3>
-          <p>
-            Each query runs in a disposable clone of a snapshotted warm Bazel
-            server.
-          </p>
-          <span class="go">ember/bazel</span>
-        </a>
-        <a class="door" href="/ember/firecracker">
-          <span class="k">explainer</span>
-          <h3>How Firecracker resumes a VM</h3>
-          <p>What a snapshot contains; a full machine back in ~22&nbsp;ms.</p>
-          <span class="go">ember/firecracker</span>
-        </a>
-        <a class="door" href="/ember/agents">
-          <span class="k">explainer</span>
-          <h3>One microVM per agent session</h3>
-          <p>Restored in 2.5 ms, killed 20 s after the last turn.</p>
-          <span class="go">ember/agents</span>
-        </a>
-        <a class="door" href="/ember/semgrep">
-          <span class="k">workload demo</span>
-          <h3>Semgrep</h3>
-          <p>Warm in a microVM, scanning your snippet in about a second.</p>
-          <span class="go">ember/semgrep</span>
-        </a>
+            <p class="sigs">
+              <a class="sig" href="/ember/firecracker">how a VM resumes in 22 ms →</a>
+              <a class="sig" href="https://github.com/jomcgi/homelab/blob/main/projects/embervm/ARCHITECTURE.md">full architecture →</a>
+            </p>
+          </div>
+        </details>
       </div>
     </section>
 
     <footer class="foot">
       <span
-        >Elixir/OTP control plane · Go node daemon · 10 of 12 roadmap milestones
-        shipped</span
+        >Elixir/OTP control plane · Go node daemon · Firecracker microVMs · 10
+        of 12 roadmap milestones shipped</span
       >
       <span class="foot-links">
         <a href="https://github.com/jomcgi/homelab/tree/main/projects/embervm"
@@ -718,8 +651,7 @@ serving                            → plain HTTP, straight into the VM</pre>
   .live a:focus-visible,
   .sig:focus-visible,
   .anchor:focus-visible,
-  .door:focus-visible,
-  .foot a:focus-visible {
+    .foot a:focus-visible {
     outline: 2px solid var(--em-ember-deep);
     outline-offset: 3px;
   }
@@ -757,6 +689,46 @@ serving                            → plain HTTP, straight into the VM</pre>
   }
 
   .stats .src:focus-visible {
+    outline: 2px solid var(--em-ember-deep);
+    outline-offset: 3px;
+  }
+
+  /* ---------- hero CTAs, picomq-style pair ---------- */
+  .ctas {
+    margin: 22px 0 0;
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .cta {
+    font-family: var(--em-mono);
+    font-size: 13px;
+    padding: 10px 18px;
+    border-radius: 8px;
+    text-decoration: none;
+    color: var(--em-ink);
+    border: 1px solid var(--eml-line-strong);
+    background: var(--eml-panel-warm);
+    box-shadow: var(--em-shadow-soft);
+    transition:
+      box-shadow 0.18s ease,
+      transform 0.18s ease;
+  }
+
+  .cta:hover {
+    box-shadow: var(--em-shadow);
+    transform: translateY(-1px);
+  }
+
+  /* Ground-on-ember text: the deep ember passes AA at this size. */
+  .cta-primary {
+    background: var(--em-ember-deep);
+    border-color: var(--em-ember-deep);
+    color: var(--em-ground);
+  }
+
+  .cta:focus-visible {
     outline: 2px solid var(--em-ember-deep);
     outline-offset: 3px;
   }
@@ -866,18 +838,10 @@ serving                            → plain HTTP, straight into the VM</pre>
     color: var(--em-ember-deep);
   }
 
-  .cname small {
-    display: block;
-    font-weight: 400;
-    color: var(--em-faint);
-    font-size: 11px;
-    margin-top: 5px;
-  }
 
-  .cline {
-    font-size: 15px;
-    line-height: 1.55;
-    color: var(--em-muted);
+  .ctag {
+    font-size: 13.5px;
+    color: var(--em-faint);
   }
 
   .class summary::after {
@@ -894,8 +858,8 @@ serving                            → plain HTTP, straight into the VM</pre>
     transform: rotate(45deg);
   }
 
-  .class summary:hover .cline {
-    color: var(--em-ink);
+  .class summary:hover .ctag {
+    color: var(--em-muted);
   }
 
   .class summary:focus-visible {
@@ -919,6 +883,17 @@ serving                            → plain HTTP, straight into the VM</pre>
     font-weight: 600;
   }
 
+  .sigs {
+    margin: 12px 0 0;
+    display: flex;
+    gap: 8px 18px;
+    flex-wrap: wrap;
+  }
+
+  .cmore .arch {
+    margin-top: 14px;
+  }
+
   .sig {
     font-family: var(--em-mono);
     font-size: 12.5px;
@@ -931,60 +906,6 @@ serving                            → plain HTTP, straight into the VM</pre>
 
   .sig:hover {
     border-bottom-color: var(--em-ember-deep);
-  }
-
-  /* ---------- diagram fold: same disclosure language as the class rows ---- */
-  .fold {
-    border-top: 1px solid var(--eml-line-strong);
-    border-bottom: 1px solid var(--em-line);
-    margin-bottom: 16px;
-  }
-
-  .fold summary {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 18px;
-    align-items: center;
-    padding: 12px 4px;
-    cursor: pointer;
-    list-style: none;
-  }
-
-  .fold summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .fold-label {
-    font-family: var(--em-mono);
-    font-size: 12.5px;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--em-faint);
-  }
-
-  .fold summary::after {
-    content: "+";
-    font-family: var(--em-mono);
-    font-size: 15px;
-    line-height: 1;
-    color: var(--em-faint);
-    justify-self: end;
-  }
-
-  .fold[open] summary::after {
-    transform: rotate(45deg);
-  }
-
-  .fold summary:hover .fold-label {
-    color: var(--em-muted);
-  }
-
-  .fold summary:focus-visible {
-    outline: 2px solid var(--em-ember-deep);
-    outline-offset: 3px;
-  }
-
-  .fold .arch {
-    margin-bottom: 14px;
   }
 
   /* ---------- architecture ---------- */
@@ -1143,120 +1064,6 @@ serving                            → plain HTTP, straight into the VM</pre>
     border-top-style: dashed;
   }
 
-  /* ---------- isolation ---------- */
-  .iso {
-    display: flex;
-    flex-direction: column;
-    border-top: 1px solid var(--eml-line-strong);
-  }
-
-  .iso p {
-    margin: 0;
-    padding: 13px 4px;
-    border-bottom: 1px solid var(--em-line);
-    font-size: 16px;
-    line-height: 1.55;
-    color: var(--em-muted);
-  }
-
-  .iso p b {
-    color: var(--em-ink);
-    font-weight: 650;
-  }
-
-  /* ---------- doors ---------- */
-  .doors {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 16px;
-  }
-
-  .door {
-    display: block;
-    text-decoration: none;
-    background: var(--eml-panel-warm);
-    border: 1px solid var(--em-line);
-    border-radius: 12px;
-    padding: 20px 22px 18px;
-    box-shadow: var(--em-shadow-soft);
-    transition:
-      border-color 0.18s ease,
-      box-shadow 0.18s ease,
-      transform 0.18s ease;
-  }
-
-  .door:hover {
-    border-color: var(--em-ember-dim);
-    box-shadow: var(--em-shadow);
-    transform: translateY(-2px);
-  }
-
-  .door .k {
-    font-family: var(--em-mono);
-    font-size: 11px;
-    letter-spacing: 0.08em;
-    color: var(--em-faint);
-    text-transform: uppercase;
-  }
-
-  .door h3 {
-    margin: 6px 0;
-    font-size: 19px;
-    font-weight: 700;
-    color: var(--em-ink);
-    letter-spacing: -0.01em;
-  }
-
-  .door:hover h3 {
-    color: var(--em-ember-deep);
-  }
-
-  .door p {
-    margin: 0;
-    font-size: 14px;
-    line-height: 1.5;
-    color: var(--em-muted);
-  }
-
-  .door .go {
-    display: inline-block;
-    margin-top: 12px;
-    font-family: var(--em-mono);
-    font-size: 12.5px;
-    color: var(--em-ember-deep);
-  }
-
-  .door .go::after {
-    content: " →";
-    transition: transform 0.18s ease;
-    display: inline-block;
-  }
-
-  .door:hover .go::after {
-    transform: translateX(4px);
-  }
-
-  /* Opening motion is opt-in: absent by default, per the reduced-motion
-     opt-in shape this repo prefers for new work. */
-  @media (prefers-reduced-motion: no-preference) {
-    .class summary::after,
-    .fold summary::after {
-      transition: transform 0.18s ease;
-    }
-
-    .class[open] .cmore,
-    .fold[open] .arch {
-      animation: em-reveal 0.22s ease;
-    }
-
-    @keyframes em-reveal {
-      from {
-        opacity: 0;
-        transform: translateY(-3px);
-      }
-    }
-  }
-
   /* ---------- footer ---------- */
   .foot {
     margin-top: 70px;
@@ -1298,19 +1105,13 @@ serving                            → plain HTTP, straight into the VM</pre>
     }
   }
 
-  @media (max-width: 700px) {
-    .doors {
-      grid-template-columns: 1fr;
-    }
-  }
-
   @media (max-width: 640px) {
     .class summary {
       grid-template-columns: minmax(0, 1fr) 18px;
       gap: 6px 14px;
     }
 
-    .class summary .cline {
+    .class summary .ctag {
       grid-column: 1;
     }
 
@@ -1326,8 +1127,7 @@ serving                            → plain HTTP, straight into the VM</pre>
 
   @media (prefers-reduced-motion: reduce) {
     .dot,
-    .door,
-    .door .go::after {
+    .cta {
       transition: none;
     }
 

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -172,9 +172,14 @@
           </summary>
           <div class="cmore">
             <p>
-              A fresh VM per job, <b>no network device</b>, destroyed after. The guest reaches exactly one thing: its channel to the host daemon.
+              A fresh VM per job, <b>no network device</b>, destroyed after. The
+              guest reaches exactly one thing: its channel to the host daemon.
             </p>
-            <p class="sigs"><a class="sig" href="/ember/semgrep">semgrep, live →</a> <a class="sig" href="/ember/bazel">a frozen Bazel brain, live →</a></p>
+            <p class="sigs">
+              <a class="sig" href="/ember/semgrep">semgrep, live →</a>
+              <a class="sig" href="/ember/bazel">a frozen Bazel brain, live →</a
+              >
+            </p>
           </div>
         </details>
         <details class="class" name="em-classes">
@@ -184,9 +189,13 @@
           </summary>
           <div class="cmore">
             <p>
-              An agent's sandbox. <b>Banked</b> between turns, <b>relit</b> with memory, processes and open files intact; snapshots offload to S3, so a session survives its node.
+              An agent's sandbox. <b>Banked</b> between turns, <b>relit</b> with memory,
+              processes and open files intact; snapshots offload to S3, so a session
+              survives its node.
             </p>
-            <p class="sigs"><a class="sig" href="/ember/agents">one microVM per agent →</a></p>
+            <p class="sigs">
+              <a class="sig" href="/ember/agents">one microVM per agent →</a>
+            </p>
           </div>
         </details>
         <details class="class" name="em-classes">
@@ -196,7 +205,10 @@
           </summary>
           <div class="cmore">
             <p>
-              A warm HTTP endpoint. Requests go through a node-local Envoy straight into the VM; <b>the control plane can restart mid-request</b> and traffic notices nothing.
+              A warm HTTP endpoint. Requests go through a node-local Envoy
+              straight into the VM; <b
+                >the control plane can restart mid-request</b
+              > and traffic notices nothing.
             </p>
           </div>
         </details>
@@ -207,9 +219,13 @@
           </summary>
           <div class="cmore">
             <p>
-              Postgres banked to disk when idle, woken by the next connection. <b>Zero compute while asleep</b>, and the disk outlives the VM.
+              Postgres banked to disk when idle, woken by the next connection. <b
+                >Zero compute while asleep</b
+              >, and the disk outlives the VM.
             </p>
-            <p class="sigs"><a class="sig" href="/ember/postgres">wake it yourself →</a></p>
+            <p class="sigs">
+              <a class="sig" href="/ember/postgres">wake it yourself →</a>
+            </p>
           </div>
         </details>
         <details class="class" name="em-classes">
@@ -219,7 +235,8 @@
           </summary>
           <div class="cmore">
             <p>
-              Several VMs, one private network, banked and relit as a unit. A scratch Kubernetes cluster ran as one workload.
+              Several VMs, one private network, banked and relit as a unit. A
+              scratch Kubernetes cluster ran as one workload.
             </p>
           </div>
         </details>
@@ -230,7 +247,11 @@
           </summary>
           <div class="cmore">
             <p>
-              <b>No VM, and nothing it was restored from, is ever shared between two customers.</b> Task and session guests have no network device at all. Quotas fail closed: quota 0 is a hard stop at submit.
+              <b
+                >No VM, and nothing it was restored from, is ever shared between
+                two customers.</b
+              > Task and session guests have no network device at all. Quotas fail
+              closed: quota 0 is a hard stop at submit.
             </p>
           </div>
         </details>
@@ -241,223 +262,305 @@
           </summary>
           <div class="cmore">
             <p>
-              An <b>Elixir control plane</b> manages Firecracker VM lifecycle
-              on Kubernetes; a Go daemon on each node owns the machines.
-              Workloads are declared as Kubernetes custom resources.
+              An <b>Elixir control plane</b> manages Firecracker VM lifecycle on Kubernetes;
+              a Go daemon on each node owns the machines. Workloads are declared as
+              Kubernetes custom resources.
             </p>
-            <pre class="api">POST /v1/workloads/:name/tasks     → 202 + a task_id
+            <pre
+              class="api">POST /v1/workloads/:name/tasks     → 202 + a task_id
 POST /v1/workloads/:name/sessions  → a session_id, then /v1/sessions/:id/invoke
 serving                            → plain HTTP, straight into the VM</pre>
             <div class="arch">
-          <svg
-            viewBox="0 0 720 300"
-            role="img"
-            aria-label="Ember architecture: callers reach the Elixir control plane, which dispatches over gRPC to the Go node daemon driving Firecracker VMs; serving traffic bypasses the control plane entirely via a node-local Envoy programmed over xDS. Snapshots and boot images are banked to S3."
-          >
-            <defs>
-              <marker
-                id="arrow-ember"
-                markerWidth="8"
-                markerHeight="8"
-                refX="7"
-                refY="4"
-                orient="auto"
+              <svg
+                viewBox="0 0 720 300"
+                role="img"
+                aria-label="Ember architecture: callers reach the Elixir control plane, which dispatches over gRPC to the Go node daemon driving Firecracker VMs; serving traffic bypasses the control plane entirely via a node-local Envoy programmed over xDS. Snapshots and boot images are banked to S3."
               >
-                <path class="mk mk-control" d="M1,1 L7,4 L1,7" />
-              </marker>
-              <marker
-                id="arrow-frost"
-                markerWidth="8"
-                markerHeight="8"
-                refX="7"
-                refY="4"
-                orient="auto"
-              >
-                <path class="mk mk-data" d="M1,1 L7,4 L1,7" />
-              </marker>
-              <marker
-                id="arrow-amber"
-                markerWidth="8"
-                markerHeight="8"
-                refX="7"
-                refY="4"
-                orient="auto"
-              >
-                <path class="mk mk-xds" d="M1,1 L7,4 L1,7" />
-              </marker>
-              <marker
-                id="arrow-slate"
-                markerWidth="8"
-                markerHeight="8"
-                refX="7"
-                refY="4"
-                orient="auto"
-              >
-                <path class="mk mk-bank" d="M1,1 L7,4 L1,7" />
-              </marker>
-            </defs>
+                <defs>
+                  <marker
+                    id="arrow-ember"
+                    markerWidth="8"
+                    markerHeight="8"
+                    refX="7"
+                    refY="4"
+                    orient="auto"
+                  >
+                    <path class="mk mk-control" d="M1,1 L7,4 L1,7" />
+                  </marker>
+                  <marker
+                    id="arrow-frost"
+                    markerWidth="8"
+                    markerHeight="8"
+                    refX="7"
+                    refY="4"
+                    orient="auto"
+                  >
+                    <path class="mk mk-data" d="M1,1 L7,4 L1,7" />
+                  </marker>
+                  <marker
+                    id="arrow-amber"
+                    markerWidth="8"
+                    markerHeight="8"
+                    refX="7"
+                    refY="4"
+                    orient="auto"
+                  >
+                    <path class="mk mk-xds" d="M1,1 L7,4 L1,7" />
+                  </marker>
+                  <marker
+                    id="arrow-slate"
+                    markerWidth="8"
+                    markerHeight="8"
+                    refX="7"
+                    refY="4"
+                    orient="auto"
+                  >
+                    <path class="mk mk-bank" d="M1,1 L7,4 L1,7" />
+                  </marker>
+                </defs>
 
-            <rect
-              class="lane"
-              x="150"
-              y="18"
-              width="230"
-              height="264"
-              rx="10"
-            />
-            <text x="162" y="38" class="lane-label"
-              >CONTROL PLANE · ELIXIR/OTP</text
-            >
-            <rect
-              class="lane"
-              x="420"
-              y="18"
-              width="286"
-              height="264"
-              rx="10"
-            />
-            <text x="432" y="38" class="lane-label">EACH FIRECRACKER NODE</text>
+                <rect
+                  class="lane"
+                  x="150"
+                  y="18"
+                  width="230"
+                  height="264"
+                  rx="10"
+                />
+                <text x="162" y="38" class="lane-label"
+                  >CONTROL PLANE · ELIXIR/OTP</text
+                >
+                <rect
+                  class="lane"
+                  x="420"
+                  y="18"
+                  width="286"
+                  height="264"
+                  rx="10"
+                />
+                <text x="432" y="38" class="lane-label"
+                  >EACH FIRECRACKER NODE</text
+                >
 
-            <rect x="14" y="74" width="100" height="44" rx="8" class="box" />
-            <text x="64" y="93" text-anchor="middle" class="node-label"
-              >caller</text
-            >
-            <text x="64" y="107" text-anchor="middle" class="node-sub"
-              >task / session</text
-            >
+                <rect
+                  x="14"
+                  y="74"
+                  width="100"
+                  height="44"
+                  rx="8"
+                  class="box"
+                />
+                <text x="64" y="93" text-anchor="middle" class="node-label"
+                  >caller</text
+                >
+                <text x="64" y="107" text-anchor="middle" class="node-sub"
+                  >task / session</text
+                >
 
-            <rect x="14" y="196" width="100" height="44" rx="8" class="box" />
-            <text x="64" y="215" text-anchor="middle" class="node-label"
-              >edge</text
-            >
-            <text x="64" y="229" text-anchor="middle" class="node-sub"
-              >HTTPRoute</text
-            >
+                <rect
+                  x="14"
+                  y="196"
+                  width="100"
+                  height="44"
+                  rx="8"
+                  class="box"
+                />
+                <text x="64" y="215" text-anchor="middle" class="node-label"
+                  >edge</text
+                >
+                <text x="64" y="229" text-anchor="middle" class="node-sub"
+                  >HTTPRoute</text
+                >
 
-            <rect x="170" y="66" width="120" height="46" rx="8" class="box" />
-            <text x="230" y="86" text-anchor="middle" class="node-label"
-              >HTTP API</text
-            >
-            <text x="230" y="101" text-anchor="middle" class="node-sub"
-              >/v1/workloads</text
-            >
+                <rect
+                  x="170"
+                  y="66"
+                  width="120"
+                  height="46"
+                  rx="8"
+                  class="box"
+                />
+                <text x="230" y="86" text-anchor="middle" class="node-label"
+                  >HTTP API</text
+                >
+                <text x="230" y="101" text-anchor="middle" class="node-sub"
+                  >/v1/workloads</text
+                >
 
-            <rect x="170" y="130" width="120" height="42" rx="8" class="box" />
-            <text x="230" y="149" text-anchor="middle" class="node-label"
-              >op-log</text
-            >
-            <text x="230" y="163" text-anchor="middle" class="node-sub"
-              >Postgres</text
-            >
+                <rect
+                  x="170"
+                  y="130"
+                  width="120"
+                  height="42"
+                  rx="8"
+                  class="box"
+                />
+                <text x="230" y="149" text-anchor="middle" class="node-label"
+                  >op-log</text
+                >
+                <text x="230" y="163" text-anchor="middle" class="node-sub"
+                  >Postgres</text
+                >
 
-            <rect x="170" y="192" width="120" height="42" rx="8" class="box" />
-            <text x="230" y="211" text-anchor="middle" class="node-label"
-              >xDS publisher</text
-            >
-            <text x="230" y="225" text-anchor="middle" class="node-sub"
-              >programs Envoy</text
-            >
+                <rect
+                  x="170"
+                  y="192"
+                  width="120"
+                  height="42"
+                  rx="8"
+                  class="box"
+                />
+                <text x="230" y="211" text-anchor="middle" class="node-label"
+                  >xDS publisher</text
+                >
+                <text x="230" y="225" text-anchor="middle" class="node-sub"
+                  >programs Envoy</text
+                >
 
-            <rect x="436" y="60" width="130" height="46" rx="8" class="box" />
-            <text x="501" y="80" text-anchor="middle" class="node-label"
-              >noded</text
-            >
-            <text x="501" y="95" text-anchor="middle" class="node-sub"
-              >Go daemon</text
-            >
+                <rect
+                  x="436"
+                  y="60"
+                  width="130"
+                  height="46"
+                  rx="8"
+                  class="box"
+                />
+                <text x="501" y="80" text-anchor="middle" class="node-label"
+                  >noded</text
+                >
+                <text x="501" y="95" text-anchor="middle" class="node-sub"
+                  >Go daemon</text
+                >
 
-            <rect x="622" y="60" width="72" height="46" rx="8" class="box" />
-            <text x="658" y="80" text-anchor="middle" class="node-label"
-              >VM</text
-            >
-            <text x="658" y="95" text-anchor="middle" class="node-sub"
-              >vsock only</text
-            >
+                <rect
+                  x="622"
+                  y="60"
+                  width="72"
+                  height="46"
+                  rx="8"
+                  class="box"
+                />
+                <text x="658" y="80" text-anchor="middle" class="node-label"
+                  >VM</text
+                >
+                <text x="658" y="95" text-anchor="middle" class="node-sub"
+                  >vsock only</text
+                >
 
-            <rect x="436" y="136" width="130" height="40" rx="8" class="box" />
-            <text x="501" y="154" text-anchor="middle" class="node-label"
-              >S3</text
-            >
-            <text x="501" y="168" text-anchor="middle" class="node-sub"
-              >snapshots + images</text
-            >
-            <path class="path-bank" d="M494,106 L494,132" />
-            <path class="path-bank" d="M508,132 L508,106" />
-            <text
-              x="548"
-              y="124"
-              text-anchor="middle"
-              class="edge-label el-bank">bank</text
-            >
+                <rect
+                  x="436"
+                  y="136"
+                  width="130"
+                  height="40"
+                  rx="8"
+                  class="box"
+                />
+                <text x="501" y="154" text-anchor="middle" class="node-label"
+                  >S3</text
+                >
+                <text x="501" y="168" text-anchor="middle" class="node-sub"
+                  >snapshots + images</text
+                >
+                <path class="path-bank" d="M494,106 L494,132" />
+                <path class="path-bank" d="M508,132 L508,106" />
+                <text
+                  x="548"
+                  y="124"
+                  text-anchor="middle"
+                  class="edge-label el-bank">bank</text
+                >
 
-            <rect x="436" y="196" width="130" height="46" rx="8" class="box" />
-            <text x="501" y="216" text-anchor="middle" class="node-label"
-              >node Envoy</text
-            >
-            <text x="501" y="231" text-anchor="middle" class="node-sub"
-              >exact-match</text
-            >
+                <rect
+                  x="436"
+                  y="196"
+                  width="130"
+                  height="46"
+                  rx="8"
+                  class="box"
+                />
+                <text x="501" y="216" text-anchor="middle" class="node-label"
+                  >node Envoy</text
+                >
+                <text x="501" y="231" text-anchor="middle" class="node-sub"
+                  >exact-match</text
+                >
 
-            <rect x="622" y="196" width="72" height="46" rx="8" class="box" />
-            <text x="658" y="216" text-anchor="middle" class="node-label"
-              >VM</text
-            >
-            <text x="658" y="231" text-anchor="middle" class="node-sub"
-              >tap NIC</text
-            >
+                <rect
+                  x="622"
+                  y="196"
+                  width="72"
+                  height="46"
+                  rx="8"
+                  class="box"
+                />
+                <text x="658" y="216" text-anchor="middle" class="node-label"
+                  >VM</text
+                >
+                <text x="658" y="231" text-anchor="middle" class="node-sub"
+                  >tap NIC</text
+                >
 
-            <path class="path-control" d="M114,92 L166,90" />
-            <path class="path-control" d="M290,86 L432,83" />
-            <text
-              x="360"
-              y="75"
-              text-anchor="middle"
-              class="edge-label el-control">gRPC</text
-            >
-            <path class="path-control" d="M566,83 L618,83" />
-            <text
-              x="592"
-              y="76"
-              text-anchor="middle"
-              class="edge-label el-control">vsock</text
-            >
+                <path class="path-control" d="M114,92 L166,90" />
+                <path class="path-control" d="M290,86 L432,83" />
+                <text
+                  x="360"
+                  y="75"
+                  text-anchor="middle"
+                  class="edge-label el-control">gRPC</text
+                >
+                <path class="path-control" d="M566,83 L618,83" />
+                <text
+                  x="592"
+                  y="76"
+                  text-anchor="middle"
+                  class="edge-label el-control">vsock</text
+                >
 
-            <path
-              class="path-data"
-              d="M114,222 C 140,222 138,262 170,262 L 350,262 C 400,262 396,222 432,222"
-            />
-            <text
-              x="260"
-              y="277"
-              text-anchor="middle"
-              class="edge-label el-data">bypasses the control plane</text
-            >
-            <path class="path-data" d="M566,219 L618,219" />
-            <text
-              x="592"
-              y="212"
-              text-anchor="middle"
-              class="edge-label el-data">DNAT</text
-            >
+                <path
+                  class="path-data"
+                  d="M114,222 C 140,222 138,262 170,262 L 350,262 C 400,262 396,222 432,222"
+                />
+                <text
+                  x="260"
+                  y="277"
+                  text-anchor="middle"
+                  class="edge-label el-data">bypasses the control plane</text
+                >
+                <path class="path-data" d="M566,219 L618,219" />
+                <text
+                  x="592"
+                  y="212"
+                  text-anchor="middle"
+                  class="edge-label el-data">DNAT</text
+                >
 
-            <path class="path-xds" d="M290,213 C 340,213 380,208 432,207" />
-            <text x="360" y="199" text-anchor="middle" class="edge-label el-xds"
-              >xDS</text
-            >
-          </svg>
-          <div class="legend">
-            <span
-              ><i class="swatch sw-control"></i> control path (tasks &amp; sessions)</span
-            >
-            <span><i class="swatch sw-data"></i> serving data path</span>
-            <span
-              ><i class="swatch sw-xds"></i> configuration, ahead of time</span
-            >
-          </div>
-        </div>
+                <path class="path-xds" d="M290,213 C 340,213 380,208 432,207" />
+                <text
+                  x="360"
+                  y="199"
+                  text-anchor="middle"
+                  class="edge-label el-xds">xDS</text
+                >
+              </svg>
+              <div class="legend">
+                <span
+                  ><i class="swatch sw-control"></i> control path (tasks &amp; sessions)</span
+                >
+                <span><i class="swatch sw-data"></i> serving data path</span>
+                <span
+                  ><i class="swatch sw-xds"></i> configuration, ahead of time</span
+                >
+              </div>
+            </div>
             <p class="sigs">
-              <a class="sig" href="/ember/firecracker">how a VM resumes in 22 ms →</a>
-              <a class="sig" href="https://github.com/jomcgi/homelab/blob/main/projects/embervm/ARCHITECTURE.md">full architecture →</a>
+              <a class="sig" href="/ember/firecracker"
+                >how a VM resumes in 22 ms →</a
+              >
+              <a
+                class="sig"
+                href="https://github.com/jomcgi/homelab/blob/main/projects/embervm/ARCHITECTURE.md"
+                >full architecture →</a
+              >
             </p>
           </div>
         </details>
@@ -651,7 +754,7 @@ serving                            → plain HTTP, straight into the VM</pre>
   .live a:focus-visible,
   .sig:focus-visible,
   .anchor:focus-visible,
-    .foot a:focus-visible {
+  .foot a:focus-visible {
     outline: 2px solid var(--em-ember-deep);
     outline-offset: 3px;
   }
@@ -837,7 +940,6 @@ serving                            → plain HTTP, straight into the VM</pre>
     line-height: 1.45;
     color: var(--em-ember-deep);
   }
-
 
   .ctag {
     font-size: 13.5px;


### PR DESCRIPTION
Third pass on `/ember`, following #5281 and #5282: the page becomes a picomq-shaped minimal landing. Visible text drops from ~420 to **~150 words**. One file changed (`projects/monolith/frontend/src/routes/public/ember/+page.svelte`); tokens, palette, and fonts untouched.

- **Hero**: three-sentence lede ("Every job gets its own tiny virtual machine. Idle ones sleep as snapshots; disk to answering queries in 78 ms. Built from scratch on this cluster."), the live status dot, the stats row, and two CTAs: `wake the database` (/ember/postgres) and `read the docs` (ARCHITECTURE.md).
- **One label-only accordion** ("What it runs"), seven rows: task, session, serving, stateful, composite, isolation, the moving parts. Rows show name + a 2-4 word tag; the sentence or two of detail, plus each row's demo links, sit behind the row (native `<details name>`, one open at a time).
- **"the moving parts"** absorbs the invocation API block, the architecture SVG + legend, and the firecracker-explainer and full-architecture links.
- The **"See it run" doors dissolve into their rows** (semgrep + bazel under task, agents under session, postgres under stateful); every demo page keeps an inbound link.
- Dead styles removed (doors, standalone isolation, diagram fold); primary CTA is ember-deep with ground-colored text, hover lift disabled under reduced motion.

The page `<title>` remains unchanged (`synthetic_probe.py` SSR sentinel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcS9EyqANPjctESssdBb1p

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcS9EyqANPjctESssdBb1p)_