### PR TITLE
fix(embervm): drop a banked or destroyed vm from the dispatcher inventory

### DIFF
--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -160,6 +160,36 @@ defmodule Embervm.Dispatcher do
   end
 
   @doc """
+  Removes a VM consumed by another control-plane lifecycle path from the primed
+  inventory and its adoption-provenance set. The operation is idempotent, so an
+  unknown VM is a no-op. This is the targeted consumption seam from #5300.
+
+  This is synchronous so a placement after a confirmed consumption cannot race
+  stale dispatcher inventory.
+
+  The exit is caught deliberately. Both callers run inside the SessionManager's
+  serialized loop, where a GenServer.call that EXITS (a dispatcher busy enough to
+  exceed the call timeout) would take down session lifecycle for what is only a
+  bookkeeping cleanup. A timed-out call is still DELIVERED and still handled, so
+  swallowing the exit costs this one caller its synchronous guarantee and nothing
+  else: the drop still lands.
+  """
+  @spec drop_vm(GenServer.server(), String.t()) :: :ok
+  def drop_vm(server \\ __MODULE__, vm_id) do
+    case GenServer.whereis(server) do
+      nil ->
+        :ok
+
+      _pid ->
+        try do
+          GenServer.call(server, {:drop_vm, vm_id})
+        catch
+          :exit, _reason -> :ok
+        end
+    end
+  end
+
+  @doc """
   Whether `principal` may submit another task to `workload` without breaching its
   per-principal queue-depth cap. A read-only advisory check the router runs
   BEFORE the durable submit to 429; the actual reservation happens on `enqueue`,
@@ -322,6 +352,10 @@ defmodule Embervm.Dispatcher do
 
   @impl true
   def handle_call(:stats, _from, state), do: {:reply, snapshot(state), state}
+
+  def handle_call({:drop_vm, vm_id}, _from, state) do
+    {:reply, :ok, drop_vm_id(state, vm_id)}
+  end
 
   def handle_call(:sweep, _from, state) do
     {:reply, :ok, run_sweep(state)}
@@ -1440,6 +1474,22 @@ defmodule Embervm.Dispatcher do
   end
 
   defp put_vm_if_unknown(state, _node_id, _wl, _vm_id), do: state
+
+  defp drop_vm_id(state, vm_id) when is_binary(vm_id) do
+    inventory =
+      for {key, queue} <- state.inventory, into: %{} do
+        remaining = queue |> :queue.to_list() |> Enum.reject(&(&1 == vm_id))
+        {key, :queue.from_list(remaining)}
+      end
+
+    %{
+      state
+      | inventory: inventory,
+        adoption_vm_ids: MapSet.delete(state.adoption_vm_ids, vm_id)
+    }
+  end
+
+  defp drop_vm_id(state, _vm_id), do: state
 
   # Every vm_id the dispatcher currently holds: parked in any inventory queue, or
   # reserved by an in-flight assign worker. The dedup basis for inventory adds.

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -787,8 +787,8 @@ defmodule Embervm.SessionManager do
 
   # The async bank worker finished: complete the durable transition + failure
   # recovery on this (serialized) process. See finish_bank.
-  def handle_info({:bank_done, session_id, node_id, outcome}, state) do
-    {:noreply, finish_bank(state, session_id, node_id, outcome)}
+  def handle_info({:bank_done, session_id, node_id, vm_id, outcome}, state) do
+    {:noreply, finish_bank(state, session_id, node_id, vm_id, outcome)}
   end
 
   def handle_info({:create_done, ref, result}, state) do
@@ -1879,7 +1879,7 @@ defmodule Embervm.SessionManager do
           end
         end
 
-      send(owner, {:bank_done, session_id, node_id, outcome})
+      send(owner, {:bank_done, session_id, node_id, vm_id, outcome})
     end)
   end
 
@@ -1892,11 +1892,12 @@ defmodule Embervm.SessionManager do
   #     no snapshot written), count the relevant failure class, and either restart a
   #     session process (so it can serve invokes + retry) or fail + destroy the VM when
   #     that class reaches its limit.
-  defp finish_bank(state, session_id, node_id, outcome) do
+  defp finish_bank(state, session_id, node_id, vm_id, outcome) do
     state =
       state
       |> decr_bank_inflight(node_id)
       |> Map.update!(:banking, &Map.delete(&1, session_id))
+      |> drop_vm_after_bank(vm_id, outcome)
 
     case SessionStore.get(state.session_store, session_id) do
       # Destroying/destroyed/expired mid-bank: teardown or a terminal state already
@@ -1912,6 +1913,13 @@ defmodule Embervm.SessionManager do
         finish_bank_active(state, session_id, node_id, outcome)
     end
   end
+
+  defp drop_vm_after_bank(state, vm_id, {:ok, _ref, _size, _generation, _parent_base_ref}) do
+    :ok = Embervm.Dispatcher.drop_vm(state.dispatcher, vm_id)
+    state
+  end
+
+  defp drop_vm_after_bank(state, _vm_id, _outcome), do: state
 
   defp finish_bank_active(state, session_id, node_id, outcome) do
     case outcome do
@@ -4361,7 +4369,10 @@ defmodule Embervm.SessionManager do
 
         try do
           case destroy_fun.(channel, vm_id) do
-            {:ok, %{teardown_confirmed: true}} -> true
+            {:ok, %{teardown_confirmed: true}} ->
+              :ok = Embervm.Dispatcher.drop_vm(state.dispatcher, vm_id)
+              true
+
             _ -> false
           end
         rescue

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -350,6 +350,49 @@ defmodule Embervm.DispatcherTest do
     assert Dispatcher.stats(ctx.name).inventory[{"node-4", "wl-a"}] == 1
   end
 
+  test "dropping an unknown vm is a no-op" do
+    ctx = start_stack()
+    put_catalog(ctx, "wl-a", cap: 10)
+    Dispatcher.deposit(ctx.name, "node-4", "wl-a", "vm-kept")
+
+    assert :ok = Dispatcher.drop_vm(ctx.name, "vm-unknown")
+    assert Dispatcher.stats(ctx.name).inventory[{"node-4", "wl-a"}] == 1
+    assert {:ok, "vm-kept"} = Dispatcher.claim(ctx.name, "node-4", "wl-a")
+  end
+
+  test "dropping a vm returns ok instead of exiting when the dispatcher is too busy to reply" do
+    # Both callers run inside the SessionManager's serialized loop, so an exit
+    # here would take down session lifecycle for a bookkeeping cleanup. Stand in
+    # a process that never replies and assert drop_vm still returns :ok and
+    # leaves the caller alive.
+    # A dead pid exits :noproc immediately, which is the same catch the call
+    # timeout takes, without making the suite wait out the 5s default.
+    dead = spawn(fn -> :ok end)
+    ref = Process.monitor(dead)
+    assert_receive {:DOWN, ^ref, :process, ^dead, _}
+
+    assert :ok = Dispatcher.drop_vm(dead, "vm-consumed")
+    assert Process.alive?(self())
+  end
+
+  test "dropping an adopted vm clears provenance and later adoption still works" do
+    ctx = start_stack()
+    put_catalog(ctx, "wl-a", cap: 10)
+    put_facts(ctx, "wl-a", free: 1, primed_ids: ["vm-consumed"], live: 1, max: 8)
+
+    Dispatcher.sweep(ctx.name)
+    assert MapSet.member?(:sys.get_state(ctx.disp).adoption_vm_ids, "vm-consumed")
+
+    assert :ok = Dispatcher.drop_vm(ctx.name, "vm-consumed")
+    refute MapSet.member?(:sys.get_state(ctx.disp).adoption_vm_ids, "vm-consumed")
+    assert Dispatcher.stats(ctx.name).inventory[{"node-4", "wl-a"}] == 0
+
+    put_facts(ctx, "wl-a", free: 1, primed_ids: ["vm-new"], live: 1, max: 8)
+    Dispatcher.sweep(ctx.name)
+
+    assert {:ok, "vm-new"} = Dispatcher.claim(ctx.name, "node-4", "wl-a")
+  end
+
   test "a miss worker's just-primed vm is not re-adopted while its assign is in flight" do
     gate = new_gate()
     parent = self()

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -13,7 +13,7 @@ defmodule Embervm.SessionManagerTest do
   """
   use ExUnit.Case, async: false
 
