### PR TITLE
fix(embervm): self-heal an unopenable SQLite op-log instead of crashlooping

### DIFF
--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -113,6 +113,7 @@ defmodule Embervm.OpLog.SQLite do
   @default_compact_batch_size 500
   # The meta key the durable ops-journal prefix marker lives at; absent reads 0.
   @marker_key "compacted_through_seq"
+  @sqlite_header "SQLite format 3\0"
 
   @ddl [
     """
@@ -448,11 +449,154 @@ defmodule Embervm.OpLog.SQLite do
   # get an unnamed, PID-addressed process.
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
+    opts = Keyword.put(opts, :path, Keyword.get(opts, :path) || default_path())
+
+    case start_gen_server(opts) do
+      {:error, {:open_failed, reason}} -> recover_open_failure(opts, reason)
+      result -> result
+    end
+  end
+
+  defp start_gen_server(opts) do
     case Keyword.get(opts, :name, __MODULE__) do
       nil -> GenServer.start_link(__MODULE__, opts)
       name -> GenServer.start_link(__MODULE__, opts, name: name)
     end
   end
+
+  # GenServer.start_link/3 waits for init/1, so an init error is still available
+  # here before start_link/1 returns it to the application supervisor. Keep the
+  # recovery at this boundary: init/1 cannot quarantine and then raise without
+  # letting that failure escape the child start contract.
+  defp recover_open_failure(opts, reason) do
+    path = Keyword.fetch!(opts, :path)
+    diagnostics = open_failure_diagnostics(path)
+
+    Logger.error(
+      "embervm SQLite op-log open failed: path=#{inspect(path)} reason=#{inspect(reason)} " <>
+        "file_size_bytes=#{format_diagnostic(diagnostics.file_size_bytes)} " <>
+        "filesystem_free_bytes=#{format_diagnostic(diagnostics.filesystem_free_bytes)}"
+    )
+
+    case quarantine_database(path) do
+      {:ok, quarantined} -> retry_after_quarantine(opts, path, reason, quarantined)
+
+      {:error, quarantine_reason} ->
+        Logger.error(
+          "embervm SQLite op-log quarantine failed: path=#{inspect(path)} " <>
+            "open_reason=#{inspect(reason)} quarantine_reason=#{inspect(quarantine_reason)}; failing hard"
+        )
+
+        {:error, {:open_failed, reason}}
+    end
+  end
+
+  defp retry_after_quarantine(opts, path, first_reason, quarantined) do
+    case start_gen_server(opts) do
+      {:ok, pid} ->
+        Logger.error(
+          "embervm SQLite op-log history was quarantined after open failure; " <>
+            "running degraded with a fresh database: path=#{inspect(path)} " <>
+            "reason=#{inspect(first_reason)} quarantined=#{inspect(quarantined)}"
+        )
+
+        {:ok, pid}
+
+      {:error, second_reason} = error ->
+        Logger.error(
+          "embervm SQLite op-log recreate failed after one quarantine retry: " <>
+            "path=#{inspect(path)} first_reason=#{inspect(first_reason)} " <>
+            "second_reason=#{inspect(second_reason)}; failing hard"
+        )
+
+        error
+    end
+  end
+
+  defp quarantine_database(path) do
+    suffix = ".quarantined-#{quarantine_timestamp()}-#{System.unique_integer([:positive])}"
+    quarantine_path = path <> suffix
+
+    [
+      {path, quarantine_path},
+      {path <> "-wal", quarantine_path <> "-wal"},
+      {path <> "-shm", quarantine_path <> "-shm"}
+    ]
+    |> Enum.filter(fn {source, _destination} -> File.regular?(source) end)
+    |> Enum.reduce_while({:ok, []}, fn {source, destination}, {:ok, quarantined} ->
+      case File.rename(source, destination) do
+        :ok -> {:cont, {:ok, [destination | quarantined]}}
+        {:error, reason} -> {:halt, {:error, {source, destination, reason}}}
+      end
+    end)
+    |> case do
+      {:ok, quarantined} -> {:ok, Enum.reverse(quarantined)}
+      error -> error
+    end
+  end
+
+  defp quarantine_timestamp do
+    DateTime.utc_now()
+    |> Calendar.strftime("%Y%m%dT%H%M%SZ")
+  end
+
+  defp open_failure_diagnostics(path) do
+    %{
+      file_size_bytes: file_size(path),
+      filesystem_free_bytes: filesystem_free_bytes(path)
+    }
+  end
+
+  defp file_size(path) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} -> size
+      {:error, :enoent} -> :missing
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # Elixir and Erlang expose file metadata but not statvfs. POSIX df -P gives a
+  # stable available-blocks column on both the Linux runtime and developer
+  # systems. Probe the nearest existing parent so diagnostics still work when
+  # the database path itself could not be created.
+  defp filesystem_free_bytes(path) do
+    probe_path = path |> Path.expand() |> Path.dirname() |> nearest_existing_directory()
+
+    try do
+      case System.cmd("df", ["-Pk", probe_path], stderr_to_stdout: true) do
+        {output, 0} -> parse_df_available_bytes(output)
+        {output, status} -> {:error, {:df_failed, status, String.trim(output)}}
+      end
+    rescue
+      error -> {:error, {:df_unavailable, Exception.message(error)}}
+    end
+  end
+
+  defp nearest_existing_directory(path) do
+    cond do
+      File.dir?(path) -> path
+      Path.dirname(path) == path -> path
+      true -> path |> Path.dirname() |> nearest_existing_directory()
+    end
+  end
+
+  defp parse_df_available_bytes(output) do
+    lines =
+      output
+      |> String.split("\n", trim: true)
+
+    with line when is_binary(line) <- List.last(lines),
+         fields <- String.split(line, ~r/\s+/, trim: true),
+         available_kib when is_binary(available_kib) <- Enum.at(fields, 3),
+         {value, ""} <- Integer.parse(available_kib) do
+      value * 1024
+    else
+      _ -> {:error, {:unexpected_df_output, String.trim(output)}}
+    end
+  end
+
+  defp format_diagnostic(value) when is_integer(value), do: Integer.to_string(value)
+  defp format_diagnostic(value), do: inspect(value)
 
   @impl Embervm.OpLog
   def append(server \\ __MODULE__, %Op{} = op) do
@@ -567,10 +711,7 @@ defmodule Embervm.OpLog.SQLite do
     journal_horizon_ms = Keyword.get(opts, :journal_horizon_ms, @default_journal_horizon_ms)
     compact_batch_size = Keyword.get(opts, :compact_batch_size, @default_compact_batch_size)
 
-    with {:ok, conn} <- Sqlite3.open(path),
-         :ok <- apply_pragmas(conn),
-         :ok <- apply_ddl(conn),
-         :ok <- apply_migrations(conn) do
+    with {:ok, conn} <- open_database(path) do
       Logger.info("embervm op-log opened at #{path}")
 
       {:ok,
@@ -583,6 +724,42 @@ defmodule Embervm.OpLog.SQLite do
        }}
     else
       {:error, reason} -> {:stop, {:open_failed, reason}}
+    end
+  end
+
+  defp open_database(path) do
+    with :ok <- validate_existing_database_header(path),
+         {:ok, conn} <- Sqlite3.open(path) do
+      case initialize_database(conn) do
+        :ok ->
+          {:ok, conn}
+
+        {:error, reason} ->
+          _ = Sqlite3.close(conn)
+          {:error, reason}
+      end
+    end
+  end
+
+  # Reject an obviously non-SQLite file before the SQLite library can inspect
+  # its sidecars. Some invalid header probes remove unusable WAL/SHM files, which
+  # would destroy forensic evidence before the one-shot quarantine can rename it.
+  # Missing and zero-byte files are valid SQLite create paths.
+  defp validate_existing_database_header(path) do
+    case File.open(path, [:read, :binary], fn file -> IO.binread(file, byte_size(@sqlite_header)) end) do
+      {:ok, @sqlite_header} -> :ok
+      {:ok, :eof} -> :ok
+      {:ok, _invalid_header} -> {:error, :invalid_database_header}
+      {:error, :enoent} -> :ok
+      {:error, reason} -> {:error, {:file_read_failed, reason}}
+    end
+  end
+
+  defp initialize_database(conn) do
+    with :ok <- apply_pragmas(conn),
+         :ok <- apply_ddl(conn),
+         :ok <- apply_migrations(conn) do
+      :ok
     end
   end
 

--- a/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
@@ -7,14 +7,22 @@ defmodule Embervm.OpLog.SQLiteTest do
   """
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias Embervm.OpLog.Op
   alias Embervm.OpLog.SQLite
   alias Exqlite.Sqlite3
 
   setup do
-    path = Path.join(System.tmp_dir!(), "embervm_oplog_test_#{System.unique_integer([:positive, :monotonic])}.db")
-    on_exit(fn -> File.rm_rf!(path) end)
-    %{path: path}
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "embervm_oplog_test_#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    %{dir: dir, path: Path.join(dir, "oplog.db")}
   end
 
   # name: nil: tests run async and each needs its own unnamed, PID-addressed
@@ -24,6 +32,96 @@ defmodule Embervm.OpLog.SQLiteTest do
     opts = Keyword.merge([path: path, name: nil], extra_opts)
     {:ok, pid} = SQLite.start_link(opts)
     pid
+  end
+
+  test "an unopenable database is quarantined and the supervised store starts with fresh history", %{
+    path: path
+  } do
+    original = "not a sqlite database\nforensic bytes\n"
+    wal = "original wal bytes"
+    shm = "original shm bytes"
+    File.write!(path, original)
+    File.write!(path <> "-wal", wal)
+    File.write!(path <> "-shm", shm)
+
+    log =
+      capture_log(fn ->
+        {:ok, supervisor} =
+          Supervisor.start_link(
+            [{SQLite, path: path, name: nil}],
+            strategy: :one_for_one
+          )
+
+        assert Process.alive?(supervisor)
+        [{_, server, :worker, [SQLite]}] = Supervisor.which_children(supervisor)
+
+        assert {:ok, 1} =
+                 SQLite.append(server, %Op{
+                   kind: :denied,
+                   tenant: "t1",
+                   ts: 100,
+                   payload: %{reason: "quota"}
+                 })
+
+        assert File.regular?(path)
+        :ok = Supervisor.stop(supervisor)
+      end)
+
+    [quarantined] =
+      path
+      |> then(&Path.wildcard(&1 <> ".quarantined-*"))
+      |> Enum.reject(&(String.ends_with?(&1, "-wal") or String.ends_with?(&1, "-shm")))
+
+    quarantined_wal = quarantined <> "-wal"
+    quarantined_shm = quarantined <> "-shm"
+
+    assert File.read!(quarantined) == original
+    assert File.read!(quarantined_wal) == wal
+    assert File.read!(quarantined_shm) == shm
+    assert log =~ "SQLite op-log open failed"
+    assert log =~ "path=#{inspect(path)}"
+    assert log =~ "file_size_bytes=#{byte_size(original)}"
+    assert log =~ "filesystem_free_bytes="
+    assert log =~ "history was quarantined"
+    assert log =~ "reason="
+    assert log =~ "running degraded with a fresh database"
+  end
+
+  test "a healthy existing database opens without quarantine and keeps its rows", %{path: path} do
+    server = start_server(path)
+
+    assert {:ok, 1} =
+             SQLite.append(server, %Op{
+               kind: :denied,
+               tenant: "t1",
+               ts: 100,
+               payload: %{reason: "quota"}
+             })
+
+    :ok = GenServer.stop(server)
+    reopened = start_server(path)
+
+    assert {:ok, [%{seq: 1, kind: :denied, tenant: "t1"}]} = SQLite.read_from(reopened, 0)
+    assert Path.wildcard(path <> ".quarantined-*") == []
+
+    :ok = GenServer.stop(reopened)
+  end
+
+  test "a second consecutive open failure fails hard after one retry", %{dir: dir} do
+    blocker = Path.join(dir, "not-a-directory")
+    File.write!(blocker, "blocking parent")
+    path = Path.join(blocker, "oplog.db")
+    Process.flag(:trap_exit, true)
+
+    log =
+      capture_log(fn ->
+        assert {:error, {:open_failed, _reason}} = SQLite.start_link(path: path, name: nil)
+      end)
+
+    assert log =~ "SQLite op-log open failed"
+    assert log =~ "recreate failed after one quarantine retry"
+    assert log =~ "failing hard"
+    assert length(Regex.scan(~r/SQLite op-log recreate failed after one quarantine retry/, log)) == 1
   end
 
   test "monotonic seq under concurrent interleaving, survives reopen", %{path: path} do


### PR DESCRIPTION
Fixes #5359.

**This is currently blocking a production remediation.** The embervm dev control plane has been crashlooping for ~12 hours (135 restarts) on an unopenable SQLite op-log. The conformance gate needs a live control plane, so no Freight can be verified, so #5357's already-merged egress fix cannot promote to prod while `claude-runtime` is down there. Dev is already on 0.47.12 with that fix; prod sits at 0.47.11 waiting on a gate that cannot run.

## The defect

`Embervm.OpLog.SQLite` is a supervised child, so an open failure propagated to `Embervm.Application.start/2` and took the BEAM down:

```
shutdown: failed to start child: Embervm.OpLog.SQLite
  ** (EXIT) {:open_failed, :database_open_failed}
Kernel pid terminated (application_controller)
```

Every restart reopened the same file and died identically. A dev op-log is disposable; a control plane that will not boot is not.

## Change

Recovery lives at `start_link/1`, deliberately not in `init/1`. `GenServer.start_link/3` waits for `init/1`, so the open error is still in hand before `start_link/1` hands it to the application supervisor. `init/1` cannot quarantine and then raise without letting the failure escape the child start contract, which would have fixed nothing.

On an open failure:

1. Log the path, the reason, the file size, and the filesystem free space. `database_open_failed` alone does not separate a corrupt file from a full disk from a permissions problem, and that ambiguity is what made this expensive to diagnose. The next occurrence says which it is.
2. Rename the database and its `-wal` and `-shm` siblings under one timestamped basename. Never unlink: the bad file stays for forensics.
3. Retry exactly once, then run degraded with a fresh database and an unmistakable log line.
4. A second failure escapes as before. At that point the filesystem or permissions are the problem and quarantining cannot help, so failing hard is correct.

A healthy database is opened normally and never quarantined.

## Scope

SQLite store only. Production uses Postgres for the op-log and its failure semantics are unchanged. The spec-trace store, which shares the same PVC, is untouched and tracked separately in #5359.

## Verification

Falsified rather than assumed. With the tests unchanged and only the recovery branch removed:

```
1) test a second consecutive open failure fails hard after one retry (Embervm.OpLog.SQLiteTest)
2) test an unopenable database is quarantined and the supervised store starts with fresh history (Embervm.OpLog.SQLiteTest)
1555 tests, 2 failures, 22 skipped
```

Restored: `1555 tests, 0 failures, 22 skipped`.

Reviewers: `ci test` gives NO signal on this suite. It is a genrule, so `bazel test` reports "Found 1 target and 0 test targets" and reads as cached-green (#4118). Build it with `bb remote ... build //bazel/erlang:mix_test_smoke` and judge the `N tests, N failures` line.

## Expected effect on merge

The published chart carries this plus #5357. Dev receives it through `argocd-update`, which runs before the verdict gate, so the control plane recovers without manual intervention, the gate runs again, and prod promotes with the egress fix. If dev's volume turns out to be full rather than the file corrupt, this correctly fails hard on the second attempt and the new diagnostics say so plainly.

## Still latent, not fixed here

`oplog.db` and `spec-trace.db` share one 1 Gi PVC. spec-trace grows continuously on a 24h TTL and #5342 enlarged every checkpoint. If that volume fills it takes the op-log down by this same path, and this fix will not save it. Noted in #5359.
