### PR TITLE
fix(embervm): adopt a sibling brick's published base instead of wedging BuildBase

### DIFF
--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -1437,7 +1437,21 @@ func (d *Driver) SnapshotBase(ctx context.Context, h substrate.Handle, baseKey s
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: publish base snapfile: %w", err)
 	}
 	if err := os.Rename(buildingDir, finalDir); err != nil {
-		return substrate.SnapshotRef{}, fmt.Errorf("driver: publish base bundle: %w", err)
+		// #4866: co-located bricks share this scratch dir but not their
+		// per-process base registries, so two bricks can be handed the SAME
+		// BuildBase while only one wins the publish. Resolve the collision
+		// instead of wedging on it (every control-plane retry would otherwise
+		// burn a full multi-minute build VM and die at this same rename).
+		adopted, cerr := resolveBasePublishCollision(buildingDir, finalDir)
+		if cerr != nil {
+			return substrate.SnapshotRef{}, fmt.Errorf("driver: publish base bundle: %w", errors.Join(err, cerr))
+		}
+		if !adopted {
+			// The destination was cleared as stale; retry the publish once.
+			if rerr := os.Rename(buildingDir, finalDir); rerr != nil {
+				return substrate.SnapshotRef{}, fmt.Errorf("driver: publish base bundle: %w", rerr)
+			}
+		}
 	}
 	return substrate.SnapshotRef{
 		ID:        baseKey,
@@ -1448,6 +1462,54 @@ func (d *Driver) SnapshotBase(ctx context.Context, h substrate.Handle, baseKey s
 		Base:      true,
 		SizeBytes: bundleSize(filepath.Join(finalDir, "snapfile"), filepath.Join(finalDir, "memfile")),
 	}, nil
+}
+
+// baseBundlePublished reports whether dir holds a fully published base bundle:
+// BOTH memfile and snapfile present as regular files. The publish discipline
+// writes memfile before snapfile and the directory itself only after both (a
+// restore reads the snapfile to locate the memfile), so their co-presence under
+// a final dir is exactly the "this bundle finished publishing" marker. imageref
+// is deliberately NOT required: the server writes it AFTER SnapshotBase returns,
+// so a sibling's just-published bundle can legitimately lack it for a moment;
+// requiring it here would misclassify that bundle as stale and destroy a
+// sibling's work (#4866).
+func baseBundlePublished(dir string) bool {
+	for _, name := range []string{"memfile", "snapfile"} {
+		fi, err := os.Lstat(filepath.Join(dir, name))
+		if err != nil || fi.IsDir() {
+			return false
+		}
+	}
+	return true
+}
+
+// resolveBasePublishCollision resolves rename(buildingDir, finalDir) failing
+// because finalDir already exists (#4866). It returns adopted=true when the
+// destination is a COMPLETE sibling bundle this build should adopt: the caller
+// then discards its redundant staging copy and reports success against the
+// sibling's bytes (same baseKey means same image+revision+vendor, so the two
+// bundles are interchangeable). An incomplete destination is stale debris from
+// an older incarnation or a crashed publish; it is removed so the caller's
+// retry can succeed, never wedged on. A missing or non-dir destination means
+// the original error was not an occupancy collision at all: it is returned so
+// the caller surfaces it unchanged.
+func resolveBasePublishCollision(buildingDir, finalDir string) (adopted bool, err error) {
+	fi, statErr := os.Lstat(finalDir)
+	if statErr != nil || !fi.IsDir() {
+		return false, statErr
+	}
+	if baseBundlePublished(finalDir) {
+		if rmErr := os.RemoveAll(buildingDir); rmErr != nil {
+			return false, fmt.Errorf("discard redundant staging bundle: %w", rmErr)
+		}
+		slog.Info("driver: adopting sibling-published base bundle",
+			"base", filepath.Base(finalDir))
+		return true, nil
+	}
+	if rmErr := os.RemoveAll(finalDir); rmErr != nil {
+		return false, fmt.Errorf("remove stale destination bundle: %w", rmErr)
+	}
+	return false, nil
 }
 
 // RemoveBaseBundle deletes a warm base's on-disk bundle (when a base is

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -790,6 +790,107 @@ func TestDriverClaimFromMissingBaseErrors(t *testing.T) {
 	}
 }
 
