### PR TITLE
feat(monolith): enable the qwen work-queue drainer in prod

### DIFF
--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -252,6 +252,15 @@ goosecracker:
 swarm:
   enabled: true
 
+# Arms the qwen work-queue drainer (ADR agents/061, #5301): the agent-drain
+# CronWorkflow tick stops no-opping and drain_cycle starts claiming due
+# qwen-drain routine jobs. Serial by design; all other knobs stay on chart
+# defaults. Suspending the CronWorkflow or reverting this line are the two
+# kill switches.
+agents:
+  drainer:
+    enabled: true
+
 # Taken offline 2026-06-14 for the ADR 006 Phase 4 transition: with the
 # gardener paused, the raw export / file moves can be done as a controlled
 # one-off, and the gardener stays down until the CLI-based version (Phase 4a-ii)


### PR DESCRIPTION
Arms the drainer shipped in #5311 (ADR agents/061, closes the rollout half of #5301). One value: `agents.drainer.enabled: true` in `projects/monolith/deploy/values.yaml`. The templates are verified live in prod and no-opping (CronWorkflow ticking, endpoint returning disabled), so this flip is the values-only second PR the rollout rule requires. Kill switches: revert this line, or suspend the agent-drain CronWorkflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A88MCbnLtwsFSHmqwuJezY