### PR TITLE
fix(signoz): pin ClickHouse back to 25.5.6 to end the 30 hour outage

### DIFF
--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -245,7 +245,8 @@ signoz:
     # reversible and destroys nothing, so it comes first.
     #
     # Removing this pin without performing the documented 25.5 -> 25.12 data
-    # migration reproduces the outage. See #5298 and the un-pin issue it links.
+    # migration reproduces the outage. See #5298 for the outage and #5308
+    # for the un-pin work.
     image:
       tag: 25.5.6
     # 7-day SigNoz working_set ~6.4Gi, growing, against the old 8Gi limit (~80%).

--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -232,6 +232,22 @@ signoz:
       # Health probes are exempt and stay on /api/v1/health at the root.
       signoz_global_external__url: https://private.jomcgi.dev/app/signoz
   clickhouse:
+    # PINNED to the version that last started cleanly. Chart 0.135.1 moved this
+    # default 25.5.6 -> 25.12.5; the chart README calls that "a significant
+    # ClickHouse version jump" and says to read the upgrade guide first. It was
+    # not read. The pod adopted the new image 16 days after the chart bump, on
+    # 2026-08-24T00:55, and has crashlooped ever since: 25.12.5 cannot load the
+    # parts 25.5.6 wrote, and aborts startup on signoz_logs.logs_v2 with
+    # "Suspiciously many (133 parts, 0.00 B in total) broken parts".
+    #
+    # The alternative fix, raising max_suspicious_broken_parts past 133, starts
+    # the server by DISCARDING those 133 parts of real log data. This pin is
+    # reversible and destroys nothing, so it comes first.
+    #
+    # Removing this pin without performing the documented 25.5 -> 25.12 data
+    # migration reproduces the outage. See #5298 and the un-pin issue it links.
+    image:
+      tag: 25.5.6
     # 7-day SigNoz working_set ~6.4Gi, growing, against the old 8Gi limit (~80%).
     # Raised request 5 -> 6.5 to reserve real usage and limit 8 -> 10 for headroom
     # (node-4 has ample room). The telemetry store is the binding signoz tenant.


### PR DESCRIPTION
Ends the SigNoz outage (#5298) by pinning ClickHouse back to the version that last started cleanly.

## Cause

Chart 0.135.1 moved `clickhouse.image.tag` from `25.5.6` to `25.12.5`. The chart README says so explicitly:

> ClickHouse has been upgraded from `25.5.6` to `25.12.5`. This is **a significant ClickHouse version jump**, so review the upgrade guide before upgrading to avoid issues with your existing data.

That bump landed 2026-08-08 in `0c4973d2f`. The pod did not adopt it for 16 days: the `Pulled` event for `25.12.5` is first-seen **2026-08-24T00:55:42**, three minutes before the first crash at 00:58:10. It has crashlooped since, aborting on:

```
Code: 231. Suspiciously many (133 parts, 0.00 B in total) broken parts to remove
while maximum allowed broken parts count is 100
... Cannot attach table `signoz_logs`.`logs_v2` (TOO_MANY_UNEXPECTED_DATA_PARTS)
```

## Why pin rather than raise the ceiling

The parts are not corrupt. They report `0.00 B` because 25.12.5 cannot interpret what 25.5.6 wrote. Raising `max_suspicious_broken_parts` past 133 would start the server by **discarding 133 parts of real log data** to work around a version-compatibility problem. This pin destroys nothing and reverts with one line, so it goes first.

The count is stable at exactly 133 (unchanged from first failure through 07:11 today), so nothing is spreading and there was no pressure to take the destructive option.

## Verification

Rendered the chart with both values files, before and after:

| | before | after |
|---|---|---|
| clickhouse-server | `25.12.5` | **`25.5.6`** |
| clickhouse-server (operator config) | `22.3` | `22.3` (unchanged) |

`ci test`: `Executed 7 out of 370 tests: 370 tests pass.` This path is genuinely covered, via `signoz_alerts_test.py` in the same package.

## What is not established

Whether 25.12.5 wrote on-disk metadata during its failed starts. It never served traffic (every attempt aborts during `loadMetadata` and shuts down), so it probably did not, but "probably" is the honest word. **If 25.5.6 also refuses to start, stop pinning and treat this as a migration.**

## Rollout caveat

`projects/platform/*` deploys on HEAD, so this lands at merge. But the last image change sat unadopted for 16 days, so a merged pin is not a fixed SigNoz. The pod has to actually restart onto 25.5.6, and that needs verifying rather than assuming. I will confirm the running image and readiness after merge.

Un-pin work is tracked separately so this does not become a permanent silent pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaA2SsVAWiexez2NPepNmo
