### PR TITLE
feat(embervm): health tiers for durability signals

### DIFF
--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -575,6 +575,36 @@ spec:
             - name: EMBERVM_WARMTH_S3_GC_INTERVAL_MS
               value: {{ .Values.warmthS3Gc.intervalMs | quote }}
             {{- end }}
+            {{- if .Values.durabilityHealth.enabled }}
+            # Durability health detector (#4338, ADR embervm/031): BOTH tiers
+            # (export-failure streaks; gc-manifests age vs 24h + sweep
+            # interval) surface on GET /v1/health/durability. Unset keeps the
+            # detector dark: no evaluation runs and the route 404s. See the
+            # durabilityHealth block in values for the flip procedure.
+            - name: EMBERVM_DURABILITY_HEALTH
+              value: {{ .Values.durabilityHealth.enabled | quote }}
+            {{- end }}
+            {{- if .Values.durabilityHealth.expectedNodes }}
+            # Tier 1's fleet contract: every listed node must report fresh
+            # capacity facts or tier 1 reads unknown (never green). Empty =
+            # tier 1 always unknown.
+            - name: EMBERVM_DURABILITY_EXPECTED_NODES
+              value: {{ join "," .Values.durabilityHealth.expectedNodes | quote }}
+            {{- end }}
+            {{- if .Values.durabilityHealth.roundIntervalMs }}
+            - name: EMBERVM_DURABILITY_ROUND_INTERVAL_MS
+              value: {{ .Values.durabilityHealth.roundIntervalMs | quote }}
+            {{- end }}
+            {{- if .Values.durabilityHealth.streakThreshold }}
+            - name: EMBERVM_DURABILITY_STREAK_THRESHOLD
+              value: {{ .Values.durabilityHealth.streakThreshold | quote }}
+            {{- end }}
+            {{- if .Values.durabilityHealth.gcSweepIntervalMs }}
+            # Must match warmthS3Gc.intervalMs so the tier-2 stall bound (24h +
+            # sweep interval) tracks the GC cadence instead of drifting from it.
+            - name: EMBERVM_DURABILITY_GC_SWEEP_INTERVAL_MS
+              value: {{ .Values.durabilityHealth.gcSweepIntervalMs | quote }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1105,6 +1105,28 @@ warmthS3Gc:
   groupSetTtlMs: ""
   intervalMs: ""
 
+# Durability health surface (#4338, ADR embervm/031): the CP-side detector
+# behind GET /v1/health/durability. Tier 1 latches unhealthy on a sustained
+# per-kind artifact-export failure streak read from node capacity facts
+# (~minutes, not hours); tier 2 degrades when the newest gc-manifests/ object
+# exceeds 24h + sweepIntervalMs. BOTH tiers end in the health surface (the
+# monolith ember-durability component reads this endpoint); missing data reads
+# unknown, never green. DARK by default per the standing rule that a
+# health-affecting detector lands suspend:true and flips on only after live
+# verification: enabled "" means no evaluation runs and the route answers 404.
+# Flip to "1" only after verifying against live fleet facts; flipping back to
+# "" is the entire rollback lever. expectedNodes is the fleet contract for
+# tier 1's freshness check (empty = tier 1 always unknown), roundIntervalMs /
+# streakThreshold tune the streak window (module defaults 30000ms x 10 rounds,
+# i.e. ~5 minutes sustained), and gcSweepIntervalMs must match warmthS3Gc
+# intervalMs so the stall bound tracks the GC cadence.
+durabilityHealth:
+  enabled: ""
+  expectedNodes: []
+  roundIntervalMs: ""
+  streakThreshold: ""
+  gcSweepIntervalMs: ""
+
 # The rootfs-builder tool image (crane + e2fsprogs + bash) that bakes each
 # workload's guest OCI image into an ext4 base rootfs at pod init. Reuses the
 # fc-invoke rootfs-builder image; Bazel pins repository:tag from its .info.

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -440,6 +440,16 @@ defmodule Embervm.Application do
       # process performs no listing or writing until a bounded rotation window
       # is explicitly armed. It never raises epoch floors or retires roots.
       {Embervm.EnvelopeRewrapSweeper, envelope_rewrap_sweeper_opts()},
+      # The durability health detector (#4338, ADR embervm/031): Tier 1
+      # aggregates per-kind artifact-export failure streaks from the
+      # NodeCapacity projections; Tier 2 measures the age of the newest
+      # gc-manifests object against 24h + sweep interval. Both tiers end in
+      # GET /v1/health/durability. Placed AFTER NodeRegistry/S3WarmthGc (it
+      # reads their state) and BEFORE Bandit (which serves its surface). It is
+      # a measurement process: it writes nothing and holds no durable state,
+      # so under :rest_for_one a crash restarts only the HTTP surface behind
+      # it, and it lands DARK (enabled defaults false) until live verification.
+      {Embervm.Durability, durability_opts()},
       # The op-log sweeper (ADR embervm/002): scheduled bounded-batch compaction of
       # the durable projection tables + ops-journal prefix. Placed LATE, right before
       # Bandit: it depends ONLY on the op-log (which starts early), so under
@@ -871,6 +881,47 @@ defmodule Embervm.Application do
     }
     |> Enum.reject(fn {_kind, ttl} -> is_nil(ttl) end)
     |> Map.new()
+  end
+
+  # The durability health detector (#4338, ADR embervm/031). The gate defaults
+  # DARK (suspend:true): EMBERVM_DURABILITY_HEALTH unset means the supervised
+  # process holds no timer, evaluates nothing, and /v1/health/durability 404s.
+  # The store credentials are the shared noded/S3WarmthGc source of truth (tier
+  # 2 reads gc-manifests from the same bucket); an empty endpoint leaves the
+  # tier-2 seam nil and the tier reads unknown (never green). expected_nodes is
+  # the same fleet-contract idea as the GC's: EMPTY means tier 1 always reads
+  # unknown, so arming requires naming the fleet.
+  defp durability_opts do
+    [
+      enabled: durability_health_enabled(),
+      endpoint: trimmed_env("EMBERVM_STORE_ENDPOINT"),
+      bucket: store_bucket(),
+      access_key_id: trimmed_env("EMBERVM_STORE_ACCESS_KEY_ID"),
+      secret_access_key: trimmed_env("EMBERVM_STORE_SECRET_ACCESS_KEY"),
+      expected_nodes: durability_expected_nodes(),
+      round_interval_ms: int_env_or_nil("EMBERVM_DURABILITY_ROUND_INTERVAL_MS"),
+      streak_threshold: int_env_or_nil("EMBERVM_DURABILITY_STREAK_THRESHOLD"),
+      sweep_interval_ms: int_env_or_nil("EMBERVM_DURABILITY_GC_SWEEP_INTERVAL_MS")
+    ]
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+  end
+
+  @doc false
+  def durability_health_enabled do
+    case trimmed_env("EMBERVM_DURABILITY_HEALTH") do
+      v when v in ["1", "true", "TRUE", "True"] -> true
+      _ -> false
+    end
+  end
+
+  # Comma-separated fleet contract (EMBERVM_DURABILITY_EXPECTED_NODES), parsed
+  # exactly like the GC's EMBERVM_WARMTH_S3_GC_EXPECTED_NODES.
+  @doc false
+  def durability_expected_nodes do
+    trimmed_env("EMBERVM_DURABILITY_EXPECTED_NODES")
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
   end
 
   defp store_bucket do

