### PR TITLE
fix(monolith): keep non-run workflows out of the swarm master view

### DIFF
--- a/projects/monolith/swarm/view.py
+++ b/projects/monolith/swarm/view.py
@@ -620,6 +620,22 @@ def compose_master(
     else:
         kwargs.update(limit=limit, sort_desc=True)
     statuses = list(dbos.list_workflows(**kwargs) or [])
+
+    # The DBOS registry also holds non-run workflows (the qwen drain_cycle),
+    # whose input has none of the run shape compose_run assumes. A workflow
+    # that names itself something other than implement_then_review is not a
+    # swarm run; one with no name at all is kept and the per-run shape guard
+    # below decides.
+    def _workflow_name(workflow):
+        status = _status(workflow)
+        return str(_value(status, "name", _value(status, "function_name", "")))
+
+    statuses = [
+        workflow
+        for workflow in statuses
+        if not _workflow_name(workflow)
+        or "implement_then_review" in _workflow_name(workflow)
+    ]
     workflow_ids = [
         _value(_status(workflow), "workflow_id", _value(workflow, "workflow_id"))
         for workflow in statuses
@@ -634,7 +650,7 @@ def compose_master(
         run = compose_run(
             dbos, wf_id, rows, server_app_version, decisions.get(wf_id, [])
         )
-        if not run:
+        if not run or not run["nodes"] or not run["task"]["text"]:
             continue
         current = next(
             (

--- a/projects/monolith/swarm/view_test.py
+++ b/projects/monolith/swarm/view_test.py
@@ -918,3 +918,35 @@ def test_composed_prose_carries_no_machine_formatting():
         for where, value in _composed_prose(run):
             assert not iso.search(value), f"{where} carries a raw timestamp: {value}"
             assert not enum.fullmatch(value.strip()), f"{where} is a raw enum: {value}"
+
+
+def test_compose_master_skips_non_run_workflows():
+    """A drain_cycle workflow in the registry must not 500 the master view.
+
+    Regression for the qwen drainer rollout: drain_cycle rows are top-level
+    DBOS workflows with an empty input, and compose_master's title line
+    (`task.text.splitlines()[0]`) raised IndexError on them, taking down
+    GET /api/swarm/runs entirely.
+    """
+    run_status = Status(
+        "wf-run", "PENDING", ["task", "repo", "main"], name="implement_then_review"
+    )
+    drain_status = Status("wf-drain", "PENDING", [], name="drain_cycle")
+
+    class ListingDBOS(DBOS):
+        def list_workflows(self, **kwargs):
+            return [Workflow(drain_status), self.workflow]
+
+        def retrieve_workflow(self, workflow_id):
+            if workflow_id == run_status.workflow_id:
+                return self.workflow
+            return Workflow(drain_status)
+
+    result = compose_master(
+        ListingDBOS(Workflow(run_status, {"plan": FX4_EXPECTED_PLAN})),
+        True,
+        {run_status.workflow_id: []},
+        "unknown",
+    )
+
+    assert [run["workflow_id"] for run in result["runs"]] == ["wf-run"]


### PR DESCRIPTION
The qwen drainer's drain_cycle workflows (#5301, PR #5311) are top-level DBOS workflows with an empty input. compose_master listed them alongside swarm runs and its title line (`task.text.splitlines()[0]`) raised IndexError, 500ing `GET /api/swarm/runs` on every poll and blanking the agents console (~700 errors in 30 minutes of prod logs).

Fix: filter the DBOS listing to implement_then_review workflows (rows with no name are kept, for the older fixtures and dict-shaped fakes), and skip any composed run missing nodes or task text so an unexpected shape degrades to absence instead of a 500. Regression test drives compose_master with a drain_cycle row in the listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A88MCbnLtwsFSHmqwuJezY