### PR TITLE
chore(embervm): size timeouts and disable gitMirror for the prod jump

### DIFF
--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1497,15 +1497,24 @@ bricks:
   #
   # RAISED to 3600 for the 0.41.7 to 0.47.x jump (#5224), and derived from a
   # measurement as the paragraph above insists. That jump moves 13 of 14 guest
-  # base digests, so a pod bakes ~7.5 GB of rootfs in its init containers before
-  # it is Ready. At the measured rate (about 8.2s per 100 MB, from two real cold
-  # bakes) that is roughly 20m per pod, and node-3 runs TWO noded pods whose
-  # Deployments roll at the same time on one 34 GB device, so they contend.
-  # 2400 would sit exactly on a 2x error; 3600 does not.
+  # base digests, so a node bakes ~7.5 GB of rootfs in init containers before
+  # its brick pods are Ready. At the measured rate (about 8.2s per 100 MB, from
+  # two real cold bakes) that is 10 to 13m for a node's cold bake.
   #
-  # Deliberately still far below the promotion budget (now 60m0s), preserving
+  # The cost is per NODE, not per pod: the builder is content addressed by guest
+  # digest into the shared node hostPath, so a second pod on an already-baked
+  # node is a hardlink cache hit. Class and floor bricks also sit in different
+  # sync waves, so two pods on one node never bake concurrently.
+  #
+  # 3600 keeps the same roughly 5x-over-worst-case ratio the 1200 above was
+  # sized at, against the new 10 to 13m worst case rather than the old one.
+  #
+  # Still below the promotion budget (now 90m0s) by a real margin, preserving
   # the ordering the paragraph above depends on: this trips first and fails
-  # argocd-wait fast, rather than letting the budget expire.
+  # argocd-wait fast, rather than letting the budget expire. The margin has to
+  # be REAL rather than nominal, because the two clocks do not start together:
+  # the budget starts at the argocd-update step, this starts only when the
+  # brick's sync wave is reached.
   progressDeadlineSeconds: 3600
   # Per-class DESIRED replica count the Embervm.BrickController reconciles the
   # brick Deployments to (and the value each renders at first create). A MAP keyed

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1494,7 +1494,19 @@ bricks:
   # would leave a genuinely wedged brick undetected until that budget expires;
   # sizing it too low is the false-red above. Derive it from a measurement, not
   # from the budget.
-  progressDeadlineSeconds: 1200
+  #
+  # RAISED to 3600 for the 0.41.7 to 0.47.x jump (#5224), and derived from a
+  # measurement as the paragraph above insists. That jump moves 13 of 14 guest
+  # base digests, so a pod bakes ~7.5 GB of rootfs in its init containers before
+  # it is Ready. At the measured rate (about 8.2s per 100 MB, from two real cold
+  # bakes) that is roughly 20m per pod, and node-3 runs TWO noded pods whose
+  # Deployments roll at the same time on one 34 GB device, so they contend.
+  # 2400 would sit exactly on a 2x error; 3600 does not.
+  #
+  # Deliberately still far below the promotion budget (now 60m0s), preserving
+  # the ordering the paragraph above depends on: this trips first and fails
+  # argocd-wait fast, rather than letting the budget expire.
+  progressDeadlineSeconds: 3600
   # Per-class DESIRED replica count the Embervm.BrickController reconciles the
   # brick Deployments to (and the value each renders at first create). A MAP keyed
   # by size-class label, not a per-class list field, so a deploy-values overlay can

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1501,20 +1501,29 @@ bricks:
   # its brick pods are Ready. At the measured rate (about 8.2s per 100 MB, from
   # two real cold bakes) that is 10 to 13m for a node's cold bake.
   #
-  # The cost is per NODE, not per pod: the builder is content addressed by guest
-  # digest into the shared node hostPath, so a second pod on an already-baked
-  # node is a hardlink cache hit. Class and floor bricks also sit in different
-  # sync waves, so two pods on one node never bake concurrently.
+  # The cost is per NODE, not per pod, and the load-bearing reason is the
+  # builder's cache: it is content addressed by guest digest into the shared
+  # node hostPath, so a second pod landing on an already-baked node hardlinks
+  # rather than bakes. That holds unconditionally. Sync waves currently separate
+  # class from floor bricks too, but lean on the cache rather than on that: all
+  # of 1gi/2gi/4gi share one class wave, so a second entry in desiredReplicas
+  # could put two class Deployments on one node at once.
   #
   # 3600 keeps the same roughly 5x-over-worst-case ratio the 1200 above was
   # sized at, against the new 10 to 13m worst case rather than the old one.
   #
