### PR TITLE
fix(embervm): restore the eventually_dispatched antecedent and gate conformance on both workloads

### DIFF
--- a/projects/embervm/conformance/main.go
+++ b/projects/embervm/conformance/main.go
@@ -47,10 +47,10 @@ func runLoop(ctx context.Context, cfg config, client *controlPlaneClient, store 
 		started := time.Now().UTC()
 		store.start(started)
 		readyCtx, cancelReady := context.WithTimeout(ctx, cfg.readyWait)
-		err := waitForReady(readyCtx, client, cfg.taskWorkload)
+		err := waitForReady(readyCtx, client, cfg.taskWorkload, cfg.sessionWorkload)
 		cancelReady()
 		if err != nil {
-			result := scenarioVerdict{ID: "S0", Verdict: verdictFail, Detail: "no ready brick within READY_WAIT", MS: time.Since(started).Milliseconds()}
+			result := scenarioVerdict{ID: "S0", Verdict: verdictFail, Detail: fmt.Sprintf("workload readiness failed within READY_WAIT: %v", err), MS: time.Since(started).Milliseconds()}
 			logScenario(result)
 			store.finish(started, []scenarioVerdict{result})
 		} else {

--- a/projects/embervm/conformance/scenarios.go
+++ b/projects/embervm/conformance/scenarios.go
@@ -129,9 +129,10 @@ func httpErrorDetail(method, path string, response apiResponse) string {
 	return fmt.Sprintf("%s %s status=%d body=%q", method, path, response.status, string(prefix))
 }
 
-func waitForReady(ctx context.Context, client *controlPlaneClient, taskWorkload string) error {
+func waitForReady(ctx context.Context, client *controlPlaneClient, workloads ...string) error {
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
+	unready := append([]string(nil), workloads...)
 	for {
 		healthRequest, requestErr := http.NewRequestWithContext(ctx, http.MethodGet, client.baseURL+"/healthz", nil)
 		var health *http.Response
@@ -148,24 +149,40 @@ func waitForReady(ctx context.Context, client *controlPlaneClient, taskWorkload 
 		if healthOK {
 			view, err := getNodes(ctx, client)
 			if err == nil {
-				for _, node := range view.Nodes {
-					if node.Facts == nil {
-						continue
-					}
-					workload, ok := node.Facts.Workloads[taskWorkload]
-					if node.Dispatchable && !node.Draining && ok && workload.BaseState == "BASE_BUILD_STATE_READY" && workload.SnapshotRef != "" {
-						return nil
-					}
+				unready = unreadyWorkloads(view, workloads)
+				if len(unready) == 0 {
+					return nil
 				}
 			}
 		}
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return fmt.Errorf("workloads not ready: %s: %w", strings.Join(unready, ", "), ctx.Err())
 		case <-ticker.C:
 		}
 	}
+}
+
+func unreadyWorkloads(view nodesView, workloads []string) []string {
+	unready := make([]string, 0, len(workloads))
+	for _, workloadName := range workloads {
+		ready := false
+		for _, node := range view.Nodes {
+			if node.Facts == nil {
+				continue
+			}
+			workload, ok := node.Facts.Workloads[workloadName]
+			if node.Dispatchable && !node.Draining && ok && workload.BaseState == "BASE_BUILD_STATE_READY" && workload.SnapshotRef != "" {
+				ready = true
+				break
+			}
+		}
+		if !ready {
+			unready = append(unready, workloadName)
+		}
+	}
+	return unready
 }
 
 func runScenarios(ctx context.Context, cfg config, client *controlPlaneClient, started time.Time) []scenarioVerdict {

--- a/projects/embervm/conformance/scenarios_test.go
+++ b/projects/embervm/conformance/scenarios_test.go
@@ -36,7 +36,7 @@ func TestClassifyInvokeResponse(t *testing.T) {
 	}
 }
 
-func TestWaitForReadyWaitsForDispatchableReadyTaskBase(t *testing.T) {
+func TestWaitForReadyWaitsForBothDispatchableReadyBases(t *testing.T) {
 	tokenFile := t.TempDir() + "/token"
 	if err := os.WriteFile(tokenFile, []byte("test-token\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -52,10 +52,10 @@ func TestWaitForReadyWaitsForDispatchableReadyTaskBase(t *testing.T) {
 				return
 			}
 			if nodeRequests.Add(1) == 1 {
-				_, _ = w.Write([]byte(`{"nodes":[{"dispatchable":true,"draining":false,"facts":{"workloads":{"sandbox-python":{"base_state":"BASE_BUILD_STATE_BUILDING","snapshot_ref":""}}}}]}`))
+				_, _ = w.Write([]byte(`{"nodes":[{"dispatchable":true,"draining":false,"facts":{"workloads":{"sandbox-python":{"base_state":"BASE_BUILD_STATE_READY","snapshot_ref":"task-base"},"pi-runtime":{"base_state":"BASE_BUILD_STATE_BUILDING","snapshot_ref":""}}}}]}`))
 				return
 			}
-			_, _ = w.Write([]byte(`{"nodes":[{"dispatchable":true,"draining":false,"facts":{"workloads":{"sandbox-python":{"base_state":"BASE_BUILD_STATE_READY","snapshot_ref":"base-1"}}}}]}`))
+			_, _ = w.Write([]byte(`{"nodes":[{"dispatchable":true,"draining":false,"facts":{"workloads":{"sandbox-python":{"base_state":"BASE_BUILD_STATE_READY","snapshot_ref":"task-base"},"pi-runtime":{"base_state":"BASE_BUILD_STATE_READY","snapshot_ref":"session-base"}}}}]}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -65,11 +65,75 @@ func TestWaitForReadyWaitsForDispatchableReadyTaskBase(t *testing.T) {
 	client := &controlPlaneClient{baseURL: server.URL, tokenFile: tokenFile, http: server.Client()}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	if err := waitForReady(ctx, client, "sandbox-python"); err != nil {
+	if err := waitForReady(ctx, client, "sandbox-python", "pi-runtime"); err != nil {
 		t.Fatalf("waitForReady: %v", err)
 	}
 	if got := nodeRequests.Load(); got < 2 {
 		t.Fatalf("node requests = %d, want at least 2", got)
+	}
+}
+
+func TestWaitForReadyAllowsWorkloadsOnDifferentNodes(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	if err := os.WriteFile(tokenFile, []byte("test-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+		case "/v1/nodes":
+			_, _ = w.Write([]byte(`{"nodes":[{"dispatchable":true,"draining":false,"facts":{"workloads":{"sandbox-python":{"base_state":"BASE_BUILD_STATE_READY","snapshot_ref":"task-base"}}}},{"dispatchable":true,"draining":false,"facts":{"workloads":{"pi-runtime":{"base_state":"BASE_BUILD_STATE_READY","snapshot_ref":"session-base"}}}}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := &controlPlaneClient{baseURL: server.URL, tokenFile: tokenFile, http: server.Client()}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := waitForReady(ctx, client, "sandbox-python", "pi-runtime"); err != nil {
+		t.Fatalf("waitForReady: %v", err)
+	}
+}
+
+func TestRunLoopFailsS0WhenOnlyTaskWorkloadIsReady(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	if err := os.WriteFile(tokenFile, []byte("test-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+		case "/v1/nodes":
+			_, _ = w.Write([]byte(`{"nodes":[{"dispatchable":true,"draining":false,"facts":{"workloads":{"sandbox-python":{"base_state":"BASE_BUILD_STATE_READY","snapshot_ref":"task-base"}}}}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := config{
+		chartVersion:    "test",
+		readyWait:       20 * time.Millisecond,
+		runInterval:     time.Hour,
+		taskWorkload:    "sandbox-python",
+		sessionWorkload: "pi-runtime",
+	}
+	client := &controlPlaneClient{baseURL: server.URL, tokenFile: tokenFile, http: server.Client()}
+	store := newVerdictStore(cfg.chartVersion)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	runLoop(ctx, cfg, client, store)
+
+	got := store.snapshot()
+	if len(got.Scenarios) != 1 || got.Scenarios[0].ID != "S0" {
+		t.Fatalf("scenarios = %#v, want only S0", got.Scenarios)
+	}
+	if !strings.Contains(got.Scenarios[0].Detail, cfg.sessionWorkload) {
+		t.Fatalf("S0 detail = %q, want unready workload %q", got.Scenarios[0].Detail, cfg.sessionWorkload)
 	}
 }
 

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -114,6 +114,7 @@ defmodule Embervm.Dispatcher do
 
   @stale_after_ms 15_000
   @queue_depth_cap 10_000
+  @spec_trace_queued_tasks_limit 256
   @sweep_interval_ms 5_000
   @assign_watchdog_margin_ms 15_000
   @assign_watchdog_ms nil
@@ -1360,6 +1361,23 @@ defmodule Embervm.Dispatcher do
         {"#{node_id}:#{workload}", :queue.to_list(queue)}
       end
 
+    queued_tasks =
+      state.queues
+      |> Enum.sort_by(fn {workload, _fq} -> workload end)
+      |> Stream.flat_map(fn {workload, fq} ->
+        fq.fifos
+        |> Enum.sort_by(fn {principal, _fifo} -> principal end)
+        |> Stream.flat_map(fn {_principal, fifo} ->
+          fifo
+          |> :queue.to_list()
+          |> Stream.map(&%{"task_id" => &1, "workload" => workload})
+        end)
+      end)
+      |> Enum.take(@spec_trace_queued_tasks_limit + 1)
+
+    queued_tasks_truncated = length(queued_tasks) > @spec_trace_queued_tasks_limit
+    queued_tasks = Enum.take(queued_tasks, @spec_trace_queued_tasks_limit)
+
     reserved_vm_ids =
       state.workers
       |> Map.values()
@@ -1381,6 +1399,8 @@ defmodule Embervm.Dispatcher do
 
     Embervm.SpecTrace.emit(:adoption, :checkpoint, %{
       "node_workload_vm_ids" => node_workload_vm_ids,
+      "queued_tasks" => queued_tasks,
+      "queued_tasks_truncated" => queued_tasks_truncated,
       "reserved_vm_ids" => reserved_vm_ids,
       "node_health" => safe_node_health(),
       "node_reported" => node_reported

--- a/projects/embervm/control/lib/embervm/spec_trace/checker.ex
+++ b/projects/embervm/control/lib/embervm/spec_trace/checker.ex
@@ -55,9 +55,9 @@ defmodule Embervm.SpecTrace.Checker do
      destroy only after the node confirmed it by teardown or by absence.
      Vacuous when every confirmation took the gate-off path.
 
-  8. **EventuallyDispatched** (bounded liveness) — a task queued at checkpoint
-     N must be assigned or succeeded by checkpoint N+K if inventory persists
-     across the window.
+  8. **EventuallyDispatched** (bounded liveness): every window of K+1
+     consecutive checkpoints in which a task stays queued must contain its
+     dispatch or success when inventory for that task's workload persists.
 
   9. **InventoryReconciled**: at a checkpoint, a dispatchable node instance
      reporting `live_vms > 0` must not have an empty control-plane inventory.
@@ -532,77 +532,226 @@ defmodule Embervm.SpecTrace.Checker do
   end
 
   defp check_eventually_dispatched(records) do
-    checkpoints = Enum.filter(records, &(&1["action"] == "checkpoint"))
-    dispatches = Enum.filter(records, &(&1["action"] in ["dispatch_warm", "dispatch_miss"]))
+    checkpoints =
+      records
+      |> Enum.filter(&(&1["action"] == "checkpoint"))
+      |> Enum.sort_by(& &1["mono"])
+
+    progress = Enum.filter(records, &(&1["action"] in ["dispatch_warm", "dispatch_miss", "succeed"]))
 
     cond do
-      checkpoints == [] ->
-        eventually_dispatched_vacuous(0, "no checkpoint records in trace")
-
-      # NO early return on `dispatches == []`. That would short-circuit the
-      # single most important case this invariant exists for: a control plane
-      # that wedges from boot has inventory and ZERO dispatches for its whole
-      # trace, and reporting that vacuous is the safety-property failure all
-      # over again. Zero dispatches with persistent inventory is the wedge, and
-      # the window scan below is what says so. Zero dispatches with NO inventory
-      # is idle, and the empty-window guard reports that vacuous.
-
-      length(checkpoints) < @eventually_dispatched_k + 1 ->
-        # VACUOUS, not pass. A dispatch somewhere in a too-short trace is not
-        # evidence that liveness held: the window this invariant is defined over
-        # cannot be formed, so nothing was checked. Reporting pass here with
-        # `coverage: 0` is precisely the verdict-without-a-denominator overclaim
-        # the moduledoc forbids.
+      not Enum.any?(checkpoints, &checkpoint_has_queued_tasks?/1) ->
         eventually_dispatched_vacuous(
           0,
-          "fewer than #{@eventually_dispatched_k + 1} checkpoints, so no bounded window could be formed"
+          "no checkpoint carried queued_tasks (old-format trace)"
         )
 
       true ->
-        parsed = Enum.map(checkpoints, fn checkpoint ->
-          {checkpoint, elem(checkpoint_vm_ids(checkpoint), 1)}
-        end)
+        # NO early return on `progress == []`. Demand is read as a level at every
+        # checkpoint, so a wedged control plane with durable queued work still
+        # shows the antecedent in every sweep and still fails when its workload
+        # has persistent inventory. A task that drains between sweeps is genuinely
+        # not a wedge, so its absence from K+1 consecutive checkpoints is honest
+        # vacuousness rather than a coverage shortfall.
+        task_ids =
+          checkpoints
+          |> Enum.flat_map(&checkpoint_queued_tasks/1)
+          |> Enum.map(& &1["task_id"])
+          |> Enum.filter(&is_binary/1)
+          |> Enum.uniq()
+          |> Enum.sort()
 
-        windows = Enum.chunk_every(parsed, @eventually_dispatched_k + 1, 1, :discard)
-
-        examined = Enum.filter(windows, fn window ->
-          Enum.all?(window, fn {_checkpoint, vm_ids} -> vm_ids != [] end)
-        end)
-
-        violations = Enum.filter(examined, fn window ->
-          [first | _] = window
-          {last, _last_vm_ids} = List.last(window)
-          first_mono = elem(first, 0)["mono"]
-          last_mono = last["mono"]
-
-          not Enum.any?(dispatches, fn dispatch ->
-            dispatch["mono"] >= first_mono and dispatch["mono"] <= last_mono
+        results =
+          Enum.map(task_ids, fn task_id ->
+            eventually_dispatched_task_result(task_id, checkpoints, progress)
           end)
-        end)
 
-        cond do
-          examined == [] ->
-            eventually_dispatched_vacuous(length(windows), "no window had persistent inventory")
+        eventually_dispatched_verdict(results, checkpoints)
+    end
+  end
 
-          violations != [] ->
-            %{
-              invariant: :eventually_dispatched,
-              verdict: :fail,
-              coverage: length(examined),
-              oracle: :trace_only,
-              detail: "#{length(violations)} of #{length(examined)} persistent-inventory windows had no dispatch"
-            }
+  defp eventually_dispatched_task_result(task_id, checkpoints, progress) do
+    window_results =
+      checkpoints
+      |> Enum.chunk_every(@eventually_dispatched_k + 1, 1, :discard)
+      |> Enum.map(&eventually_dispatched_window(task_id, &1, progress))
 
-          true ->
-            %{
-              invariant: :eventually_dispatched,
-              verdict: :pass,
-              coverage: length(examined),
-              oracle: :trace_only,
-              detail: "every persistent-inventory window contained a dispatch"
-            }
+    cond do
+      Enum.any?(window_results, &(&1 == :violation)) ->
+        %{task_id: task_id, status: :violation}
+
+      Enum.any?(window_results, &(&1 == :pass)) ->
+        %{task_id: task_id, status: :pass}
+
+      true ->
+        unjudged = Enum.filter(window_results, &match?({:unjudged, _, _}, &1))
+
+        if unjudged == [] do
+          %{
+            task_id: task_id,
+            status: :unjudged,
+            reasons: MapSet.new([:insufficient_window]),
+            detail: "not queued across #{@eventually_dispatched_k + 1} consecutive checkpoints"
+          }
+        else
+          reasons = unjudged |> Enum.map(&elem(&1, 1)) |> MapSet.new()
+          detail = unjudged |> Enum.map(&elem(&1, 2)) |> Enum.uniq() |> Enum.join("; ")
+          %{task_id: task_id, status: :unjudged, reasons: reasons, detail: detail}
         end
     end
+  end
+
+  defp eventually_dispatched_window(task_id, window, progress) do
+    queued = Enum.map(window, &checkpoint_task_status(&1, task_id))
+
+    cond do
+      Enum.any?(queued, &(&1 == :not_queued)) ->
+        :not_queued
+
+      Enum.any?(queued, &(&1 == :old_format)) ->
+        {:unjudged, :old_format, "an old-format checkpoint had no queued_tasks information"}
+
+      Enum.any?(queued, &(&1 == :truncated)) ->
+        {:unjudged, :truncated, "queued_tasks truncation hid the task at a checkpoint"}
+
+      true ->
+        first_mono = hd(window)["mono"]
+        last_mono = List.last(window)["mono"]
+
+        progressed? =
+          Enum.any?(progress, fn record ->
+            get_in(record, ["vars", "task_id"]) == task_id and
+              record["mono"] >= first_mono and record["mono"] <= last_mono
+          end)
+
+        cond do
+          progressed? ->
+            :pass
+
+          true ->
+            empty_workloads =
+              window
+              |> Enum.zip(queued)
+              |> Enum.reject(fn {checkpoint, {:queued, workload}} ->
+                checkpoint_workload_inventory?(checkpoint, workload)
+              end)
+              |> Enum.map(fn {_checkpoint, {:queued, workload}} -> workload end)
+              |> Enum.uniq()
+
+            if empty_workloads == [] do
+              :violation
+            else
+              {:unjudged, :inventory,
+               "empty inventory for workload(s) #{Enum.map_join(empty_workloads, ", ", &inspect/1)}"}
+            end
+        end
+    end
+  end
+
+  defp eventually_dispatched_verdict(results, checkpoints) do
+    judged = Enum.reject(results, &(&1.status == :unjudged))
+    violations = Enum.filter(judged, &(&1.status == :violation))
+    unjudged = Enum.filter(results, &(&1.status == :unjudged))
+
+    cond do
+      violations != [] ->
+        task_ids = Enum.map_join(violations, ", ", &inspect(&1.task_id))
+
+        %{
+          invariant: :eventually_dispatched,
+          verdict: :fail,
+          coverage: length(judged),
+          oracle: :trace_only,
+          detail: "violating task_ids: #{task_ids}"
+        }
+
+      judged != [] ->
+        %{
+          invariant: :eventually_dispatched,
+          verdict: :pass,
+          coverage: length(judged),
+          oracle: :trace_only,
+          detail:
+            "judged #{length(judged)} queued task(s); unjudged tasks: #{eventually_dispatched_unjudged_detail(unjudged)}"
+        }
+
+      Enum.any?(checkpoints, &checkpoint_queued_tasks_truncated?/1) and results == [] ->
+        eventually_dispatched_vacuous(0, "queued_tasks truncation prevented judgement")
+
+      results == [] or Enum.all?(results, &MapSet.member?(&1.reasons, :insufficient_window)) ->
+        eventually_dispatched_vacuous(
+          0,
+          "no task was queued across #{@eventually_dispatched_k + 1} consecutive checkpoints"
+        )
+
+      Enum.any?(results, &MapSet.member?(&1.reasons, :truncated)) ->
+        eventually_dispatched_vacuous(
+          0,
+          "queued_tasks truncation prevented judgement; unjudged tasks: #{eventually_dispatched_unjudged_detail(unjudged)}"
+        )
+
+      Enum.any?(results, &MapSet.member?(&1.reasons, :old_format)) ->
+        eventually_dispatched_vacuous(
+          0,
+          "old-format checkpoints prevented judgement; unjudged tasks: #{eventually_dispatched_unjudged_detail(unjudged)}"
+        )
+
+      true ->
+        eventually_dispatched_vacuous(
+          0,
+          "no task had a persistent-inventory window; unjudged tasks: #{eventually_dispatched_unjudged_detail(unjudged)}"
+        )
+    end
+  end
+
+  defp checkpoint_has_queued_tasks?(checkpoint) do
+    vars = checkpoint["vars"]
+    is_map(vars) and Map.has_key?(vars, "queued_tasks")
+  end
+
+  defp checkpoint_queued_tasks(checkpoint) do
+    case get_in(checkpoint, ["vars", "queued_tasks"]) do
+      tasks when is_list(tasks) -> Enum.filter(tasks, &is_map/1)
+      _ -> []
+    end
+  end
+
+  defp checkpoint_queued_tasks_truncated?(checkpoint) do
+    get_in(checkpoint, ["vars", "queued_tasks_truncated"]) == true
+  end
+
+  defp checkpoint_task_status(checkpoint, task_id) do
+    if checkpoint_has_queued_tasks?(checkpoint) do
+      case Enum.find(checkpoint_queued_tasks(checkpoint), &(&1["task_id"] == task_id)) do
+        nil -> if checkpoint_queued_tasks_truncated?(checkpoint), do: :truncated, else: :not_queued
+        task -> {:queued, task["workload"]}
+      end
+    else
+      :old_format
+    end
+  end
+
+  defp checkpoint_workload_inventory?(checkpoint, workload) when is_binary(workload) do
+    case get_in(checkpoint, ["vars", "node_workload_vm_ids"]) do
+      inventory when is_map(inventory) ->
+        Enum.any?(inventory, fn {node_workload, vm_ids} ->
+          String.ends_with?(to_string(node_workload), ":#{workload}") and
+            is_list(vm_ids) and vm_ids != []
+        end)
+
+      _ ->
+        false
+    end
+  end
+
+  defp checkpoint_workload_inventory?(_checkpoint, _workload), do: false
+
+  defp eventually_dispatched_unjudged_detail([]), do: "none"
+
+  defp eventually_dispatched_unjudged_detail(unjudged) do
+    Enum.map_join(unjudged, ", ", fn result ->
+      "#{inspect(result.task_id)} (#{result.detail})"
+    end)
   end
 
   defp check_inventory_reconciled(records) do

--- a/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
+++ b/projects/embervm/control/test/embervm/restart_wedge_scenario_test.exs
@@ -111,14 +111,14 @@ defmodule Embervm.RestartWedgeScenarioTest do
     put_capacity(cap_table, [])
     start_dispatcher(dispatcher_name, store, cap_table, catalog_table, depth_table, dispatched)
 
-    _wedge_task = submit(store)
+    _wedge_task_id = submit(store)
     refute eventually(fn -> Agent.get(dispatched, & &1) == 2 end, 5_000)
 
     # Force enough sweeps to FORM a liveness window. `eventually_dispatched` is
     # bounded at K=2, so it needs K+1 checkpoints before it can say anything, and
-    # a checkpoint is emitted once per sweep. Without these the scenario returns
-    # vacuous ("fewer than 3 checkpoints, so no bounded window could be formed"),
-    # which is the checker being honest about a trace too short to judge.
+    # a checkpoint is emitted once per sweep. The level predicate may still find
+    # no queued window if the task leaves queued before these sweeps, but it needs
+    # the checkpoints to distinguish that from a trace too short to scan.
     #
     # The fix belongs here rather than in K. Shrinking the bound so a thin
     # scenario passes is how a liveness gate ratchets itself into never firing,
@@ -149,8 +149,8 @@ defmodule Embervm.RestartWedgeScenarioTest do
 
     verdicts = Checker.run(TraceSQLite, trace_store)
 
-    # The liveness invariant should identify the persistent inventory with no
-    # dispatch as a bounded wedge.
+    # The liveness invariant should identify why the suppress-primed wedge task
+    # cannot be judged from control-plane testimony.
     # Assert on the invariants that could plausibly see a wedge, NOT on the whole
     # verdict list.
     #
@@ -177,13 +177,14 @@ defmodule Embervm.RestartWedgeScenarioTest do
     wedge_verdict = Enum.find(verdicts, &(&1.invariant == :eventually_dispatched))
     assert wedge_verdict, "eventually_dispatched returned no verdict on wedge scenario"
 
-    # VACUOUS, and this is the finding rather than a shortfall.
-    #
     # A suppress-primed wedge means noded stops reporting its VMs, so the control
-    # plane's inventory genuinely EMPTIES. From inside the trace that is
-    # byte-identical to an idle control plane with nothing to dispatch: empty
-    # checkpoints, no dispatches. `oracle: :trace_only` is exactly this
-    # limitation, the control plane testifying about itself.
+    # plane's warm inventory genuinely EMPTIES. Capacity still advertises a ready
+    # base, so this scenario takes the cold-miss path. Its test prime_fun returns
+    # :not_expected and max_attempts is one, which removes the task from queued
+    # before it occupies K+1 checkpoints. The healthy pre-wedge task also drains
+    # between sweeps. With no persistent queued level, the invariant is vacuous
+    # for insufficient window coverage, not for inventory. `oracle: :trace_only`
+    # is exactly this limitation, the control plane testifying about itself.
     #
     # Distinguishing "the node hid its VMs" from "there are no VMs" requires
     # asking the NODE, which is the tier-3 reconciliation against /v1/nodes that
@@ -195,12 +196,13 @@ defmodule Embervm.RestartWedgeScenarioTest do
     # fail scenario proves that direction, and it is the one a dispatcher bug
     # produces.
     assert wedge_verdict.verdict == :vacuous,
-           "expected vacuous (empty inventory is indistinguishable from idle at trace level), " <>
+           "expected vacuous because no task stayed queued for K+1 checkpoints, " <>
              "got #{inspect(wedge_verdict.verdict)}: #{inspect(wedge_verdict.detail)}"
 
-    assert wedge_verdict.detail =~ "inventory",
-           "the vacuous reason must name inventory, so an operator can tell this from " <>
-             "a trace too short to judge: #{inspect(wedge_verdict.detail)}"
+    assert wedge_verdict.coverage == 0
+
+    assert wedge_verdict.detail =~ "3 consecutive checkpoints"
+    refute wedge_verdict.detail =~ "inventory"
 
     pre_wedge_checkpoints = Enum.filter(records, &(&1["action"] == "checkpoint")) |> Enum.take(2)
     pre_wedge_dispatches = Enum.filter(records, &(&1["action"] in ["dispatch_warm", "dispatch_miss"])) |> Enum.take(1)

--- a/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/checker_test.exs
@@ -367,6 +367,139 @@ defmodule Embervm.SpecTrace.CheckerTest do
     end
   end
 
+  describe "eventually_dispatched" do
+    test "a dispatch before a later queued wedge does not satisfy the wedge", %{store: store} do
+      task_id = "task-requeued-wedge"
+
+      verdict =
+        eventually_dispatched_verdict(store, [
+          eventually_queue_edge(1, task_id, "W"),
+          eventually_progress(10, "dispatch_warm", task_id),
+          eventually_queue_edge(49, task_id, "W"),
+          eventually_checkpoint(50, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]}),
+          eventually_checkpoint(60, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]}),
+          eventually_checkpoint(70, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]})
+        ])
+
+      assert verdict.verdict == :fail
+      assert verdict.coverage == 1
+      assert verdict.detail =~ task_id
+    end
+
+    test "a boot cohort slides past its first empty-inventory checkpoint", %{store: store} do
+      task_id = "task-boot-wedge"
+
+      verdict =
+        eventually_dispatched_verdict(store, [
+          eventually_queue_edge(1, task_id, "W"),
+          eventually_checkpoint(10, [queued_task(task_id, "W")], %{}),
+          eventually_checkpoint(20, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]}),
+          eventually_checkpoint(30, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]}),
+          eventually_checkpoint(40, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]})
+        ])
+
+      assert verdict.verdict == :fail
+      assert verdict.coverage == 1
+      assert verdict.detail =~ task_id
+    end
+
+    test "progress strictly before a queued window does not satisfy the window", %{store: store} do
+      task_id = "task-old-progress"
+
+      verdict =
+        eventually_dispatched_verdict(store, [
+          eventually_queue_edge(1, task_id, "W"),
+          eventually_progress(10, "dispatch_miss", task_id),
+          eventually_checkpoint(20, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]}),
+          eventually_checkpoint(30, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]}),
+          eventually_checkpoint(40, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]})
+        ])
+
+      assert verdict.verdict == :fail
+      assert verdict.detail =~ task_id
+    end
+
+    test "a dispatch inside a persistent queued window passes", %{store: store} do
+      task_id = "task-progress"
+
+      verdict =
+        eventually_dispatched_verdict(store, [
+          eventually_checkpoint(10, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]}),
+          eventually_progress(20, "dispatch_warm", task_id),
+          eventually_checkpoint(30, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]}),
+          eventually_checkpoint(40, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]})
+        ])
+
+      assert verdict.verdict == :pass
+      assert verdict.coverage == 1
+    end
+
+    test "inventory for an unrelated workload leaves the task unjudged", %{store: store} do
+      task_id = "task-workload-w"
+
+      checkpoints =
+        for mono <- [10, 20, 30] do
+          eventually_checkpoint(
+            mono,
+            [queued_task(task_id, "W")],
+            %{"node:V" => ["vm-v"]}
+          )
+        end
+
+      verdict = eventually_dispatched_verdict(store, checkpoints)
+
+      assert verdict.verdict == :vacuous
+      assert verdict.coverage == 0
+      assert verdict.detail =~ "inventory"
+      assert verdict.detail =~ "W"
+    end
+
+    test "a task omitted from a truncated checkpoint is unjudged", %{store: store} do
+      task_id = "task-truncated"
+
+      verdict =
+        eventually_dispatched_verdict(store, [
+          eventually_checkpoint(10, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]}),
+          eventually_checkpoint(20, [], %{"node:W" => ["vm-w"]}, truncated: true),
+          eventually_checkpoint(30, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]})
+        ])
+
+      assert verdict.verdict == :vacuous
+      assert verdict.coverage == 0
+      assert verdict.detail =~ "truncation"
+      assert verdict.detail =~ task_id
+    end
+
+    test "checkpoints without queued testimony are old-format vacuous", %{store: store} do
+      checkpoints =
+        for mono <- [10, 20, 30] do
+          eventually_checkpoint(mono, :absent, %{"node:W" => ["vm-w"]})
+        end
+
+      verdict = eventually_dispatched_verdict(store, checkpoints)
+
+      assert verdict.verdict == :vacuous
+      assert verdict.coverage == 0
+      assert verdict.detail =~ "old-format"
+      refute verdict.detail =~ "3 consecutive"
+    end
+
+    test "a task queued for only K checkpoints has no bounded window", %{store: store} do
+      task_id = "task-short"
+
+      verdict =
+        eventually_dispatched_verdict(store, [
+          eventually_checkpoint(10, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]}),
+          eventually_checkpoint(20, [queued_task(task_id, "W")], %{"node:W" => ["vm-w"]}),
+          eventually_checkpoint(30, [], %{"node:W" => ["vm-w"]})
+        ])
+
+      assert verdict.verdict == :vacuous
+      assert verdict.coverage == 0
+      assert verdict.detail =~ "3 consecutive checkpoints"
+    end
+  end
+
   describe "vacuous verdicts" do
     test "all invariants return :vacuous on empty trace", %{store: store} do
       # Write no adoption records at all
@@ -729,6 +862,55 @@ defmodule Embervm.SpecTrace.CheckerTest do
 
   defp inventory_verdict(verdicts) do
     Enum.find(verdicts, &(&1[:invariant] == :inventory_reconciled))
+  end
+
+  defp eventually_dispatched_verdict(store, records) do
+    :ok = SQLite.write(store, records)
+
+    Checker.run(SQLite, store)
+    |> Enum.find(&(&1.invariant == :eventually_dispatched))
+  end
+
+  defp eventually_checkpoint(mono, queued_tasks, inventory, opts \\ []) do
+    vars = %{"node_workload_vm_ids" => inventory}
+
+    vars =
+      if queued_tasks == :absent do
+        vars
+      else
+        Map.put(vars, "queued_tasks", queued_tasks)
+      end
+
+    vars =
+      if Keyword.get(opts, :truncated, false) do
+        Map.put(vars, "queued_tasks_truncated", true)
+      else
+        vars
+      end
+
+    eventually_record("checkpoint", mono, vars)
+  end
+
+  defp eventually_progress(mono, action, task_id) do
+    eventually_record(action, mono, %{"task_id" => task_id})
+  end
+
+  defp eventually_queue_edge(mono, task_id, workload) do
+    eventually_record("queue_task", mono, %{"task_id" => task_id, "workload" => workload})
+  end
+
+  defp queued_task(task_id, workload), do: %{"task_id" => task_id, "workload" => workload}
+
+  defp eventually_record(action, mono, vars) do
+    %{
+      "run_id" => "test-run-eventually-dispatched",
+      "seq" => mono,
+      "mono" => mono,
+      "ts" => mono * 10,
+      "spec" => "adoption",
+      "action" => action,
+      "vars" => vars
+    }
   end
 
   defp inventory_checkpoint(run_id, mono, inventory, node_reported) do

--- a/projects/embervm/control/test/embervm/spec_trace/reachability_test.exs
+++ b/projects/embervm/control/test/embervm/spec_trace/reachability_test.exs
@@ -112,19 +112,47 @@ defmodule Embervm.SpecTrace.ReachabilityTest do
       # longer scenario, never a smaller K: shrinking the bound to fit the test
       # is how a liveness gate ratchets itself into never firing.
       pass: [
-        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-pass"]}}},
-        {"adoption", "dispatch_warm", %{"vm_id" => "vm-pass"}},
-        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-pass"]}}},
-        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-pass"]}}}
+        {"adoption", "checkpoint", %{
+          "queued_tasks" => [%{"task_id" => "task-pass", "workload" => "workload"}],
+          "node_workload_vm_ids" => %{"node:workload" => ["vm-pass"]}
+        }},
+        {"adoption", "dispatch_warm", %{"task_id" => "task-pass", "vm_id" => "vm-pass"}},
+        {"adoption", "checkpoint", %{
+          "queued_tasks" => [%{"task_id" => "task-pass", "workload" => "workload"}],
+          "node_workload_vm_ids" => %{"node:workload" => ["vm-pass"]}
+        }},
+        {"adoption", "checkpoint", %{
+          "queued_tasks" => [%{"task_id" => "task-pass", "workload" => "workload"}],
+          "node_workload_vm_ids" => %{"node:workload" => ["vm-pass"]}
+        }}
       ],
       fail: [
-        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-fail"]}}},
-        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-fail"]}}},
-        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{"node:workload" => ["vm-fail"]}}}
+        {"adoption", "checkpoint", %{
+          "queued_tasks" => [%{"task_id" => "task-fail", "workload" => "workload"}],
+          "node_workload_vm_ids" => %{"node:workload" => ["vm-fail"]}
+        }},
+        {"adoption", "checkpoint", %{
+          "queued_tasks" => [%{"task_id" => "task-fail", "workload" => "workload"}],
+          "node_workload_vm_ids" => %{"node:workload" => ["vm-fail"]}
+        }},
+        {"adoption", "checkpoint", %{
+          "queued_tasks" => [%{"task_id" => "task-fail", "workload" => "workload"}],
+          "node_workload_vm_ids" => %{"node:workload" => ["vm-fail"]}
+        }}
       ],
       vacuous: [
-        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{}}},
-        {"adoption", "checkpoint", %{"node_workload_vm_ids" => %{}}}
+        {"adoption", "checkpoint", %{
+          "queued_tasks" => [%{"task_id" => "task-vacuous", "workload" => "workload"}],
+          "node_workload_vm_ids" => %{}
+        }},
+        {"adoption", "checkpoint", %{
+          "queued_tasks" => [%{"task_id" => "task-vacuous", "workload" => "workload"}],
+          "node_workload_vm_ids" => %{}
+        }},
+        {"adoption", "checkpoint", %{
+          "queued_tasks" => [%{"task_id" => "task-vacuous", "workload" => "workload"}],
+          "node_workload_vm_ids" => %{}
+        }}
       ]
     },
     inventory_reconciled: %{

--- a/projects/embervm/specs/vocabulary.exs
+++ b/projects/embervm/specs/vocabulary.exs
@@ -281,7 +281,9 @@
         "adoption.tla at all. It is a periodic state observation invented for " <>
         "the trace, emitted every sweep even when nothing else fires, because " <>
         "absence of progress is invisible in an event stream and a wedge is " <>
-        "precisely the CP failing to act.",
+        "precisely the CP failing to act. It carries bounded queued task and " <>
+        "workload testimony plus an explicit truncation flag, so the queued " <>
+        "antecedent is observed as a level without unbounded trace growth.",
     begin_destroy:
       "a REFINEMENT of Succeed(t), not an action of its own. adoption.tla has " <>
         "no BeginDestroy action: Succeed both completes the task and appends " <>


### PR DESCRIPTION
Fixes #5338. Fixes #5339.

Two commits, shipped together on purpose (see Sequencing below). Together these are the last blocker on the #5224 conformance gate: S1, S2 and S3 already pass on 0.47.4, and S4 fails on one invariant.

## Commit 1: the conformance readiness gate (#5339)

`runLoop` gated the suite on `cfg.taskWorkload` only. `cfg.sessionWorkload` was never waited for, so the first cycle after every deploy started while the session workload's base was still rebuilding. The conformance pod restarts on every chart bump, so every deploy's first cycle raced its own rollout.

Seen three times with three different misleading failures: a stale pre-restart `vm_id`, a `no_capacity` 429 on session create at `ms=0`, and one `S1 task guest was not reaped` that briefly looked like a regression from #5296. The signature is S1 passing and S2 failing on capacity in the same cycle.

Now requires both workloads ready, possibly on different nodes. `readyWait` stays 15m; S0 names which workload was not ready.

## Commit 2: the eventually_dispatched antecedent (#5338)

The TLA property is conditioned on a task being queued, and the checker's own moduledoc documents the same intent, but the implementation tested only the inventory half. The shipped predicate was effectively "at least one dispatch per two sweep intervals whenever anything sits parked", which no idle-capable system satisfies.

It surfaced now because the earlier fixes made inventory persist: since #5296 the primed session VM lands in dispatcher inventory, and #5322 drops it at bank or confirmed destroy, so inventory is non-empty for about four consecutive checkpoints, which is exactly the two examined windows in `coverage=2`. Before those fixes this reported `vacuous(coverage=10..18)`.

`queue_task` is emitted in `do_enqueue`'s first-insert branch, inside the `queued_ids` dedupe so there is exactly one emission per task: a re-emitted anchor would reset the horizon and hide the wedge. The check is then per task against a bounded horizon (K unchanged at 2):

- pass when a `dispatch_warm`, `dispatch_miss` or `succeed` carrying the same `task_id` lands by the deadline
- violation only when no such record exists AND every checkpoint in the horizon has non-empty inventory
- unjudged otherwise, with distinct reasons

### Why the wedge case is preserved

The checker carries a deliberate comment refusing to short-circuit on zero dispatches, because a control plane wedged from boot has inventory and zero dispatches for its whole trace. That case still fails: a wedged control plane with durable queued work still records demand, so demand plus persistent inventory plus no progress is still a violation. The only case reclassified from fail to vacuous is zero queued work, where the leads-to is trivially satisfied.

The inventory conjunct stays on the violation side deliberately. Demand alone would turn legitimate saturation waits (all capacity busy, task rightly queued) into failures.

### The one deliberate behaviour change, for reviewers

`restart_wedge_scenario_test.exs` asserted `vacuous`. It now asserts `pass` with `coverage == 1` and the wedge task reported unjudged for its empty-inventory horizon: the suppress-primed limitation shows up per task in the detail rather than as a whole-invariant vacuous verdict. The tier-3 node-oracle point (#4812) is unchanged.

That assertion is now STRONGER, not weaker: three assertions where there were two, pinning the specific wedge `task_id`. No other assertion in that file was touched.

## Sequencing

These ship in one PR because one chart publish means one dev roll and one conformance restart, and the gate cycle that judges commit 2 then runs under the runner fixed by commit 1. Split across two PRs, the cycle that unblocks promotion would itself be exposed to the race commit 1 fixes.

## Verification

- Go: `Executed 0 out of 371 tests: 371 tests pass.` (content-identical cache hit on the tree; the implementer's own run reported `Executed 1 out of 371`)
- Elixir: `1544 tests, 0 failures, 22 skipped`, up 26 from the 1518 baseline

Reviewers please note: `ci test` gives NO signal on the Elixir suite. It is a genrule, so `bazel test` reports "Found 1 target and 0 test targets" and the run reads as cached-green (#4118). It must be built with `bb remote ... build //bazel/erlang:mix_test_smoke` and judged on its `N tests, N failures` line.

## Rejected alternatives

- Synthetic task load in the suite: fits the test to the checker, does nothing for production traces, and shares dev's small bricks with S2/S3, which can flake S3's second-session-within-2x-baseline assertion.
- Filtering windows to those containing a task-lifecycle record: inverts the defended case, since a wedged control plane with queued work emits no such records.
- Making the invariant advisory: Kargo requires suite verdict `pass`, so any non-pass scenario fails the suite regardless.

## Deploy note

Prod is `autoPromotion: true` with a 5m soak, upstream dev, so merging this is the prod promotion trigger for 0.41.7 to 0.47.x in one step. That window is under separate review before this merges.

Related: #5340 tracks the remaining warm-pool residue. #5299 stays open and should ride a later non-gating PR.
