### PR TITLE
fix(signoz): let ClickHouse drop the 133 zero-length parts and start

### DIFF
--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -232,6 +232,24 @@ signoz:
       # Health probes are exempt and stay on /api/v1/health at the root.
       signoz_global_external__url: https://private.jomcgi.dev/app/signoz
   clickhouse:
+    # TEMPORARY, REMOVE ONCE CLICKHOUSE IS SERVING. Default is 100.
+    #
+    # A storage event on 2026-08-24 left 133 part directories in
+    # signoz_logs.logs_v2 where every file is zero length: data.bin, columns.txt,
+    # checksums.txt, count.txt, primary.cidx, all 0 bytes. ClickHouse refuses to
+    # start rather than silently discard more than 100 broken parts, so SigNoz
+    # has been down since. The parts hold nothing, so dropping them costs only
+    # what was in flight at 00:58 that morning.
+    #
+    # Raised to 200 for margin over 133. ClickHouse aborts at the first table
+    # over the ceiling, so if another table is also affected it will surface as
+    # a new failure with its own count rather than being masked by this.
+    #
+    # This disarms a real guardrail. Restore the default as soon as the server
+    # is up and the empty parts are gone: see #5317.
+    settings:
+      merge_tree/max_suspicious_broken_parts: 200
+
     # DO NOT PIN BACK TO 25.5.6. Tried in #5307 and reverted here: 25.5.6
     # cannot read what 25.12.5 wrote. It fails to attach
     # signoz_metrics.samples_v4_agg_5m with "Unknown version of serialization


### PR DESCRIPTION
Ends the SigNoz outage (#5298) by letting ClickHouse discard 133 empty part directories and finish starting.

## The blocker

```
Code: 231. Suspiciously many (133 parts, 0.00 B in total) broken parts to remove
while maximum allowed broken parts count is 100
... Cannot attach table `signoz_logs`.`logs_v2` (TOO_MANY_UNEXPECTED_DATA_PARTS)
```

## Why raising the ceiling is safe here

The parts are literally empty. The per-part error enumerates every file at zero bytes:

```
while loading part 20260824-15-0_371_371_0 ...
Part contains files: data.bin (0 bytes), columns.txt (0 bytes),
  checksums.txt (0 bytes), count.txt (0 bytes), primary.cidx (0 bytes),
  serialization.json (0 bytes), metadata_version.txt (0 bytes) [every file, 0 bytes]
Part is empty. (CANNOT_PARSE_INPUT_ASSERTION_FAILED)
```

Partitions are dated `20260824`. ClickHouse created the directories and files; nothing was written into them. Dropping them costs only the log data in flight at 00:58 that morning.

This is worth stating because I argued the opposite in #5307, where I called these "133 parts of real log data" and rejected this fix on that basis. That was wrong: `0.00 B` was in the error text the whole time.

## Value

`merge_tree/max_suspicious_broken_parts: 200`, up from the default 100. Margin over 133 without being open ended. ClickHouse aborts at the first table over the ceiling, so if another table is also affected it surfaces as a new failure with its own count rather than being masked.

Renders into the CHI `settings` block alongside the existing defaults:

```yaml
settings:
  format_schema_path: /etc/clickhouse-server/config.d/
  merge_tree/max_suspicious_broken_parts: 200
  prometheus/endpoint: /metrics
  ...
```

## Temporary

This disarms a guardrail whose job is to make silent part destruction loud. #5317 tracks restoring the default **and** finding what wrote 133 zero-length parts. Without that second half this is a workaround that will be needed again.

## On the disk-space caveat I raised earlier

I said this was blocked on an on-LAN PVC free-space check. I over-stated that. If the volume is full, this change makes ClickHouse start, immediately fail to write, and log ENOSPC plainly, which is a faster and clearer diagnosis than the current state and destroys nothing (the discarded parts are zero bytes either way). The free-space question stays open on #5317 as root cause, not as a gate on recovery.

## Verification

`ci test`: `Executed 4 out of 139 tests: 139 tests pass.`

`projects/platform/*` deploys on HEAD, so this lands at merge. I will confirm the pod actually starts and SigNoz serves rather than calling it done at merge.

## Prior wrong turns, for the record

Recorded in full on #5298: the 25.12.5 downgrade theory (#5307, reverted in #5309) and the 16-day image adoption gap. Both came from reading summary lines instead of the per-part detail underneath them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaA2SsVAWiexez2NPepNmo
