### PR TITLE
fix(agents): accept the broker's in-flight device code instead of erroring

### DIFF
--- a/projects/embervm/tokenbroker/cmd/tokenbroker/main.go
+++ b/projects/embervm/tokenbroker/cmd/tokenbroker/main.go
@@ -37,19 +37,22 @@ type forceRefreshState struct {
 	lastForced time.Time
 }
 type server struct {
-	broker   *broker.Broker
-	store    store.Store
-	adapters map[string]provider.Adapter
-	configs  map[string]grantConfig
-	logins   sync.Map
-	forced   sync.Map
-	logger   *slog.Logger
+	broker           *broker.Broker
+	store            store.Store
+	adapters         map[string]provider.Adapter
+	configs          map[string]grantConfig
+	logins           sync.Map
+	forced           sync.Map
+	logger           *slog.Logger
+	startWaitTimeout time.Duration
 }
 
 const (
 	forceRefreshCooldown = 60 * time.Second
-	// loginStartWaitTimeout bounds one OAuth device-code round-trip.
-	loginStartWaitTimeout = 10 * time.Second
+	// loginStartWaitTimeout is coupled to the 10-second client-side proxy budget in
+	// projects/monolith/frontend/src/routes/private/agents/codex-login/start/+server.js.
+	// Do not raise either timeout in isolation. Preserve headroom for monolith latency.
+	loginStartWaitTimeout = 5 * time.Second
 )
 
 func main() {
@@ -76,7 +79,7 @@ func main() {
 	}
 	m := metrics.New()
 	m.Register(prometheus.DefaultRegisterer)
-	s := &server{store: st, adapters: adapters, configs: configMap, logger: logger}
+	s := &server{store: st, adapters: adapters, configs: configMap, logger: logger, startWaitTimeout: loginStartWaitTimeout}
 	s.broker = broker.New(st, adapters, brokerConfigs, logger, m)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", s.health)
@@ -184,23 +187,25 @@ func (s *server) loginStart(name string, w http.ResponseWriter, r *http.Request)
 		}
 		readyChan := state.ready
 		state.mu.Unlock()
