### PR TITLE
fix(signoz): give the otel collector recovery headroom above 1.5Gi

### DIFF
--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -319,13 +319,17 @@ signoz:
           cpu: 1
           memory: 1.5Gi
   otelCollector:
-    # 7-day SigNoz peak RSS 667Mi / working_set 680Mi: the old 2Gi request / 4Gi
-    # limit reserved ~3x the real peak. Trimmed to 768Mi / 1.5Gi (above the 680Mi
-    # peak with ~2x burst headroom for incident-time telemetry spikes).
+    # 7-day SigNoz peak RSS 667Mi / working_set 680Mi, so 768Mi request sits above
+    # the steady-state peak. The limit is sized for recovery, not steady state:
+    # the pipeline has no memory_limiter processor, so when the collector comes
+    # back after an outage every agent drains its buffer at once with nothing
+    # applying backpressure. At a 1.5Gi ceiling that drain OOMKilled the pod in
+    # ~114s on a loop (262 restarts on 2026-08-26) even with ClickHouse healthy.
+    # 3Gi absorbs the drain. Adding memory_limiter is the durable fix.
     resources:
       requests:
         cpu: 200m
         memory: 768Mi
       limits:
         cpu: 2
-        memory: 1.5Gi
+        memory: 3Gi


### PR DESCRIPTION
## What

Raise the SigNoz otel-collector memory limit from 1.5Gi to 3Gi. The 768Mi request is unchanged.

## Why

During the 2026-08-26 SigNoz outage the collector stayed OOMKilled in a loop (262 restarts) even after ClickHouse was repaired. Each attempt started clean, logged `Everything is ready. Begin running and processing data.` with zero export errors, then died ~114s later at the 1.5Gi ceiling.

The collector pipeline has no `memory_limiter` processor, so on recovery every agent drains its buffered telemetry at once with nothing applying backpressure. The earlier right-sizing round measured a 667Mi RSS / 680Mi working-set steady-state peak, which is accurate, but a ceiling chosen from steady state leaves no room for the post-outage drain.

3Gi absorbs the drain while keeping the request at the measured steady-state figure, so scheduling pressure does not change.

## Follow-up

Adding a `memory_limiter` processor is the durable fix: it would let the collector shed load instead of dying, and would make a tighter ceiling safe again.

## Verification

- `ci lint` clean.
- `projects/platform/*` deploys on HEAD, so this rolls the collector on merge.