### PR TITLE
fix(embervm): open the egress lane for base-build guests

### DIFF
--- a/projects/embervm/noded/server/egress_test.go
+++ b/projects/embervm/noded/server/egress_test.go
@@ -1,12 +1,18 @@
 package server
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
 
 	"github.com/jomcgi/homelab/projects/embervm/noded/config"
 )
@@ -47,5 +53,203 @@ func TestStartEgressHonorsWorkloadScope(t *testing.T) {
 	noOp()
 	if _, err := os.Stat(disallowed + "_1025"); !os.IsNotExist(err) {
 		t.Fatalf("forwarder started for a disallowed workload, stat err = %v", err)
+	}
+}
+
+type buildEgressResult struct {
+	resp *nodev1.BuildBaseResponse
+	err  error
+}
+
+func newBuildEgressServer(t *testing.T, enabled bool, workloads []string, tr *fakeTransport, logger *slog.Logger) (*Server, *fakeDriver) {
+	t.Helper()
+	build := &fakeDriver{vsockDir: t.TempDir()}
+	s := New(Options{
+		Config: config.Config{
+			Arch:              "amd64",
+			Node:              "node-4",
+			SnapshotRoot:      t.TempDir(),
+			BootReadyTimeout:  5 * time.Second,
+			Images:            map[string]config.Image{"img:1": {RootfsPath: "/rootfs.ext4"}},
+			EgressEnabled:     enabled,
+			EgressWorkloads:   workloads,
+			EgressSidecarAddr: "127.0.0.1:1",
+		},
+		Driver:         &fakeDriver{},
+		Transport:      tr,
+		NewBuildDriver: func(BuildDriverSpec) BuildDriver { return build },
+		Logger:         logger,
+	})
+	return s, build
+}
+
+func startBuildEgressTest(s *Server, workload string) <-chan buildEgressResult {
+	result := make(chan buildEgressResult, 1)
+	go func() {
+		resp, err := s.BuildBase(context.Background(), &nodev1.BuildBaseRequest{
+			Trace:            &nodev1.Trace{Workload: workload},
+			ImageRef:         "img:1",
+			WorkloadRevision: "r1",
+			ReadyPath:        "/shim/ready",
+		})
+		result <- buildEgressResult{resp: resp, err: err}
+	}()
+	return result
+}
+
+func waitForBuildReady(t *testing.T, started <-chan string) string {
+	t.Helper()
+	select {
+	case uds := <-started:
+		return uds
+	case <-time.After(2 * time.Second):
+		t.Fatal("base build did not reach WaitReady")
+		return ""
+	}
+}
+
+func waitForEgressSocket(t *testing.T, path string, present bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_, err := os.Stat(path)
+		if present && err == nil {
+			return
+		}
+		if !present && os.IsNotExist(err) {
+			return
+		}
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatalf("stat egress socket %q: %v", path, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("egress socket %q present = %v, want %v", path, err == nil, present)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func assertNoEgressSocket(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			t.Fatalf("unexpected egress socket %q", path)
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat egress socket %q: %v", path, err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func receiveBuildEgressResult(t *testing.T, result <-chan buildEgressResult) buildEgressResult {
+	t.Helper()
+	select {
+	case got := <-result:
+		return got
+	case <-time.After(2 * time.Second):
+		t.Fatal("base build did not return")
+		return buildEgressResult{}
+	}
+}
+
+func TestBuildBaseEgressUsesExactWorkloadAndCancelsOnSuccess(t *testing.T) {
+	started := make(chan string, 1)
+	continueReady := make(chan struct{})
+	tr := &fakeTransport{waitReadyStarted: started, waitReadyContinue: continueReady}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	workload := "claude.runtime"
+	s, build := newBuildEgressServer(t, true, []string{workload}, tr, logger)
+	result := startBuildEgressTest(s, workload)
+
+	uds := waitForBuildReady(t, started)
+	egressSocket := uds + "_1025"
+	// The dot in the request workload is changed to an underscore in baseKey.
+	// Reaching this listener proves runBuild received the exact request workload
+	// instead of recovering a lossy value from the base key.
+	waitForEgressSocket(t, egressSocket, true)
+	close(continueReady)
+
+	got := receiveBuildEgressResult(t, result)
+	if got.err != nil || got.resp.GetSnapshotRef() == "" {
+		t.Fatalf("BuildBase = %+v, %v, want successful snapshot", got.resp, got.err)
+	}
+	waitForEgressSocket(t, egressSocket, false)
+	claims, releases, removeBundles, _ := build.counts()
+	if claims != 1 || releases != 1 || removeBundles != 1 || build.snapshots != 1 {
+		t.Fatalf("build lifecycle claims=%d releases=%d removeBundles=%d snapshots=%d, want 1/1/1/1",
+			claims, releases, removeBundles, build.snapshots)
+	}
+}
+
+func TestBuildBaseEgressCancelsOnWaitReadyFailure(t *testing.T) {
+	started := make(chan string, 1)
+	continueReady := make(chan struct{})
+	tr := &fakeTransport{
+		waitReadyStarted:  started,
+		waitReadyContinue: continueReady,
+		waitReadyErr:      errors.New("guest not ready"),
+	}
+	s, build := newBuildEgressServer(t, true, []string{"claude-runtime"}, tr, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	result := startBuildEgressTest(s, "claude-runtime")
+
+	uds := waitForBuildReady(t, started)
+	egressSocket := uds + "_1025"
+	waitForEgressSocket(t, egressSocket, true)
+	close(continueReady)
+
+	got := receiveBuildEgressResult(t, result)
+	if got.err == nil || !strings.Contains(got.err.Error(), "guest readiness: guest not ready") {
+		t.Fatalf("BuildBase error = %v, want guest readiness failure", got.err)
+	}
+	waitForEgressSocket(t, egressSocket, false)
+	claims, releases, removeBundles, _ := build.counts()
+	if claims != 1 || releases != 1 || removeBundles != 1 || build.snapshots != 0 {
+		t.Fatalf("failed build lifecycle claims=%d releases=%d removeBundles=%d snapshots=%d, want 1/1/1/0",
+			claims, releases, removeBundles, build.snapshots)
+	}
+}
+
+func TestBuildBaseEgressSkipsWorkloadOutsideScope(t *testing.T) {
+	started := make(chan string, 1)
+	continueReady := make(chan struct{})
+	tr := &fakeTransport{waitReadyStarted: started, waitReadyContinue: continueReady}
+	var logs bytes.Buffer
+	s, build := newBuildEgressServer(t, true, []string{"claude-runtime"}, tr, slog.New(slog.NewTextHandler(&logs, nil)))
+	result := startBuildEgressTest(s, "outside.runtime")
+
+	uds := waitForBuildReady(t, started)
+	assertNoEgressSocket(t, uds+"_1025")
+	logText := logs.String()
+	if !strings.Contains(logText, "egress lane not opened; workload is outside the configured scope") ||
+		!strings.Contains(logText, "workload=outside.runtime") {
+		t.Fatalf("egress skip log = %q, want skip message with exact workload", logText)
+	}
+	close(continueReady)
+	if got := receiveBuildEgressResult(t, result); got.err != nil {
+		t.Fatalf("BuildBase outside egress scope: %v", got.err)
+	}
+	_, releases, removeBundles, _ := build.counts()
+	if releases != 1 || removeBundles != 1 {
+		t.Fatalf("build teardown releases=%d removeBundles=%d, want 1/1", releases, removeBundles)
+	}
+}
+
+func TestBuildBaseEgressDisabledDoesNotChangeTeardown(t *testing.T) {
+	started := make(chan string, 1)
+	continueReady := make(chan struct{})
+	tr := &fakeTransport{waitReadyStarted: started, waitReadyContinue: continueReady}
+	s, build := newBuildEgressServer(t, false, []string{"claude-runtime"}, tr, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	result := startBuildEgressTest(s, "claude-runtime")
+
+	uds := waitForBuildReady(t, started)
+	assertNoEgressSocket(t, uds+"_1025")
+	close(continueReady)
+	if got := receiveBuildEgressResult(t, result); got.err != nil {
+		t.Fatalf("BuildBase with egress disabled: %v", got.err)
+	}
+	_, releases, removeBundles, _ := build.counts()
+	if releases != 1 || removeBundles != 1 {
+		t.Fatalf("build teardown releases=%d removeBundles=%d, want 1/1", releases, removeBundles)
 	}
 }

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -817,7 +817,7 @@ func (s *Server) driveBuild(ctx context.Context, req *nodev1.BuildBaseRequest, b
 		MemMib:      int(res.GetMemMib()),
 	})
 
-	sizeBytes, err := s.runBuild(buildCtx, bd, baseKey, readyPath, archive)
+	sizeBytes, err := s.runBuild(buildCtx, bd, baseKey, workload, readyPath, archive)
 	if err != nil {
 		s.bases.failBuild(baseKey, err.Error())
 		s.signalChange()
@@ -956,13 +956,15 @@ func (s *Server) adoptSiblingBaseBundle(baseKey, workload, imageDigest, rootfsPa
 // Sequence: Claim (cold boot) -> Prime (drain the vsock path via /shim/healthz)
 // -> Hydrate (POST the archive; zip lane only) -> WaitReady (/shim/ready flips 200
 // only after the shim unpacks + imports the handler) -> SnapshotBase.
-func (s *Server) runBuild(ctx context.Context, bd BuildDriver, baseKey, readyPath string, archive []byte) (int64, error) {
+func (s *Server) runBuild(ctx context.Context, bd BuildDriver, baseKey, workload, readyPath string, archive []byte) (int64, error) {
 	spec := substrate.ClaimSpec{Arch: s.cfg.Arch, ThreadID: newID("build")}
 	h, err := bd.Claim(ctx, spec)
 	if err != nil {
 		return 0, fmt.Errorf("cold boot: %w", err)
 	}
+	egressCancel := func() {}
 	defer func() {
+		egressCancel()
 		if rerr := bd.Release(context.Background(), h); rerr != nil {
 			s.logger.Warn("noded: release build guest", "base", baseKey, "err", rerr)
 		}
@@ -972,6 +974,7 @@ func (s *Server) runBuild(ctx context.Context, bd BuildDriver, baseKey, readyPat
 	}()
 
 	uds := bd.VsockUDSPath(h.ThreadID)
+	egressCancel = s.startEgress(uds, h.ID, workload)
 
 	// Zip lane: prime the vsock path open, then hydrate the shim with the archive
 	// BEFORE the readiness wait. The shim serves /shim/healthz immediately but stays

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -58,6 +58,9 @@ type fakeDriver struct {
 	// an archive drive (it hydrates over vsock), so a test asserts the build guest
 	// claimed with only its rootfs (no extra drive fields exist on ClaimSpec now).
 	lastClaim substrate.ClaimSpec
+	// vsockDir relocates fake guest sockets under a test-owned temporary
+	// directory. Empty preserves the historical /tmp path.
+	vsockDir string
 
 	// Session-driver seam (R2). sessionBundles is the in-memory stand-in for the
 	// on-disk sessions/ dir: a Bank writes a ref -> marker entry (the "state" the
@@ -123,7 +126,12 @@ func (f *fakeDriver) RemoveBundle(_ string) error {
 	return nil
 }
 
-func (f *fakeDriver) VsockUDSPath(threadID string) string { return "/tmp/" + threadID + ".sock" }
+func (f *fakeDriver) VsockUDSPath(threadID string) string {
+	if f.vsockDir != "" {
+		return filepath.Join(f.vsockDir, threadID+".sock")
+	}
+	return "/tmp/" + threadID + ".sock"
+}
 
 func (f *fakeDriver) Stats(_ substrate.Handle) (substrate.GuestStats, error) {
 	f.mu.Lock()
@@ -247,10 +255,12 @@ func (f *fakeDriver) counts() (claims, releases, removeBundles, statsCalls int) 
 // fakeTransport is an in-memory transport. RoundTrip echoes "ok:"+body unless
 // roundTripErr is set.
 type fakeTransport struct {
-	mu           sync.Mutex
-	roundTrips   int
-	waitReadyErr error
-	roundTripErr error
+	mu                sync.Mutex
+	roundTrips        int
+	waitReadyErr      error
+	waitReadyStarted  chan string
+	waitReadyContinue <-chan struct{}
+	roundTripErr      error
 	// hydrate capture: hydrates counts the calls, hydrateBytes records the last
 	// archive delivered so a zip test can assert the exact bytes were hydrated, and
 	// hydrateErr injects a hydrate failure (a bad archive) to fail the build.
@@ -273,8 +283,27 @@ type fakeTransport struct {
 	blockRoundTrip chan struct{}
 }
 
-func (f *fakeTransport) WaitReady(_ context.Context, _, _ string) error {
-	return f.waitReadyErr // nosemgrep: no-bare-error-return
+func (f *fakeTransport) WaitReady(ctx context.Context, udsPath, _ string) error {
+	f.mu.Lock()
+	started := f.waitReadyStarted
+	continueCh := f.waitReadyContinue
+	waitErr := f.waitReadyErr
+	f.mu.Unlock()
+	if started != nil {
+		select {
+		case started <- udsPath:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if continueCh != nil {
+		select {
+		case <-continueCh:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return waitErr // nosemgrep: no-bare-error-return
 }
 func (f *fakeTransport) Prime(_ context.Context, _ string) error { return nil }
 


### PR DESCRIPTION
Fixes #5357. **Live production outage**: `claude-runtime` has been unable to build a base since 2026-08-26 16:47 UTC, retrying every 60s. `Ready=False/BaseNotBuilt`, and neither 16gi node holds any claude base.

## Cause

`startEgress` was called from Prime and Relight only, never from the base-build path, so a build guest booted with nothing behind its vsock egress port.

That was harmless until #4423 moved the prewarm list into the image. Prewarm now runs on every base build, and the Claude CLI's init blocks on network. The guest's own serial log:

```
ember-claude-shim: cli-probe: exit=0 stdout='2.1.220 (Claude Code)\n' stderr=''
ember-claude-shim: egress listening on 127.0.0.1:1024
ember-claude-shim: listening on vsock port 1027
ember-claude-shim: egress vsock connect failed after 3 attempts: [Errno 104] Connection reset by peer
   (x20)
ember-claude-shim: initialization timed out after 30 seconds, sending SIGINT
ember-claude-shim: CLI prewarm failed: timed out waiting for Claude initialization after 30 seconds
```

The `--version` probe succeeds, so the binary is sound. The real spawn blocks waiting for Claude's `{"type":"system","subtype":"init"}` event, which never arrives. `prewarm` sets `fatal_error`, `ready()` refuses while that is set, `/shim/ready` never flips, `WaitReady` times out, and the control plane retries forever.

## Change

Seven lines in `runBuild`. Start the forwarder as soon as the build guest's uds is known, which is before Prime, Hydrate and WaitReady, so it is listening before the shim dials. Cancel it first in the existing teardown, ahead of releasing the guest. The cancel initializes to a no-op so the defer is safe on every path, including a Claim failure.

The workload comes from `driveBuild`'s `req.GetTrace().GetWorkload()`, threaded explicitly rather than split out of `baseKey`. `startEgress`'s own comment warns that a wrong or missing workload name is indistinguishable from a guest that was never meant to have egress, so the name has to come from the request, exactly as Relight takes it.

## This widens nothing

`startEgress` already no-ops when `EgressEnabled` is false, and no-ops with a logged skip when the workload is outside `EgressWorkloads`. Build guests now get the same reach their primed counterparts already have, for workloads already in scope. `claude-runtime` is already in prod's scope (`["claude-runtime","pi-runtime","shotter"]`).

That said, please review this as a deliberate change to the base-build network posture rather than as a pure bug fix. It restores behaviour #4423 broke by accident, but the posture change is real.

## The prewarm gate is deliberately untouched

`ready()` requires every configured prewarm CLI alive when the placeholder volume has no ext4, which is the base-build condition. That guard is correct: "a snapshot with a dead CLI would restore warmth that is not there." The bug was that warming Claude needs egress and base builds had none, making the precondition unsatisfiable rather than merely unsatisfied. Weakening the guard would ship bases whose warmth is a lie.

## Verification

Falsified rather than assumed. With the tests unchanged and ONLY the `startEgress` call removed:

```
--- FAIL: TestBuildBaseEgressUsesExactWorkloadAndCancelsOnSuccess (2.00s)
--- FAIL: TestBuildBaseEgressCancelsOnWaitReadyFailure (2.00s)
--- FAIL: TestBuildBaseEgressSkipsWorkloadOutsideScope (0.10s)
Executed 1 out of 1 test: 1 fails remotely.
```

Restored: `1 test passes`.

Note for reviewers: a bare `ci test` on this branch reports "affected-targets: no changes, nothing to test" and exits 0 despite the branch being ahead of origin/main. That is a false green of the #4118 family. Run the target explicitly: `ci test -- //projects/embervm/noded/server:server_test`.

## Alternatives rejected

- Skipping prewarm during base builds: defeats the point of a warm base.
- Making prewarm failure non-fatal during builds: ships bases whose warmth is a lie, which is what the guard prevents.
- Reverting #4423's image-side prewarm: restores service but loses the codex and pi prewarm, and leaves the same trap for the next workload whose CLI needs network.

Found during the 0.41.7 to 0.47.11 prod jump (#5224). Twelve other workloads built cleanly.