-		select {
-		case <-readyChan:
-			state.mu.RLock()
-			if state.code != nil {
-				response := map[string]any{
-					"reason":           "login_pending",
-					"verification_url": state.code.VerificationURL,
-					"user_code":        state.code.UserCode,
-					"expires_in":       state.code.ExpiresIn,
+		if readyChan != nil {
+			select {
+			case <-readyChan:
+				state.mu.RLock()
+				if state.code != nil {
+					response := map[string]any{
+						"reason":           "login_pending",
+						"verification_url": state.code.VerificationURL,
+						"user_code":        state.code.UserCode,
+						"expires_in":       state.code.ExpiresIn,
+					}
+					state.mu.RUnlock()
+					writeJSON(w, http.StatusConflict, response)
+					return
 				}
 				state.mu.RUnlock()
-				writeJSON(w, http.StatusConflict, response)
-				return
+			case <-r.Context().Done():
+			case <-time.After(s.startWaitTimeout):
 			}
-			state.mu.RUnlock()
-		case <-r.Context().Done():
-		case <-time.After(loginStartWaitTimeout):
 		}
 		writeJSON(w, http.StatusConflict, map[string]string{"reason": "login_starting"})
 		return
@@ -209,11 +214,18 @@ func (s *server) loginStart(name string, w http.ResponseWriter, r *http.Request)
 	state.ready = make(chan struct{})
 	readyChan := state.ready
 	state.mu.Unlock()
+	defer func() {
+		state.mu.Lock()
+		close(readyChan)
+		if state.ready == readyChan {
+			state.ready = nil
+		}
+		state.mu.Unlock()
+	}()
 	adapter := s.adapters[s.configs[name].ProviderName]
 	code, err := adapter.StartDeviceFlow(r.Context())
 	if err != nil {
 		s.setLogin(name, "failed", err.Error())
-		close(readyChan)
 		writeJSON(w, http.StatusBadGateway, map[string]string{"reason": "device_code_failed"})
 		return
 	}
@@ -221,7 +233,6 @@ func (s *server) loginStart(name string, w http.ResponseWriter, r *http.Request)
 	codeCopy := code
 	state.code = &codeCopy
 	state.mu.Unlock()
-	close(readyChan)
 	go s.pollLogin(name, adapter, code)
 	writeJSON(w, http.StatusOK, map[string]any{"verification_url": code.VerificationURL, "user_code": code.UserCode, "expires_in": code.ExpiresIn})
 }

--- a/projects/embervm/tokenbroker/cmd/tokenbroker/main.go
+++ b/projects/embervm/tokenbroker/cmd/tokenbroker/main.go
@@ -30,6 +30,7 @@ type loginState struct {
 	mu            sync.RWMutex
 	state, detail string
 	code          *provider.DeviceCodeResponse
+	ready         chan struct{}
 }
 type forceRefreshState struct {
 	mu         sync.Mutex
@@ -45,7 +46,11 @@ type server struct {
 	logger   *slog.Logger
 }
 
-const forceRefreshCooldown = 60 * time.Second
+const (
+	forceRefreshCooldown = 60 * time.Second
+	// loginStartWaitTimeout bounds one OAuth device-code round-trip.
+	loginStartWaitTimeout = 10 * time.Second
+)
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
@@ -166,22 +171,49 @@ func (s *server) loginStart(name string, w http.ResponseWriter, r *http.Request)
 	state := value.(*loginState)
 	state.mu.Lock()
 	if state.state == "pending" {
-		response := map[string]any{"reason": "login_pending", "verification_url": "", "user_code": "", "expires_in": provider.FlexInt(0)}
 		if state.code != nil {
-			response["verification_url"] = state.code.VerificationURL
-			response["user_code"] = state.code.UserCode
-			response["expires_in"] = state.code.ExpiresIn
+			response := map[string]any{
+				"reason":           "login_pending",
+				"verification_url": state.code.VerificationURL,
+				"user_code":        state.code.UserCode,
+				"expires_in":       state.code.ExpiresIn,
+			}
+			state.mu.Unlock()
+			writeJSON(w, http.StatusConflict, response)
+			return
 		}
+		readyChan := state.ready
 		state.mu.Unlock()
-		writeJSON(w, http.StatusConflict, response)
+		select {
+		case <-readyChan:
+			state.mu.RLock()
+			if state.code != nil {
+				response := map[string]any{
+					"reason":           "login_pending",
+					"verification_url": state.code.VerificationURL,
+					"user_code":        state.code.UserCode,
+					"expires_in":       state.code.ExpiresIn,
+				}
+				state.mu.RUnlock()
+				writeJSON(w, http.StatusConflict, response)
+				return
+			}
+			state.mu.RUnlock()
+		case <-r.Context().Done():
+		case <-time.After(loginStartWaitTimeout):
+		}
+		writeJSON(w, http.StatusConflict, map[string]string{"reason": "login_starting"})
 		return
 	}
 	state.state, state.detail, state.code = "pending", "approval required", nil
+	state.ready = make(chan struct{})
+	readyChan := state.ready
 	state.mu.Unlock()
 	adapter := s.adapters[s.configs[name].ProviderName]
 	code, err := adapter.StartDeviceFlow(r.Context())
 	if err != nil {
 		s.setLogin(name, "failed", err.Error())
+		close(readyChan)
 		writeJSON(w, http.StatusBadGateway, map[string]string{"reason": "device_code_failed"})
 		return
 	}
@@ -189,6 +221,7 @@ func (s *server) loginStart(name string, w http.ResponseWriter, r *http.Request)
 	codeCopy := code
 	state.code = &codeCopy
 	state.mu.Unlock()
+	close(readyChan)
 	go s.pollLogin(name, adapter, code)
 	writeJSON(w, http.StatusOK, map[string]any{"verification_url": code.VerificationURL, "user_code": code.UserCode, "expires_in": code.ExpiresIn})
 }

--- a/projects/embervm/tokenbroker/cmd/tokenbroker/main_test.go
+++ b/projects/embervm/tokenbroker/cmd/tokenbroker/main_test.go
@@ -42,13 +42,27 @@ func (s *fakeStore) SaveGrantIfNewer(grant store.Grant) error {
 }
 
 type fakeAdapter struct {
-	refreshErr error
-	deviceCode provider.DeviceCodeResponse
-	pollWait   <-chan struct{}
+	refreshErr  error
+	deviceCode  provider.DeviceCodeResponse
+	deviceErr   error
+	startWait   <-chan struct{}
+	startCalled chan struct{}
+	startOnce   sync.Once
+	pollWait    <-chan struct{}
 }
 
-func (a *fakeAdapter) StartDeviceFlow(context.Context) (provider.DeviceCodeResponse, error) {
-	return a.deviceCode, nil
+func (a *fakeAdapter) StartDeviceFlow(ctx context.Context) (provider.DeviceCodeResponse, error) {
+	if a.startCalled != nil {
+		a.startOnce.Do(func() { close(a.startCalled) })
+	}
+	if a.startWait != nil {
+		select {
+		case <-a.startWait:
+		case <-ctx.Done():
+			return provider.DeviceCodeResponse{}, ctx.Err()
+		}
+	}
+	return a.deviceCode, a.deviceErr
 }
 
 func (a *fakeAdapter) PollForAuthorization(ctx context.Context, _ provider.DeviceCodeResponse) (provider.AuthorizationCodeResponse, error) {
@@ -97,6 +111,31 @@ func decodeBody(t *testing.T, recorder *httptest.ResponseRecorder) map[string]an
 		t.Fatal(err)
 	}
 	return body
+}
+
+type signalingContext struct {
+	context.Context
+	entered chan time.Time
+	once    sync.Once
+}
+
+func (c *signalingContext) Done() <-chan struct{} {
+	c.once.Do(func() {
+		c.entered <- time.Now()
+		close(c.entered)
+	})
+	return c.Context.Done()
+}
+
+func requestGrantAsync(s *server, ctx context.Context) <-chan *httptest.ResponseRecorder {
+	result := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodPost, "/grants/codex-cluster/login/start", nil).WithContext(ctx)
+		recorder := httptest.NewRecorder()
+		s.grants(recorder, req)
+		result <- recorder
+	}()
+	return result
 }
 
 func TestForceRefreshReturnsMetadataWithoutCredentialAndEnforcesCooldown(t *testing.T) {
@@ -181,4 +220,93 @@ func TestPendingLoginStatusAndConflictRepeatLiveDeviceCode(t *testing.T) {
 	if conflict.Code != http.StatusConflict || conflictBody["reason"] != "login_pending" || conflictBody["verification_url"] != "https://auth.example/device" || conflictBody["user_code"] != "ABCD-EFGH" || conflictBody["expires_in"] != float64(900) {
 		t.Fatalf("conflict = %d %#v", conflict.Code, conflictBody)
 	}
+}
+
+func TestConcurrentLoginStartWaitsForDeviceCode(t *testing.T) {
+	startWait := make(chan struct{})
+	startCalled := make(chan struct{})
+	pollWait := make(chan struct{})
+	defer close(pollWait)
+	adapter := &fakeAdapter{
+		deviceCode:  provider.DeviceCodeResponse{VerificationURL: "https://auth.example/device", UserCode: "ABCD-EFGH", ExpiresIn: 900},
+		startWait:   startWait,
+		startCalled: startCalled,
+		pollWait:    pollWait,
+	}
+	s := newTestServer(&fakeStore{grants: make(map[string]store.Grant)}, adapter)
+
+	firstResult := requestGrantAsync(s, context.Background())
+	<-startCalled
+	waiting := make(chan time.Time, 1)
+	secondResult := requestGrantAsync(s, &signalingContext{Context: context.Background(), entered: waiting})
+	<-waiting
+	close(startWait)
+
+	first := <-firstResult
+	firstBody := decodeBody(t, first)
+	if first.Code != http.StatusOK || firstBody["verification_url"] != "https://auth.example/device" || firstBody["user_code"] != "ABCD-EFGH" || firstBody["expires_in"] != float64(900) {
+		t.Fatalf("first = %d %#v", first.Code, firstBody)
+	}
+	second := <-secondResult
+	secondBody := decodeBody(t, second)
+	if second.Code != http.StatusConflict || secondBody["reason"] != "login_pending" || secondBody["verification_url"] != "https://auth.example/device" || secondBody["user_code"] != "ABCD-EFGH" || secondBody["expires_in"] != float64(900) {
+		t.Fatalf("second = %d %#v", second.Code, secondBody)
+	}
+}
+
+func TestConcurrentLoginStartReportsStartingWhenDeviceCodeFails(t *testing.T) {
+	startWait := make(chan struct{})
+	startCalled := make(chan struct{})
+	adapter := &fakeAdapter{
+		deviceErr:   errors.New("device flow unavailable"),
+		startWait:   startWait,
+		startCalled: startCalled,
+	}
+	s := newTestServer(&fakeStore{grants: make(map[string]store.Grant)}, adapter)
+
+	firstResult := requestGrantAsync(s, context.Background())
+	<-startCalled
+	waiting := make(chan time.Time, 1)
+	secondResult := requestGrantAsync(s, &signalingContext{Context: context.Background(), entered: waiting})
+	<-waiting
+	close(startWait)
+
+	first := <-firstResult
+	if first.Code != http.StatusBadGateway || decodeBody(t, first)["reason"] != "device_code_failed" {
+		t.Fatalf("first = %d %s", first.Code, first.Body.String())
+	}
+	second := <-secondResult
+	secondBody := decodeBody(t, second)
+	if second.Code != http.StatusConflict || len(secondBody) != 1 || secondBody["reason"] != "login_starting" {
+		t.Fatalf("second = %d %#v", second.Code, secondBody)
+	}
+}
+
+func TestConcurrentLoginStartTimesOutWaitingForDeviceCode(t *testing.T) {
+	startWait := make(chan struct{})
+	startCalled := make(chan struct{})
+	adapter := &fakeAdapter{
+		deviceCode:  provider.DeviceCodeResponse{VerificationURL: "https://auth.example/device", UserCode: "ABCD-EFGH", ExpiresIn: 900},
+		startWait:   startWait,
+		startCalled: startCalled,
+	}
+	s := newTestServer(&fakeStore{grants: make(map[string]store.Grant)}, adapter)
+
+	firstResult := requestGrantAsync(s, context.Background())
+	<-startCalled
+	waiting := make(chan time.Time, 1)
+	secondResult := requestGrantAsync(s, &signalingContext{Context: context.Background(), entered: waiting})
+	startedAt := <-waiting
+	second := <-secondResult
+	elapsed := time.Since(startedAt)
+	if elapsed < loginStartWaitTimeout || elapsed > loginStartWaitTimeout+5*time.Second {
+		t.Fatalf("wait duration = %s, want about %s", elapsed, loginStartWaitTimeout)
+	}
+	secondBody := decodeBody(t, second)
+	if second.Code != http.StatusConflict || len(secondBody) != 1 || secondBody["reason"] != "login_starting" {
+		t.Fatalf("second = %d %#v", second.Code, secondBody)
+	}
+
+	close(startWait)
+	<-firstResult
 }

--- a/projects/embervm/tokenbroker/cmd/tokenbroker/main_test.go
+++ b/projects/embervm/tokenbroker/cmd/tokenbroker/main_test.go
@@ -45,6 +45,7 @@ type fakeAdapter struct {
 	refreshErr  error
 	deviceCode  provider.DeviceCodeResponse
 	deviceErr   error
+	startPanic  any
 	startWait   <-chan struct{}
 	startCalled chan struct{}
 	startOnce   sync.Once
@@ -52,6 +53,9 @@ type fakeAdapter struct {
 }
 
 func (a *fakeAdapter) StartDeviceFlow(ctx context.Context) (provider.DeviceCodeResponse, error) {
+	if a.startPanic != nil {
+		panic(a.startPanic)
+	}
 	if a.startCalled != nil {
 		a.startOnce.Do(func() { close(a.startCalled) })
 	}
@@ -93,7 +97,7 @@ func newTestServer(st *fakeStore, adapter *fakeAdapter) *server {
 	adapters := map[string]provider.Adapter{"test": adapter}
 	configs := map[string]grantConfig{"codex-cluster": {Name: "codex-cluster", ProviderName: "test"}}
 	b := broker.New(st, adapters, []broker.GrantConfig{{Name: "codex-cluster", ProviderName: "test"}}, logger, nil)
-	return &server{broker: b, store: st, adapters: adapters, configs: configs, logger: logger}
+	return &server{broker: b, store: st, adapters: adapters, configs: configs, logger: logger, startWaitTimeout: loginStartWaitTimeout}
 }
 
 func requestGrant(t *testing.T, s *server, method, path string) *httptest.ResponseRecorder {
@@ -136,6 +140,18 @@ func requestGrantAsync(s *server, ctx context.Context) <-chan *httptest.Response
 		result <- recorder
 	}()
 	return result
+}
+
+func receiveWithin[T any](t *testing.T, ch <-chan T, description string) T {
+	t.Helper()
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+		var zero T
+		return zero
+	}
 }
 
 func TestForceRefreshReturnsMetadataWithoutCredentialAndEnforcesCooldown(t *testing.T) {
@@ -236,18 +252,18 @@ func TestConcurrentLoginStartWaitsForDeviceCode(t *testing.T) {
 	s := newTestServer(&fakeStore{grants: make(map[string]store.Grant)}, adapter)
 
 	firstResult := requestGrantAsync(s, context.Background())
-	<-startCalled
+	receiveWithin(t, startCalled, "first caller to start the device flow")
 	waiting := make(chan time.Time, 1)
 	secondResult := requestGrantAsync(s, &signalingContext{Context: context.Background(), entered: waiting})
-	<-waiting
+	receiveWithin(t, waiting, "second caller to enter the wait")
 	close(startWait)
 
-	first := <-firstResult
+	first := receiveWithin(t, firstResult, "first login response")
 	firstBody := decodeBody(t, first)
 	if first.Code != http.StatusOK || firstBody["verification_url"] != "https://auth.example/device" || firstBody["user_code"] != "ABCD-EFGH" || firstBody["expires_in"] != float64(900) {
 		t.Fatalf("first = %d %#v", first.Code, firstBody)
 	}
-	second := <-secondResult
+	second := receiveWithin(t, secondResult, "second login response")
 	secondBody := decodeBody(t, second)
 	if second.Code != http.StatusConflict || secondBody["reason"] != "login_pending" || secondBody["verification_url"] != "https://auth.example/device" || secondBody["user_code"] != "ABCD-EFGH" || secondBody["expires_in"] != float64(900) {
 		t.Fatalf("second = %d %#v", second.Code, secondBody)
@@ -265,17 +281,17 @@ func TestConcurrentLoginStartReportsStartingWhenDeviceCodeFails(t *testing.T) {
 	s := newTestServer(&fakeStore{grants: make(map[string]store.Grant)}, adapter)
 
 	firstResult := requestGrantAsync(s, context.Background())
-	<-startCalled
+	receiveWithin(t, startCalled, "first caller to start the device flow")
 	waiting := make(chan time.Time, 1)
 	secondResult := requestGrantAsync(s, &signalingContext{Context: context.Background(), entered: waiting})
-	<-waiting
+	receiveWithin(t, waiting, "second caller to enter the wait")
 	close(startWait)
 
-	first := <-firstResult
+	first := receiveWithin(t, firstResult, "first login response")
 	if first.Code != http.StatusBadGateway || decodeBody(t, first)["reason"] != "device_code_failed" {
 		t.Fatalf("first = %d %s", first.Code, first.Body.String())
 	}
-	second := <-secondResult
+	second := receiveWithin(t, secondResult, "second login response")
 	secondBody := decodeBody(t, second)
 	if second.Code != http.StatusConflict || len(secondBody) != 1 || secondBody["reason"] != "login_starting" {
 		t.Fatalf("second = %d %#v", second.Code, secondBody)
@@ -291,16 +307,17 @@ func TestConcurrentLoginStartTimesOutWaitingForDeviceCode(t *testing.T) {
 		startCalled: startCalled,
 	}
 	s := newTestServer(&fakeStore{grants: make(map[string]store.Grant)}, adapter)
+	s.startWaitTimeout = time.Millisecond
 
 	firstResult := requestGrantAsync(s, context.Background())
-	<-startCalled
+	receiveWithin(t, startCalled, "first caller to start the device flow")
 	waiting := make(chan time.Time, 1)
 	secondResult := requestGrantAsync(s, &signalingContext{Context: context.Background(), entered: waiting})
-	startedAt := <-waiting
-	second := <-secondResult
+	startedAt := receiveWithin(t, waiting, "second caller to enter the wait")
+	second := receiveWithin(t, secondResult, "second login response")
 	elapsed := time.Since(startedAt)
-	if elapsed < loginStartWaitTimeout || elapsed > loginStartWaitTimeout+5*time.Second {
-		t.Fatalf("wait duration = %s, want about %s", elapsed, loginStartWaitTimeout)
+	if elapsed < s.startWaitTimeout || elapsed > s.startWaitTimeout+time.Second {
+		t.Fatalf("wait duration = %s, want about %s", elapsed, s.startWaitTimeout)
 	}
 	secondBody := decodeBody(t, second)
 	if second.Code != http.StatusConflict || len(secondBody) != 1 || secondBody["reason"] != "login_starting" {
@@ -308,5 +325,34 @@ func TestConcurrentLoginStartTimesOutWaitingForDeviceCode(t *testing.T) {
 	}
 
 	close(startWait)
-	<-firstResult
+	receiveWithin(t, firstResult, "first login response")
+}
+
+func TestLoginStartClosesReadyChannelWhenDeviceFlowPanics(t *testing.T) {
+	s := newTestServer(
+		&fakeStore{grants: make(map[string]store.Grant)},
+		&fakeAdapter{startPanic: "device flow panic"},
+	)
+	s.startWaitTimeout = 500 * time.Millisecond
+
+	panicked := false
+	func() {
+		defer func() {
+			panicked = recover() != nil
+		}()
+		requestGrant(t, s, http.MethodPost, "/grants/codex-cluster/login/start")
+	}()
+	if !panicked {
+		t.Fatal("StartDeviceFlow did not panic")
+	}
+
+	startedAt := time.Now()
+	response := requestGrant(t, s, http.MethodPost, "/grants/codex-cluster/login/start")
+	if elapsed := time.Since(startedAt); elapsed >= s.startWaitTimeout {
+		t.Fatalf("response after panic waited %s", elapsed)
+	}
+	body := decodeBody(t, response)
+	if response.Code != http.StatusConflict || len(body) != 1 || body["reason"] != "login_starting" {
+		t.Fatalf("response after panic = %d %#v", response.Code, body)
+	}
 }

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -289,13 +289,23 @@ async def codex_login_start(grant: str = Query(default="codex-cluster")):
                 pending_data = exc.response.json()
             except Exception:
                 pending_data = {}
-            if isinstance(pending_data, dict) and pending_data.get("user_code"):
-                return {
-                    "verification_url": pending_data.get("verification_url"),
-                    "user_code": pending_data.get("user_code"),
-                    "expires_in": pending_data.get("expires_in"),
-                    "pending": True,
-                }
+            if isinstance(pending_data, dict):
+                reason = pending_data.get("reason")
+                has_code = bool(pending_data.get("user_code"))
+                has_code_fields = has_code or bool(pending_data.get("verification_url"))
+                if reason == "login_starting" and not has_code_fields:
+                    return {
+                        "retry_after": 10,
+                        "message": "Device flow is starting, try again shortly.",
+                        "pending": False,
+                    }
+                if has_code and reason in (None, "login_pending"):
+                    return {
+                        "verification_url": pending_data.get("verification_url"),
+                        "user_code": pending_data.get("user_code"),
+                        "expires_in": pending_data.get("expires_in"),
+                        "pending": True,
+                    }
         return JSONResponse(
             status_code=502,
             content={"error": "Codex login broker unavailable"},

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -284,8 +284,7 @@ async def codex_login_start(grant: str = Query(default="codex-cluster")):
     try:
         data = await mcp._broker_request("POST", f"/grants/{grant}/login/start")
     except httpx.HTTPStatusError as exc:
-        status = exc.response.status_code
-        if status == 409:
+        if exc.response.status_code == 409:
             try:
                 pending_data = exc.response.json()
             except Exception:
@@ -299,19 +298,12 @@ async def codex_login_start(grant: str = Query(default="codex-cluster")):
                 }
         return JSONResponse(
             status_code=502,
-            content={
-                "error": "Codex login broker unavailable",
-                "status": status,
-            },
+            content={"error": "Codex login broker unavailable"},
         )
-    except Exception as exc:
-        response = getattr(exc, "response", None)
+    except Exception:
         return JSONResponse(
             status_code=502,
-            content={
-                "error": "Codex login broker unavailable",
-                "status": getattr(response, "status_code", None),
-            },
+            content={"error": "Codex login broker unavailable"},
         )
     return {
         "verification_url": data.get("verification_url"),

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -283,15 +283,41 @@ async def codex_login_start(grant: str = Query(default="codex-cluster")):
         raise HTTPException(status_code=400, detail="invalid grant name") from exc
     try:
         data = await mcp._broker_request("POST", f"/grants/{grant}/login/start")
-    except Exception:
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        if status == 409:
+            try:
+                pending_data = exc.response.json()
+            except Exception:
+                pending_data = {}
+            if isinstance(pending_data, dict) and pending_data.get("user_code"):
+                return {
+                    "verification_url": pending_data.get("verification_url"),
+                    "user_code": pending_data.get("user_code"),
+                    "expires_in": pending_data.get("expires_in"),
+                    "pending": True,
+                }
         return JSONResponse(
             status_code=502,
-            content={"error": "Codex login broker unavailable"},
+            content={
+                "error": "Codex login broker unavailable",
+                "status": status,
+            },
+        )
+    except Exception as exc:
+        response = getattr(exc, "response", None)
+        return JSONResponse(
+            status_code=502,
+            content={
+                "error": "Codex login broker unavailable",
+                "status": getattr(response, "status_code", None),
+            },
         )
     return {
         "verification_url": data.get("verification_url"),
         "user_code": data.get("user_code"),
         "expires_in": data.get("expires_in"),
+        "pending": False,
     }
 
 

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -252,17 +252,21 @@ def test_codex_login_start_proxies_broker(client, monkeypatch):
     assert calls == [("POST", "/grants/codex-cluster/login/start")]
 
 
-def test_codex_login_start_returns_in_flight_broker_login(client, monkeypatch):
+@pytest.mark.parametrize("reason", [None, "login_pending"])
+def test_codex_login_start_returns_in_flight_broker_login(client, monkeypatch, reason):
     async def broker_request(*_args):
+        body = {
+            "verification_url": "https://example.test/device",
+            "user_code": "PENDING-123",
+            "expires_in": 600,
+            "ignored": "not exposed",
+        }
+        if reason is not None:
+            body["reason"] = reason
         response = httpx.Response(
             409,
             request=httpx.Request("POST", "https://broker/login/start"),
-            json={
-                "verification_url": "https://example.test/device",
-                "user_code": "PENDING-123",
-                "expires_in": 600,
-                "ignored": "not exposed",
-            },
+            json=body,
         )
         raise httpx.HTTPStatusError(
             "login pending", request=response.request, response=response
@@ -278,6 +282,34 @@ def test_codex_login_start_returns_in_flight_broker_login(client, monkeypatch):
         "user_code": "PENDING-123",
         "expires_in": 600,
         "pending": True,
+    }
+
+
+def test_codex_login_start_returns_retry_when_broker_is_starting(client, monkeypatch):
+    async def broker_request(*_args):
+        response = httpx.Response(
+            409,
+            request=httpx.Request("POST", "https://broker/login/start"),
+            json={
+                "reason": "login_starting",
+                "verification_url": "",
+                "user_code": "",
+                "expires_in": 0,
+            },
+        )
+        raise httpx.HTTPStatusError(
+            "login starting", request=response.request, response=response
+        )
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+
+    response = client.post("/api/agents/codex-login/start")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "retry_after": 10,
+        "message": "Device flow is starting, try again shortly.",
+        "pending": False,
     }
 
 

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -310,13 +310,12 @@ def test_codex_login_start_rejects_unusable_pending_body(
     response = client.post("/api/agents/codex-login/start")
 
     assert response.status_code == 502
-    assert response.json() == {
-        "error": "Codex login broker unavailable",
-        "status": 409,
-    }
+    assert response.json() == {"error": "Codex login broker unavailable"}
 
 
-def test_codex_login_start_carries_non_conflict_upstream_status(client, monkeypatch):
+def test_codex_login_start_returns_502_for_non_conflict_upstream_error(
+    client, monkeypatch
+):
     async def broker_request(*_args):
         response = httpx.Response(
             503,
@@ -331,10 +330,7 @@ def test_codex_login_start_carries_non_conflict_upstream_status(client, monkeypa
     response = client.post("/api/agents/codex-login/start")
 
     assert response.status_code == 502
-    assert response.json() == {
-        "error": "Codex login broker unavailable",
-        "status": 503,
-    }
+    assert response.json() == {"error": "Codex login broker unavailable"}
 
 
 @pytest.mark.parametrize(
@@ -348,7 +344,7 @@ def test_codex_login_start_carries_non_conflict_upstream_status(client, monkeypa
         (
             "post",
             "/api/agents/codex-login/start",
-            {"error": "Codex login broker unavailable", "status": None},
+            {"error": "Codex login broker unavailable"},
         ),
     ],
 )

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -365,34 +365,19 @@ def test_codex_login_start_returns_502_for_non_conflict_upstream_error(
     assert response.json() == {"error": "Codex login broker unavailable"}
 
 
-@pytest.mark.parametrize(
-    ("method", "path", "expected"),
-    [
-        (
-            "get",
-            "/api/agents/codex-login/status",
-            {"error": "Codex login broker unavailable"},
-        ),
-        (
-            "post",
-            "/api/agents/codex-login/start",
-            {"error": "Codex login broker unavailable"},
-        ),
-    ],
-)
-def test_codex_login_endpoints_return_json_502_when_broker_unreachable(
-    client, monkeypatch, method, path, expected
+def test_codex_login_status_returns_json_502_when_broker_unreachable(
+    client, monkeypatch
 ):
     async def broker_request(*_args):
         raise httpx.ConnectError("offline")
 
     monkeypatch.setattr(mcp, "_broker_request", broker_request)
 
-    response = getattr(client, method)(path)
+    response = client.get("/api/agents/codex-login/status")
 
     assert response.status_code == 502
     assert response.headers["content-type"] == "application/json"
-    assert response.json() == expected
+    assert response.json() == {"error": "Codex login broker unavailable"}
 
 
 def test_codex_login_endpoints_validate_grant(client, monkeypatch):

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -247,19 +247,113 @@ def test_codex_login_start_proxies_broker(client, monkeypatch):
         "verification_url": "https://example.test/device",
         "user_code": "CODE-123",
         "expires_in": 900,
+        "pending": False,
     }
     assert calls == [("POST", "/grants/codex-cluster/login/start")]
 
 
+def test_codex_login_start_returns_in_flight_broker_login(client, monkeypatch):
+    async def broker_request(*_args):
+        response = httpx.Response(
+            409,
+            request=httpx.Request("POST", "https://broker/login/start"),
+            json={
+                "verification_url": "https://example.test/device",
+                "user_code": "PENDING-123",
+                "expires_in": 600,
+                "ignored": "not exposed",
+            },
+        )
+        raise httpx.HTTPStatusError(
+            "login pending", request=response.request, response=response
+        )
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+
+    response = client.post("/api/agents/codex-login/start")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "verification_url": "https://example.test/device",
+        "user_code": "PENDING-123",
+        "expires_in": 600,
+        "pending": True,
+    }
+
+
 @pytest.mark.parametrize(
-    ("method", "path"),
+    "response_kwargs",
     [
-        ("get", "/api/agents/codex-login/status"),
-        ("post", "/api/agents/codex-login/start"),
+        {"json": {"verification_url": "https://example.test/device"}},
+        {"json": ["not", "a", "login"]},
+        {
+            "content": b"not JSON",
+            "headers": {"Content-Type": "application/json"},
+        },
+    ],
+)
+def test_codex_login_start_rejects_unusable_pending_body(
+    client, monkeypatch, response_kwargs
+):
+    async def broker_request(*_args):
+        response = httpx.Response(
+            409,
+            request=httpx.Request("POST", "https://broker/login/start"),
+            **response_kwargs,
+        )
+        raise httpx.HTTPStatusError(
+            "login pending", request=response.request, response=response
+        )
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+
+    response = client.post("/api/agents/codex-login/start")
+
+    assert response.status_code == 502
+    assert response.json() == {
+        "error": "Codex login broker unavailable",
+        "status": 409,
+    }
+
+
+def test_codex_login_start_carries_non_conflict_upstream_status(client, monkeypatch):
+    async def broker_request(*_args):
+        response = httpx.Response(
+            503,
+            request=httpx.Request("POST", "https://broker/login/start"),
+        )
+        raise httpx.HTTPStatusError(
+            "broker unavailable", request=response.request, response=response
+        )
+
+    monkeypatch.setattr(mcp, "_broker_request", broker_request)
+
+    response = client.post("/api/agents/codex-login/start")
+
+    assert response.status_code == 502
+    assert response.json() == {
+        "error": "Codex login broker unavailable",
+        "status": 503,
+    }
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "expected"),
+    [
+        (
+            "get",
+            "/api/agents/codex-login/status",
+            {"error": "Codex login broker unavailable"},
+        ),
+        (
+            "post",
+            "/api/agents/codex-login/start",
+            {"error": "Codex login broker unavailable", "status": None},
+        ),
     ],
 )
 def test_codex_login_endpoints_return_json_502_when_broker_unreachable(
-    client, monkeypatch, method, path
+    client, monkeypatch, method, path, expected
 ):
     async def broker_request(*_args):
         raise httpx.ConnectError("offline")
@@ -270,7 +364,7 @@ def test_codex_login_endpoints_return_json_502_when_broker_unreachable(
 
     assert response.status_code == 502
     assert response.headers["content-type"] == "application/json"
-    assert response.json() == {"error": "Codex login broker unavailable"}
+    assert response.json() == expected
 
 
 def test_codex_login_endpoints_validate_grant(client, monkeypatch):

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -185,6 +185,7 @@
   let errorMessage = $state(
     data.error ? "Unable to load agent sessions" : null,
   );
+  let noticeMessage = $state(null);
   let searchController = null;
   let requestSequence = 0;
   let renderedPending = $state({});
@@ -1915,13 +1916,13 @@
                   copiedLabel={P.labels.copied}
                   unavailableLabel={P.labels.codexLoginUnavailable}
                   invalidResponseLabel={P.labels.codexLoginInvalidResponse}
-                  codeLabel={P.labels.codexLoginCode}
                   openLinkLabel={P.labels.codexLoginOpenLink}
                   requestNewCodeLabel={P.labels.codexLoginRequestNewCode}
                   startingLabel={P.labels.codexLoginStarting}
                   initialUserCode={selectedCodexLoginCode}
                   initialVerificationUrl={selectedCodexLoginUrl}
                   onError={(message) => (errorMessage = message)}
+                  onNotice={(message) => (noticeMessage = message)}
                 />
               {/if}
               <span
@@ -2202,9 +2203,16 @@
     onOpenVoice={openVoiceMode}
   />
 
-  {#if errorMessage}<div class="error-banner" role="status">
-      {errorMessage}
-    </div>{/if}
+  {#if noticeMessage || errorMessage}
+    <div class="message-banners">
+      {#if noticeMessage}<div class="notice-banner" role="status">
+          {noticeMessage}
+        </div>{/if}
+      {#if errorMessage}<div class="error-banner" role="status">
+          {errorMessage}
+        </div>{/if}
+    </div>
+  {/if}
 </main>
 
 {#snippet inboxRow(item, attention)}
@@ -3124,17 +3132,29 @@
   .transcript-empty {
     padding: 32px 0;
   }
-  .error-banner {
+  .message-banners {
     position: fixed;
     right: 16px;
     bottom: 16px;
+    display: grid;
+    gap: 8px;
     max-width: 420px;
+  }
+  .notice-banner,
+  .error-banner {
     padding: 8px 12px;
-    border: 1px solid var(--err-line);
     border-radius: var(--radius-lg);
+    font-size: var(--size-detail);
+  }
+  .notice-banner {
+    border: 1px solid var(--line-strong);
+    color: var(--text);
+    background: var(--panel-bg);
+  }
+  .error-banner {
+    border: 1px solid var(--err-line);
     color: var(--err);
     background: var(--err-bg);
-    font-size: var(--size-detail);
   }
   @media (prefers-reduced-motion: no-preference) {
     .dot.working {

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1918,6 +1918,7 @@
                   codeLabel={P.labels.codexLoginCode}
                   openLinkLabel={P.labels.codexLoginOpenLink}
                   requestNewCodeLabel={P.labels.codexLoginRequestNewCode}
+                  startingLabel={P.labels.codexLoginStarting}
                   initialUserCode={selectedCodexLoginCode}
                   initialVerificationUrl={selectedCodexLoginUrl}
                   onError={(message) => (errorMessage = message)}

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1917,6 +1917,7 @@
                   invalidResponseLabel={P.labels.codexLoginInvalidResponse}
                   codeLabel={P.labels.codexLoginCode}
                   openLinkLabel={P.labels.codexLoginOpenLink}
+                  requestNewCodeLabel={P.labels.codexLoginRequestNewCode}
                   initialUserCode={selectedCodexLoginCode}
                   initialVerificationUrl={selectedCodexLoginUrl}
                   onError={(message) => (errorMessage = message)}

--- a/projects/monolith/frontend/src/routes/private/agents/CodexLogin.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/CodexLogin.svelte
@@ -7,13 +7,13 @@
     copiedLabel,
     unavailableLabel,
     invalidResponseLabel,
-    codeLabel,
     openLinkLabel,
     requestNewCodeLabel,
     startingLabel,
     initialUserCode = null,
     initialVerificationUrl = null,
     onError = () => {},
+    onNotice = () => {},
   } = $props();
 
   let authorizing = $state(false);
@@ -27,7 +27,7 @@
   let copiedTimer;
 
   $effect(() => {
-    initialUserCode;
+    if (!initialUserCode) return;
     requestedUserCode = null;
     requestedVerificationUrl = null;
   });
@@ -40,6 +40,7 @@
     copied = false;
     clearTimeout(copiedTimer);
     onError(null);
+    onNotice(null);
     try {
       const response = await fetch("/private/agents/codex-login/start", {
         method: "POST",
@@ -53,7 +54,8 @@
         );
       }
       if (typeof body.retry_after === "number" && body.retry_after > 0) {
-        throw new Error(startingLabel);
+        onNotice(startingLabel);
+        return;
       }
       if (
         typeof body.user_code !== "string" ||
@@ -87,7 +89,7 @@
 
 {#if userCode}
   <div class="codex-login-control">
-    <code id="codex-device-code" tabindex="0">{userCode}</code>
+    <code id="codex-device-code">{userCode}</code>
     {#if verificationUrl}
       <a
         class="primary-action"

--- a/projects/monolith/frontend/src/routes/private/agents/CodexLogin.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/CodexLogin.svelte
@@ -25,6 +25,12 @@
   );
   let copiedTimer;
 
+  $effect(() => {
+    initialUserCode;
+    requestedUserCode = null;
+    requestedVerificationUrl = null;
+  });
+
   onDestroy(() => clearTimeout(copiedTimer));
 
   async function authorize() {
@@ -77,15 +83,16 @@
 
 {#if userCode}
   <div class="codex-login-control">
+    <code id="codex-device-code" tabindex="0">{userCode}</code>
     {#if verificationUrl}
       <a
         class="primary-action"
         href={verificationUrl}
         target="_blank"
+        aria-describedby="codex-device-code"
         rel="noopener noreferrer">{openLinkLabel}</a
       >
     {/if}
-    <code aria-label={codeLabel} tabindex="0">{userCode}</code>
     <button
       class="secondary-action"
       type="button"
@@ -124,10 +131,14 @@
     padding: 0 9px;
     border: 1px solid var(--line-strong);
     border-radius: var(--radius-md);
-    color: var(--panel-bg);
-    background: var(--text);
+    color: var(--ink-text);
+    background: var(--ink);
     font: 600 12px var(--font-mono);
     text-decoration: none;
+  }
+  .primary-action:focus-visible {
+    outline: 2px solid var(--info);
+    outline-offset: 2px;
   }
   /* Keep the filled treatment on hover. Swapping to --hover here flips a
      solid dark button to a pale chip mid-gesture, which reads as the control
@@ -137,20 +148,25 @@
   }
   .secondary-action {
     min-height: 28px;
-    padding: 0 5px;
-    border: 0;
-    color: var(--muted);
+    padding: 0 7px;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-md);
+    color: var(--text);
     background: var(--panel-bg);
     font: 500 11px var(--font-mono);
-    text-decoration: underline;
   }
   .secondary-action:hover:not(:disabled) {
     color: var(--text);
     background: var(--hover);
   }
-  button:disabled {
+  button:not(.primary-action):disabled {
     color: var(--muted);
     cursor: wait;
+  }
+  button.primary-action:disabled {
+    color: var(--ink-text);
+    cursor: wait;
+    opacity: 0.62;
   }
   code {
     color: var(--attn-text);

--- a/projects/monolith/frontend/src/routes/private/agents/CodexLogin.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/CodexLogin.svelte
@@ -10,6 +10,7 @@
     codeLabel,
     openLinkLabel,
     requestNewCodeLabel,
+    startingLabel,
     initialUserCode = null,
     initialVerificationUrl = null,
     onError = () => {},
@@ -50,6 +51,9 @@
             body?.detail ||
             `${unavailableLabel} (HTTP ${response.status})`,
         );
+      }
+      if (typeof body.retry_after === "number" && body.retry_after > 0) {
+        throw new Error(startingLabel);
       }
       if (
         typeof body.user_code !== "string" ||

--- a/projects/monolith/frontend/src/routes/private/agents/CodexLogin.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/CodexLogin.svelte
@@ -9,6 +9,7 @@
     invalidResponseLabel,
     codeLabel,
     openLinkLabel,
+    requestNewCodeLabel,
     initialUserCode = null,
     initialVerificationUrl = null,
     onError = () => {},
@@ -38,7 +39,11 @@
       });
       const body = await response.json().catch(() => ({}));
       if (!response.ok) {
-        throw new Error(body.error || body.detail || unavailableLabel);
+        throw new Error(
+          body?.error ||
+            body?.detail ||
+            `${unavailableLabel} (HTTP ${response.status})`,
+        );
       }
       if (
         typeof body.user_code !== "string" ||
@@ -47,18 +52,21 @@
         throw new Error(invalidResponseLabel);
       }
 
+      const previousUserCode = userCode;
       requestedUserCode = body.user_code;
       requestedVerificationUrl = body.verification_url;
       if (navigator.clipboard?.writeText) {
         try {
-          await navigator.clipboard.writeText(userCode);
+          await navigator.clipboard.writeText(body.user_code);
           copied = true;
           copiedTimer = setTimeout(() => (copied = false), 1200);
         } catch {
           copied = false;
         }
       }
-      window.open(body.verification_url, "_blank", "noopener,noreferrer");
+      if (body.pending !== true || body.user_code !== previousUserCode) {
+        window.open(body.verification_url, "_blank", "noopener,noreferrer");
+      }
     } catch (error) {
       onError(error instanceof Error ? error.message : unavailableLabel);
     } finally {
@@ -67,37 +75,75 @@
   }
 </script>
 
-<div class="codex-login-control">
-  <button type="button" disabled={authorizing} onclick={authorize}>
+{#if userCode}
+  <div class="codex-login-control">
+    {#if verificationUrl}
+      <a
+        class="primary-action"
+        href={verificationUrl}
+        target="_blank"
+        rel="noopener noreferrer">{openLinkLabel}</a
+      >
+    {/if}
+    <code aria-label={codeLabel} tabindex="0">{userCode}</code>
+    <button
+      class="secondary-action"
+      type="button"
+      disabled={authorizing}
+      onclick={authorize}
+    >
+      {authorizing ? authorizingLabel : requestNewCodeLabel}
+    </button>
+    {#if copied}<span class="copied" role="status">{copiedLabel}</span>{/if}
+  </div>
+{:else}
+  <button
+    class="primary-action"
+    type="button"
+    disabled={authorizing}
+    onclick={authorize}
+  >
     {authorizing ? authorizingLabel : authorizeLabel}
   </button>
-  {#if userCode}
-    <code aria-label={codeLabel} tabindex="0">{userCode}</code>
-  {/if}
-  {#if verificationUrl}
-    <a href={verificationUrl} target="_blank" rel="noopener noreferrer"
-      >{openLinkLabel}</a
-    >
-  {/if}
-  {#if copied}<span class="copied" role="status">{copiedLabel}</span>{/if}
-</div>
+{/if}
 
 <style>
   .codex-login-control {
     display: inline-flex;
     align-items: center;
     gap: 7px;
+    padding: 6px;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-md);
+    background: var(--panel-bg);
   }
-  button {
+  .primary-action {
+    display: inline-flex;
+    align-items: center;
     min-height: 28px;
     padding: 0 9px;
     border: 1px solid var(--line-strong);
     border-radius: var(--radius-md);
-    color: var(--text);
-    background: var(--panel-bg);
+    color: var(--panel-bg);
+    background: var(--text);
     font: 600 12px var(--font-mono);
+    text-decoration: none;
   }
-  button:hover:not(:disabled) {
+  .primary-action:hover:not(:disabled) {
+    color: var(--text);
+    background: var(--hover);
+  }
+  .secondary-action {
+    min-height: 28px;
+    padding: 0 5px;
+    border: 0;
+    color: var(--muted);
+    background: var(--panel-bg);
+    font: 500 11px var(--font-mono);
+    text-decoration: underline;
+  }
+  .secondary-action:hover:not(:disabled) {
+    color: var(--text);
     background: var(--hover);
   }
   button:disabled {
@@ -108,10 +154,6 @@
     color: var(--attn-text);
     font: 600 12px var(--font-mono);
     user-select: text;
-  }
-  a {
-    color: var(--attn-text);
-    font-size: 11px;
   }
   .copied {
     color: var(--muted);

--- a/projects/monolith/frontend/src/routes/private/agents/CodexLogin.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/CodexLogin.svelte
@@ -129,9 +129,11 @@
     font: 600 12px var(--font-mono);
     text-decoration: none;
   }
+  /* Keep the filled treatment on hover. Swapping to --hover here flips a
+     solid dark button to a pale chip mid-gesture, which reads as the control
+     losing its state rather than responding to the pointer. */
   .primary-action:hover:not(:disabled) {
-    color: var(--text);
-    background: var(--hover);
+    opacity: 0.85;
   }
   .secondary-action {
     min-height: 28px;

--- a/projects/monolith/frontend/src/routes/private/agents/CodexLogin.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/CodexLogin.test.js
@@ -1,37 +1,43 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { mount, tick, unmount } from "svelte";
+import { createClassComponent } from "svelte/legacy";
 import CodexLogin from "./CodexLogin.svelte";
 import { RUN_LEXICON as P } from "./run-lexicon.js";
 
 const mounted = [];
 
-async function render(onError = vi.fn(), props = {}) {
+async function render(onError = vi.fn(), props = {}, mutable = false) {
   const target = document.createElement("div");
   document.body.append(target);
-  const component = mount(CodexLogin, {
-    target,
-    props: {
-      authorizeLabel: P.labels.authorizeCodex,
-      authorizingLabel: P.labels.authorizingCodex,
-      copiedLabel: P.labels.copied,
-      unavailableLabel: P.labels.codexLoginUnavailable,
-      invalidResponseLabel: P.labels.codexLoginInvalidResponse,
-      codeLabel: P.labels.codexLoginCode,
-      openLinkLabel: P.labels.codexLoginOpenLink,
-      requestNewCodeLabel: P.labels.codexLoginRequestNewCode,
-      onError,
-      ...props,
-    },
-  });
-  mounted.push({ component, target });
+  const componentProps = {
+    authorizeLabel: P.labels.authorizeCodex,
+    authorizingLabel: P.labels.authorizingCodex,
+    copiedLabel: P.labels.copied,
+    unavailableLabel: P.labels.codexLoginUnavailable,
+    invalidResponseLabel: P.labels.codexLoginInvalidResponse,
+    codeLabel: P.labels.codexLoginCode,
+    openLinkLabel: P.labels.codexLoginOpenLink,
+    requestNewCodeLabel: P.labels.codexLoginRequestNewCode,
+    onError,
+    ...props,
+  };
+  const component = mutable
+    ? createClassComponent({
+        component: CodexLogin,
+        target,
+        props: componentProps,
+      })
+    : mount(CodexLogin, { target, props: componentProps });
+  mounted.push({ component, target, mutable });
   await tick();
-  return { target, onError };
+  return { component, target, onError };
 }
 
 afterEach(async () => {
-  for (const { component, target } of mounted.splice(0)) {
-    await unmount(component);
+  for (const { component, target, mutable } of mounted.splice(0)) {
+    if (mutable) component.$destroy();
+    else await unmount(component);
     target.remove();
   }
   vi.restoreAllMocks();
@@ -63,6 +69,11 @@ describe("Codex authorization", () => {
     expect(target.querySelector("code")?.textContent).toBe("READY-123");
     expect(button?.textContent.trim()).toBe(P.labels.codexLoginRequestNewCode);
     expect(target.querySelectorAll("a, button")).toHaveLength(2);
+    expect(target.querySelector("code")?.nextElementSibling).toBe(link);
+    expect(link?.getAttribute("aria-describedby")).toBe("codex-device-code");
+    expect(target.querySelector("code")?.hasAttribute("aria-label")).toBe(
+      false,
+    );
   });
 
   test("posts once, copies the code, and opens the verification URL", async () => {
@@ -197,6 +208,74 @@ describe("Codex authorization", () => {
     expect(onError).toHaveBeenLastCalledWith(null);
     expect(open).not.toHaveBeenCalled();
     expect(target.querySelector("code")?.textContent).toBe("PENDING-123");
+  });
+
+  test("opens a new pending flow when no prior code exists", async () => {
+    vi.stubGlobal("navigator", {});
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            verification_url: "https://example.test/device",
+            user_code: "NEW-CODE",
+            expires_in: 600,
+            pending: true,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    const { target } = await render();
+
+    target.querySelector("button.primary-action").click();
+
+    await vi.waitFor(() =>
+      expect(target.querySelector("code")?.textContent).toBe("NEW-CODE"),
+    );
+    expect(open).toHaveBeenCalledWith(
+      "https://example.test/device",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  test("replaces stale code when initialUserCode prop changes", async () => {
+    vi.stubGlobal("navigator", {});
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            verification_url: "https://example.test/requested",
+            user_code: "REQUESTED-X",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.spyOn(window, "open").mockImplementation(() => null);
+    const { component, target } = await render(
+      vi.fn(),
+      {
+        initialUserCode: "INITIAL-X",
+        initialVerificationUrl: "https://example.test/initial",
+      },
+      true,
+    );
+
+    target.querySelector("button.secondary-action").click();
+    await vi.waitFor(() =>
+      expect(target.querySelector("code")?.textContent).toBe("REQUESTED-X"),
+    );
+
+    component.$set({
+      initialUserCode: "INITIAL-Y",
+      initialVerificationUrl: "https://example.test/next",
+    });
+    await tick();
+
+    expect(target.querySelector("code")?.textContent).toBe("INITIAL-Y");
+    expect(target.querySelector("a")?.getAttribute("href")).toBe(
+      "https://example.test/next",
+    );
   });
 
   test("renders the verification URL as a link when the popup is blocked", async () => {

--- a/projects/monolith/frontend/src/routes/private/agents/CodexLogin.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/CodexLogin.test.js
@@ -19,6 +19,7 @@ async function render(onError = vi.fn(), props = {}, mutable = false) {
     codeLabel: P.labels.codexLoginCode,
     openLinkLabel: P.labels.codexLoginOpenLink,
     requestNewCodeLabel: P.labels.codexLoginRequestNewCode,
+    startingLabel: P.labels.codexLoginStarting,
     onError,
     ...props,
   };
@@ -157,6 +158,31 @@ describe("Codex authorization", () => {
 
     await vi.waitFor(() =>
       expect(onError).toHaveBeenLastCalledWith("broker unavailable"),
+    );
+    expect(target.querySelector("button").disabled).toBe(false);
+    expect(target.querySelector("code")).toBeNull();
+  });
+
+  test("surfaces device flow startup as a retriable state", async () => {
+    vi.stubGlobal("navigator", {});
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            retry_after: 10,
+            message: "Device flow is starting, try again shortly.",
+            pending: false,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.spyOn(window, "open").mockImplementation(() => null);
+    const { target, onError } = await render();
+
+    target.querySelector("button").click();
+
+    await vi.waitFor(() =>
+      expect(onError).toHaveBeenLastCalledWith(P.labels.codexLoginStarting),
     );
     expect(target.querySelector("button").disabled).toBe(false);
     expect(target.querySelector("code")).toBeNull();

--- a/projects/monolith/frontend/src/routes/private/agents/CodexLogin.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/CodexLogin.test.js
@@ -10,17 +10,18 @@ const mounted = [];
 async function render(onError = vi.fn(), props = {}, mutable = false) {
   const target = document.createElement("div");
   document.body.append(target);
+  const onNotice = props.onNotice ?? vi.fn();
   const componentProps = {
     authorizeLabel: P.labels.authorizeCodex,
     authorizingLabel: P.labels.authorizingCodex,
     copiedLabel: P.labels.copied,
     unavailableLabel: P.labels.codexLoginUnavailable,
     invalidResponseLabel: P.labels.codexLoginInvalidResponse,
-    codeLabel: P.labels.codexLoginCode,
     openLinkLabel: P.labels.codexLoginOpenLink,
     requestNewCodeLabel: P.labels.codexLoginRequestNewCode,
     startingLabel: P.labels.codexLoginStarting,
     onError,
+    onNotice,
     ...props,
   };
   const component = mutable
@@ -32,7 +33,7 @@ async function render(onError = vi.fn(), props = {}, mutable = false) {
     : mount(CodexLogin, { target, props: componentProps });
   mounted.push({ component, target, mutable });
   await tick();
-  return { component, target, onError };
+  return { component, target, onError, onNotice };
 }
 
 afterEach(async () => {
@@ -139,7 +140,7 @@ describe("Codex authorization", () => {
       expect(target.querySelector("code")?.textContent).toBe("FALL-BACK"),
     );
     expect(open).toHaveBeenCalledTimes(1);
-    expect(target.querySelector("code").getAttribute("tabindex")).toBe("0");
+    expect(target.querySelector("code").hasAttribute("tabindex")).toBe(false);
   });
 
   test("surfaces endpoint failures and re-enables the button", async () => {
@@ -163,27 +164,37 @@ describe("Codex authorization", () => {
     expect(target.querySelector("code")).toBeNull();
   });
 
-  test("surfaces device flow startup as a retriable state", async () => {
+  test("reports device flow startup as a notice", async () => {
     vi.stubGlobal("navigator", {});
+    let resolveResponse;
     globalThis.fetch = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
-            retry_after: 10,
-            message: "Device flow is starting, try again shortly.",
-            pending: false,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
+      () =>
+        new Promise((resolve) => {
+          resolveResponse = resolve;
+        }),
     );
     vi.spyOn(window, "open").mockImplementation(() => null);
-    const { target, onError } = await render();
+    const { target, onError, onNotice } = await render();
 
     target.querySelector("button").click();
+    expect(onError).toHaveBeenCalledWith(null);
+    onError.mockClear();
+    resolveResponse(
+      new Response(
+        JSON.stringify({
+          retry_after: 10,
+          message: "Device flow is starting, try again shortly.",
+          pending: false,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
 
     await vi.waitFor(() =>
-      expect(onError).toHaveBeenLastCalledWith(P.labels.codexLoginStarting),
+      expect(onNotice).toHaveBeenLastCalledWith(P.labels.codexLoginStarting),
     );
+    expect(onNotice).toHaveBeenNthCalledWith(1, null);
+    expect(onError).not.toHaveBeenCalled();
     expect(target.querySelector("button").disabled).toBe(false);
     expect(target.querySelector("code")).toBeNull();
   });
@@ -301,6 +312,45 @@ describe("Codex authorization", () => {
     expect(target.querySelector("code")?.textContent).toBe("INITIAL-Y");
     expect(target.querySelector("a")?.getAttribute("href")).toBe(
       "https://example.test/next",
+    );
+  });
+
+  test("keeps a requested code when initialUserCode changes to null", async () => {
+    vi.stubGlobal("navigator", {});
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            verification_url: "https://example.test/requested",
+            user_code: "REQUESTED-X",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.spyOn(window, "open").mockImplementation(() => null);
+    const { component, target } = await render(
+      vi.fn(),
+      {
+        initialUserCode: "INITIAL-X",
+        initialVerificationUrl: "https://example.test/initial",
+      },
+      true,
+    );
+
+    target.querySelector("button.secondary-action").click();
+    await vi.waitFor(() =>
+      expect(target.querySelector("code")?.textContent).toBe("REQUESTED-X"),
+    );
+
+    component.$set({
+      initialUserCode: null,
+      initialVerificationUrl: null,
+    });
+    await tick();
+
+    expect(target.querySelector("code")?.textContent).toBe("REQUESTED-X");
+    expect(target.querySelector("a")?.getAttribute("href")).toBe(
+      "https://example.test/requested",
     );
   });
 

--- a/projects/monolith/frontend/src/routes/private/agents/CodexLogin.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/CodexLogin.test.js
@@ -6,7 +6,7 @@ import { RUN_LEXICON as P } from "./run-lexicon.js";
 
 const mounted = [];
 
-async function render(onError = vi.fn()) {
+async function render(onError = vi.fn(), props = {}) {
   const target = document.createElement("div");
   document.body.append(target);
   const component = mount(CodexLogin, {
@@ -19,7 +19,9 @@ async function render(onError = vi.fn()) {
       invalidResponseLabel: P.labels.codexLoginInvalidResponse,
       codeLabel: P.labels.codexLoginCode,
       openLinkLabel: P.labels.codexLoginOpenLink,
+      requestNewCodeLabel: P.labels.codexLoginRequestNewCode,
       onError,
+      ...props,
     },
   });
   mounted.push({ component, target });
@@ -37,6 +39,32 @@ afterEach(async () => {
 });
 
 describe("Codex authorization", () => {
+  test("renders authorize as the only control before a code exists", async () => {
+    const { target } = await render();
+
+    const controls = target.querySelectorAll("a, button");
+    expect(controls).toHaveLength(1);
+    expect(controls[0].tagName).toBe("BUTTON");
+    expect(controls[0].classList.contains("primary-action")).toBe(true);
+    expect(controls[0].textContent.trim()).toBe(P.labels.authorizeCodex);
+    expect(target.querySelector("code")).toBeNull();
+  });
+
+  test("makes the login link primary and requesting a new code secondary", async () => {
+    const { target } = await render(vi.fn(), {
+      initialUserCode: "READY-123",
+      initialVerificationUrl: "https://example.test/device",
+    });
+
+    const link = target.querySelector("a.primary-action");
+    const button = target.querySelector("button.secondary-action");
+    expect(link?.textContent.trim()).toBe(P.labels.codexLoginOpenLink);
+    expect(link?.getAttribute("href")).toBe("https://example.test/device");
+    expect(target.querySelector("code")?.textContent).toBe("READY-123");
+    expect(button?.textContent.trim()).toBe(P.labels.codexLoginRequestNewCode);
+    expect(target.querySelectorAll("a, button")).toHaveLength(2);
+  });
+
   test("posts once, copies the code, and opens the verification URL", async () => {
     const writeText = vi.fn(async () => {});
     vi.stubGlobal("navigator", { clipboard: { writeText } });
@@ -121,6 +149,54 @@ describe("Codex authorization", () => {
     );
     expect(target.querySelector("button").disabled).toBe(false);
     expect(target.querySelector("code")).toBeNull();
+  });
+
+  test("includes the HTTP status when an error response has no message", async () => {
+    vi.stubGlobal("navigator", {});
+    globalThis.fetch = vi.fn(async () => new Response("", { status: 503 }));
+    vi.spyOn(window, "open").mockImplementation(() => null);
+    const { target, onError } = await render();
+
+    target.querySelector("button").click();
+
+    await vi.waitFor(() =>
+      expect(onError).toHaveBeenLastCalledWith(
+        `${P.labels.codexLoginUnavailable} (HTTP 503)`,
+      ),
+    );
+    expect(target.querySelector("button").disabled).toBe(false);
+  });
+
+  test("accepts an identical pending code without reopening the login page", async () => {
+    const writeText = vi.fn(async () => {});
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            verification_url: "https://example.test/device",
+            user_code: "PENDING-123",
+            expires_in: 600,
+            pending: true,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    const onError = vi.fn();
+    const { target } = await render(onError, {
+      initialUserCode: "PENDING-123",
+      initialVerificationUrl: "https://example.test/device",
+    });
+
+    target.querySelector("button.secondary-action").click();
+
+    await vi.waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith("PENDING-123"),
+    );
+    expect(onError).toHaveBeenLastCalledWith(null);
+    expect(open).not.toHaveBeenCalled();
+    expect(target.querySelector("code")?.textContent).toBe("PENDING-123");
   });
 
   test("renders the verification URL as a link when the popup is blocked", async () => {

--- a/projects/monolith/frontend/src/routes/private/agents/codex-login/codex-login-server.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/codex-login/codex-login-server.test.js
@@ -73,6 +73,5 @@ describe("Codex login proxies", () => {
     expect(response.headers.get("content-type")).toBe("application/json");
     const body = await response.json();
     expect(body.error).toContain("Codex login");
-    expect(body.status).toBe(502);
   });
 });

--- a/projects/monolith/frontend/src/routes/private/agents/codex-login/codex-login-server.test.js
+++ b/projects/monolith/frontend/src/routes/private/agents/codex-login/codex-login-server.test.js
@@ -71,6 +71,8 @@ describe("Codex login proxies", () => {
 
     expect(response.status).toBe(502);
     expect(response.headers.get("content-type")).toBe("application/json");
-    expect((await response.json()).error).toContain("Codex login");
+    const body = await response.json();
+    expect(body.error).toContain("Codex login");
+    expect(body.status).toBe(502);
   });
 });

--- a/projects/monolith/frontend/src/routes/private/agents/codex-login/start/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/codex-login/start/+server.js
@@ -15,7 +15,10 @@ export async function POST({ url }) {
     });
   } catch {
     return new Response(
-      JSON.stringify({ error: "Codex login start unavailable" }),
+      JSON.stringify({
+        error: "Codex login start unavailable",
+        status: 502,
+      }),
       {
         status: 502,
         headers: { "Content-Type": "application/json" },

--- a/projects/monolith/frontend/src/routes/private/agents/codex-login/start/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/codex-login/start/+server.js
@@ -17,7 +17,6 @@ export async function POST({ url }) {
     return new Response(
       JSON.stringify({
         error: "Codex login start unavailable",
-        status: 502,
       }),
       {
         status: 502,

--- a/projects/monolith/frontend/src/routes/private/agents/codex-login/status/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/codex-login/status/+server.js
@@ -16,7 +16,6 @@ export async function GET({ url }) {
     return new Response(
       JSON.stringify({
         error: "Codex login status unavailable",
-        status: 502,
       }),
       {
         status: 502,

--- a/projects/monolith/frontend/src/routes/private/agents/codex-login/status/+server.js
+++ b/projects/monolith/frontend/src/routes/private/agents/codex-login/status/+server.js
@@ -14,7 +14,10 @@ export async function GET({ url }) {
     });
   } catch {
     return new Response(
-      JSON.stringify({ error: "Codex login status unavailable" }),
+      JSON.stringify({
+        error: "Codex login status unavailable",
+        status: 502,
+      }),
       {
         status: 502,
         headers: { "Content-Type": "application/json" },

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -103,6 +103,7 @@ export const RUN_LEXICON = {
     authorizingCodex: "authorizing…",
     codexLoginCode: "Codex device code",
     codexLoginOpenLink: "open login page",
+    codexLoginRequestNewCode: "request a new code",
     codexLoginUnavailable: "Codex login is unavailable",
     codexLoginInvalidResponse: "Codex login returned an invalid response",
     codexLoginRequired: "Codex login is required before this turn can start.",

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -104,6 +104,7 @@ export const RUN_LEXICON = {
     codexLoginCode: "Codex device code",
     codexLoginOpenLink: "open login page",
     codexLoginRequestNewCode: "request a new code",
+    codexLoginStarting: "device flow is starting, try again shortly…",
     codexLoginUnavailable: "Codex login is unavailable",
     codexLoginInvalidResponse: "Codex login returned an invalid response",
     codexLoginRequired: "Codex login is required before this turn can start.",

--- a/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
+++ b/projects/monolith/frontend/src/routes/private/agents/run-lexicon.js
@@ -101,7 +101,6 @@ export const RUN_LEXICON = {
     awaitingLogin: "awaiting login",
     authorizeCodex: "Authorize Codex",
     authorizingCodex: "authorizing…",
-    codexLoginCode: "Codex device code",
     codexLoginOpenLink: "open login page",
     codexLoginRequestNewCode: "request a new code",
     codexLoginStarting: "device flow is starting, try again shortly…",


### PR DESCRIPTION
Closes #5352.

The `Authorize Codex` button was dead in every state it could be shown in.

The console renders it only while a session is `awaiting_login`, and by then `codex_login_gate` has already started a device flow. The broker handles that correctly: `loginStart` returns **409 carrying the in-flight `verification_url`, `user_code` and `expires_in`**, which is the same code already on screen. The monolith threw it away, because `_broker_request` calls `raise_for_status()` and `codex_login_start` caught bare `Exception` and returned 502. The console surfaced that as a red toast.

Observed in prod on 2026-08-26: the button toasted a failure while the `open login page` link beside it, rendered from the gate's hint, worked and completed the login.

## The fix

**Backend.** `codex_login_start` catches `httpx.HTTPStatusError` ahead of the bare handler and returns the 409's in-flight code as a normal 200 with `pending: true`. A 409 whose body carries no `user_code` still falls through to 502, so this cannot return a 200 full of nulls.

**Broker.** The 409-with-empty-strings window is closed rather than documented. `loginStart` set `state = "pending"` with `code = nil` before awaiting `StartDeviceFlow`, so a concurrent caller got a 409 of empty strings and reproduced the same red toast. A concurrent caller now waits on a per-attempt `ready` channel and receives the real code. `login_starting` is the fallback only when the first caller fails or the wait expires.

The wait is 5s, deliberately inside the SvelteKit proxy's 10s `AbortSignal.timeout`, which starts first and adds a monolith round trip. At 10s the proxy aborted first and the broker's reply landed on a dead socket, making the whole branch unreachable. The timeout is injected through `server` so tests do not burn wall clock: the package's critical path went from 70.8s to 1.45s.

**Console.** The primary/secondary inversion is fixed. `open login page` was tiny link text while `Authorize Codex`, the control that cannot work while a flow is pending, was the primary button. When a code exists the link becomes primary and the button demotes to a secondary "request a new code". `login_starting` renders as a neutral notice banner rather than the red error banner, because a transient "try again shortly" is not a failure.

**Diagnosability.** The generic "Codex login is unavailable" toast was unfalsifiable: it could not distinguish a 404 from a 502 from a Cloudflare error page. The client now appends the HTTP status when a response carries no `error`/`detail`.

## Notable review catches, fixed in this PR

- An unwired `status` field was added to four files and read by nothing; removed, which also collapsed a dead `except Exception as exc` branch whose `getattr(exc, "response", None)` could only ever be `None`.
- The `$effect` added to fix stale-code shadowing cleared on any change of `initialUserCode`, including to `null`. Since `codex_login_gate`'s 409 branch returns no code, that wiped a live code the user was mid-approval on. Now guarded on a truthy code.
- `codeLabel` became a dead prop when the `aria-label` came off `<code>`; the prop, its pass-through and its lexicon key are removed, along with a `tabindex="0"` focus stop that no longer had an accessible name.
- The `ready` channel now closes via `defer`, so a panic in `StartDeviceFlow` cannot leave later callers paying the full wait.
- The Go tests failed a reverted fix by hanging to the package timeout rather than asserting; every channel receive now has a deadline and a `t.Fatal`.

## Verification

- PR CI green.
- `//projects/embervm/tokenbroker/cmd/tokenbroker:tokenbroker_test` run directly against the pushed HEAD with `--nocache_test_results`: `Executed 1 out of 1 test: 1 test passes.`
- Reviewed twice by Opus against the merge-base.

Rollout ordering is safe in either direction: the old broker never emits `login_starting`, and the new broker's `login_pending`-with-code body is what the pre-PR monolith already 502'd on.

## Known residual

A panic inside `StartDeviceFlow` still leaves the grant `pending` until the broker restarts. Pre-existing and unchanged in kind; callers now get an immediate `login_starting` instead of an immediate 502.

## Not covered

The prod incident that surfaced this had a second, unrelated cause: the egress-proxy sidecar was injecting an access token ChatGPT had revoked early, because it caches by nominal expiry and the deployed build had no invalidate-on-401. That is fixed by `a123dda8b` and went live with embervm 0.47.11.