-  # Still below the promotion budget (now 90m0s) by a real margin, preserving
-  # the ordering the paragraph above depends on: this trips first and fails
-  # argocd-wait fast, rather than letting the budget expire. The margin has to
-  # be REAL rather than nominal, because the two clocks do not start together:
-  # the budget starts at the argocd-update step, this starts only when the
-  # brick's sync wave is reached.
+  # Below the promotion budget (now 90m0s), but the ordering the paragraph above
+  # wants holds only for the FIRST brick wave, and that is deliberate. The two
+  # clocks do not start together: the budget starts at the argocd-update step,
+  # this starts only when the brick's own sync wave is reached. So the detector
+  # wins where the wave's lead-in is under 30m, which is wave 2, the first cold
+  # bakes on the tightest nodes and where a jump-related bake wedge actually
+  # lives. Later waves report as a budget expiry instead, and that is an
+  # acceptable trade: by then the roll has already cleared every earlier wave,
+  # so ArgoCD shows which wave is parked. Covering wave 5 would need the budget
+  # above a full healthy roll plus this deadline, roughly 120m0s, which doubles
+  # the hang on a genuinely wedged environment to buy a better error string for
+  # cases that are already localised.
   progressDeadlineSeconds: 3600
   # Per-class DESIRED replica count the Embervm.BrickController reconciles the
   # brick Deployments to (and the value each renders at first create). A MAP keyed

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -658,7 +658,23 @@ egress:
 # falls back to its credentialed GitHub clone for repos this list does not
 # carry, so catalog drift degrades to today's path instead of failed sessions.
 gitMirror:
-  enabled: true
+  # FALSE for the 0.41.7 to 0.47.x jump (#5224), to be re-enabled as its own
+  # single-change roll once prod has settled.
+  #
+  # This flag has been true here for a while but has never rendered anything:
+  # chart 0.41.7 carries no template for it. The moment the chart moves, every
+  # noded pod gains a THIRD container that has run nowhere. Dev cannot have
+  # exercised it either, since dev runs no egress-proxy and the sidecar is
+  # gated on `and egress.enabled gitMirror.enabled`, so dev's noded pod has a
+  # single container.
+  #
+  # That would ride in on the largest rollout this pipeline has attempted (13
+  # of 14 guest base digests rebuilding on every node). Landing an unexercised
+  # sidecar and a full-fleet guest rebuild together means a failure in either
+  # one is diagnosed against both. Flipping it here is values-only and deploys
+  # on HEAD, so it takes effect BEFORE the chart moves, which is the whole
+  # point of the flag existing.
+  enabled: false
   port: 9419
   refreshIntervalSeconds: 60
   # The MCP agent tool defaults every session to jomcgi/homelab (#4473), which

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -661,12 +661,20 @@ gitMirror:
   # FALSE for the 0.41.7 to 0.47.x jump (#5224), to be re-enabled as its own
   # single-change roll once prod has settled.
   #
-  # This flag has been true here for a while but has never rendered anything:
-  # chart 0.41.7 carries no template for it. The moment the chart moves, every
-  # noded pod gains a THIRD container that has run nowhere. Dev cannot have
-  # exercised it either, since dev runs no egress-proxy and the sidecar is
-  # gated on `and egress.enabled gitMirror.enabled`, so dev's noded pod has a
-  # single container.
+  # This flag arrived true on 2026-08-24 (e01071c77, the same commit that added
+  # the template, chart 0.45.3) and has never rendered anything, because prod
+  # has been pinned at 0.41.7 which carries no template for it. The moment the
+  # chart moves, every noded pod gains a THIRD container that has run nowhere.
+  # Dev cannot have exercised it either, since dev runs no egress-proxy and the
+  # sidecar is gated on `and egress.enabled gitMirror.enabled`, so dev's noded
+  # pod has a single container.
+  #
+  # This stops the SIDECAR, not the guest half. The shim defaults to
+  # http://git-mirror.egress.internal:9419 and EMBER_GIT_MIRROR_URL is set by
+  # nothing, so on 0.47.x every session hydration tries the mirror first, is
+  # denied by the egress proxy (the reserved host resolves nowhere with the
+  # seam off), and falls back to its GitHub clone. Fast and safe, but expect
+  # mirror-named lines in hydration logs during the jump.
   #
   # That would ride in on the largest rollout this pipeline has attempted (13
   # of 14 guest base digests rebuilding on every node). Landing an unexercised