+// TestDriverSnapshotBaseAdoptsSiblingBundle proves the #4866 publish-collision
+// adoption: when a co-located sibling brick published the SAME base bundle
+// while this process was building, the rename collision is resolved as ADOPTION
+// (success against the sibling's bytes), never a permanent "file exists"
+// failure. The sibling's imageref sidecar is deliberately omitted from the
+// just-published subtest: the server writes it only after SnapshotBase returns,
+// so a complete memfile+snapfile pair alone must count as published.
+func TestDriverSnapshotBaseAdoptsSiblingBundle(t *testing.T) {
+	for _, tc := range []struct{ name string }{
+		{"published"},
+		{"just-published-no-imageref-yet"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			d := testDriver(t)
+			h, err := d.Claim(ctx, substrate.ClaimSpec{ThreadID: "wedge"})
+			if err != nil {
+				t.Fatalf("Claim: %v", err)
+			}
+
+			const key = "wl__sibling00"
+			siblingDir := d.baseDir(key)
+			if err := os.MkdirAll(siblingDir, 0o750); err != nil {
+				t.Fatalf("mkdir sibling dir: %v", err)
+			}
+			files := map[string]string{"memfile": "SIBLING-mem", "snapfile": "SIBLING-snap"}
+			if tc.name == "published" {
+				files["imageref"] = "img:1"
+			}
+			for name, content := range files {
+				if err := os.WriteFile(filepath.Join(siblingDir, name), []byte(content), 0o600); err != nil {
+					t.Fatalf("write sibling %s: %v", name, err)
+				}
+			}
+
+			ref, err := d.SnapshotBase(ctx, h, key)
+			if err != nil {
+				t.Fatalf("SnapshotBase must adopt the sibling bundle, got error: %v", err)
+			}
+			if !ref.Base || ref.ID != key || ref.SizeBytes == 0 {
+				t.Errorf("adopted ref = %+v, want Base with the key and a size", ref)
+			}
+			if _, err := os.Stat(siblingDir + ".building"); !os.IsNotExist(err) {
+				t.Errorf("redundant staging dir still exists, stat err=%v", err)
+			}
+			for _, f := range []string{"memfile", "snapfile"} {
+				got, rerr := os.ReadFile(filepath.Join(siblingDir, f))
+				if rerr != nil || string(got) != files[f] {
+					t.Errorf("sibling %s = %q (%v), want untouched %q", f, got, rerr, files[f])
+				}
+			}
+			if err := d.Release(ctx, h); err != nil {
+				t.Fatalf("Release: %v", err)
+			}
+		})
+	}
+}
+
+// TestDriverSnapshotBaseClearsStaleDestinationAndPublishes proves the other
+// #4866 collision branch: an INCOMPLETE destination (debris from an older
+// incarnation or a crashed publish) is removed and the publish proceeds, so a
+// stale dir never wedges a legitimate build at the rename.
+func TestDriverSnapshotBaseClearsStaleDestinationAndPublishes(t *testing.T) {
+	ctx := context.Background()
+	d := testDriver(t)
+	h, err := d.Claim(ctx, substrate.ClaimSpec{ThreadID: "wedge-stale"})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	const key = "wl__stale00001"
+	staleDir := d.baseDir(key)
+	if err := os.MkdirAll(staleDir, 0o750); err != nil {
+		t.Fatalf("mkdir stale dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staleDir, "memfile"), []byte("STALE"), 0o600); err != nil {
+		t.Fatalf("write stale memfile: %v", err)
+	}
+
+	ref, err := d.SnapshotBase(ctx, h, key)
+	if err != nil {
+		t.Fatalf("SnapshotBase must clear the stale destination and publish, got error: %v", err)
+	}
+	if !ref.Base || ref.ID != key || ref.SizeBytes == 0 {
+		t.Errorf("ref = %+v, want Base with the key and a size", ref)
+	}
+	gotMem, merr := os.ReadFile(filepath.Join(staleDir, "memfile"))
+	if merr != nil || string(gotMem) != "mem-image-bytes" {
+		t.Errorf("final memfile = %q (%v), want the fresh publish", gotMem, merr)
+	}
+	if _, serr := os.Stat(filepath.Join(staleDir, "snapfile")); serr != nil {
+		t.Errorf("final snapfile missing: %v", serr)
+	}
+	if _, serr := os.Stat(staleDir + ".building"); !os.IsNotExist(serr) {
+		t.Errorf("staging dir still exists, stat err=%v", serr)
+	}
+	if err := d.Release(ctx, h); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+}
+
 // TestDriverSessionSnapshotRestoreRoundTrip proves the R2 session bank/relight
 // mechanic on the real driver: snapshot a live session VM into a self-contained
 // bundle under sessions/<ref> (SnapshotSession, no resume, so the caller destroys),

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -781,6 +781,14 @@ func (s *Server) driveBuild(ctx context.Context, req *nodev1.BuildBaseRequest, b
 			AlreadyBuilt:  true,
 		}, nil
 	}
