### PR TITLE
fix(monolith-public): enforce destination-scoped egress

### DIFF
--- a/projects/monolith-public/chart/BUILD
+++ b/projects/monolith-public/chart/BUILD
@@ -18,6 +18,24 @@ filegroup(
     visibility = ["//projects/monolith:__pkg__"],
 )
 
+# Guard (#5142): render inputs so the guard test can run `helm template` against
+# the REAL values (chart + deploy) and pin the enforced policy shape. Chart.lock
+# plus the charts/ glob are load-bearing: helm aborts when a locked dependency
+# has no packaged tarball on disk. This chart has no migrations/ directory, so
+# there is no migrations glob to carry (unlike projects/monolith/chart).
+filegroup(
+    name = "chart_render_inputs",
+    srcs = [
+        "Chart.yaml",
+        "Chart.lock",
+        "values.yaml",
+    ] + glob([
+        "templates/**/*",
+        "charts/**/*",
+    ]),
+    visibility = ["//projects/monolith:__pkg__"],
+)
+
 # Guard (ADR 005): the Turnstile *secret* must stay in the backend ("web"); the
 # frontend may reference only the public site-key literal. The test asserting
 # this lives in the Python-native //projects/monolith package and reads this

--- a/projects/monolith-public/chart/BUILD
+++ b/projects/monolith-public/chart/BUILD
@@ -26,8 +26,8 @@ filegroup(
 filegroup(
     name = "chart_render_inputs",
     srcs = [
-        "Chart.yaml",
         "Chart.lock",
+        "Chart.yaml",
         "values.yaml",
     ] + glob([
         "templates/**/*",

--- a/projects/monolith-public/chart/templates/cilium-policy-scoped-egress.yaml
+++ b/projects/monolith-public/chart/templates/cilium-policy-scoped-egress.yaml
@@ -5,17 +5,18 @@
 # a compromised public pod can dial any pod on any port. These policies replace
 # that with one `toEndpoints` rule per real dependency, on its real port.
 #
-# ROLLOUT IS TWO STEPS, gated by ciliumPolicy.egress.scoped in deploy/values:
+# ROLLOUT MODES, gated by ciliumPolicy.egress.scoped in deploy/values:
 #
-#   "off"      this file renders nothing.
-#   "audit"    these policies render with `enableDefaultDeny.egress: false`, so
-#              they ADD allows and never switch an endpoint to default-deny on
-#              their own. Enforcement is unchanged: the broad policies in
-#              cilium-policy.yaml still carry the deny and the `cluster` allow.
-#              What changes is Hubble's policy correlation: every allowed egress
-#              flow now names every policy that allowed it, so a flow allowed
-#              ONLY by the broad policy is a dependency this file missed.
-#              Read it for a day of public traffic:
+#   "off"      this file renders nothing. The broad policies in
+#              cilium-policy.yaml carry the deny and the wide `cluster` allow.
+#   "audit"    these policies render ADDITIVELY (`enableDefaultDeny.egress:
+#              false`), so they never switch an endpoint to default-deny on
+#              their own; enforcement is unchanged and the broad policies keep
+#              carrying both the deny and the `cluster` allow. What changes is
+#              Hubble's policy correlation: every allowed egress flow now names
+#              every policy that allowed it, so a flow allowed ONLY by the broad
+#              policy is a dependency this file missed. Read it for a day of
+#              public traffic:
 #
 #                hubble observe --from-namespace monolith-public --type policy-verdict -o json \
 #                  | jq -c 'select(.flow.egress_allowed_by != null)
@@ -23,40 +24,66 @@
 #                           | {src: .flow.source.pod_name, dst: .flow.destination, l4: .flow.l4}'
 #
 #              An empty result over the window means the list below is complete.
-#   "enforce"  NOT IN THIS CHART YET. The follow-up PR adds it: the broad
-#              `toEntities: cluster` rules come out of cilium-policy.yaml, the
-#              Turnstile allow moves here, and these policies carry the deny. A
-#              dependency still missing at that point fails as a SILENT DIAL
-#              TIMEOUT, which is why the audit window comes first.
+#   "enforce"  the broad `toEntities: cluster` rules do NOT render at all (see
+#              cilium-policy.yaml), these policies omit enableDefaultDeny and so
+#              carry the default-deny themselves, and the ONE sanctioned
+#              off-cluster allow (Turnstile siteverify, IP-pinned to Cloudflare's
+#              published ranges) renders inside the web policy here. A dependency
+#              missing from the list now fails as a SILENT DIAL TIMEOUT, which is
+#              why the audit window comes first: only flip enforce after it came
+#              back empty.
 #
 # Not a true Cilium audit mode: that is an agent-wide flag (policy-audit-mode)
 # that would stop enforcing every policy in the cluster, or an imperative
 # per-endpoint `cilium endpoint config` that GitOps cannot carry. The
 # additive-policy shape above is the one the cluster can express declaratively.
 #
-# Why these destinations (each is an env var on the live pod, or observed in
-# hubble): the backend reads and writes the CNPG cluster directly (monolith-pg-ro
-# and -rw select the instance pods, there is no pooler), calls inference and
-# embeddings, signs and serves S3 objects from SeaweedFS, invokes EmberVM for
-# the public /functions router, and exports OTLP to the SigNoz collector. The
-# frontend calls only the backend and forwards browser traces to the
-# host-networked SigNoz agent, which Cilium classifies as `host` on the same
-# node and `remote-node` elsewhere: that is the ONLY reason those two entities
-# survive, and they are pinned to 4318. imgproxy fetches from SeaweedFS alone.
+# Why these destinations (each names the env var that proves it on the live pod,
+# or the one sanctioned external call):
+#
+#   web       Postgres RO and RW via DATABASE_URL / PUBLIC_WRITER_DATABASE_URL:
+#             both Services select the CNPG instance pods directly (label
+#             cnpg.io/cluster), there is no pooler. vLLM inference via
+#             CHAT_PUBLIC_INFERENCE_URL, embeddings via EMBEDDING_URL (both in
+#             the inference namespace), SeaweedFS S3 via SEAWEEDFS_S3_ENDPOINT
+#             (stars/trips/artifact/knowledge reads), the EmberVM control plane
+#             via EMBERVM_URL (the public /functions router plus demo-postgres
+#             status/reset), and the EmberVM SERVING Envoy DaemonSet via
+#             DEMO_POSTGRES_DSN: the demo postgres exhibit's psycopg connect
+#             lands on embervm-embervm-serving:5401, whose pods select
+#             app.kubernetes.io/name: embervm-serving-envoy, a DIFFERENT
+#             selector AND port from the control plane above. Omitting either
+#             EmberVM rule black-holes a live public path as a silent dial
+#             timeout. Finally Cloudflare Turnstile siteverify
+#             (challenges.cloudflare.com) on 443, the only OFF-CLUSTER
+#             destination, IP-pinned to Cloudflare's published CIDR list.
+#             There is deliberately NO otel-collector rule: the public binary
+#             never initialises OpenTelemetry (framework/core.py build_app
+#             returns for Tier.PUBLIC before _setup_otel) and no OTEL_* env is
+#             set on these pods, so a collector allow would be dead surface.
+#   frontend  the backend only (API_BASE / CHAT_API_BASE), plus browser traces
+#             forwarded by the same-origin /otel proxy to the SigNoz k8s-infra
+#             agent (OTEL_COLLECTOR_HTTP_URL). That agent is a hostNetwork
+#             DaemonSet (projects/platform/signoz/application.yaml), so Cilium
+#             classifies the destination as the node itself: `host` on the same
+#             node, `remote-node` elsewhere. That is the ONLY reason those two
+#             entities survive here, pinned to the OTLP/HTTP port 4318.
+#   imgproxy  SeaweedFS alone (IMGPROXY_S3_ENDPOINT).
+#
 # Every pod resolves through kube-dns. The apiserver is absent because the
-# public tier holds no RBAC. FC_INVOKE_URL in chart/values.yaml points at a
-# Service that no longer exists, so it gets no rule.
+# public tier holds no RBAC (its SA token is identity-only: presented TO
+# EmberVM, which does the TokenReview).
 #
 # Kept as separate objects rather than extra rules on the existing policies on
 # purpose: Hubble correlates by policy NAME, so the audit only works if the
 # scoped allows live in their own objects.
 
 {{- $mode := .Values.ciliumPolicy.egress.scoped | default "off" }}
-{{- if not (has $mode (list "off" "audit")) }}
-{{- fail (printf "ciliumPolicy.egress.scoped must be off or audit (enforce lands with the follow-up to #5142); got %q" $mode) }}
+{{- if not (has $mode (list "off" "audit" "enforce")) }}
+{{- fail (printf "ciliumPolicy.egress.scoped must be off, audit or enforce; got %q" $mode) }}
 {{- end }}
-{{- if and .Values.ciliumPolicy.egress.enabled (eq $mode "audit") }}
-{{- $audit := true }}
+{{- if .Values.ciliumPolicy.egress.enabled }}
+{{- if ne $mode "off" }}
 {{- $dns := .Values.ciliumPolicy.egress.scopedTargets.dns }}
 {{- $t := .Values.ciliumPolicy.egress.scopedTargets }}
 {{- if .Values.web.enabled }}
@@ -72,7 +99,7 @@ spec:
     matchLabels:
       {{- include "monolith-public.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: web
-  {{- if $audit }}
+  {{- if eq $mode "audit" }}
   enableDefaultDeny:
     egress: false
   {{- end }}
@@ -87,7 +114,7 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
-    {{- range $dep := list $t.postgres $t.inference $t.embeddings $t.seaweedfs $t.embervm $t.otelCollector }}
+    {{- range $dep := list $t.postgres $t.inference $t.embeddings $t.seaweedfs $t.embervm $t.embervmServing }}
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: {{ $dep.namespace }}
@@ -95,6 +122,23 @@ spec:
       toPorts:
         - ports:
             - port: {{ $dep.port | quote }}
+              protocol: TCP
+    {{- end }}
+    {{- if eq $mode "enforce" }}
+    # THE ONE SANCTIONED OFF-CLUSTER EGRESS (ADR 005, Public Chat V3): Cloudflare
+    # Turnstile siteverify (challenges.cloudflare.com) on 443. Pinned to
+    # Cloudflare's published IP ranges rather than a toFQDNs hostname match:
+    # Turnstile's ~42s DNS TTL over a rotating anycast pool made a toFQDNs allow
+    # race and intermittently DROP live connections, failing closed -> 5xx. In
+    # audit mode this rule lives in the broad web policy instead (it carries
+    # enforcement until this file does), so it renders here only when enforcing.
+    - toCIDRSet:
+        {{- range .Values.ciliumPolicy.egress.turnstileCidrs }}
+        - cidr: {{ . | quote }}
+        {{- end }}
+      toPorts:
+        - ports:
+            - port: "443"
               protocol: TCP
     {{- end }}
 {{- end }}
@@ -111,7 +155,7 @@ spec:
     matchLabels:
       {{- include "monolith-public.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: frontend
-  {{- if $audit }}
+  {{- if eq $mode "audit" }}
   enableDefaultDeny:
     egress: false
   {{- end }}
@@ -158,7 +202,7 @@ spec:
     matchLabels:
       {{- include "monolith-public.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: imgproxy
-  {{- if $audit }}
+  {{- if eq $mode "audit" }}
   enableDefaultDeny:
     egress: false
   {{- end }}
@@ -181,5 +225,6 @@ spec:
         - ports:
             - port: {{ $t.seaweedfs.port | quote }}
               protocol: TCP
+{{- end }}
 {{- end }}
 {{- end }}

--- a/projects/monolith-public/chart/templates/cilium-policy.yaml
+++ b/projects/monolith-public/chart/templates/cilium-policy.yaml
@@ -22,6 +22,13 @@
 #     tested follow-up AFTER the window (watch flows with `hubble observe`), so
 #     an unproven egress deny is not stacked onto the irreversible CNI swap.
 #
+#   ciliumPolicy.egress.scoped   - #5142 destination scoping, with an
+#     off/audit/enforce ladder documented in
+#     templates/cilium-policy-scoped-egress.yaml. While it is "enforce", the
+#     three broad egress policies below DO NOT RENDER AT ALL: the scoped file
+#     owns the whole direction (per-dependency toEndpoints allows, the
+#     Turnstile toCIDRSet, and the default-deny itself).
+#
 # imgproxy note: its INGRESS is deliberately left unrestricted (it has no
 # Linkerd Server today and also answers on private.jomcgi.dev). Its EGRESS is
 # locked down, because the Linkerd EgressNetwork deny is namespace-wide and
@@ -124,6 +131,8 @@ spec:
 {{- end }}
 
 {{- if .Values.ciliumPolicy.egress.enabled }}
+{{- $scopedMode := .Values.ciliumPolicy.egress.scoped | default "off" }}
+{{- if ne $scopedMode "enforce" }}
 {{- if .Values.web.enabled }}
 ---
 # Backend egress: default-deny OFF-cluster (replaces the namespace EgressNetwork
@@ -223,5 +232,6 @@ spec:
         - cluster
         - host
         - remote-node
+{{- end }}
 {{- end }}
 {{- end }}

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -699,9 +699,11 @@ ciliumPolicy:
     enabled: false
   egress:
     enabled: false
-    # Destination-scoped egress rollout (#5142): "off" or "audit". See
-    # templates/cilium-policy-scoped-egress.yaml for what each does and how to
-    # read the audit. Only meaningful while egress.enabled is true.
+    # Destination-scoped egress rollout (#5142): "off", "audit" or "enforce".
+    # See templates/cilium-policy-scoped-egress.yaml for what each does and how
+    # to read the audit. Only meaningful while egress.enabled is true; in
+    # "enforce" the broad toEntities policies in cilium-policy.yaml stop
+    # rendering entirely and these scoped policies carry the deny.
     scoped: off
     # The public tier's real egress destinations, one selector + port each,
     # rendered as toEndpoints rules by the scoped policies. Selectors mirror the
@@ -740,20 +742,30 @@ ciliumPolicy:
           app.kubernetes.io/name: seaweedfs
           app.kubernetes.io/component: s3
         port: 8333
-      # EMBERVM_URL: the public /functions/<name> router.
+      # EMBERVM_URL: the public /functions router plus the demo-postgres
+      # status/reset calls (the control-plane Deployment's pods).
       embervm:
         namespace: embervm
         matchLabels:
           app.kubernetes.io/name: embervm
           app.kubernetes.io/instance: embervm
         port: 8080
-      # OTEL_EXPORTER_OTLP_ENDPOINT (grpc) from the backend.
-      otelCollector:
-        namespace: signoz
+      # DEMO_POSTGRES_DSN: the ember postgres exhibit's psycopg connect lands on
+      # the SERVING Envoy DaemonSet, whose pods select a DIFFERENT name
+      # (embervm-serving-envoy) from the control plane above, on the demo listen
+      # port 5401 (scratchPostgres.demoListenPort in the monolith chart; inside
+      # the serving chart's statefulTcpPortRange 5400-5409). A policy with only
+      # the control-plane rule black-holes /api/ember/postgres queries.
+      embervmServing:
+        namespace: embervm
         matchLabels:
-          app.kubernetes.io/name: signoz
-          app.kubernetes.io/component: otel-collector
-        port: 4317
+          app.kubernetes.io/name: embervm-serving-envoy
+          app.kubernetes.io/instance: embervm
+        port: 5401
+      # NOTE: deliberately NO otel-collector target. The public binary never
+      # initialises OpenTelemetry (framework/core.py build_app returns for
+      # Tier.PUBLIC before _setup_otel) and no OTEL_* env exists on these pods,
+      # so an allow for the SigNoz collector would be dead surface.
       # OTEL_COLLECTOR_HTTP_URL from the frontend's /otel proxy reaches the
       # hostNetwork SigNoz k8s-infra agent, so it is a host/remote-node entity
       # on this port rather than a pod selector.

--- a/projects/monolith-public/deploy/BUILD
+++ b/projects/monolith-public/deploy/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "deploy_values",
+    srcs = ["values.yaml"],
+    visibility = ["//projects/monolith:__subpackages__"],
+)

--- a/projects/monolith-public/deploy/values.yaml
+++ b/projects/monolith-public/deploy/values.yaml
@@ -64,20 +64,22 @@ cfIngress:
 #   ingress: gateway -> frontend, frontend -> web (flipped during the window).
 #   egress:  off-cluster default-deny with the single sanctioned Turnstile allow
 #            (challenges.cloudflare.com siteverify, IP-pinned to Cloudflare's
-#            published ranges via toCIDRSet), all in-cluster allowed, DNS at L4.
-#            Flipped in a tested follow-up: hubble showed the only off-cluster
-#            egress is web -> Turnstile; frontend/imgproxy reach nothing
-#            off-cluster (imgproxy sources from in-cluster SeaweedFS).
-# See the chart's templates/cilium-policy.yaml rationale.
+#            published ranges via toCIDRSet), now DESTINATION-SCOPED in-cluster
+#            too: one toEndpoints rule per real dependency (#5142), DNS on 53.
+# See the chart's templates/cilium-policy-scoped-egress.yaml for the ladder and
+# templates/cilium-policy.yaml for the rationale.
 ciliumPolicy:
   ingress:
     enabled: true
   egress:
     enabled: true
     # #5142 step 1: destination-scoped egress policies in AUDIT shape (additive
-    # allows, enforcement unchanged). Flipped here in the same PR as the
-    # template on purpose: the previous chart has no reader for this key, so
-    # the value is inert until the new chart publishes, and nothing misrenders
-    # in between. Read hubble for a day (recipe in the template header) before
-    # the follow-up PR moves to enforcement.
-    scoped: audit
+    # allows, enforcement unchanged). Landed in fc1c213fb (2026-08-22).
+    #
+    # #5142 step 2: ENFORCE. The broad `toEntities: cluster` grants stop
+    # rendering, the scoped policies carry the deny, and the Turnstile allow
+    # moves into the web scoped policy. Anything missing from scopedTargets now
+    # fails as a SILENT DIAL TIMEOUT: if a public path starts timing out, diff
+    # its destination against chart/values.yaml scopedTargets before loosening
+    # anything.
+    scoped: enforce

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -5461,13 +5461,26 @@ py_test(
 )
 
 # Guard (#5142): the public tier's destination-scoped Cilium egress policies
-# must never regain `toEntities: cluster`. Same cross-package data-dep shape as
-# the HTTPRoute guard above.
+# must never regain `toEntities: cluster`, and the ENFORCED render must allow
+# exactly the audited dependency set. Same cross-package data-dep shape as the
+# HTTPRoute guard, plus what `helm template` needs: Chart.lock and the charts/
+# glob (helm aborts when a locked subchart tarball is missing; this chart has
+# no migrations/ directory), the deploy values, and the helm binary.
 py_test(
     name = "public_cilium_scoped_egress_guard_test",
     srcs = ["public_cilium_scoped_egress_guard_test.py"],
-    data = ["//projects/monolith-public/chart:cilium_scoped_egress_template"],
+    data = [
+        "//projects/monolith-public/chart:cilium_scoped_egress_template",
+        "//projects/monolith-public/chart:chart_render_inputs",
+        "//projects/monolith-public/deploy:deploy_values",
+        "@multitool//tools/helm",
+    ],
+    env = {
+        "HELM_BIN": "$(rootpath @multitool//tools/helm)",
+        "DEPLOY_VALUES": "$(rootpath //projects/monolith-public/deploy:deploy_values)",
+    },
     imports = ["."],
+    deps = ["@pip//pyyaml"],
 )
 
 # Guard: the packaged homelab-library must deploy images by content digest, not

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -5470,8 +5470,8 @@ py_test(
     name = "public_cilium_scoped_egress_guard_test",
     srcs = ["public_cilium_scoped_egress_guard_test.py"],
     data = [
-        "//projects/monolith-public/chart:cilium_scoped_egress_template",
         "//projects/monolith-public/chart:chart_render_inputs",
+        "//projects/monolith-public/chart:cilium_scoped_egress_template",
         "//projects/monolith-public/deploy:deploy_values",
         "@multitool//tools/helm",
     ],

--- a/projects/monolith/public_cilium_scoped_egress_guard_test.py
+++ b/projects/monolith/public_cilium_scoped_egress_guard_test.py
@@ -8,13 +8,25 @@ into the scoped file to make a dial timeout go away, which silently returns the
 public tier to "anything in the cluster" reach. This reads the raw template
 (Go-templated, so not parseable as YAML) and fails on that shape, and on a
 scoped policy that forgot DNS, which is the first thing every pod needs.
+
+The second half runs `helm template` against chart/values.yaml PLUS the live
+deploy/values.yaml and pins the rendered policy shape in all three rollout
+modes. Enforce mode (the shipped shape) is pinned hardest: no ``toEntities``
+beyond the hostNetwork OTLP agent's node entities anywhere, the broad policies
+gone, and the exact per-dependency allow set the audit window cleared. A
+dependency dropped from scopedTargets now fails HERE instead of as a
+production silent dial timeout.
 """
 
 from __future__ import annotations
 
 import os
 import re
+import subprocess
+import tempfile
 from pathlib import Path
+
+import yaml
 
 TEMPLATE = "cilium-policy-scoped-egress.yaml"
 
@@ -35,8 +47,19 @@ def _template_path() -> Path:
     )
     if candidate.exists():
         return candidate
+    # Plain pytest against the worktree: the chart lives one directory over.
+    worktree = (
+        Path(__file__).resolve().parent.parent
+        / "monolith-public"
+        / "chart"
+        / "templates"
+        / TEMPLATE
+    )
+    if worktree.exists():
+        return worktree
     raise FileNotFoundError(
-        f"{TEMPLATE} not found at {here} or {candidate} (TEST_SRCDIR={srcdir!r})"
+        f"{TEMPLATE} not found at {here}, {candidate} or {worktree} "
+        f"(TEST_SRCDIR={srcdir!r})"
     )
 
 
@@ -51,6 +74,132 @@ def _entities(chunk: str) -> set[str]:
     for block in re.finditer(r"toEntities:\n((?:\s+- \S+\n)+)", chunk):
         found.update(re.findall(r"- (\S+)", block.group(1)))
     return found
+
+
+# ---------------------------------------------------------------------------
+# Render-level pins (helm template against the real values).
+# ---------------------------------------------------------------------------
+
+
+def _chart_dir() -> Path:
+    here = Path(__file__).resolve().parent
+    local = here.parent / "monolith-public" / "chart"
+    if (local / "Chart.yaml").exists():
+        return local
+    srcdir = os.environ.get("TEST_SRCDIR", "")
+    candidate = Path(srcdir) / "_main" / "projects" / "monolith-public" / "chart"
+    if (candidate / "Chart.yaml").exists():
+        return candidate
+    raise FileNotFoundError(f"chart not found at {local} or {candidate}")
+
+
+def _deploy_values_path() -> Path:
+    env = os.environ.get("DEPLOY_VALUES")
+    if env:
+        return Path(env)
+    local = (
+        Path(__file__).resolve().parent.parent
+        / "monolith-public"
+        / "deploy"
+        / "values.yaml"
+    )
+    if local.exists():
+        return local
+    raise FileNotFoundError("deploy values not found and DEPLOY_VALUES unset")
+
+
+def _render(extra_values: dict | None = None) -> list[dict]:
+    """helm template with chart values + deploy values (+ an optional override).
+
+    Returns every non-null YAML document of the render.
+    """
+    argv = [
+        os.environ.get("HELM_BIN", "helm"),
+        "template",
+        "monolith-public",
+        str(_chart_dir()),
+        "--namespace",
+        "monolith-public",
+        "--values",
+        str(_chart_dir() / "values.yaml"),
+        "--values",
+        str(_deploy_values_path()),
+    ]
+    override_path = None
+    if extra_values:
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as handle:
+            yaml.safe_dump(extra_values, handle)
+            override_path = handle.name
+        argv += ["--values", override_path]
+    try:
+        result = subprocess.run(argv, capture_output=True, text=True)
+    finally:
+        if override_path:
+            os.unlink(override_path)
+    if result.returncode != 0:
+        raise RuntimeError(f"helm template failed: {result.stderr}")
+    return [d for d in yaml.safe_load_all(result.stdout) if d is not None]
+
+
+def _cnps(docs: list[dict]) -> list[dict]:
+    return [d for d in docs if d.get("kind") == "CiliumNetworkPolicy"]
+
+
+def _by_name(cnps: list[dict], suffix: str) -> dict:
+    matches = [d for d in cnps if d["metadata"]["name"].endswith(suffix)]
+    assert len(matches) == 1, (
+        f"expected exactly one CiliumNetworkPolicy named *{suffix}, got "
+        f"{[d['metadata']['name'] for d in matches]}"
+    )
+    return matches[0]
+
+
+def _fmt(rules: set[tuple]) -> list[str]:
+    """Readable sort for rule sets; the frontend's same-namespace rule has a
+    None namespace, which sorted() refuses to order against strings."""
+    return sorted((repr(r) for r in rules))
+
+
+# DNS allow, in the order _endpoint_rules normalises to.
+DNS_PORTS = (("53", "TCP"), ("53", "UDP"))
+
+
+def _endpoint_rules(doc: dict) -> set[tuple]:
+    """Every (namespace, selector labels, ports) triple a policy allows."""
+    rules: set[tuple] = set()
+    for rule in doc.get("spec", {}).get("egress", []) or []:
+        for endpoint in rule.get("toEndpoints", []) or []:
+            labels = dict(endpoint.get("matchLabels", {}))
+            namespace = labels.pop("k8s:io.kubernetes.pod.namespace", None)
+            ports = tuple(
+                sorted(
+                    (str(port["port"]), port["protocol"])
+                    for block in rule.get("toPorts", []) or []
+                    for port in block.get("ports", [])
+                )
+            )
+            rules.add((namespace, tuple(sorted(labels.items())), ports))
+    return rules
+
+
+def _entities_in(doc: dict) -> set[str]:
+    found: set[str] = set()
+    for rule in doc.get("spec", {}).get("egress", []) or []:
+        found.update(rule.get("toEntities", []) or [])
+    return found
+
+
+def _declared_targets() -> dict:
+    values = yaml.safe_load((_chart_dir() / "values.yaml").read_text())
+    return values["ciliumPolicy"]["egress"]["scopedTargets"]
+
+
+def _expected_rule(target: dict, ports: tuple) -> tuple:
+    return (
+        target["namespace"],
+        tuple(sorted(target["matchLabels"].items())),
+        ports,
+    )
 
 
 def test_scoped_egress_never_grants_cluster_or_world():
@@ -88,3 +237,259 @@ def test_audit_mode_is_additive():
     for chunk in _policies(text):
         assert "enableDefaultDeny:" in chunk
         assert re.search(r"enableDefaultDeny:\n\s+egress: false", chunk)
+
+
+def _enforced_render() -> list[dict]:
+    """The shipped shape: deploy/values.yaml says scoped: enforce."""
+    docs = _render()
+    scoped = [
+        d["metadata"]["name"]
+        for d in _cnps(docs)
+        if d["metadata"]["name"].endswith("-egress-scoped")
+    ]
+    assert len(scoped) == 3, (
+        f"enforce mode must render the three scoped egress policies, got {scoped}; "
+        "is deploy/values.yaml still on scoped: enforce?"
+    )
+    return docs
+
+
+def test_enforced_render_has_no_cluster_grant_on_any_pod():
+    """The #5142 acceptance criterion, on the real deploy values."""
+    for doc in _cnps(_enforced_render()):
+        entities = _entities_in(doc)
+        assert "cluster" not in entities, (
+            f"{doc['metadata']['name']} grants toEntities: cluster; the public "
+            "tier must stay destination-scoped"
+        )
+        assert not ({"world", "all"} & entities), (
+            f"{doc['metadata']['name']} grants {sorted(entities)}"
+        )
+    # Guard the guard: enforce mode must actually select endpoints, otherwise
+    # the loop above passes while nothing is enforced.
+    assert _cnps(_enforced_render()), "no CiliumNetworkPolicy rendered at all"
+
+
+def test_enforced_render_drops_the_broad_egress_policies():
+    names = {d["metadata"]["name"] for d in _cnps(_enforced_render())}
+    for broad in ("-web-egress", "-frontend-egress", "-imgproxy-egress"):
+        assert not any(n.endswith(broad) for n in names), (
+            f"{broad} still renders under scoped: enforce; the broad "
+            "toEntities rules must yield entirely to the scoped policies"
+        )
+
+
+def test_enforced_web_policy_pins_exactly_the_audited_destinations():
+    """The load-bearing pin: web's allows equal the audited inventory.
+
+    Derived from scopedTargets itself (structural half), then compared against
+    a hardcoded expected set (semantic half). The first catches template
+    drift; the second catches an accidental addition or removal in values,
+    either of which ships as a silent dial timeout or as dead surface.
+    """
+    doc = _by_name(_cnps(_enforced_render()), "-web-egress-scoped")
+    targets = _declared_targets()
+    expected_from_values = {
+        _expected_rule(targets["dns"], DNS_PORTS),
+        *(
+            _expected_rule(targets[key], ((str(targets[key]["port"]), "TCP"),))
+            for key in (
+                "postgres",
+                "inference",
+                "embeddings",
+                "seaweedfs",
+                "embervm",
+                "embervmServing",
+            )
+        ),
+    }
+    rendered = _endpoint_rules(doc)
+    assert rendered == expected_from_values, (
+        "web scoped egress drifted from scopedTargets:\n"
+        f"  only in render: {_fmt(rendered - expected_from_values)}\n"
+        f"  only in values: {_fmt(expected_from_values - rendered)}"
+    )
+
+    expected_semantic = {
+        # kube-dns, both protocols.
+        ("kube-system", (("k8s-app", "kube-dns"),), DNS_PORTS),
+        # CNPG instance pods directly (no pooler): ro + rw credentials.
+        ("monolith", (("cnpg.io/cluster", "monolith-pg"),), (("5432", "TCP"),)),
+        # vLLM inference and llama.cpp embeddings.
+        (
+            "inference",
+            (
+                ("app.kubernetes.io/component", "inference"),
+                ("app.kubernetes.io/name", "inference"),
+            ),
+            (("8080", "TCP"),),
+        ),
+        (
+            "inference",
+            (
+                ("app.kubernetes.io/component", "embeddings"),
+                ("app.kubernetes.io/name", "inference"),
+            ),
+            (("8080", "TCP"),),
+        ),
+        # SeaweedFS S3 gateway.
+        (
+            "seaweedfs",
+            (
+                ("app.kubernetes.io/component", "s3"),
+                ("app.kubernetes.io/name", "seaweedfs"),
+            ),
+            (("8333", "TCP"),),
+        ),
+        # EmberVM control plane (/functions router, demo-postgres status/reset).
+        (
+            "embervm",
+            (
+                ("app.kubernetes.io/instance", "embervm"),
+                ("app.kubernetes.io/name", "embervm"),
+            ),
+            (("8080", "TCP"),),
+        ),
+        # EmberVM SERVING Envoy DaemonSet (demo-postgres DSN, distinct selector
+        # AND port from the control plane).
+        (
+            "embervm",
+            (
+                ("app.kubernetes.io/instance", "embervm"),
+                ("app.kubernetes.io/name", "embervm-serving-envoy"),
+            ),
+            (("5401", "TCP"),),
+        ),
+    }
+    assert rendered == expected_semantic, (
+        "web scoped egress drifted from the audited destination inventory:\n"
+        f"  unexpected: {_fmt(rendered - expected_semantic)}\n"
+        f"  missing: {_fmt(expected_semantic - rendered)}\n"
+        "If you added or removed a dependency deliberately, re-run the Hubble "
+        "audit before changing this set."
+    )
+
+    # Turnstile siteverify moves here in enforce mode: Cloudflare CIDRs on 443.
+    cidr_rules = [rule for rule in doc["spec"]["egress"] if rule.get("toCIDRSet")]
+    assert len(cidr_rules) == 1, "exactly one toCIDRSet rule (Turnstile) expected"
+    ports = {
+        (str(p["port"]), p["protocol"])
+        for block in cidr_rules[0]["toPorts"]
+        for p in block["ports"]
+    }
+    assert ports == {("443", "TCP")}, f"Turnstile allow must be 443/TCP, got {ports}"
+    assert any("173.245.48.0/20" in c["cidr"] for c in cidr_rules[0]["toCIDRSet"]), (
+        "the Cloudflare published-range list lost its first entry"
+    )
+
+    # Enforce mode carries the deny: no additive escape hatch left behind.
+    assert "enableDefaultDeny" not in doc["spec"], (
+        "enforce mode must not render enableDefaultDeny.egress: false"
+    )
+
+
+def test_enforced_frontend_and_imgproxy_policies_pin_their_shapes():
+    cnps = _cnps(_enforced_render())
+    targets = _declared_targets()
+
+    frontend = _by_name(cnps, "-frontend-egress-scoped")
+    frontend_expected = {
+        _expected_rule(targets["dns"], DNS_PORTS),
+        # Same-namespace backend Service: no namespace label on this selector.
+        (
+            None,
+            (
+                ("app.kubernetes.io/component", "web"),
+                ("app.kubernetes.io/instance", "monolith-public"),
+                ("app.kubernetes.io/name", "monolith-public"),
+            ),
+            (("8000", "TCP"),),
+        ),
+    }
+    assert _endpoint_rules(frontend) == frontend_expected, (
+        f"frontend scoped egress drifted: {_fmt(_endpoint_rules(frontend))}"
+    )
+    # The ONLY entity grant in the whole tier: the hostNetwork OTLP agent,
+    # reachable as the node itself, pinned to its single HTTP port.
+    assert _entities_in(frontend) == {"host", "remote-node"}, (
+        f"frontend entity grants drifted: {sorted(_entities_in(frontend))}"
+    )
+    entity_ports = {
+        (str(p["port"]), p["protocol"])
+        for rule in frontend["spec"]["egress"]
+        if rule.get("toEntities")
+        for block in rule.get("toPorts", [])
+        for p in block["ports"]
+    }
+    assert entity_ports == {(str(targets["otelAgentHostPort"]), "TCP")}, (
+        f"host/remote-node must stay pinned to the OTLP agent port, got {entity_ports}"
+    )
+
+    imgproxy = _by_name(cnps, "-imgproxy-egress-scoped")
+    imgproxy_expected = {
+        _expected_rule(targets["dns"], DNS_PORTS),
+        _expected_rule(
+            targets["seaweedfs"], ((str(targets["seaweedfs"]["port"]), "TCP"),)
+        ),
+    }
+    assert _endpoint_rules(imgproxy) == imgproxy_expected, (
+        f"imgproxy scoped egress drifted: {_fmt(_endpoint_rules(imgproxy))}"
+    )
+    assert not (_entities_in(imgproxy)), "imgproxy needs no entity grants"
+
+
+def test_audit_mode_still_coexists_with_the_broad_policies():
+    """The intermediate rung keeps its additive shape and today's enforcement."""
+    docs = _render({"ciliumPolicy": {"egress": {"enabled": True, "scoped": "audit"}}})
+    cnps = _cnps(docs)
+    for suffix in ("-web-egress", "-frontend-egress", "-imgproxy-egress"):
+        broad = _by_name(cnps, suffix)
+        assert "cluster" in _entities_in(broad), (
+            f"{broad['metadata']['name']} lost the wide cluster grant; audit "
+            "mode changes correlation only, never enforcement"
+        )
+    for suffix in (
+        "-web-egress-scoped",
+        "-frontend-egress-scoped",
+        "-imgproxy-egress-scoped",
+    ):
+        scoped = _by_name(cnps, suffix)
+        deny = scoped["spec"].get("enableDefaultDeny")
+        assert deny == {"egress": False}, (
+            f"{scoped['metadata']['name']} must stay additive in audit mode, got {deny}"
+        )
+
+
+def test_off_mode_renders_the_pre_scoping_shape():
+    docs = _render({"ciliumPolicy": {"egress": {"enabled": True, "scoped": "off"}}})
+    names = {d["metadata"]["name"] for d in _cnps(docs)}
+    assert not any(n.endswith("-egress-scoped") for n in names), (
+        "scoped: off must render no scoped policies"
+    )
+    for suffix in ("-web-egress", "-frontend-egress", "-imgproxy-egress"):
+        _by_name([d for d in _cnps(docs)], suffix)
+
+
+def test_invalid_mode_fails_the_render():
+    result = subprocess.run(
+        [
+            os.environ.get("HELM_BIN", "helm"),
+            "template",
+            "monolith-public",
+            str(_chart_dir()),
+            "--namespace",
+            "monolith-public",
+            "--values",
+            str(_chart_dir() / "values.yaml"),
+            "--values",
+            str(_deploy_values_path()),
+            "--set",
+            "ciliumPolicy.egress.enabled=true",
+            "--set",
+            "ciliumPolicy.egress.scoped=yolo",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, "an unknown scoped mode must fail the render"
+    assert "off, audit or enforce" in result.stderr


### PR DESCRIPTION
Refs #5142. Completes step 2 of the ladder started in fc1c213fb: with `ciliumPolicy.egress.scoped: enforce`, the broad `toEntities: cluster` grants stop rendering, the scoped policies carry default-deny, and the Turnstile siteverify CIDR allow moves into the web policy.

**Re-enumerating every dial against code found two problems with the audited target list:**

- **A fifth and sixth destination the issue's four missed.** The demo-postgres DSN lands on the EmberVM *serving* Envoy DaemonSet (different selector, port 5401), not the control plane. Enforcing the previously merged shape would have black-holed `/api/ember/postgres` as a silent dial timeout. Added as `embervmServing`.
- **There is no CNPG pooler.** Both `-ro` and `-rw` select the instance pods directly and the pod holds both credentials, so one postgres rule covers public_reader and public_writer.
- **Dead allow removed:** the signoz otel-collector 4317 target claimed an `OTEL_EXPORTER_OTLP_ENDPOINT` that does not exist on these pods; the public binary returns before `_setup_otel` (`framework/core.py`), verified independently.
- `host`/`remote-node` entities stay, port-pinned to 4318, because the frontend forwards browser traces to the hostNetwork OTLP agent.

Full destination inventory with file:line evidence for every dial (and the ruled-out ones: kube-apiserver, private-tier scrapers) is in the worktree report.

Guard test now renders the chart and pins the enforced shape: no cluster/world/all entity anywhere, broad policies gone, per-component allow sets equal to the audited inventory. `ci` green (772 pass).

Live-only confirmation after rollout: watch for policy-denied drops (the #4659 alert) and exercise `/api/ember/postgres` plus a chat turn.

Implemented by ox-alpha via opencode, reviewed on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K