--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -292,6 +292,23 @@ auth:
 # above so the runner can exercise the management API with its projected token.
 conformance:
   enabled: true
+  # RAISED from the chart's 15m for the 0.41.7 to 0.47.x jump (#5224).
+  #
+  # The runner rolls with the chart, so on a roll that rebuilds guest bases it
+  # starts while its own brick is still baking. That jump moves 13 of 14 base
+  # digests, which is 10 to 25m of init-container bake here, so a 15m wait
+  # expires mid-bake and the runner writes an S0 FAIL for the new chart version.
+  # Kargo's dev verdict poll reads that through its failure expression and the
+  # promotion fails; prod autoPromotion fires on NEW Freight rather than on
+  # failure, so the Freight then sits unverified with no poller on the next
+  # healthy cycle.
+  #
+  # Must stay strictly BELOW the dev stage's verdictTimeout in
+  # projects/platform/kargo/values.yaml (40m0s), which also has to cover the
+  # roughly 4m suite after this wait ends. It is a bound on waiting for bricks,
+  # not a budget for the suite, so a fast roll is unaffected: readiness is
+  # polled, not slept.
+  readyWait: 30m0s
 
 usageAdmins:
   - system:serviceaccount:embervm-dev:embervm-dev-embervm

--- a/projects/embervm/dev/deploy/values.yaml
+++ b/projects/embervm/dev/deploy/values.yaml
@@ -305,7 +305,9 @@ conformance:
   #
   # Must stay strictly BELOW the dev stage's verdictTimeout in
   # projects/platform/kargo/values.yaml (40m0s), which also has to cover the
-  # roughly 4m suite after this wait ends. It is a bound on waiting for bricks,
+  # 5m10s suite after this wait ends (s1 60s + s2 180s + s3 60s + s4 10s,
+  # summed as totalBudget in conformance/main.go). 30m plus 5m10s leaves about
+  # 5m of real margin at 40m0s. It is a bound on waiting for bricks,
   # not a budget for the suite, so a fast roll is unaffected: readiness is
   # polled, not slept.
   readyWait: 30m0s

--- a/projects/platform/kargo/values.yaml
+++ b/projects/platform/kargo/values.yaml
@@ -228,7 +228,21 @@ promotion:
       # This bound is still not the detector: progressDeadlineSeconds trips the
       # Application to Degraded first and argocd-wait fails fast on that. It
       # only catches a workload that never reaches a terminal state at all.
-      waitTimeout: 30m0s
+      #
+      # RAISED to 60m0s for the 0.41.7 to 0.47.x jump (#5224). The 30m0s above
+      # was measured on a roll where the guest base refs did NOT move, which is
+      # the common case and the one the paragraph above describes. That jump
+      # moves 13 of 14 base digests (a renovate apko lock refresh rewrote every
+      # runtime lock), so every brick pod bakes ~7.5 GB of rootfs in its init
+      # containers before it reports Ready. At the measured bake rate that is
+      # 10 to 25m per pod, and maxSurge 0 / maxUnavailable 1 over 4 replicas
+      # serializes them.
+      #
+      # Left at 60m0s afterwards rather than reverted: undershooting fails a
+      # HEALTHY roll, which the comment above calls the worst thing a gate can
+      # do, while overshooting only delays the report of a roll that was never
+      # going to finish. progressDeadlineSeconds is still the real detector.
+      waitTimeout: 60m0s
       stages:
         - name: dev
           application: embervm-dev
@@ -239,11 +253,25 @@ promotion:
           # for THIS chart version. The runner rolls with the chart, waits up
           # to 15m for a ready brick, then runs a suite budgeted at about 4m
           # (task cold boot, session create / bank / relight / destroy,
-          # create-after-destroy, control-plane invariants). 20m0s covers the
+          # create-after-destroy, control-plane invariants). 20m0s covered the
           # runner's own wait plus the suite plus one retry; a wedged brick
           # rebuild already failed argocd-wait before this step runs.