+	// #4866: a co-located sibling brick shares this scratch dir but not this
+	// per-process registry, so ITS completed build is invisible above. Adopt a
+	// complete bundle for this exact key from disk BEFORE booting anything: a
+	// rebuild would spend a full multi-minute build guest only to collide with
+	// the same bundle at the publish rename.
+	if resp, ok := s.adoptSiblingBaseBundle(baseKey, workload, imageDigest, img.RootfsPath, readyPath); ok {
+		return resp, nil
+	}
 	// Serialize builds per key. A concurrent duplicate is rejected rather than
 	// double-booting a build guest.
 	if !s.bases.beginBuild(baseKey, workload, img.RootfsPath, readyPath) {
@@ -877,6 +885,66 @@ func (s *Server) driveBuild(ctx context.Context, req *nodev1.BuildBaseRequest, b
 		AlreadyBuilt:    false,
 		ServingImageRef: servingImageRef,
 	}, nil
+}
+
+// adoptSiblingBaseBundle adopts a COMPLETE base bundle published on shared
+// scratch by a co-located sibling brick (#4866) and reports it as an
+// AlreadyBuilt hit. The baseKey is a pure function of (workload, image identity,
+// revision, vendor), so a complete bundle at that key IS this build's output:
+// the request's imageDigest and rootfsPath are exactly what the sibling recorded.
+// Adoption registers READY (as ReconcileBasesFromDisk would) and returns true;
+// false means "no complete bundle" or "complete but not adoptable HERE", and the
+// caller proceeds with a normal build. The checks mirror reconcile's adoption
+// gates: the same completeness rule as the inventory scan (isCompleteBase), the
+// register-time snapshot-format validation (#4407: never adopt a snapshot this
+// node cannot load), and the rootfs rule (a recorded-but-missing backing rootfs
+// cannot restore; an unrecorded path stays adoptable).
+func (s *Server) adoptSiblingBaseBundle(baseKey, workload, imageDigest, rootfsPath, readyPath string) (*nodev1.BuildBaseResponse, bool) {
+	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", baseKey)
+	if !isCompleteBase(dir, nodev1.BaseBuildState_BASE_BUILD_STATE_UNSPECIFIED) {
+		return nil, false
+	}
+	snapfile := filepath.Join(dir, "snapfile")
+	if refusal := s.snapshotFormatRefusal(snapfile); refusal != "" {
+		s.logger.Warn("noded: declining to adopt sibling base bundle with unusable snapshot format",
+			"base", baseKey, "reason", refusal)
+		return nil, false
+	}
+	if rootfsPath != "" {
+		if _, err := os.Stat(rootfsPath); err != nil {
+			s.logger.Warn("noded: declining to adopt sibling base bundle with missing rootfs",
+				"base", baseKey, "rootfs", rootfsPath, "err", err)
+			return nil, false
+		}
+	}
+	fi, err := os.Stat(snapfile)
+	if err != nil {
+		return nil, false
+	}
+	size := fi.Size()
+	if mfi, err := os.Stat(filepath.Join(dir, "memfile")); err == nil {
+		size += mfi.Size()
+	}
+	s.bases.register(baseEntry{
+		snapshotRef:     baseKey,
+		workload:        workload,
+		imageDigest:     imageDigest,
+		rootfsPath:      rootfsPath,
+		readyPath:       readyPath,
+		sizeBytes:       size,
+		createdAtUnixMs: baseCreatedAtUnixMs(dir),
+		state:           nodev1.BaseBuildState_BASE_BUILD_STATE_READY,
+	})
+	s.signalChange()
+	s.logger.Info("noded: adopted sibling-published base bundle",
+		"base", baseKey, "size_bytes", size)
+	return &nodev1.BuildBaseResponse{
+		SnapshotRef:   baseKey,
+		ImageDigest:   imageDigest,
+		BaseSizeBytes: uint64(size),
+		Arch:          s.cfg.Arch,
+		AlreadyBuilt:  true,
+	}, true
 }
 
 // runBuild cold-boots a build guest, (for the zip lane) hydrates it with the

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -1005,11 +1005,18 @@ func TestBuildBaseUnknownImage(t *testing.T) {
 // instead of spending a multi-minute rebuild that would collide at publish.
 func TestBuildBaseAdoptsSiblingBundleFromDisk(t *testing.T) {
 	build := &fakeDriver{}
+	// The backing rootfs must EXIST: adoption declines a bundle whose recorded
+	// rootfs is missing (it could not restore), so a nonexistent path here would
+	// silently exercise the decline path instead of the adoption path.
+	rootfs := filepath.Join(t.TempDir(), "rootfs.ext4")
+	if err := os.WriteFile(rootfs, []byte("rootfs"), 0o600); err != nil {
+		t.Fatalf("write rootfs: %v", err)
+	}
 	s := New(Options{
 		Config: config.Config{
 			Arch: "amd64", Node: "node-4", SnapshotRoot: t.TempDir(),
 			BootReadyTimeout: time.Second,
-			Images:           map[string]config.Image{"img:1": {RootfsPath: "/rootfs.ext4"}},
+			Images:           map[string]config.Image{"img:1": {RootfsPath: rootfs}},
 		},
 		Driver:         &fakeDriver{},
 		Transport:      &fakeTransport{},
@@ -1061,7 +1068,7 @@ func TestBuildBaseAdoptsSiblingBundleFromDisk(t *testing.T) {
 	if !ok || entry.state != nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
 		t.Errorf("registry entry = %+v ok=%v, want READY", entry, ok)
 	} else {
-		if entry.imageDigest != "img:1" || entry.rootfsPath != "/rootfs.ext4" || entry.workload != "echo" {
+		if entry.imageDigest != "img:1" || entry.rootfsPath != rootfs || entry.workload != "echo" {
 			t.Errorf("registry entry identity = %+v, want request-derived values", entry)
 		}
 	}
@@ -1080,11 +1087,18 @@ func TestBuildBaseAdoptsSiblingBundleFromDisk(t *testing.T) {
 // cleared by the driver at publish time (covered driver-side).
 func TestBuildBaseIncompleteBundleFallsThroughToBuild(t *testing.T) {
 	build := &fakeDriver{}
+	// The backing rootfs must EXIST: adoption declines a bundle whose recorded
+	// rootfs is missing (it could not restore), so a nonexistent path here would
+	// silently exercise the decline path instead of the adoption path.
+	rootfs := filepath.Join(t.TempDir(), "rootfs.ext4")
+	if err := os.WriteFile(rootfs, []byte("rootfs"), 0o600); err != nil {
+		t.Fatalf("write rootfs: %v", err)
+	}
 	s := New(Options{
 		Config: config.Config{
 			Arch: "amd64", Node: "node-4", SnapshotRoot: t.TempDir(),
 			BootReadyTimeout: time.Second,
-			Images:           map[string]config.Image{"img:1": {RootfsPath: "/rootfs.ext4"}},
+			Images:           map[string]config.Image{"img:1": {RootfsPath: rootfs}},
 		},
 		Driver:         &fakeDriver{},
 		Transport:      &fakeTransport{},

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -997,6 +997,129 @@ func TestBuildBaseUnknownImage(t *testing.T) {
 	}
 }
 
+// TestBuildBaseAdoptsSiblingBundleFromDisk proves the #4866 adoption gate: a
+// co-located sibling brick shares this node's scratch dir but not this
+// process's base registry, so its completed build is invisible to the registry
+// short-circuit. A COMPLETE bundle at this request's derived key must be
+// adopted READY and reported already_built WITHOUT booting a build guest,
+// instead of spending a multi-minute rebuild that would collide at publish.
+func TestBuildBaseAdoptsSiblingBundleFromDisk(t *testing.T) {
+	build := &fakeDriver{}
+	s := New(Options{
+		Config: config.Config{
+			Arch: "amd64", Node: "node-4", SnapshotRoot: t.TempDir(),
+			BootReadyTimeout: time.Second,
+			Images:           map[string]config.Image{"img:1": {RootfsPath: "/rootfs.ext4"}},
+		},
+		Driver:         &fakeDriver{},
+		Transport:      &fakeTransport{},
+		NewBuildDriver: func(BuildDriverSpec) BuildDriver { return build },
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	baseKey := baseKeyFor("echo", "img:1", "r1", s.cfg.CpuVendor)
+	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", baseKey)
+	memBytes := strings.Repeat("m", 100)
+	snapBytes := strings.Repeat("s", 50)
+	for name, content := range map[string]string{
+		"imageref": "img:1",
+		"memfile":  memBytes,
+		"snapfile": snapBytes,
+	} {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatalf("mkdir bundle dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("write sibling %s: %v", name, err)
+		}
+	}
+
+	resp, err := s.BuildBase(context.Background(), &nodev1.BuildBaseRequest{
+		Trace:            &nodev1.Trace{Workload: "echo"},
+		ImageRef:         "img:1",
+		WorkloadRevision: "r1",
+		ReadyPath:        "/shim/ready",
+	})
+	if err != nil {
+		t.Fatalf("BuildBase: %v", err)
+	}
+	if !resp.GetAlreadyBuilt() || resp.GetSnapshotRef() != baseKey {
+		t.Errorf("resp = %+v, want already_built=true with ref %q", resp, baseKey)
+	}
+	if resp.GetImageDigest() != "img:1" {
+		t.Errorf("image_digest = %q, want img:1 from the request identity", resp.GetImageDigest())
+	}
+	if resp.GetBaseSizeBytes() != uint64(len(memBytes)+len(snapBytes)) {
+		t.Errorf("base_size_bytes = %d, want %d", resp.GetBaseSizeBytes(), len(memBytes)+len(snapBytes))
+	}
+	// No build guest was ever booted.
+	if claims, _, _, _ := build.counts(); claims != 0 || build.snapshots != 0 {
+		t.Errorf("build driver claims=%d snapshots=%d, want 0/0 (no guest booted)", claims, build.snapshots)
+	}
+	// The adopted bundle is registered READY so WatchNode advertises it and the
+	// registry short-circuit serves later repeats without re-touching disk.
+	entry, ok := s.bases.get(baseKey)
+	if !ok || entry.state != nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
+		t.Errorf("registry entry = %+v ok=%v, want READY", entry, ok)
+	} else {
+		if entry.imageDigest != "img:1" || entry.rootfsPath != "/rootfs.ext4" || entry.workload != "echo" {
+			t.Errorf("registry entry identity = %+v, want request-derived values", entry)
+		}
+	}
+	// The sibling's bytes were adopted, not disturbed.
+	for name, content := range map[string]string{"imageref": "img:1", "memfile": memBytes, "snapfile": snapBytes} {
+		got, rerr := os.ReadFile(filepath.Join(dir, name))
+		if rerr != nil || string(got) != content {
+			t.Errorf("bundle %s = %q (%v), want untouched %q", name, got, rerr, content)
+		}
+	}
+}
+
+// TestBuildBaseIncompleteBundleFallsThroughToBuild proves an INCOMPLETE on-disk
+// bundle never adopts (#4866 acceptance): a dir missing its snapfile fails the
+// completeness rule, so the build proceeds normally. The stale debris itself is
+// cleared by the driver at publish time (covered driver-side).
+func TestBuildBaseIncompleteBundleFallsThroughToBuild(t *testing.T) {
+	build := &fakeDriver{}
+	s := New(Options{
+		Config: config.Config{
+			Arch: "amd64", Node: "node-4", SnapshotRoot: t.TempDir(),
+			BootReadyTimeout: time.Second,
+			Images:           map[string]config.Image{"img:1": {RootfsPath: "/rootfs.ext4"}},
+		},
+		Driver:         &fakeDriver{},
+		Transport:      &fakeTransport{},
+		NewBuildDriver: func(BuildDriverSpec) BuildDriver { return build },
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	baseKey := baseKeyFor("echo", "img:1", "r1", s.cfg.CpuVendor)
+	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", baseKey)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir stale dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "memfile"), []byte("STALE"), 0o600); err != nil {
+		t.Fatalf("write stale memfile: %v", err)
+	}
+
+	resp, err := s.BuildBase(context.Background(), &nodev1.BuildBaseRequest{
+		Trace:            &nodev1.Trace{Workload: "echo"},
+		ImageRef:         "img:1",
+		WorkloadRevision: "r1",
+		ReadyPath:        "/shim/ready",
+	})
+	if err != nil {
+		t.Fatalf("BuildBase: %v", err)
+	}
+	if resp.GetAlreadyBuilt() {
+		t.Errorf("resp = %+v, want a fresh build (already_built=false)", resp)
+	}
+	if claims, _, _, _ := build.counts(); claims != 1 || build.snapshots != 1 {
+		t.Errorf("build driver claims=%d snapshots=%d, want 1/1 (stale dir must not adopt)", claims, build.snapshots)
+	}
+	if entry, ok := s.bases.get(baseKey); !ok || entry.state != nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
+		t.Errorf("registry entry = %+v ok=%v, want READY after the build", entry, ok)
+	}
+}
+
 // newZipTestServer wires a Server for the zip lane: a build driver recorder, a
 // fake transport (the hydrate seam), a fake archive HTTP server serving
 // archiveBytes, and the runtime image provisioned in the config table. Returns the


### PR DESCRIPTION
Closes #4866.

Co-located bricks share the node's base scratch but keep per-process registries, so a sibling's completed build was invisible to both the BuildBase idempotency gate and the publish rename: every control-plane retry burned a full multi-minute build guest and died at `rename(bases/<key>.building, bases/<key>)` with "file exists" until a pod restart finally rescanned the bundle.

Two layers:

- `driveBuild` adopts a COMPLETE bundle for the same derived key straight off disk (same completeness rule as the inventory scan, plus the #4407 snapshot-format check and the rootfs rule) and reports `AlreadyBuilt` without booting anything.
- `SnapshotBase` resolves a publish collision instead of failing on it: a complete destination is adopted, a stale one is cleared and the rename retried.

Review notes: the worker skipped local verification, and its own new test then failed in CI (adoption declined because the fixture's `RootfsPath` pointed at a nonexistent `/rootfs.ext4`, so a build guest still booted). Fixed here in follow-up commits: the fixture now creates a real backing rootfs, and the identity assertion compares against it. The feature itself is confirmed by that same test now passing: adoption fires, the bundle registers READY at the sibling's size, and the build driver records zero claims and zero snapshots.

pr-checks and semgrep green.

Implemented by ox-alpha via opencode, corrected and reviewed on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iEUSJoVU6sZhjAxqAhT5K