--- a/projects/embervm/control/lib/embervm/durability.ex
+++ b/projects/embervm/control/lib/embervm/durability.ex
@@ -1,0 +1,505 @@
+defmodule Embervm.Durability do
+  @moduledoc """
+  EmberVM durability health, classified by time-to-impact into the two ADR
+  embervm/031 tiers (#4338). Both tiers end in the health surface, not
+  alert-only: #4317 proved an alert-only signal goes unread (the S3 warmth GC
+  aborted silently for 11 days) and that create/send synthetic probes stay
+  green straight through a fleet-wide artifact-export outage.
+
+  ## Tier 1: sustained artifact export failures (unhealthy NOW)
+
+  While SeaweedFS was 500ing every PUT in #4317, noded kept reporting banked
+  session/serving/stateful bundles and group sets whose store copy never became
+  current (`exported == true` only on a confirmed off-node copy), and bases
+  stayed present-but-unexported while BaseBuilder re-issued ExportArtifact.
+  This module aggregates those per-kind facts across every dispatchable node's
+  NodeCapacity projection: a kind is PENDING in a round when any reported
+  artifact of that kind has its local copy present but no confirmed store copy.
+  Pending rounds accumulate per kind; crossing `:streak_threshold` consecutive
+  rounds (~minutes, not hours) marks ember unhealthy immediately, because a
+  session parking inside such a window rehydrates blank: user-visible data loss
+  happening now, even while create/send keeps serving.
+
+  Known gap, documented deliberately: SessionVolume carries no exported flag on
+  the wire yet, so a WORKSPACE-only export failure (the #4317 victim named in
+  the issue) is not directly visible to the CP; the incident itself would have
+  fired this detector within minutes because BASE/VOLUME/STATEFUL/session
+  exports were failing fleet-wide at the same time.
+
+  ## Tier 2: GC sweep stall older than 24h + sweep interval
+
+  An aborted warmth-GC sweep produces no `gc-manifests/<ts>.json` audit object
+  for that cycle, whatever the abort reason (fleet-freshness gate, empty-store
+  guard, list failure), so the age of the NEWEST gc-manifests object is a
+  complete stall signal that survives CP restarts by construction (it reads a
+  durable S3 object, not an in-process counter). Age beyond 24h PLUS the sweep
+  interval marks ember unhealthy: days of runway, so it must not page like a
+  live outage, but it can never again be alert-only.
+
+  ## Vacuous-green guards (the failure class this repo keeps hitting)
+
+  Missing data NEVER reads healthy:
+
+    * expectedNodes unset or no expected node reporting fresh -> tier 1 reads
+      `unknown` (not ok), because absence of node reports is not evidence of
+      exports succeeding.
+    * no gc-manifests objects, a failed listing, or no store endpoint -> tier 2
+      reads `unknown` (not ok).
+
+  ## Dark landing (#4338 standing rule)
+
+  The detector ships suspend:true/dark: `enabled` defaults false (chart value
+  `durabilityHealth.enabled`, env EMBERVM_DURABILITY_HEALTH). While suspended
+  the supervised process holds no timer and evaluates nothing, and
+  GET /v1/health/durability answers 404. It flips on only after live
+  verification. Streak counters are in-memory and rebuild from live reports
+  within one streak window after a CP restart; tier 2 needs no rebuild (S3).
+  """
+
+  use GenServer
+  require Logger
+
+  alias Embervm.NodeCapacity
+
+  # -- Tier 1 knobs ------------------------------------------------------------
+  # One round ~= one noded status-report interval (the GC's freshness contract
+  # assumes ~30s between projections). The threshold is deliberately "a handful
+  # of consecutive failures, minutes not hours" (issue #4338): 10 rounds x 30s
+  # = ~5 minutes of sustained failure before latching, which absorbs a fresh
+  # bank's normal seconds-to-minutes export latency and the queue-full drop +
+  # reconcile retry cycle, but cannot absorb an outage like #4317's hours.
+  @round_interval_ms 30_000
+  @streak_threshold 10
+  # Same freshness window the S3 GC uses for its fleet-freshness precondition:
+  # ~2 status-report intervals.
+  @freshness_window_ms 120_000
+
+  # The artifact kinds whose store-copy confirmation rides NodeStatus today.
+  # VOLUMES are excluded on purpose: exported_generation routinely LAGS the
+  # live generation between banks (banks outnumber wakes), so a lagging volume
+  # is normal operation, not a failing export.
+  @kinds [:base, :session, :serving, :stateful, :group_set]
+
+  # -- Tier 2 knobs ------------------------------------------------------------
+  @manifest_prefix "gc-manifests/"
+  # The ADR floor: unhealthy only after >24h sustained. Deliberately generous;
+  # not a tuned alarm threshold (ADR embervm/031 Consequences).
+  @tier2_max_age_ms 86_400_000
+  # Grace added on top of the floor, stated RELATIVE to the sweep cadence so it
+  # tracks the interval rather than needing a manual update alongside it (ADR
+  # risk row 3). Default matches S3WarmthGc's own @sweep_interval_ms.
+  @default_sweep_interval_ms 3_600_000
+
+  # -- Client API --------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  The latest durability evaluation, computing one synchronously when the first
+  round has not run yet. `:suspended` while the detector is dark
+  (`enabled: false`), which the router surfaces as 404: a dark detector must
+  neither read green nor page anybody.
+  """
+  @spec snapshot(GenServer.server()) :: map() | :suspended
+  def snapshot(server \\ __MODULE__) do
+    GenServer.call(server, :snapshot, 30_000)
+  end
+
+  # -- Pure evaluation (public for tests) --------------------------------------
+
+  @doc """
+  Evaluate both tiers from one capacity-table read. PURE: every input is
+  injected, so tests drive each boundary deterministically. Contract: called
+  once per round (~`:round_interval_ms` apart); `prev_streaks` carries the
+  previous round's per-kind counters (an empty map on the first round).
+
+  Options:
+
+    * `:now_mono` - monotonic ms now (node-fact freshness)
+    * `:now_wall` - wall-clock unix ms (tier 2 manifest age)
+    * `:freshness_window_ms`, `:streak_threshold`, `:sweep_interval_ms`
+    * `:s3` - nil or `%{list: fun}` where list returns
+      `{:ok, [%{key:, size:, last_modified_ms:}]}` | `{:error, term}`
+  """
+  def evaluate(facts, expected_nodes, prev_streaks, opts \\ []) do
+    now_mono = Keyword.get(opts, :now_mono, System.monotonic_time(:millisecond))
+    now_wall = Keyword.get(opts, :now_wall, System.system_time(:millisecond))
+    freshness_window_ms = Keyword.get(opts, :freshness_window_ms, @freshness_window_ms)
+    threshold = Keyword.get(opts, :streak_threshold, @streak_threshold)
+    sweep_interval_ms = Keyword.get(opts, :sweep_interval_ms, @default_sweep_interval_ms)
+    s3 = Keyword.get(opts, :s3)
+
+    {fresh, missing} = split_fresh(facts, expected_nodes, now_mono, freshness_window_ms)
+    tier1 = evaluate_tier1(facts, fresh, missing, prev_streaks, threshold)
+    tier2 = evaluate_tier2(s3, now_wall, sweep_interval_ms)
+
+    %{
+      ok: tier1.ok and tier2.ok,
+      evaluated_at_unix_ms: now_wall,
+      tier1: Map.merge(tier1, %{threshold_rounds: threshold, fresh_nodes: fresh, missing_nodes: missing}),
+      tier2: Map.put(tier2, :stall_bound_ms, bound_ms(sweep_interval_ms))
+    }
+  end
+
+  @doc """
+  The kinds with at least one present-but-unexported artifact in these facts,
+  as `%{kind => pending_artifact_count}`. One fact map per dispatchable
+  instance (NodeCapacity.all shape); missing lists read as empty.
+  """
+  def pending_kinds(facts) when is_list(facts) do
+    Enum.reduce(facts, %{}, fn fact, acc ->
+      acc
+      |> count_unexported(fact, :session, :session_snapshots, :snapshot_ref)
+      |> count_unexported(fact, :serving, :serving_snapshots, :snapshot_ref)
+      |> count_unexported(fact, :stateful, :stateful_bundles, :snapshot_ref)
+      |> count_unexported(fact, :group_set, :group_bundle_sets, :set_id)
+      |> count_unexported_bases(fact)
+    end)
+  end
+
+  defp count_unexported(acc, fact, kind, list_key, id_key) do
+    entries = Map.get(fact, list_key, []) || []
+
+    pending =
+      Enum.count(entries, fn entry ->
+        ref = Map.get(entry, id_key)
+        is_binary(ref) and ref != "" and Map.get(entry, :exported) != true
+      end)
+
+    if pending > 0, do: Map.update(acc, kind, pending, &(&1 + pending)), else: acc
+  end
+
+  # A base counts when it is READY (built) with a current snapshot_ref but no
+  # confirmed store copy: exactly the state BaseBuilder's bounded reconcile
+  # keeps trying to export. Building/priming states are not pending exports.
+  defp count_unexported_bases(acc, fact) do
+    workloads = Map.get(fact, :workloads, %{}) || %{}
+
+    pending =
+      Enum.count(workloads, fn {_workload, wc} ->
+        is_map(wc) and Map.get(wc, :base_state) == :BASE_BUILD_STATE_READY and
+          is_binary(Map.get(wc, :snapshot_ref)) and Map.get(wc, :snapshot_ref) != "" and
+          Map.get(wc, :exported) != true
+      end)
+
+    if pending > 0, do: Map.update(acc, :base, pending, &(&1 + pending)), else: acc
+  end
+
+  # Fresh = present AND updated within the window, mirroring the S3 GC's
+  # fleet-freshness semantics: NodeCapacity DROPS a non-dispatchable node's
+  # row, so absence is indistinguishable from staleness here and both are
+  # "missing". An EMPTY expected-node list leaves everything missing: no fleet
+  # contract means no basis to call tier 1 green.
+  defp split_fresh(_facts, [], _now, _window), do: {[], []}
+
+  defp split_fresh(facts, expected_nodes, now, window) do
+    by_node =
+      for fact <- facts,
+          node = Map.get(fact, :node_id),
+          is_binary(node),
+          into: %{},
+          do: {node, now - (Map.get(fact, :updated_at, now - window - 1) || now - window - 1)}
+
+    Enum.split_with(expected_nodes, fn node ->
+      case Map.fetch(by_node, node) do
+        {:ok, age} when is_integer(age) -> age <= window
+        :error -> false
+      end
+    end)
+  end
+
+  # No fresh expected node at all (none configured, or none reporting): tier 1
+  # cannot judge. A streak that has ALREADY latched stays latched (the health
+  # surface must not heal just because the witnesses went silent); otherwise
+  # this reads UNKNOWN, never green (vacuous-green guard).
+  defp evaluate_tier1(_facts, [], missing, prev_streaks, threshold) do
+    latched =
+      prev_streaks
+      |> Enum.filter(fn {_kind, count} -> count >= threshold end)
+      |> Enum.map(fn {kind, _count} -> kind end)
+      |> Enum.sort()
+
+    cond do
+      latched != [] ->
+        %{
+          ok: false,
+          verdict: :export_failure_streak,
+          detail:
+            "export failure streak already latched for kinds: " <>
+              "#{Enum.join(Enum.map(latched, &Atom.to_string/1), ", ")}; no fresh fleet " <>
+              "facts to prove recovery (missing/stale nodes: #{inspect(missing)})",
+          streaks: prev_streaks,
+          failing_kinds: latched
+        }
+
+      missing == [] ->
+        unknown_tier1(
+          "no expected nodes configured; tier 1 cannot judge export durability",
+          prev_streaks,
+          threshold
+        )
+
+      true ->
+        unknown_tier1(
+          "none of the expected nodes are reporting fresh capacity facts: #{inspect(missing)}",
+          prev_streaks,
+          threshold
+        )
+    end
+  end
+
+  defp evaluate_tier1(facts, fresh, missing, prev_streaks, threshold) do
+    pending = pending_kinds(facts)
+
+    streaks =
+      Map.new(@kinds, fn kind ->
+        if Map.has_key?(pending, kind) do
+          {kind, Map.get(prev_streaks, kind, 0) + 1}
+        else
+          {kind, 0}
+        end
+      end)
+
+    failing =
+      streaks
+      |> Enum.filter(fn {_kind, count} -> count >= threshold end)
+      |> Enum.map(fn {kind, _count} -> kind end)
+      |> Enum.sort()
+
+    cond do
+      failing != [] ->
+        %{
+          ok: false,
+          verdict: :export_failure_streak,
+          detail:
+            "artifact exports have been failing for #{threshold} consecutive rounds (~" <>
+              "#{div(threshold * @round_interval_ms, 60_000)} min) for kinds: " <>
+              "#{Enum.join(Enum.map(failing, &Atom.to_string/1), ", ")}; " <>
+              "sessions parking in this window rehydrate blank",
+          streaks: streaks,
+          failing_kinds: failing
+        }
+
+      # Some expected nodes missing/stale but nothing firing: the silence could
+      # be the outage, so this is unknown, never green (vacuous-green guard).
+      missing != [] ->
+        unknown_tier1(
+          "expected nodes missing or stale in capacity facts: #{inspect(missing)}",
+          streaks,
+          threshold
+        )
+
+      true ->
+        %{
+          ok: true,
+          verdict: :ok,
+          detail: "all tracked artifact kinds have confirmed store copies",
+          streaks: streaks,
+          failing_kinds: []
+        }
+    end
+  end
+
+  defp unknown_tier1(detail, streaks_or_prev, _threshold) do
+    %{
+      ok: false,
+      verdict: :unknown,
+      detail: detail,
+      # Keep whatever counters exist so a streak survives a transient
+      # fleet-stale round instead of resetting on it.
+      streaks: streaks_or_prev,
+      failing_kinds: []
+    }
+  end
+
+  defp evaluate_tier2(s3, now_wall, sweep_interval_ms) do
+    case s3 do
+      nil ->
+        unknown_tier2("no object store configured; gc-manifests are unreadable")
+
+      %{list: list} ->
+        case safe_list(list) do
+          {:ok, []} ->
+            unknown_tier2("no #{trim_prefix()} objects: no sweep has ever persisted a manifest")
+
+          {:ok, entries} ->
+            newest =
+              entries
+              |> Enum.map(&Map.get(&1, :last_modified_ms, 0))
+              |> Enum.max()
+
+            age = now_wall - newest
+            bound = bound_ms(sweep_interval_ms)
+
+            if age > bound do
+              %{
+                ok: false,
+                verdict: :gc_sweep_stalled,
+                detail:
+                  "newest gc-manifests object is #{age}ms old, beyond the " <>
+                    "#{bound}ms stall bound (24h + sweep interval): the warmth GC has " <>
+                    "not completed a sweep, for any reason, since then",
+                newest_manifest_age_ms: age
+              }
+            else
+              %{
+                ok: true,
+                verdict: :ok,
+                detail: "newest gc-manifests object is fresh",
+                newest_manifest_age_ms: age
+              }
+            end
+
+          {:error, reason} ->
+            unknown_tier2("gc-manifests listing failed: #{inspect(reason)}")
+        end
+
+      other ->
+        unknown_tier2("malformed s3 seam: #{inspect(other)}")
+    end
+  end
+
+  # A raising list fun is an evaluation failure, not a healthy signal.
+  defp safe_list(list) do
+    try do
+      list.(@manifest_prefix)
+    rescue
+      e -> {:error, e}
+    catch
+      kind, reason -> {:error, {kind, reason}}
+    end
+  end
+
+  defp unknown_tier2(detail) do
+    %{ok: false, verdict: :unknown, detail: detail, newest_manifest_age_ms: nil}
+  end
+
+  defp bound_ms(sweep_interval_ms), do: @tier2_max_age_ms + sweep_interval_ms
+
+  defp trim_prefix, do: String.trim_trailing(@manifest_prefix, "/")
+
+  # -- GenServer ---------------------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    endpoint = Keyword.get(opts, :endpoint, "")
+    bucket = Keyword.get(opts, :bucket, "embervm")
+    access_key_id = Keyword.get(opts, :access_key_id, "") || ""
+    secret_access_key = Keyword.get(opts, :secret_access_key, "") || ""
+
+    credential_opts =
+      cond do
+        access_key_id == "" and secret_access_key == "" -> []
+        access_key_id == "" or secret_access_key == "" -> []
+        true -> [access_key_id: access_key_id, secret_access_key: secret_access_key]
+      end
+
+    client =
+      if endpoint != "",
+        do: Embervm.S3Client.new(endpoint, bucket, credential_opts),
+        else: nil
+
+    # Only the listing seam is needed: tier 2 measures the NEWEST manifest's
+    # age from the listing itself, so it never fetches object bodies.
+    s3 =
+      Keyword.get_lazy(opts, :s3, fn ->
+        if client, do: %{list: fn prefix -> Embervm.S3Client.list_all(client, prefix) end}
+      end)
+
+    state = %{
+      enabled: Keyword.get(opts, :enabled, false),
+      capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
+      expected_nodes: Keyword.get(opts, :expected_nodes, []),
+      round_interval_ms: Keyword.get(opts, :round_interval_ms, @round_interval_ms),
+      streak_threshold: Keyword.get(opts, :streak_threshold, @streak_threshold),
+      freshness_window_ms: Keyword.get(opts, :freshness_window_ms, @freshness_window_ms),
+      sweep_interval_ms: Keyword.get(opts, :sweep_interval_ms, @default_sweep_interval_ms),
+      s3: s3,
+      clock: Keyword.get(opts, :clock, fn -> System.monotonic_time(:millisecond) end),
+      wall_clock: Keyword.get(opts, :wall_clock, fn -> System.system_time(:millisecond) end),
+      streaks: %{},
+      last: nil
+    }
+
+    if state.enabled and state.round_interval_ms > 0 do
+      # First round asynchronously (never delay boot behind an S3 listing);
+      # a snapshot arriving first computes synchronously instead.
+      Process.send_after(self(), :round, 0)
+    end
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:snapshot, _from, %{enabled: false} = state), do: {:reply, :suspended, state}
+
+  def handle_call(:snapshot, _from, %{last: nil} = state) do
+    {report, streaks} = run_round(state)
+    {:reply, report, %{state | last: report, streaks: streaks}}
+  end
+
+  def handle_call(:snapshot, _from, state), do: {:reply, state.last, state}
+
+  def handle_call(:round_now, _from, state) do
+    {report, streaks} = run_round(state)
+    {:reply, report, %{state | last: report, streaks: streaks}}
+  end
+
+  @impl true
+  def handle_info(:round, %{enabled: true, round_interval_ms: ms} = state) do
+    {report, streaks} = run_round(state)
+    Process.send_after(self(), :round, ms)
+    {:noreply, %{state | last: report, streaks: streaks}}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  defp run_round(state) do
+    opts = [
+      now_mono: state.clock.(),
+      now_wall: state.wall_clock.(),
+      freshness_window_ms: state.freshness_window_ms,
+      streak_threshold: state.streak_threshold,
+      sweep_interval_ms: state.sweep_interval_ms,
+      s3: state.s3
+    ]
+
+    report = evaluate(NodeCapacity.all(state.capacity_table), state.expected_nodes, state.streaks, opts)
+    log_transitions(state.last, report)
+    {report, get_in(report, [:tier1, :streaks]) || %{}}
+  end
+
+  # Log only EDGES, not every round: a sustained outage logs once on latch and
+  # once on recovery, keeping the log readable during exactly the incidents
+  # this module exists for.
+  defp log_transitions(nil, report) do
+    unless report.ok, do: log_not_ok(report)
+  end
+
+  defp log_transitions(%{ok: true}, %{ok: false} = report), do: log_not_ok(report)
+
+  defp log_transitions(%{ok: false}, %{ok: true} = report) do
+    Logger.info("embervm durability health: RECOVERED: both durability tiers ok")
+    Logger.info("embervm durability health: #{format_report(report)}")
+  end
+
+  defp log_transitions(_was, _now), do: :ok
+
+  defp log_not_ok(report) do
+    Logger.warning("embervm durability health: NOT OK: #{format_report(report)}")
+  end
+
+  defp format_report(report) do
+    t1 = report.tier1
+    t2 = report.tier2
+
+    "tier1=#{t1.verdict} tier1_detail=\"#{t1.detail}\" " <>
+      "tier2=#{t2.verdict} tier2_detail=\"#{t2.detail}\""
+  end
+end

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -14,6 +14,9 @@ defmodule Embervm.Router do
     * `POST /v1/tasks/:id/redrive`     re-queue a dead-lettered task (audited).
     * `GET  /v1/nodes`                 read-only node health + dispatcher snapshot
       (operational introspection: capacity facts, inventory, denials).
+    * `GET  /v1/health/durability`     both ADR 031 durability tiers (#4338):
+      tier 1 export-failure streaks + tier 2 gc-manifests stall. 200 ok /
+      503 not-ok / 404 while dark.
     * `GET  /healthz`                  unauthenticated liveness/readiness.
 
   ## Task envelope
@@ -93,6 +96,15 @@ defmodule Embervm.Router do
 
   get "/v1/conformance" do
     handle_conformance(conn)
+  end
+
+  # GET /v1/health/durability (#4338, ADR embervm/031): both durability tiers
+  # as one machine-readable surface. 200 when both tiers read ok, 503 with the
+  # SAME report body otherwise (unknown/missing data is never green), and 404
+  # while the detector is dark (durabilityHealth.enabled unset), so a suspended
+  # detector neither reads healthy nor pages anybody.
+  get "/v1/health/durability" do
+    handle_durability(conn)
   end
 
   # POST /v1/nodes/register (NODE auth ONLY): the dial-home registration a noded
@@ -557,6 +569,41 @@ defmodule Embervm.Router do
       {:ok, view} -> send_json(conn, 200, view)
       {:error, reason} -> send_json(conn, 500, %{error: "store error: #{inspect(reason)}"})
     end
+  end
+
+  # The durability module resolves from app env (the :durability key) so a
+  # request test can inject a fake without the supervised process, mirroring
+  # the :authenticator seam. A dead/unavailable evaluator is a durability
+  # UNKNOWN (503 with the same body shape), never a 500 crash and never green.
+  defp handle_durability(conn) do
+    mod = Application.get_env(:embervm, :durability, Embervm.Durability)
+
+    case try_durability_snapshot(mod) do
+      :suspended ->
+        # Dark landing: the detector ships suspend:true and flips on only after
+        # live verification (#4338 standing rule), so an unset gate reads as an
+        # absent route.
+        send_json(conn, 404, %{error: "not found"})
+
+      {:error, reason} ->
+        send_json(conn, 503, %{
+          ok: false,
+          error: "durability evaluation failed",
+          detail: inspect(reason)
+        })
+
+      report when is_map(report) ->
+        status = if report.ok, do: 200, else: 503
+        send_json(conn, status, json_nullify(report))
+    end
+  end
+
+  defp try_durability_snapshot(mod) do
+    mod.snapshot()
+  catch
+    :exit, reason -> {:error, reason}
+  rescue
+    e -> {:error, e}
   end
 
   defp conformance_view(query_params) do

--- a/projects/embervm/control/test/embervm/durability_test.exs
+++ b/projects/embervm/control/test/embervm/durability_test.exs
@@ -1,0 +1,360 @@
+defmodule Embervm.DurabilityTest do
+  use ExUnit.Case, async: true
+
+  alias Embervm.{Durability, NodeCapacity}
+
+  # Fixed clocks injected into every evaluation so each boundary is asserted
+  # deterministically (same idiom as S3WarmthGcTest).
+  @mono 1_000_000_000
+  @wall 1_756_000_000_000
+  @hour 3_600_000
+  @day 86_400_000
+
+  defp opts(extra \\ []) do
+    Keyword.merge(
+      [
+        now_mono: @mono,
+        now_wall: @wall,
+        freshness_window_ms: 120_000,
+        streak_threshold: 10,
+        sweep_interval_ms: @hour,
+        # A fresh manifest by default, so overall `ok` tracks tier 1 in the
+        # tier-1 tests; tier-2 tests override explicitly.
+        s3: manifest_s3(@hour)
+      ],
+      extra
+    )
+  end
+
+  defp new_cap_table do
+    table = :"dur_cap_#{System.unique_integer([:positive])}"
+    NodeCapacity.create(table)
+    table
+  end
+
+  # A node fact reporting one artifact per tracked kind. Every id is unique so
+  # counts are unambiguous; `exported?` stamps every artifact at once.
+  defp node_fact(node_id, exported?, updated_at \\ @mono) do
+    %{
+      node_id: node_id,
+      updated_at: updated_at,
+      session_snapshots: [%{snapshot_ref: "sref-#{node_id}", session_id: "s", workload: "wl", exported: exported?}],
+      serving_snapshots: [%{snapshot_ref: "vref-#{node_id}", workload: "wl", exported: exported?}],
+      stateful_bundles: [%{snapshot_ref: "bref-#{node_id}", workload: "wl", exported: exported?}],
+      group_bundle_sets: [%{set_id: "set-#{node_id}", group_instance_id: "g", exported: exported?}],
+      workloads: %{
+        "wl" => %{snapshot_ref: "base-#{node_id}", base_state: :BASE_BUILD_STATE_READY, exported: exported?}
+      }
+    }
+  end
+
+  # The tier-2 seam: `%{list: fun}` answering with a listing whose newest
+  # object sits `age_ms` before the fixed wall clock.
+  defp manifest_s3(age_ms) do
+    listing = [%{key: "gc-manifests/x.json", size: 10, last_modified_ms: @wall - age_ms}]
+    %{list: fn _prefix -> {:ok, listing} end}
+  end
+
+  defp listing_s3(result), do: %{list: fn _prefix -> result end}
+
+  # -- Tier 1 ------------------------------------------------------------------
+
+  describe "tier 1: export failure streaks" do
+    test "fresh signals stay healthy: everything exported and fleet fresh reads ok" do
+      report = Durability.evaluate([node_fact("node-1", true)], ["node-1"], %{}, opts())
+
+      assert report.ok
+      assert report.tier1.ok
+      assert report.tier1.verdict == :ok
+      # Every kind's streak is at zero on a clean read.
+      assert report.tier1.streaks == %{base: 0, group_set: 0, serving: 0, session: 0, stateful: 0}
+      assert report.tier1.failing_kinds == []
+      assert report.tier1.fresh_nodes == ["node-1"]
+      assert report.tier1.missing_nodes == []
+    end
+
+    test "a pending kind crossing the threshold flips unhealthy immediately" do
+      fact = node_fact("node-1", false)
+
+      # Below the threshold: still ok (a fresh bank exports within minutes).
+      {report, streaks} = run_rounds([fact], ["node-1"], %{}, 9)
+      assert report.ok
+      assert report.tier1.verdict == :ok
+
+      # The threshold round latches tier 1 NOW (minutes, not hours). The
+      # fixture has every kind pending, so every kind fires together.
+      {report, _} = run_rounds([fact], ["node-1"], streaks, 1)
+      refute report.ok
+      refute report.tier1.ok
+      assert report.tier1.verdict == :export_failure_streak
+      assert report.tier1.failing_kinds == [:base, :group_set, :serving, :session, :stateful]
+      assert get_in(report, [:tier1, :streaks, :session]) == 10
+    end
+
+    test "the failing kinds recover once their store copies confirm" do
+      fact = node_fact("node-1", false)
+
+      {_, streaks} = run_rounds([fact], ["node-1"], %{}, 12)
+      assert streaks[:session] >= 10
+
+      # Exports succeed again: the very next round clears the streak.
+      recovered = Durability.evaluate([node_fact("node-1", true)], ["node-1"], streaks, opts())
+      assert recovered.ok
+      assert recovered.tier1.verdict == :ok
+      assert recovered.tier1.failing_kinds == []
+      assert get_in(recovered, [:tier1, :streaks, :session]) == 0
+    end
+
+    test "kinds are independent: a recovered kind does not clear a still-failing one" do
+      fact = node_fact("node-1", false)
+
+      {_, streaks} = run_rounds([fact], ["node-1"], %{}, 11)
+
+      # Everything confirms EXCEPT the stateful bundle.
+      partial =
+        node_fact("node-1", true)
+        |> Map.put(:stateful_bundles, [%{snapshot_ref: "bref-node-1", workload: "wl", exported: false}])
+
+      report = Durability.evaluate([partial], ["node-1"], streaks, opts())
+      refute report.ok
+      assert report.tier1.verdict == :export_failure_streak
+      assert report.tier1.failing_kinds == [:stateful]
+      assert get_in(report, [:tier1, :streaks, :session]) == 0
+    end
+
+    test "an artifact leaving the facts resets its kind instead of firing forever" do
+      fact = node_fact("node-1", false)
+      {_, streaks} = run_rounds([fact], ["node-1"], %{}, 5)
+
+      # The banked snapshot was evicted/retired: nothing pending anymore.
+      empty =
+        node_fact("node-1", true)
+        |> Map.put(:session_snapshots, [])
+
+      report = Durability.evaluate([empty], ["node-1"], streaks, opts())
+      assert get_in(report, [:tier1, :streaks, :session]) == 0
+    end
+  end
+
+  describe "tier 1 vacuous-green guards" do
+    test "no expected nodes configured reads unknown, never green" do
+      report = Durability.evaluate([node_fact("node-1", true)], [], %{}, opts())
+
+      refute report.ok
+      refute report.tier1.ok
+      assert report.tier1.verdict == :unknown
+    end
+
+    test "no expected node reporting fresh reads unknown, never green" do
+      report = Durability.evaluate([], ["node-1"], %{}, opts())
+
+      refute report.ok
+      assert report.tier1.verdict == :unknown
+      assert report.tier1.missing_nodes == ["node-1"]
+    end
+
+    test "a stale expected node with nothing pending reads unknown, not green" do
+      stale = node_fact("node-1", true, @mono - 120_001)
+      report = Durability.evaluate([stale], ["node-1"], %{}, opts())
+
+      refute report.ok
+      assert report.tier1.verdict == :unknown
+      assert report.tier1.missing_nodes == ["node-1"]
+    end
+
+    test "a firing streak stands even while another expected node is missing" do
+      fact = node_fact("node-1", false)
+      {_, streaks} = run_rounds([fact], ["node-1"], %{}, 10)
+
+      report = Durability.evaluate([fact], ["node-1", "node-2"], streaks, opts())
+      refute report.ok
+      # The failure evidence is real regardless of the silent node.
+      assert report.tier1.verdict == :export_failure_streak
+      assert report.tier1.missing_nodes == ["node-2"]
+    end
+
+    test "a streak survives a transient unknown round without resetting" do
+      fact = node_fact("node-1", false)
+      {_, streaks} = run_rounds([fact], ["node-1"], %{}, 6)
+
+      # A fleet-stale round (all nodes missing) keeps the counters.
+      report = Durability.evaluate([], ["node-1"], streaks, opts())
+      assert report.tier1.verdict == :unknown
+      assert get_in(report, [:tier1, :streaks, :session]) == streaks[:session]
+    end
+
+    test "a LATCHED streak stays latched when the whole fleet goes silent" do
+      # Only the session bundle is pending; everything else confirms.
+      fact =
+        node_fact("node-1", true)
+        |> Map.put(:session_snapshots, [%{snapshot_ref: "sref-node-1", session_id: "s", workload: "wl", exported: false}])
+
+      {_, streaks} = run_rounds([fact], ["node-1"], %{}, 10)
+
+      # All witnesses disappear: the latch must not heal on missing data.
+      report = Durability.evaluate([], ["node-1"], streaks, opts())
+      refute report.ok
+      assert report.tier1.verdict == :export_failure_streak
+      assert report.tier1.failing_kinds == [:session]
+    end
+  end
+
+  # -- Tier 2 ------------------------------------------------------------------
+
+  describe "tier 2: gc sweep stall" do
+    test "a fresh manifest stays healthy" do
+      report = Durability.evaluate([node_fact("node-1", true)], ["node-1"], %{}, opts(s3: manifest_s3(@hour)))
+
+      assert report.tier2.ok
+      assert report.tier2.verdict == :ok
+      assert report.tier2.newest_manifest_age_ms == @hour
+      # Bound is 24h + sweep interval.
+      assert report.tier2.stall_bound_ms == @day + @hour
+    end
+
+    test "a stalled sweep older than the bound degrades; exactly at the bound does not" do
+      bound = @day + @hour
+
+      at_bound = Durability.evaluate([node_fact("node-1", true)], ["node-1"], %{}, opts(s3: manifest_s3(bound)))
+      assert at_bound.tier2.verdict == :ok
+      assert at_bound.ok
+
+      past_bound = Durability.evaluate([node_fact("node-1", true)], ["node-1"], %{}, opts(s3: manifest_s3(bound + 1)))
+      refute past_bound.tier2.ok
+      assert past_bound.tier2.verdict == :gc_sweep_stalled
+      refute past_bound.ok
+    end
+
+    test "the newest object decides: an old stall heals when a fresh manifest lands" do
+      entries = [
+        %{key: "gc-manifests/old.json", size: 10, last_modified_ms: @wall - 3 * @day},
+        %{key: "gc-manifests/new.json", size: 10, last_modified_ms: @wall - 2 * @hour}
+      ]
+
+      report =
+        Durability.evaluate([node_fact("node-1", true)], ["node-1"], %{}, opts(s3: listing_s3({:ok, entries})))
+
+      assert report.tier2.ok
+      assert report.tier2.newest_manifest_age_ms == 2 * @hour
+    end
+
+    test "an EMPTY gc-manifests listing never reads healthy" do
+      report =
+        Durability.evaluate([node_fact("node-1", true)], ["node-1"], %{}, opts(s3: listing_s3({:ok, []})))
+
+      refute report.ok
+      refute report.tier2.ok
+      assert report.tier2.verdict == :unknown
+      assert report.tier2.newest_manifest_age_ms == nil
+    end
+
+    test "a failed listing never reads healthy" do
+      for result <- [{:error, :boom}, {:error, %RuntimeError{}}] do
+        report =
+          Durability.evaluate([node_fact("node-1", true)], ["node-1"], %{}, opts(s3: listing_s3(result)))
+
+        refute report.ok
+        assert report.tier2.verdict == :unknown
+      end
+    end
+
+    test "a raising list fun never reads healthy" do
+      raising = fn _prefix -> raise "s3 down" end
+
+      report =
+        Durability.evaluate([node_fact("node-1", true)], ["node-1"], %{}, opts(s3: %{list: raising}))
+
+      refute report.ok
+      assert report.tier2.verdict == :unknown
+    end
+
+    test "no store configured never reads healthy" do
+      report = Durability.evaluate([node_fact("node-1", true)], ["node-1"], %{}, opts(s3: nil))
+
+      refute report.ok
+      assert report.tier2.verdict == :unknown
+    end
+  end
+
+  # -- supervised process --------------------------------------------------------
+
+  describe "supervised process" do
+    test "accumulates streaks across rounds through its own capacity read" do
+      table = new_cap_table()
+      put_fact(table, node_fact("node-1", false))
+
+      {:ok, pid} =
+        Durability.start_link(
+          name: nil,
+          enabled: true,
+          capacity_table: table,
+          expected_nodes: ["node-1"],
+          round_interval_ms: 0,
+          streak_threshold: 3,
+          s3: manifest_s3(@hour),
+          clock: fn -> @mono end,
+          wall_clock: fn -> @wall end
+        )
+
+      # The first snapshot computes synchronously (round one).
+      first = Durability.snapshot(pid)
+      assert get_in(first, [:tier1, :streaks, :session]) == 1
+
+      for n <- 2..4 do
+        report = GenServer.call(pid, :round_now)
+        assert get_in(report, [:tier1, :streaks, :session]) == n
+      end
+
+      latched = GenServer.call(pid, :round_now)
+      refute latched.ok
+      assert latched.tier1.verdict == :export_failure_streak
+
+      # Snapshot now returns the CACHED verdict without recomputing.
+      assert Durability.snapshot(pid).tier1.verdict == :export_failure_streak
+
+      # Recovery: the node reports confirmed store copies.
+      put_fact(table, node_fact("node-1", true))
+      recovered = GenServer.call(pid, :round_now)
+      assert recovered.ok
+      assert recovered.tier1.verdict == :ok
+    end
+
+    test "dark process answers :suspended and evaluates nothing" do
+      {:ok, pid} = Durability.start_link(name: nil, enabled: false, capacity_table: new_cap_table())
+      assert Durability.snapshot(pid) == :suspended
+    end
+
+    test "missing expected nodes surface as unknown through the process too" do
+      {:ok, pid} =
+        Durability.start_link(
+          name: nil,
+          enabled: true,
+          capacity_table: new_cap_table(),
+          expected_nodes: ["node-none"],
+          round_interval_ms: 0,
+          s3: manifest_s3(@hour),
+          clock: fn -> @mono end,
+          wall_clock: fn -> @wall end
+        )
+
+      report = Durability.snapshot(pid)
+      refute report.ok
+      assert report.tier1.verdict == :unknown
+    end
+  end
+
+  # -- helpers -----------------------------------------------------------------
+
+  # Run `n` rounds of the pure evaluation, threading streaks through, returning
+  # the last report + final streak map.
+  defp run_rounds(facts, expected, initial_streaks, n) do
+    Enum.reduce(1..n//1, {%{}, initial_streaks}, fn _i, {_rep, streaks} ->
+      report = Durability.evaluate(facts, expected, streaks, opts())
+      {report, get_in(report, [:tier1, :streaks])}
+    end)
+  end
+
+  defp put_fact(table, fact) do
+    NodeCapacity.put(table, {fact.node_id, "pod"}, fact)
+  end
+end

--- a/projects/embervm/control/test/embervm/router_durability_test.exs
+++ b/projects/embervm/control/test/embervm/router_durability_test.exs
@@ -1,0 +1,131 @@
+defmodule Embervm.RouterDurabilityTest do
+  @moduledoc """
+  Request tests for GET /v1/health/durability (#4338), driving the LIVE Bandit
+  instance the application boots (same harness as RouterTest) with an injected
+  fake authenticator and an injected durability module (the router's
+  `:embervm :durability` app-env seam, mirroring the `:authenticator` seam).
+  `async: false` because these mutate global application env and share the one
+  running control-plane instance.
+  """
+
+  use ExUnit.Case, async: false
+
+  defmodule FakeAuth do
+    # The monolith service account: the caller the durability flip would use
+    # (it is already on the embervm auth allow-list in deploy values).
+    def authenticate("good"), do: {:ok, "system:serviceaccount:monolith:monolith"}
+    def authenticate(_), do: {:error, :unauthenticated}
+  end
+
+  # A healthy report shaped exactly like Embervm.Durability.evaluate's output.
+  @healthy_report %{
+    ok: true,
+    evaluated_at_unix_ms: 1_756_000_000_000,
+    tier1: %{
+      ok: true,
+      verdict: :ok,
+      detail: "all tracked artifact kinds have confirmed store copies",
+      streaks: %{base: 0, group_set: 0, serving: 0, session: 0, stateful: 0},
+      failing_kinds: [],
+      threshold_rounds: 10,
+      fresh_nodes: ["node-1"],
+      missing_nodes: []
+    },
+    tier2: %{
+      ok: true,
+      verdict: :ok,
+      detail: "newest gc-manifests object is fresh",
+      newest_manifest_age_ms: 3_600_000,
+      stall_bound_ms: 90_000_000
+    }
+  }
+
+  defmodule StubDurability do
+    def snapshot do
+      case Application.get_env(:embervm, :durability_stub_report, :suspended) do
+        :raise -> {:error, :s3_down}
+        other -> other
+      end
+    end
+  end
+
+  setup do
+    Application.put_env(:embervm, :authenticator, FakeAuth)
+    on_exit(fn ->
+      Application.delete_env(:embervm, :authenticator)
+      Application.delete_env(:embervm, :durability)
+      Application.delete_env(:embervm, :durability_stub_report)
+    end)
+
+    :ok
+  end
+
+  defp req(method, path, headers \\ []) do
+    Finch.build(method, "http://127.0.0.1:8080#{path}", headers)
+    |> Finch.request(Embervm.Finch)
+    |> then(fn {:ok, resp} -> resp end)
+  end
+
+  defp auth(token), do: [{"authorization", "Bearer " <> token}]
+
+  test "with the detector dark (no seam wired) the route reads as absent" do
+    resp = req(:get, "/v1/health/durability", auth("good"))
+    assert resp.status == 404
+  end
+
+  test "a healthy report answers 200 with both tiers ok" do
+    Application.put_env(:embervm, :durability, StubDurability)
+    Application.put_env(:embervm, :durability_stub_report, @healthy_report)
+
+    resp = req(:get, "/v1/health/durability", auth("good"))
+    assert resp.status == 200
+
+    body = :json.decode(resp.body)
+    assert body["ok"] == true
+    assert body["tier1"]["verdict"] == "ok"
+    assert body["tier2"]["verdict"] == "ok"
+  end
+
+  test "an unhealthy report answers 503 with the SAME report body (never green)" do
+    Application.put_env(:embervm, :durability, StubDurability)
+
+    not_ok = %{
+      @healthy_report
+      | ok: false,
+        tier1: %{
+          @healthy_report.tier1
+          | ok: false,
+            verdict: :export_failure_streak,
+            failing_kinds: [:session],
+            detail: "artifact exports have been failing"
+        }
+    }
+
+    Application.put_env(:embervm, :durability_stub_report, not_ok)
+
+    resp = req(:get, "/v1/health/durability", auth("good"))
+    assert resp.status == 503
+    body = :json.decode(resp.body)
+    assert body["ok"] == false
+    assert body["tier1"]["verdict"] == "export_failure_streak"
+    assert body["tier1"]["failing_kinds"] == ["session"]
+  end
+
+  test "an evaluator crash answers 503 unknown rather than 500 or green" do
+    Application.put_env(:embervm, :durability, StubDurability)
+    Application.put_env(:embervm, :durability_stub_report, :raise)
+
+    resp = req(:get, "/v1/health/durability", auth("good"))
+    assert resp.status == 503
+    body = :json.decode(resp.body)
+    assert body["ok"] == false
+  end
+
+  test "the route requires the management bearer token like every /v1 route" do
+    Application.put_env(:embervm, :durability, StubDurability)
+    Application.put_env(:embervm, :durability_stub_report, @healthy_report)
+
+    resp = req(:get, "/v1/health/durability")
+    assert resp.status == 401
+  end
+end

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -106,6 +106,14 @@ spec:
             - name: EMBERVM_URL
               value: {{ .Values.semgrep.embervmUrl | quote }}
             {{- end }}
+            {{- if .Values.emberDurability.url }}
+            # ember-durability health component (#4338): the CP durability
+            # surface (GET /v1/health/durability) folded into /api/health as a
+            # FATAL-tier component. Empty (the default) keeps it dark: nothing
+            # registers and no env renders.
+            - name: EMBER_DURABILITY_HEALTH_URL
+              value: {{ .Values.emberDurability.url | quote }}
+            {{- end }}
             {{- if .Values.emberSynthetic.baseUrl }}
             - name: EMBER_SYNTHETIC_BASE_URL
               value: {{ .Values.emberSynthetic.baseUrl | quote }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -1085,6 +1085,20 @@ cdHealth:
   # public reader treats a row older than 2.5x this as a dead writer.
   probeIntervalSeconds: 300
 
+# ember-durability health component (#4338, ADR embervm/031): a FATAL-tier
+# /api/health component reading the EmberVM control plane's durability surface
+# (GET /v1/health/durability): tier 1 sustained artifact-export failure
+# streaks, tier 2 gc-manifests age past 24h + sweep interval. Both tiers end
+# in the health surface, so this is registered under register_health (never
+# advisory). DARK by default per the standing rule that a health-affecting
+# detector flips on only after live verification: empty URL means nothing is
+# registered and this block renders no env. To arm, set this to the CP service
+# URL with the /v1/health/durability path (the monolith SA is already on the
+# embervm auth allow-list) AFTER verifying the detector against live fleet
+# facts; clearing it is the entire rollback lever.
+emberDurability:
+  url: ""
+
 chat:
   enabled: false
   # The compare proxy reads this field from the existing chat 1Password item.

--- a/projects/monolith/ember_public/durability.py
+++ b/projects/monolith/ember_public/durability.py
@@ -1,0 +1,135 @@
+"""The ember-durability health component (#4338, ADR embervm/031).
+
+Reads the EmberVM control plane's GET /v1/health/durability surface, which
+classifies durability signals by time-to-impact into two tiers: tier 1 latches
+unhealthy on a sustained per-kind artifact-export failure streak (minutes, not
+hours: a session parking inside such a window rehydrates blank) and tier 2 on
+the newest gc-manifests object aging past 24h + sweep interval. BOTH tiers are
+fatal components of this composite (never advisory: an advisory signal pages
+nobody, and #4317 is direct proof that a nobody-watching signal goes unread).
+
+Dark by default per the standing rule that a health-affecting detector lands
+suspend:true and flips on only after live verification: when
+EMBER_DURABILITY_HEALTH_URL is unset the factory returns None and NOTHING is
+registered, so shipping this module changes no existing health response.
+
+Vacuous-green guards: a transport failure, a non-200, an unparseable body, or
+a 200 body without an explicit ``ok: true`` all read NOT ok. Absence of signal
+is never evidence of health.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+import httpx
+
+from shared.k8s_auth import auth_headers
+
+logger = logging.getLogger(__name__)
+
+ENV_URL = "EMBER_DURABILITY_HEALTH_URL"
+
+CONNECT_TIMEOUT_S = 5.0
+READ_TIMEOUT_S = 10.0
+
+
+def configured_url() -> str:
+    """The configured CP durability endpoint, or "" while dark."""
+    return os.environ.get(ENV_URL, "").strip()
+
+
+def build_durability_health(
+    url: str | None = None,
+    transport: httpx.BaseTransport | None = None,
+):
+    """Build the ember-durability component, or None while unconfigured.
+
+    ``url``/``transport`` are injectable so tests can drive every branch
+    against httpx.MockTransport without a live control plane.
+    """
+    resolved = configured_url() if url is None else url
+    if not resolved:
+        return None
+
+    async def check() -> dict:
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(READ_TIMEOUT_S, connect=CONNECT_TIMEOUT_S),
+                transport=transport,
+            ) as client:
+                resp = await client.get(resolved, headers=auth_headers())
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "ember-durability endpoint unreachable at %s: %s", resolved, exc
+            )
+            return {"ok": False, "detail": f"durability endpoint unreachable: {exc}"}
+
+        if resp.status_code != 200:
+            # The CP answers 503 WITH the full report body when a tier is not
+            # ok, so surface the tier verdicts rather than just the status.
+            # 404 means the detector is dark on the CP side (suspend:true).
+            detail = f"durability endpoint returned HTTP {resp.status_code}"
+            try:
+                payload = resp.json()
+                if isinstance(payload, dict):
+                    parts = [
+                        f"{name}={tier.get('verdict')}: {tier.get('detail')}"
+                        for name, tier in (
+                            ("tier1", payload.get("tier1")),
+                            ("tier2", payload.get("tier2")),
+                        )
+                        if isinstance(tier, dict)
+                    ]
+
+                    if parts:
+                        detail = f"{detail}; " + "; ".join(parts)
+                    elif payload.get("error"):
+                        detail = f"{detail}: {payload['error']}"
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+            return {"ok": False, "detail": detail}
+
+        try:
+            payload = resp.json()
+        except (json.JSONDecodeError, ValueError):
+            return {
+                "ok": False,
+                "detail": "durability endpoint returned a non-JSON body",
+            }
+
+        if not isinstance(payload, dict):
+            return {
+                "ok": False,
+                "detail": "durability endpoint returned a non-object body",
+            }
+
+        tier1, tier2 = payload.get("tier1"), payload.get("tier2")
+
+        if (
+            payload.get("ok") is True
+            and isinstance(tier1, dict)
+            and tier1.get("ok") is True
+            and isinstance(tier2, dict)
+            and tier2.get("ok") is True
+        ):
+            return {
+                "ok": True,
+                "detail": f"durability ok (tier1={tier1.get('verdict')}, tier2={tier2.get('verdict')})",
+            }
+
+        # Anything else (an explicit ok:false, missing fields, an unknown shape)
+        # reads NOT ok: absence of signal is never evidence of health.
+        parts = []
+        for name, tier in (("tier1", tier1), ("tier2", tier2)):
+            if isinstance(tier, dict):
+                parts.append(f"{name}={tier.get('verdict')}: {tier.get('detail')}")
+            else:
+                parts.append(f"{name}=missing")
+
+        return {"ok": False, "detail": "; ".join(parts)}
+
+    return check

--- a/projects/monolith/ember_public/durability_test.py
+++ b/projects/monolith/ember_public/durability_test.py
@@ -1,0 +1,199 @@
+"""Tests for the ember-durability health component (#4338, ADR embervm/031)."""
+
+from __future__ import annotations
+
+import json
+import httpx
+import pytest
+
+from ember_public import durability
+
+
+HEALTHY_PAYLOAD = {
+    "ok": True,
+    "evaluated_at_unix_ms": 1756000000000,
+    "tier1": {
+        "ok": True,
+        "verdict": "ok",
+        "detail": "all tracked artifact kinds have confirmed store copies",
+        "streaks": {"session": 0},
+        "failing_kinds": [],
+        "fresh_nodes": ["node-1"],
+        "missing_nodes": [],
+    },
+    "tier2": {
+        "ok": True,
+        "verdict": "ok",
+        "detail": "newest gc-manifests object is fresh",
+        "newest_manifest_age_ms": 3600000,
+        "stall_bound_ms": 90000000,
+    },
+}
+
+
+def _transport(
+    status_code: int = 200, body: bytes | None = None
+) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code,
+            content=body if body is not None else json.dumps(HEALTHY_PAYLOAD).encode(),
+            headers={"content-type": "application/json"},
+            request=request,
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def _run(check):
+    import asyncio
+
+    return asyncio.run(check())
+
+
+# -- factory / dark landing -----------------------------------------------------
+
+
+def test_factory_returns_none_while_unconfigured() -> None:
+    assert durability.build_durability_health("") is None
+    assert durability.build_durability_health(None) is None
+
+
+def test_configured_url_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(durability.ENV_URL, raising=False)
+    assert durability.configured_url() == ""
+    monkeypatch.setenv(durability.ENV_URL, "http://embervm:8080/v1/health/durability")
+    assert durability.configured_url() == "http://embervm:8080/v1/health/durability"
+
+
+def test_module_registration_stays_dark_without_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Importing the module must not blow up and, with no URL configured, must
+    # not add an ember-durability component at all.
+    monkeypatch.delenv(durability.ENV_URL, raising=False)
+    from ember_public.module import MODULE  # noqa: PLC0415
+
+    assert MODULE.register_health is not None
+    assert "ember-durability" not in MODULE.register_health
+
+
+def test_module_registration_appears_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(durability.ENV_URL, "http://embervm:8080/v1/health/durability")
+    import importlib
+
+    from ember_public import module as module_mod  # noqa: PLC0415
+
+    importlib.reload(module_mod)
+    try:
+        assert module_mod.MODULE.register_health is not None
+        check = module_mod.MODULE.register_health.get("ember-durability")
+        assert check is not None
+        # It must be a FATAL-tier registration (register_health), never in the
+        # advisory map: an advisory signal pages nobody, and both tiers end in
+        # the health surface.
+        assert module_mod.MODULE.register_health_advisory in (None, {})
+    finally:
+        monkeypatch.delenv(durability.ENV_URL, raising=False)
+        importlib.reload(module_mod)
+
+
+# -- the check itself -------------------------------------------------------------
+
+
+def test_healthy_payload_reads_ok() -> None:
+    check = durability.build_durability_health(
+        "http://x/durability", transport=_transport()
+    )
+    result = _run(check)
+    assert result == {
+        "ok": True,
+        "detail": "durability ok (tier1=ok, tier2=ok)",
+    }
+
+
+def test_explicit_not_ok_reads_fatal_with_tier_detail() -> None:
+    payload = {
+        "ok": False,
+        "tier1": {
+            "ok": False,
+            "verdict": "export_failure_streak",
+            "detail": "exports failing for session",
+        },
+        "tier2": {"ok": True, "verdict": "ok", "detail": "fresh"},
+    }
+    check = durability.build_durability_health(
+        "http://x/durability", transport=_transport(body=json.dumps(payload).encode())
+    )
+    result = _run(check)
+    assert result["ok"] is False
+    assert "tier1=export_failure_streak" in result["detail"]
+    assert "exports failing" in result["detail"]
+
+
+def test_http_503_from_the_cp_never_reads_ok_and_keeps_tier_detail() -> None:
+    # The CP answers 503 WITH the report body when a tier is not ok; the
+    # component must read not-ok AND surface which tier and why.
+    payload = {
+        "ok": False,
+        "tier1": {
+            "ok": False,
+            "verdict": "gc_sweep_stalled",
+            "detail": "newest gc-manifests object is too old",
+        },
+        "tier2": {"ok": False, "verdict": "gc_sweep_stalled", "detail": "old"},
+    }
+    check = durability.build_durability_health(
+        "http://x/durability",
+        transport=_transport(status_code=503, body=json.dumps(payload).encode()),
+    )
+    result = _run(check)
+    assert result["ok"] is False
+    assert "HTTP 503" in result["detail"]
+    assert "gc_sweep_stalled" in result["detail"]
+
+
+def test_http_404_dark_cp_reads_not_ok_with_hint() -> None:
+    check = durability.build_durability_health(
+        "http://x/durability",
+        transport=_transport(status_code=404, body=b'{"error": "not found"}'),
+    )
+    result = _run(check)
+    assert result["ok"] is False
+    assert "HTTP 404" in result["detail"]
+    assert "not found" in result["detail"]
+
+
+def test_missing_ok_field_never_reads_ok() -> None:
+    # The vacuous-green guard: a 200 body without an explicit ok:true (a shape
+    # drift, an empty object, a proxy's default page) reads NOT ok.
+    for body in [b"{}", b"<html>proxy error</html>", b"null"]:
+        check = durability.build_durability_health(
+            "http://x/durability", transport=_transport(body=body)
+        )
+        result = _run(check)
+        assert result["ok"] is False, body
+
+
+def test_transport_error_never_reads_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    check = durability.build_durability_health(
+        "http://x/durability", transport=httpx.MockTransport(handler)
+    )
+    result = _run(check)
+    assert result["ok"] is False
+    assert "unreachable" in result["detail"]
+
+
+def test_tier_missing_from_payload_reads_not_ok() -> None:
+    payload = {"ok": True, "tier1": HEALTHY_PAYLOAD["tier1"]}
+    check = durability.build_durability_health(
+        "http://x/durability", transport=_transport(body=json.dumps(payload).encode())
+    )
+    result = _run(check)
+    assert result["ok"] is False
+    assert "tier2=missing" in result["detail"]

--- a/projects/monolith/ember_public/module.py
+++ b/projects/monolith/ember_public/module.py
@@ -6,6 +6,7 @@ demos/module.py.
 """
 
 import ember_public as _domain
+from ember_public.durability import build_durability_health
 from ember_public.health import (
     EMBER_QWEN_STALENESS_S,
     EMBER_SYNTHETIC_STALENESS_S,
@@ -13,6 +14,14 @@ from ember_public.health import (
 )
 
 from framework import Module as _Module
+
+# The ember-durability component (#4338, ADR embervm/031): a FATAL-tier check
+# reading the CP's /v1/health/durability surface (export-failure streaks +
+# gc-manifest stall), never an advisory: both durability tiers end in the
+# health surface. Dark while EMBER_DURABILITY_HEALTH_URL is unset, per the
+# standing rule that a health-affecting detector lands suspend:true and flips
+# on only after live verification; the flip is a values/env change only.
+_DURABILITY_CHECK = build_durability_health()
 
 
 MODULE = _Module(
@@ -31,5 +40,6 @@ MODULE = _Module(
         # invisible to health. Registered here on its OWN staleness because its
         # CronWorkflow is hourly, not the 5-minute one (see EMBER_QWEN_*).
         "ember_qwen": synthetic_probe_health("qwen", EMBER_QWEN_STALENESS_S),
+        **({"ember-durability": _DURABILITY_CHECK} if _DURABILITY_CHECK else {}),
     },
 )


### PR DESCRIPTION
Closes #4338. Implements ADR embervm/031: durability signals classify by time-to-impact and both tiers end in the health surface, never alert-only.

- **Tier 1 (immediate)**: `Embervm.Durability` aggregates per-kind artifact export failure streaks from the node capacity facts noded already reports. Crossing 10 consecutive rounds (~5 min) latches unhealthy, because a session parking in that window rehydrates blank (the #4317 data-loss shape the synthetic probe cannot see).
- **Tier 2 (>24h)**: age of the newest gc-manifests object beyond 24h + sweep interval. Reads durable S3 state, so it survives CP restarts and covers every GC abort reason by construction.
- Both surface on `GET /v1/health/durability`; the monolith gains a **fatal-tier** `ember-durability` component reading it.

**No vacuous green**: missing data reads `unknown`, never healthy. Unset `expectedNodes`, silent nodes, or an empty/failed manifest listing hold the tier at unknown, and a latched streak does not heal just because witnesses go quiet.

**Lands dark on both sides** (`durabilityHealth.enabled: ""`, `emberDurability.url: ""`), so nothing evaluates until you flip it with a values-only change after live verification. Worth doing in that order given the monolith component is fatal-tier.

Known gap, documented in the module: `SessionVolume` carries no exported flag on the wire, so a workspace-only export failure stays invisible to the CP; #4317 itself would still have fired within minutes because every other kind was failing fleet-wide.

Verified: new suites 26/0 and the durability router tests; full ExUnit failures baseline-compared against stashed-change runs and all pre-existing; `ci` green (218 pass, 87 executed).

Implemented by ox-alpha via opencode, reviewed on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K