-  alias Embervm.{NodeCapacity, SessionManager, SessionStore, WorkloadCatalog}
+  alias Embervm.{Dispatcher, NodeCapacity, SessionManager, SessionStore, TaskStore, WorkloadCatalog}
   alias Embervm.KeyService.Envelope
   alias Embervm.OpLog.SQLite
   alias Embervm.Node.V1.{BankResponse, GuestResponse, PrimeResponse, RelightResponse, SessionAssignResponse, UsageStats}
@@ -124,6 +124,7 @@ defmodule Embervm.SessionManagerTest do
       [
         name: nil,
         session_store: store,
+        dispatcher: Keyword.get(opts, :dispatcher, Embervm.Dispatcher),
         supervisor: sup,
         registry: registry,
         capacity_table: cap_table,
@@ -195,7 +196,7 @@ defmodule Embervm.SessionManagerTest do
           free_primed_slots: 1,
           snapshot_ref: "snap-#{wl}",
           base_state: :BASE_BUILD_STATE_READY,
-          primed_vm_ids: []
+          primed_vm_ids: Keyword.get(opts, :primed_ids, [])
         }
       },
       live_vms: Keyword.get(opts, :live, 0),
@@ -246,6 +247,31 @@ defmodule Embervm.SessionManagerTest do
   end
 
   defp fake_claim_fun(vm_id), do: fn _dispatcher, _node, _workload -> {:ok, vm_id} end
