### PR TITLE
fix(signoz): revert the ClickHouse 25.5.6 pin, it fails worse than 25.12.5

### DIFF
--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -232,23 +232,12 @@ signoz:
       # Health probes are exempt and stay on /api/v1/health at the root.
       signoz_global_external__url: https://private.jomcgi.dev/app/signoz
   clickhouse:
-    # PINNED to the version that last started cleanly. Chart 0.135.1 moved this
-    # default 25.5.6 -> 25.12.5; the chart README calls that "a significant
-    # ClickHouse version jump" and says to read the upgrade guide first. It was
-    # not read. The pod adopted the new image 16 days after the chart bump, on
-    # 2026-08-24T00:55, and has crashlooped ever since: 25.12.5 cannot load the
-    # parts 25.5.6 wrote, and aborts startup on signoz_logs.logs_v2 with
-    # "Suspiciously many (133 parts, 0.00 B in total) broken parts".
-    #
-    # The alternative fix, raising max_suspicious_broken_parts past 133, starts
-    # the server by DISCARDING those 133 parts of real log data. This pin is
-    # reversible and destroys nothing, so it comes first.
-    #
-    # Removing this pin without performing the documented 25.5 -> 25.12 data
-    # migration reproduces the outage. See #5298 for the outage and #5308
-    # for the un-pin work.
-    image:
-      tag: 25.5.6
+    # DO NOT PIN BACK TO 25.5.6. Tried in #5307 and reverted here: 25.5.6
+    # cannot read what 25.12.5 wrote. It fails to attach
+    # signoz_metrics.samples_v4_agg_5m with "Unknown version of serialization
+    # infos (1). Should be less or equal than 0" across 126 parts totalling
+    # 964 MiB of real metrics data. Downgrading trades a blocker on empty
+    # parts for a blocker on a gigabyte of good data. See #5298 and #5308.
     # 7-day SigNoz working_set ~6.4Gi, growing, against the old 8Gi limit (~80%).
     # Raised request 5 -> 6.5 to reserve real usage and limit 8 -> 10 for headroom
     # (node-4 has ample room). The telemetry store is the binding signoz tenant.


### PR DESCRIPTION
Reverts the pin from #5307. It deployed, and the evidence falsified the theory behind it.

## What happened

25.5.6 does not start either. It fails on a **different** table:

```
Code: 231. Suspiciously many (126 parts, 964.09 MiB in total) broken parts
... Cannot attach table `signoz_metrics`.`samples_v4_agg_5m`
```

with each part failing as:

```
Code: 246. Unknown version of serialization infos (1). Should be less or equal than 0.
(CORRUPTED_DATA)
```

That is the reverse incompatibility. 25.12.5 **wrote** those parts in a newer serialization format that 25.5.6 cannot read.

## What I got wrong in #5307

I claimed 25.12.5 never served, and that the pod adopted the new image 16 days after the chart bump. Both were wrong, and they came from the same mistake: I read `Pulled 25.12.5 first-seen 2026-08-24T00:55:42` as the first ever pull. That field is truncated by event retention, not a first-occurrence guarantee.

The parts 25.5.6 now rejects carry partition dates of **2026-08-18 and 2026-08-20**, days before the 08-24 crash. So 25.12.5 was running and writing normally, almost certainly from the chart bump on 08-08, and something separate broke `logs_v2` on 08-24.

## Why revert rather than stay pinned

The two failures are not equivalent:

| version | blocks on | size |
|---|---|---|
| 25.12.5 | 133 parts in `signoz_logs.logs_v2` | **0.00 B** (empty) |
| 25.5.6 | 126 parts in `signoz_metrics.samples_v4_agg_5m` | **964 MiB** (real data) |

Staying on 25.5.6 leaves a gigabyte of good metrics data one raised ceiling away from being discarded by whoever picks this up next. Reverting puts the blocker back on parts that are worth nothing.

I left a `DO NOT PIN BACK TO 25.5.6` comment where the pin was, with the reason, so the downgrade is not tried a third time.

## This also inverts the recommendation I gave

In #5307 I argued against raising `max_suspicious_broken_parts` because it would "discard 133 parts of real log data". That was wrong: those parts total **0.00 B**. They are empty. Raising the ceiling on 25.12.5 discards nothing of value and is now the most likely correct fix, which is close to the opposite of what I advised.

I am not doing that in this PR. It is the destructive-shaped option and it should be a deliberate call with the corrected numbers in hand, not something folded into a revert.

## State

SigNoz is still down. This restores the better of two broken states; it does not fix it. #5298 carries the diagnosis and #5308 the migration work, both updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaA2SsVAWiexez2NPepNmo