+          #
+          # RAISED to 40m0s alongside the dev readyWait going to 30m for the
+          # 0.41.7 to 0.47.x jump (#5224). Both old numbers assumed a roll that
+          # does not rebuild guest bases. On that jump the dev brick bakes the
+          # same 13 changed digests the prod fleet does, so the runner's own
+          # wait has to outlast the bake or it writes an S0 FAIL for the new
+          # chart version, this poll reads that verdict through its failure
+          # expression, and the dev promotion fails. Prod autoPromotion fires on
+          # NEW Freight rather than on failure, so that Freight would then sit
+          # unverified with no poller on the next healthy cycle.
+          #
+          # This must stay strictly greater than conformance.readyWait plus the
+          # suite budget, or the poll gives up while the runner is still
+          # legitimately waiting for its bricks.
           verdictURL: http://embervm-dev-embervm-conformance.embervm-dev.svc.cluster.local:8080/verdict
-          verdictTimeout: 20m0s
+          verdictTimeout: 40m0s
         - name: prod
           application: embervm
           upstream:

--- a/projects/platform/kargo/values.yaml
+++ b/projects/platform/kargo/values.yaml
@@ -229,20 +229,34 @@ promotion:
       # Application to Degraded first and argocd-wait fails fast on that. It
       # only catches a workload that never reaches a terminal state at all.
       #
-      # RAISED to 60m0s for the 0.41.7 to 0.47.x jump (#5224). The 30m0s above
+      # RAISED to 90m0s for the 0.41.7 to 0.47.x jump (#5224). The 30m0s above
       # was measured on a roll where the guest base refs did NOT move, which is
       # the common case and the one the paragraph above describes. That jump
       # moves 13 of 14 base digests (a renovate apko lock refresh rewrote every
-      # runtime lock), so every brick pod bakes ~7.5 GB of rootfs in its init
-      # containers before it reports Ready. At the measured bake rate that is
-      # 10 to 25m per pod, and maxSurge 0 / maxUnavailable 1 over 4 replicas
-      # serializes them.
+      # runtime lock), so a node bakes ~7.5 GB of rootfs before its brick pods
+      # report Ready.
       #
-      # Left at 60m0s afterwards rather than reverted: undershooting fails a
+      # The cost is PER NODE, not per pod: the builder is content addressed by
+      # guest digest into the shared node hostPath, so a second pod landing on
+      # a node that already baked is a hardlink cache hit. Four nodes need a
+      # cold bake, three of them serialized inside the 2gi class wave by
+      # maxUnavailable 1. At the measured rate that is roughly 40m.
+      #
+      # 90m0s rather than 60m0s because this MUST stay above
+      # bricks.progressDeadlineSeconds (3600s) by a real margin, or the ordering
+      # the paragraph above depends on inverts. The two clocks do not start
+      # together: this budget starts when the argocd-update step starts, while a
+      # brick's Progressing clock starts only once its sync wave is reached,
+      # which is minutes to tens of minutes later. At 60m0s the detector could
+      # never win the race, and a wedged brick would surface as an
+      # uninformative "step timed out" at the full budget instead of a
+      # ProgressDeadlineExceeded naming the Deployment.
+      #
+      # Left at 90m0s afterwards rather than reverted: undershooting fails a
       # HEALTHY roll, which the comment above calls the worst thing a gate can
       # do, while overshooting only delays the report of a roll that was never
-      # going to finish. progressDeadlineSeconds is still the real detector.
-      waitTimeout: 60m0s
+      # going to finish. progressDeadlineSeconds stays the real detector.
+      waitTimeout: 90m0s
       stages:
         - name: dev
           application: embervm-dev
@@ -254,8 +268,11 @@ promotion:
           # to 15m for a ready brick, then runs a suite budgeted at about 4m
           # (task cold boot, session create / bank / relight / destroy,
           # create-after-destroy, control-plane invariants). 20m0s covered the
-          # runner's own wait plus the suite plus one retry; a wedged brick
-          # rebuild already failed argocd-wait before this step runs.
+          # runner's own wait plus that suite; a wedged brick rebuild already
+          # failed argocd-wait before this step runs. It never covered a retry
+          # and neither does the raised value: runInterval is 30m, so a failed
+          # cycle's next verdict lands a full interval later. Do not re-derive
+          # either number from a retry that does not fit.
           #
           # RAISED to 40m0s alongside the dev readyWait going to 30m for the
           # 0.41.7 to 0.47.x jump (#5224). Both old numbers assumed a roll that
@@ -269,7 +286,10 @@ promotion:
           #
           # This must stay strictly greater than conformance.readyWait plus the
           # suite budget, or the poll gives up while the runner is still