+
+  defp start_dispatcher(ctx, name) do
+    suffix = System.unique_integer([:positive])
+    depth_table = :"session_disp_depth_#{suffix}"
+
+    {:ok, task_store} =
+      TaskStore.start_link(
+        name: nil,
+        op_log: ctx.op_log,
+        on_queued: fn task -> Dispatcher.enqueue(name, task) end
+      )
+
+    {:ok, dispatcher} =
+      Dispatcher.start_link(
+        name: name,
+        task_store: task_store,
+        capacity_table: ctx.cap_table,
+        catalog_table: ctx.cat_table,
+        depth_table: depth_table,
+        clock: fn -> 5_000_000 end,
+        start_sweep: false
+      )
+
+    %{pid: dispatcher, name: name, task_store: task_store}
+  end
 
   defp fake_prime_fun(vm_id), do: fn _channel, _req -> {:ok, %PrimeResponse{vm_id: vm_id}} end
 
@@ -485,6 +511,63 @@ defmodule Embervm.SessionManagerTest do
     assert :ok = SessionManager.bank(ctx.mgr, created.session_id)
     assert wait_for_state(ctx, created.session_id, :banked).state == :banked
     assert_receive {:bank_dialed, "node-4/bank-owner"}
+  end
+
+  test "a successful bank drops stale dispatcher inventory before another placement" do
+    dispatcher_name = :"bank_inventory_dispatcher_#{System.unique_integer([:positive])}"
+
+    ctx =
+      start_stack(
+        dispatcher: dispatcher_name,
+        claim_fun: &Dispatcher.claim/3
+      )
+
+    dispatcher = start_dispatcher(ctx, dispatcher_name)
+    put_session_workload(ctx, "wl-bank-inventory", primed_ids: ["vm-banked"], live: 1)
+
+    Dispatcher.sweep(dispatcher.name)
+    assert Dispatcher.stats(dispatcher.name).inventory[{"node-4", "wl-bank-inventory"}] == 1
+
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-bank-inventory", "p1")
+
+    # The node status still advertises the claimed VM until Bank adopts it into
+    # the session registry. A sweep during that window re-adopts the stale copy.
+    Dispatcher.sweep(dispatcher.name)
+    assert Dispatcher.stats(dispatcher.name).inventory[{"node-4", "wl-bank-inventory"}] == 1
+
+    assert :ok = SessionManager.bank(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :banked).state == :banked
+
+    assert Dispatcher.stats(dispatcher.name).inventory[{"node-4", "wl-bank-inventory"}] == 0
+    assert :miss = Dispatcher.claim(dispatcher.name, "node-4", "wl-bank-inventory")
+
+    put_session_workload(ctx, "wl-bank-inventory", primed_ids: ["vm-new"], live: 1)
+    Dispatcher.sweep(dispatcher.name)
+    assert {:ok, "vm-new"} = Dispatcher.claim(dispatcher.name, "node-4", "wl-bank-inventory")
+  end
+
+  test "a confirmed destroy drops stale dispatcher inventory" do
+    dispatcher_name = :"destroy_inventory_dispatcher_#{System.unique_integer([:positive])}"
+
+    ctx =
+      start_stack(
+        dispatcher: dispatcher_name,
+        claim_fun: &Dispatcher.claim/3
+      )
+
+    dispatcher = start_dispatcher(ctx, dispatcher_name)
+    put_session_workload(ctx, "wl-destroy-inventory", primed_ids: ["vm-destroyed"], live: 1)
+
+    Dispatcher.sweep(dispatcher.name)
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-destroy-inventory", "p1")
+    Dispatcher.sweep(dispatcher.name)
+    assert Dispatcher.stats(dispatcher.name).inventory[{"node-4", "wl-destroy-inventory"}] == 1
+
+    assert {:ok, _} = SessionManager.destroy(ctx.mgr, created.session_id)
+    assert wait_for_state(ctx, created.session_id, :destroyed).state == :destroyed
+
+    assert Dispatcher.stats(dispatcher.name).inventory[{"node-4", "wl-destroy-inventory"}] == 0
+    assert :miss = Dispatcher.claim(dispatcher.name, "node-4", "wl-destroy-inventory")
   end
 
   test "a bank dial miss returns to running without counting a strike" do


