### PR TITLE
fix(embervm): route the guest shim to the CLI its image actually ships

### DIFF
--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -3742,6 +3742,9 @@ class ProcessManager:
             return self.pi
         if isinstance(model, str) and model in CODEX_MODELS:
             return self.codex
+        configured_clis = getattr(self, "_prewarm_clis", ())
+        if "claude" not in configured_clis and len(configured_clis) == 1:
+            return getattr(self, configured_clis[0])
         return self.claude
 
     def ready(self):

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -753,6 +753,48 @@ def test_manager_routes_qwen_to_pi(tmp_path, monkeypatch):
     assert manager._adapter(None) is manager.claude
 
 
+def _adapter_manager(prewarm_clis):
+    manager = _new_process_manager()
+    manager._prewarm_clis = prewarm_clis
+    manager.claude = object()
+    manager.codex = object()
+    manager.pi = object()
+    return manager
+
+
+def test_manager_routes_unspecified_model_to_only_configured_cli():
+    manager = _adapter_manager(("pi",))
+
+    assert manager._adapter(None) is manager.pi
+
+
+def test_manager_routes_unspecified_model_to_claude_when_configured():
+    manager = _adapter_manager(("claude", "codex", "pi"))
+
+    assert manager._adapter(None) is manager.claude
+
+
+@pytest.mark.parametrize("prewarm_clis", [("pi",), ("claude", "codex", "pi")])
+def test_manager_explicit_model_routing_precedes_cli_fallback(prewarm_clis):
+    manager = _adapter_manager(prewarm_clis)
+    codex_model = next(iter(shim.CODEX_MODELS))
+
+    assert manager._adapter("qwen") is manager.pi
+    assert manager._adapter(codex_model) is manager.codex
+
+
+def test_manager_empty_configured_clis_fall_back_to_claude():
+    manager = _adapter_manager(())
+
+    assert manager._adapter(None) is manager.claude
+
+
+def test_manager_ambiguous_configured_clis_fall_back_to_claude():
+    manager = _adapter_manager(("codex", "pi"))
+
+    assert manager._adapter(None) is manager.claude
+
+
 def test_codex_first_turn_returns_thread_voice_and_usage(tmp_path, monkeypatch):
     manager = _codex_manager(tmp_path, monkeypatch)
     record = manager.turn("first", model="luna")
@@ -1236,6 +1278,7 @@ def _manager(tmp_path, monkeypatch, api_key="none"):
 
 def _new_process_manager():
     manager = object.__new__(shim.ProcessManager)
+    manager._prewarm_clis = ()
     manager._mount_lock = threading.Lock()
     manager._thread_factory = threading.Thread
     return manager


### PR DESCRIPTION
Fixes #5315.

`ProcessManager._adapter` fell back to a hardcoded `self.claude` for any model it did not recognise. That is a property of the binary name rather than of the guest image, so a `pi-runtime` session invoked without a `model` field returned:

```
422 {"error":"[Errno 2] No such file or directory: 'claude'"}
```

The pi-runtime image ships only `pi` (`projects/embervm/runtimes/pi/prewarm-clis`).

## Why it matters now

This is what conformance S2 hits immediately after banking starts working (#5296). S2 invokes a relit session to prove the relight happened, and `classifyInvokeResponse` passes on a 2xx or on a model-unreachable marker, because dev has no reachable model. A missing-binary 422 is neither, so S2 fails and the Kargo dev to prod gate stays red.

That the harness expects the pi adapter here is not an inference: one of its accepted markers is the pi-specific string `pi turn produced no output`.

## Change

Resolve the fallback against the CLIs the image actually carries, using the `_prewarm_clis` set `ProcessManager` already reads. When the image lists `claude` the behaviour is unchanged, so the claude-runtime guest (`claude,codex,pi`) is untouched. An image with exactly one CLI and no claude routes to that one. Empty or ambiguous multi-CLI sets keep the claude fallback rather than becoming unpredictable.

Explicit `qwen` and `CODEX_MODELS` routing keep priority over the fallback.

`getattr(self, name)` is safe here because `_read_prewarm_clis` raises `StartupError` on anything outside `SUPPORTED_PREWARM_CLIS`, and `ready()` already uses the same pattern.

## Verification

The regression test was falsified rather than assumed. With the test file unchanged and ONLY the three-line fix reverted:

```
projects/embervm/runtimes/claude/shim_test.py::test_manager_routes_unspecified_model_to_only_configured_cli FAILED
Executed 1 out of 137 tests: 136 tests pass and 1 fails remotely.
```

With the fix restored: `Executed 1 out of 139 tests: 139 tests pass.`

Five cases covered: single-CLI routing, claude-runtime unchanged, qwen and codex routing under both configurations, empty set, and the ambiguous multi-CLI set.

## Not this

Distinct from #5293/#5296 (banking) and #5300 (the control plane recycling a consumed vm_id). Fixing this alone will not turn the gate green; #5300 is the other half.
