### PR TITLE
fix(agents): hide qwen synthetics from console

### DIFF
--- a/projects/monolith/agent_sessions/api.py
+++ b/projects/monolith/agent_sessions/api.py
@@ -10,6 +10,7 @@ from sqlmodel import Session
 
 from agent_sessions import model_family, store
 from agent_sessions.codex_login import codex_login_gate, watch_for_login
+from agent_sessions.constants import SYNTHETIC_SESSION_PREFIX
 from agent_sessions.mcp import (
     _append_rationale_trailer,
     _clear_ember_bindings_for,
@@ -44,7 +45,7 @@ async def run_synthetic_session(prompt: str, model: str = "qwen"):
     model_family(model)
     row = await asyncio.to_thread(
         _persist_session,
-        str(uuid4()),
+        f"{SYNTHETIC_SESSION_PREFIX}{uuid4()}",
         "<guest>",
         "main",
         model,

--- a/projects/monolith/agent_sessions/api_test.py
+++ b/projects/monolith/agent_sessions/api_test.py
@@ -3,9 +3,40 @@ from sqlmodel import Session, SQLModel, create_engine
 
 import agent_sessions.api as api
 import agent_sessions.mcp as mcp
+from agent_sessions.constants import SYNTHETIC_SESSION_PREFIX
 from agent_sessions.models import AgentSession
 from agent_sessions.transport import EmberSessionGone
 from faas.embervm_client import EmberVMTransportError
+
+
+@pytest.mark.asyncio
+async def test_run_synthetic_session_marks_its_origin(monkeypatch):
+    local_ids = []
+
+    def persist(local_session_id, workspace, branch, model, repo):
+        local_ids.append(local_session_id)
+        return AgentSession(
+            id=1,
+            local_session_id=local_session_id,
+            workspace=workspace,
+            branch=branch,
+            model=model,
+            repo=repo,
+        )
+
+    async def fail_delivery(*args, **kwargs):
+        raise RuntimeError("synthetic failure")
+
+    monkeypatch.setattr(api, "_persist_session", persist)
+    monkeypatch.setattr(api, "_persist_pending_message", lambda *args: 1)
+    monkeypatch.setattr(api, "_mark_turn_error_sync", lambda *args: None)
+    monkeypatch.setattr(api._transport, "deliver", fail_delivery)
+
+    with pytest.raises(RuntimeError, match="synthetic failure"):
+        await api.run_synthetic_session("probe")
+
+    assert len(local_ids) == 1
+    assert local_ids[0].startswith(SYNTHETIC_SESSION_PREFIX)
 
 
 def test_start_session_for_swarm_retry_preserves_original_workflow_id(

--- a/projects/monolith/agent_sessions/constants.py
+++ b/projects/monolith/agent_sessions/constants.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 # This session node key is deliberately independent of configurable DRAINER_JOB_KIND.
 DRAINER_NODE_KEY = "qwen-drain"
 
+# Synthetic sessions are persisted for health debugging but are not operator
+# work, so console queries use this origin marker to keep them out of the UI.
+SYNTHETIC_SESSION_PREFIX = "synthetic:"
+QWEN_SYNTHETIC_PROMPT = "Reply with exactly: qwen synthetic ok"
+
 # Terminal reasons that mean the turn ended normally. The claude lane reports
 # "completed" or "end_turn"; the pi lane passes the model's raw stopReason
 # through, which is "stop" for a normal qwen turn (see runtimes/claude/shim.py).

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -22,6 +22,7 @@ from agent_sessions import (
     voice_ui,
 )
 from agent_sessions.codex_login import codex_login_gate, watch_for_login
+from agent_sessions.constants import QWEN_SYNTHETIC_PROMPT, SYNTHETIC_SESSION_PREFIX
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.mcp import (
     _append_rationale_trailer,
@@ -121,6 +122,19 @@ def _aggregate_statement(status: str | None = None, session_id: int | None = Non
         .outerjoin(pending, pending.c.session_id == AgentSession.id)
         .order_by(AgentSession.last_turn_at.desc())
     )
+    if session_id is None:
+        # Persisted health probes are useful for diagnosis by id, but they are
+        # not operator work and should not consume the console's recent list.
+        # The prompt clause also hides rows created before the origin prefix
+        # was introduced.
+        statement = statement.where(
+            ~AgentSession.local_session_id.startswith(SYNTHETIC_SESSION_PREFIX),
+            (func.coalesce(AgentSession.model, "") != "qwen")
+            | (
+                func.coalesce(first_turn_prompt, first_pending_prompt, "")
+                != QWEN_SYNTHETIC_PROMPT
+            ),
+        )
     if status is not None:
         statement = statement.where(AgentSession.status == status)
     return statement

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -14,6 +14,7 @@ from agent_sessions import mcp
 from agent_sessions import transport
 import agent_sessions.router as agent_router
 from agent_sessions.codex_login import codex_login_gate
+from agent_sessions.constants import QWEN_SYNTHETIC_PROMPT, SYNTHETIC_SESSION_PREFIX
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.router import router
 from core.db import get_session
@@ -108,6 +109,56 @@ def test_list_sessions_with_status_filter(client, session):
 
     body = client.get("/api/agents/sessions?status=completed").json()
     assert [item["local_session_id"] for item in body] == ["done"]
+
+
+def test_list_sessions_excludes_qwen_synthetics(client, session):
+    completed = _session(session, "legacy-completed", model="qwen")
+    pending = _session(session, "legacy-pending", model="qwen")
+    _session(
+        session,
+        f"{SYNTHETIC_SESSION_PREFIX}new",
+        model="qwen",
+        title="A changed future probe prompt",
+    )
+    ordinary_qwen = _session(session, "ordinary-qwen", model="qwen")
+    same_prompt_other_model = _session(session, "ordinary-luna", model="luna")
+    session.add_all(
+        [
+            AgentTurn(
+                session_id=completed.id,
+                seq=1,
+                prompt=QWEN_SYNTHETIC_PROMPT,
+                result_text="qwen synthetic ok",
+            ),
+            PendingMessage(
+                session_id=pending.id,
+                seq=1,
+                message_text=QWEN_SYNTHETIC_PROMPT,
+                model="qwen",
+            ),
+            AgentTurn(
+                session_id=ordinary_qwen.id,
+                seq=1,
+                prompt="Help with an ordinary task",
+                result_text="done",
+            ),
+            AgentTurn(
+                session_id=same_prompt_other_model.id,
+                seq=1,
+                prompt=QWEN_SYNTHETIC_PROMPT,
+                result_text="done",
+            ),
+        ]
+    )
+    session.commit()
+
+    body = client.get("/api/agents/sessions").json()
+
+    assert {item["local_session_id"] for item in body} == {
+        "ordinary-qwen",
+        "ordinary-luna",
+    }
+    assert client.get(f"/api/agents/sessions/{completed.id}").status_code == 200
 
 
 def test_models_endpoint_offers_everything_when_env_unset(client, monkeypatch):

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -11,6 +11,7 @@ from sqlalchemy import func, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
+from agent_sessions.constants import QWEN_SYNTHETIC_PROMPT, SYNTHETIC_SESSION_PREFIX
 from agent_sessions.models import (
     AgentSession,
     AgentTurn,
@@ -455,10 +456,23 @@ def lexical_search(session: Session, query_text: str, limit: int = 20) -> list[d
         "FROM agent_sessions.agent_turns t "
         "JOIN agent_sessions.agent_sessions s ON t.session_id = s.id, q "
         "WHERE t.fts_vector @@ q.q "
+        "AND s.local_session_id NOT LIKE :synthetic_prefix "
+        "AND NOT (COALESCE(s.model, '') = 'qwen' AND COALESCE(("
+        "SELECT first_turn.prompt FROM agent_sessions.agent_turns first_turn "
+        "WHERE first_turn.session_id = s.id ORDER BY first_turn.seq LIMIT 1"
+        "), '') = :qwen_synthetic_prompt) "
         "ORDER BY rank DESC, t.created_at DESC LIMIT :limit"
         ") AS ranked"
     )
-    result = session.exec(sql, params={"q": query_text, "limit": limit})
+    result = session.exec(
+        sql,
+        params={
+            "q": query_text,
+            "limit": limit,
+            "synthetic_prefix": f"{SYNTHETIC_SESSION_PREFIX}%",
+            "qwen_synthetic_prompt": QWEN_SYNTHETIC_PROMPT,
+        },
+    )
     keys = (
         "session_id",
         "local_session_id",

--- a/projects/monolith/agent_sessions/store_test.py
+++ b/projects/monolith/agent_sessions/store_test.py
@@ -7,7 +7,24 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, SQLModel, create_engine, select
 
 from agent_sessions import store
+from agent_sessions.constants import QWEN_SYNTHETIC_PROMPT, SYNTHETIC_SESSION_PREFIX
 from agent_sessions.models import AgentSession, PendingMessage
+
+
+def test_lexical_search_excludes_synthetic_sessions():
+    captured = {}
+
+    class FakeSession:
+        def exec(self, statement, params):
+            captured["sql"] = str(statement)
+            captured["params"] = params
+            return []
+
+    assert store.lexical_search(FakeSession(), "qwen") == []
+    assert "s.local_session_id NOT LIKE :synthetic_prefix" in captured["sql"]
+    assert "first_turn.session_id = s.id" in captured["sql"]
+    assert captured["params"]["synthetic_prefix"] == (f"{SYNTHETIC_SESSION_PREFIX}%")
+    assert captured["params"]["qwen_synthetic_prompt"] == QWEN_SYNTHETIC_PROMPT
 
 
 def _database(monkeypatch, tmp_path):

--- a/projects/monolith/ember_public/synthetic_probe.py
+++ b/projects/monolith/ember_public/synthetic_probe.py
@@ -279,9 +279,10 @@ async def probe_qwen() -> dict:
     started = perf_counter()
     try:
         from agent_sessions.api import run_synthetic_session
+        from agent_sessions.constants import QWEN_SYNTHETIC_PROMPT
 
         turn = await run_synthetic_session(
-            "Reply with exactly: qwen synthetic ok",
+            QWEN_SYNTHETIC_PROMPT,
             model="qwen",
         )
         if turn.terminal_reason not in {"completed", "stop"}:


### PR DESCRIPTION
## Summary

- mark newly persisted health-probe sessions with a synthetic origin prefix
- hide both marked and historical Qwen probe sessions from the Agents session list and turn search
- preserve direct session lookup for probe diagnostics

## Validation

- pre-push `ci test` passed using remote Linux execution
- `pytest -q projects/monolith/agent_sessions/store_test.py` passed, 11 tests
- `ruff check` and `ruff format --check` passed for all changed Python files
- `python3 -m compileall` passed for all changed Python files
- router and API pytest collection is unavailable locally because `pydantic_ai` is not installed