-          # legitimately waiting for its bricks.
+          # legitimately waiting for its bricks. The suite budget is 5m10s (s1
+          # 60s + s2 180s + s3 60s + s4 10s, summed as totalBudget in
+          # conformance/main.go), so 30m readyWait puts the worst case at
+          # 35m10s against this 40m0s: about 5m of real margin.
           verdictURL: http://embervm-dev-embervm-conformance.embervm-dev.svc.cluster.local:8080/verdict
           verdictTimeout: 40m0s
         - name: prod


### PR DESCRIPTION
Prep for the embervm 0.41.7 to 0.47.x prod jump (#5224). Values only, no chart move, no code. Everything here deploys on HEAD, so it lands BEFORE the chart moves, which is the point.

Prod has been pinned at 0.41.7 since 2026-08-24 because the conformance gate was red. The gate fix is #5342 and is deliberately NOT in this PR: merging that one is the promotion trigger, because prod is `autoPromotion: true` with a 5m soak upstream of dev. This PR is what makes that trigger safe to pull.

## Why any of this is needed

A renovate apko lock refresh (`2779f2243`) rewrote every runtime lock, so **13 of 14 guest base digests change** across the jump. Verified by pulling the published 0.47.4 chart, rendering it against PROD `deploy/values.yaml`, and diffing every `BASE_ROOTFS_PATH` against the live 0.41.7 Deployment. Only `ping` is stable.

That makes this a full-fleet guest rebuild: each brick pod bakes roughly 7.5 GB of rootfs in its init containers before it reports Ready. At the measured rate (about 8.2s per 100 MB, from two real cold bakes on node-1) that is 10 to 25m per pod. Four of the bounds in this repo were measured on rolls where base refs did NOT move, and each says so in its own comment.

## The changes

**`waitTimeout` 30m0s to 60m0s.** `maxSurge 0 / maxUnavailable 1` over 4 replicas serializes the pods, with 5 other brick Deployments rolling concurrently. Undershooting reds a healthy roll, which the existing comment calls the worst thing a gate can do.

**dev `verdictTimeout` 20m0s to 40m0s, and dev `conformance.readyWait` 15m to 30m.** These two move together and are the least obvious part of this PR. The dev leg bakes the same 13 digests. The conformance runner rolls with the chart, so it starts while its own brick is still baking; a 15m readyWait expires mid-bake and the runner writes an S0 FAIL for the new chart version. Kargo's dev poll reads that through its failure expression and the dev promotion fails. Prod `autoPromotion` fires on NEW Freight rather than on failure, so that Freight would then sit unverified with no poller on the next healthy cycle: the jump would simply not happen, and the reason would be a timeout rather than anything about the change. `readyWait` must stay strictly below `verdictTimeout`, which also has to cover the roughly 4m suite.

**`bricks.progressDeadlineSeconds` 1200 to 3600.** Derived from a measurement, as its comment insists. About 20m per pod at the measured rate, and node-3 runs two noded pods whose Deployments roll together on one 34 GB device, so they contend. 2400 would sit exactly on a 2x error. Still far below the promotion budget, so the ordering the comment depends on holds: this trips first and fails argocd-wait fast.

**`gitMirror.enabled: false` in prod.** The flag has been true here for a while and has rendered nothing, because 0.41.7 carries no template for it. The moment the chart moves, every noded pod gains a third container that has run nowhere. Dev cannot have exercised it either: the sidecar is gated on `and egress.enabled gitMirror.enabled` and dev runs no egress-proxy, so dev's noded pod has a single container. Landing an unexercised sidecar together with the largest rollout this pipeline has attempted means a failure in either one is diagnosed against both.

## Renders verified

- New chart with these prod values: **0** `git-mirror` containers, **0** `EGRESS_GIT_MIRROR_ADDR` seams. The flag genuinely gates it.
- Deployed 0.41.7 with these values versus current values: **byte-identical**. Nothing rolls on merge of this PR.
- `progressDeadlineSeconds: 3600` renders on the brick Deployments.
- No test asserts any of the four constants (grepped; TTL-class numbers do get asserted in this repo, so this was checked rather than assumed).

## Sequencing

Merge this first and confirm it landed. Then #5342 is the go button. `gitMirror` gets re-enabled afterwards as its own single-change roll, which is what the flag is for.

Refs #5224. Related: #5338, #5339, #5340.