### PR DESCRIPTION
Fixes #5300.

`adopt_inventory` in `dispatcher.ex` is additive only, and deliberately so. Its own comment gives the reason a blanket drop on a status read would be wrong: a vm_id reserved for an in-flight assign is still reported primed by the node until the Assign lands, so dropping on status would race the reserve and could double-dispatch.

Since #5296 a `Bank` adopts a primed session VM, and `claimForSession` DELETES that vm_id from noded's task registry, so noded stops advertising it. The control plane kept it forever and dispatched a later session onto a vm_id that exists in neither of noded's registries. Its idle bank then failed three times 20s apart until the session went terminal `failed`. The recovery the comment relies on, "one failed-then-retried assign", does not exist on the bank path.

## Live evidence

Alternating conformance results in embervm-dev on 2026-08-25, noded stable throughout:

```
13:05  S2 fail (guest 422, #5315)        bank SUCCEEDED, consumed the primed VM
13:35  S2 vacuous "bank never observed"  dispatched onto the consumed vm_id
14:06  S2 fail (guest 422, #5315)        primed fresh, bank succeeded again
```

In the 13:35 cycle `adopt_idempotent` is back to `vacuous(coverage=0)` and `prime_before_checkpoint` to `vacuous(coverage=13)`, the pre-#5296 pattern.

## Change

Drop the vm_id where the control plane KNOWS it consumed the VM, rather than inferring a removal from a status snapshot:

- a successful bank, via the `vm_id` now carried in the `{:bank_done, ...}` completion message
- a confirmed destroy, which had the same staleness and no existing removal

Both are consumption events the control plane performed itself, so no in-flight assign can be racing them. `adopt_inventory` stays additive and the reserve race it guards against stays guarded (there is a test for that).

The removal is idempotent: an unknown vm_id is a no-op.

## On the synchronous call

`drop_vm` is a `GenServer.call` so a placement after a confirmed consumption cannot race stale inventory, but its exit is caught. Both callers run inside the SessionManager's serialized loop, where a `GenServer.call` that EXITS (a dispatcher busy enough to exceed the call timeout) would take down session lifecycle for what is only a bookkeeping cleanup. This file already carries a comment about being bitten by exactly that hazard on the node-channel call.

Catching costs nothing functionally: a timed-out call is still delivered and still handled, so the drop lands either way. Only this one caller loses its synchronous guarantee, in the rare case where it was going to crash instead.

## Verification

The regression tests were falsified rather than assumed. With the tests unchanged and ONLY `drop_vm_id`'s body neutered (API kept, so failures are assertions rather than a compile error):

```
1) test dropping an adopted vm clears provenance and later adoption still works (Embervm.DispatcherTest)
2) test a successful bank drops stale dispatcher inventory before another placement (Embervm.SessionManagerTest)
3) test a confirmed destroy drops stale dispatcher inventory (Embervm.SessionManagerTest)
1518 tests, 3 failures, 22 skipped
```

Restored: `1518 tests, 0 failures, 22 skipped`.

Note for reviewers: `ci test` gives NO signal on this suite. The ExUnit suite is a genrule, so `bazel test` reports "Found 1 target and 0 test targets" and the run looks cached-green. It has to be built (`bb remote ... build //bazel/erlang:mix_test_smoke`) and judged by its `N tests, N failures` line.

## Not this

#5319 fixes the guest shim routing that S2 hits next. Neither PR turns the gate green alone.
