### PR TITLE
fix(embervm): apply the egress CA trust during prewarm so base builds work

### DIFF
--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -690,17 +690,14 @@ def fetch_egress_ca(timeout=EGRESS_VSOCK_CONNECT_TIMEOUT_SECONDS):
 def apply_egress_ca_trust():
     """Fetch + install the egress CA and export the trust variables.
 
-    Called PER TURN, not at startup. A session guest is restored from a shared
-    snapshot, so its process memory is cloned with main() long since finished:
-    anything done there runs once, at base-build time, on a different machine,
-    and can never run again for a real session. At base-build time the egress
-    lane is not open either, so the fetch there fails with ECONNRESET and the
-    trust is simply absent for every session that base ever serves.
+    Since #5358 the egress lane is open during base builds. Prewarm applies the
+    trust once before spawning any CLI, so the resulting snapshot carries both
+    the installed bundle and these environment variables into every session.
 
-    A turn is the first moment that is guaranteed to be post-restore with the
-    lane live, which is why ensure_workspace_volume() is called from the same
-    place. Re-running is cheap (one vsock round trip) and is what keeps a CA
-    rotation from needing a fleet base rebuild.
+    A session guest is restored from that shared snapshot, so the per-turn call
+    remains necessary for CA rotation without a fleet base rebuild. Re-running
+    is cheap (one vsock round trip) and updates the environment before a turn
+    can lazily spawn a new CLI.
     """
     bundle = install_egress_ca()
     if not bundle:
@@ -3467,6 +3464,7 @@ class ProcessManager:
     def prewarm(self):
         """Start configured CLIs and leave them ready for the first turn."""
         try:
+            apply_egress_ca_trust()
             _ensure_cli_dir(self.claude.workspace)
             for cli in self._prewarm_clis:
                 if cli == "claude":
@@ -3474,7 +3472,10 @@ class ProcessManager:
                         session_id=None,
                         first_message=None,
                         model=None,
-                        init_timeout=30,
+                        # Base build also pays for the CA fetch while the node
+                        # may be baking other guests, so allow a cold init more
+                        # room than an ordinary lazy session spawn.
+                        init_timeout=60,
                     )
                     # Claude emits a generated id in init, but a parked process
                     # has not adopted a session until its first user message.
@@ -3862,9 +3863,8 @@ class ProcessManager:
         total_start = _turn_timing_now()
         with self._mount_lock:
             ensure_workspace_volume()
-        # Per turn, for the same reason ensure_workspace_volume is: this is the
-        # first point guaranteed to be post-restore with the egress lane live.
-        # Doing it at startup put it at base-build time, where the lane is shut.
+        # Re-apply per turn so a restored guest picks up CA rotation without a
+        # fleet base rebuild. Prewarm already applied the build-time CA once.
         apply_egress_ca_trust()
         if getattr(self.claude, "workspace", None):
             _ensure_cli_dir(self.claude.workspace)

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -28,6 +28,15 @@ import pytest
 import shim
 
 
+EGRESS_CA_TRUST_ENV_KEYS = (
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "GIT_SSL_CAINFO",
+    "NODE_EXTRA_CA_CERTS",
+)
+
+
 FAKE_CLI = r"""#!/usr/bin/env python3
 import json
 import os
@@ -51,6 +60,22 @@ if egress_env_path:
                     "https_proxy",
                     "http_proxy",
                     "no_proxy",
+                )
+            },
+            stream,
+        )
+trust_env_path = os.environ.get("FAKE_TRUST_ENV")
+if trust_env_path:
+    with open(trust_env_path, "w") as stream:
+        json.dump(
+            {
+                key: os.environ.get(key)
+                for key in (
+                    "SSL_CERT_FILE",
+                    "REQUESTS_CA_BUNDLE",
+                    "CURL_CA_BUNDLE",
+                    "GIT_SSL_CAINFO",
+                    "NODE_EXTRA_CA_CERTS",
                 )
             },
             stream,
@@ -1369,7 +1394,7 @@ def test_process_manager_prewarm_marks_ready_after_init(tmp_path, monkeypatch):
         process = _FakeLiveProcess()
 
         def _spawn(self, **kwargs):
-            calls.append(kwargs)
+            calls.append(("spawn", kwargs))
 
         def ready(self):
             return True
@@ -1383,6 +1408,9 @@ def test_process_manager_prewarm_marks_ready_after_init(tmp_path, monkeypatch):
     temp_b.turn_lock = threading.Lock()
     manager.pi = temp_b
     manager._close_process = lambda **_kwargs: None
+    monkeypatch.setattr(
+        shim, "apply_egress_ca_trust", lambda: calls.append(("trust", None))
+    )
     manager.prewarm()
 
     # Mock the external state checks so ready() returns True.
@@ -1390,19 +1418,23 @@ def test_process_manager_prewarm_marks_ready_after_init(tmp_path, monkeypatch):
     monkeypatch.setattr(shim, "_volume_has_ext4", lambda: False)
 
     assert calls == [
-        {
-            "session_id": None,
-            "first_message": None,
-            "model": None,
-            "init_timeout": 30,
-        }
+        ("trust", None),
+        (
+            "spawn",
+            {
+                "session_id": None,
+                "first_message": None,
+                "model": None,
+                "init_timeout": 60,
+            },
+        ),
     ]
     assert manager.claude.session_id is None
     assert manager._prewarm_complete
     assert manager.ready()
 
 
-def test_process_manager_prewarm_failure_is_not_ready(tmp_path):
+def test_process_manager_prewarm_failure_is_not_ready(tmp_path, monkeypatch):
     manager = _new_process_manager()
     manager._prewarm_clis = ("claude",)
     manager._prewarm_complete = False
@@ -1427,13 +1459,16 @@ def test_process_manager_prewarm_failure_is_not_ready(tmp_path):
     temp_b.turn_lock = threading.Lock()
     manager.pi = temp_b
     manager._close_process = lambda **_kwargs: None
+    monkeypatch.setattr(shim, "apply_egress_ca_trust", lambda: None)
     manager.prewarm()
 
     assert not manager.ready()
     assert "CLI prewarm failed" in manager.fatal_error
 
 
-def test_process_manager_prewarm_spawns_every_configured_family_parked(tmp_path):
+def test_process_manager_prewarm_spawns_every_configured_family_parked(
+    tmp_path, monkeypatch
+):
     """#4423: codex and pi park like claude, each per its own init profile.
 
     Claude parks with no session identity (init emits a throwaway id), codex
@@ -1469,6 +1504,7 @@ def test_process_manager_prewarm_spawns_every_configured_family_parked(tmp_path)
         adapter.turn_lock = threading.Lock()
         setattr(manager, name, adapter)
     manager._close_process = lambda **_kwargs: None
+    monkeypatch.setattr(shim, "apply_egress_ca_trust", lambda: None)
     manager.prewarm()
 
     assert calls["claude"] == (
@@ -1477,7 +1513,7 @@ def test_process_manager_prewarm_spawns_every_configured_family_parked(tmp_path)
             "session_id": None,
             "first_message": None,
             "model": None,
-            "init_timeout": 30,
+            "init_timeout": 60,
         },
     )
     # Codex's whole init is the app-server spawn plus initialize handshake:
@@ -1492,7 +1528,7 @@ def test_process_manager_prewarm_spawns_every_configured_family_parked(tmp_path)
     assert manager._prewarm_complete
 
 
-def test_process_manager_prewarm_failure_closes_every_cli(tmp_path):
+def test_process_manager_prewarm_failure_closes_every_cli(tmp_path, monkeypatch):
     """A half-prewarmed guest must not hold resident CLIs while unready."""
     workspace = tmp_path / "workspace" / "src"
     workspace.mkdir(parents=True)
@@ -1531,6 +1567,7 @@ def test_process_manager_prewarm_failure_closes_every_cli(tmp_path):
             getattr(manager, name)._close_process(kill=kill)
 
     manager._close_process = close_all
+    monkeypatch.setattr(shim, "apply_egress_ca_trust", lambda: None)
     manager.prewarm()
 
     assert "CLI prewarm failed" in manager.fatal_error
@@ -1539,7 +1576,70 @@ def test_process_manager_prewarm_failure_closes_every_cli(tmp_path):
         assert getattr(manager, name).closed is True
 
 
-def test_process_manager_turn_always_ensures_workspace_volume(monkeypatch):
+def test_process_manager_prewarm_without_egress_ca_spawns_untrusted_cli(
+    tmp_path, monkeypatch
+):
+    trust_env_path = tmp_path / "trust-env.json"
+    monkeypatch.setenv("FAKE_TRUST_ENV", str(trust_env_path))
+    for key in EGRESS_CA_TRUST_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(shim, "fetch_egress_ca", lambda: None)
+
+    manager = _new_process_manager()
+    manager._prewarm_clis = ("claude",)
+    manager._prewarm_complete = False
+    manager.fatal_error = None
+    manager.claude = _manager(tmp_path, monkeypatch)
+
+    try:
+        manager.prewarm()
+
+        assert manager.fatal_error is None
+        assert manager._prewarm_complete
+        assert json.loads(trust_env_path.read_text()) == {
+            key: None for key in EGRESS_CA_TRUST_ENV_KEYS
+        }
+    finally:
+        manager.claude._close_process(kill=True)
+
+
+def test_process_manager_prewarm_child_inherits_fetched_egress_ca_trust(
+    tmp_path, monkeypatch
+):
+    trust_env_path = tmp_path / "trust-env.json"
+    bundle = tmp_path / "ember-ca-bundle.crt"
+    system_bundle = tmp_path / "system-ca-bundle.crt"
+    system_bundle.write_bytes(b"system certificate\n")
+    monkeypatch.setenv("FAKE_TRUST_ENV", str(trust_env_path))
+    for key in EGRESS_CA_TRUST_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(shim, "CA_BUNDLE_PATH", str(bundle))
+    monkeypatch.setattr(shim, "SYSTEM_CA_BUNDLE", str(system_bundle))
+    monkeypatch.setattr(
+        shim,
+        "fetch_egress_ca",
+        lambda: b"-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n",
+    )
+
+    manager = _new_process_manager()
+    manager._prewarm_clis = ("claude",)
+    manager._prewarm_complete = False
+    manager.fatal_error = None
+    manager.claude = _manager(tmp_path, monkeypatch)
+
+    try:
+        manager.prewarm()
+
+        assert manager.fatal_error is None
+        assert manager._prewarm_complete
+        assert json.loads(trust_env_path.read_text()) == {
+            key: str(bundle) for key in EGRESS_CA_TRUST_ENV_KEYS
+        }
+    finally:
+        manager.claude._close_process(kill=True)
+
+
+def test_process_manager_turn_applies_per_turn_trust_after_volume(monkeypatch):
     manager = _new_process_manager()
     calls = []
 
@@ -1556,11 +1656,14 @@ def test_process_manager_turn_always_ensures_workspace_volume(monkeypatch):
     temp_b = Adapter()
     temp_b.turn_lock = threading.Lock()
     manager.pi = temp_b
-    monkeypatch.setattr(shim, "ensure_workspace_volume", lambda: calls.append(True))
+    monkeypatch.setattr(
+        shim, "ensure_workspace_volume", lambda: calls.append("workspace")
+    )
+    monkeypatch.setattr(shim, "apply_egress_ca_trust", lambda: calls.append("trust"))
     monkeypatch.setattr(shim, "_sync_session_volume", lambda: None)
 
     assert manager.turn("hello") == {"ok": True}
-    assert calls == [True]
+    assert calls == ["workspace", "trust"]
 
 
 @pytest.mark.parametrize("checkout_state", ["missing", "git_failure"])


### PR DESCRIPTION
**Ends a live production outage.** `claude-runtime` has been unable to build a base in embervm prod for roughly 14 hours, retrying every 60s. Twelve of thirteen workloads are `BaseBuilt`; this is the last one.

## Cause

`prewarm` spawns the CLIs during a base build without applying the egress CA trust. The egress proxy MITMs the catalog hosts to inject credentials (the guest never holds them, which is the design), so the Claude CLI, which is Node, rejects the minted leaf without `NODE_EXTRA_CA_CERTS`. Its init blocks, the init timeout fires, `prewarm` sets `fatal_error`, `ready()` refuses while that is set, and `WaitReady` times out.

Observed in prod, guest serial and sidecar log respectively:

```
ember-claude-shim: egress-copy: up closed total=342 err=none
ember-claude-shim: egress-copy: down closed total=2334 err=none
ember-claude-shim: initialization timed out after 30 seconds, sending SIGINT
ember-claude-shim: CLI prewarm failed: timed out waiting for Claude initialization
```
```
INFO  egress allowed (inject, tls)  dest=api.anthropic.com:443
WARN  egress swap: guest TLS handshake failed  host=api.anthropic.com  err=EOF
```

## Why nobody wired it

`apply_egress_ca_trust` already does the whole job, and session guests call it every turn. Its docstring said why the build path did not:

> At base-build time the egress lane is not open either, so the fetch there fails with ECONNRESET and the trust is simply absent for every session that base ever serves.

That was true when written. #5358 (issue #5357) opened the egress lane during base builds and invalidated it, but nothing added the trust step, because the comment still said it was impossible. The lane has been open and untrusted since.

## Change

Call `apply_egress_ca_trust()` once at the top of `prewarm`, before the first spawn. The exported variables land in `os.environ` and every CLI child inherits them via `child_env = os.environ.copy()`. The resulting snapshot then carries both the installed bundle and the trust variables into every session restored from it.

The per-turn call is untouched. That is what lets a CA rotation take effect without a fleet base rebuild, and a restored guest still needs it because the snapshot carries build-time values.

`init_timeout` 30 to 60: a build now pays a CA fetch plus a cold authenticated init on a node that may be baking other guests. Two tests pinned 30 and now assert 60.

Both stale comments are rewritten to name #5358 as what changed the premise. That old text is what sent this investigation toward "ADR 023's unsolved problem" mid-outage, when the delivery mechanism had in fact been solved for the GitHub lane and prod already runs `egress.ca.enabled: true`. Tracked separately in #5366.

## Security

The guest gains only the CA's PUBLIC certificate. The private key stays sidecar-only and never reaches a guest, so this does not let a guest mint leaves, impersonate a host, or reach anything new. Trusting the CA only permits the sidecar to MITM the guest, which is the design, and prod session guests already apply this exact trust every turn. ADR 023 decision 3's boundary is unchanged.

Two facts worth recording: the base build now completes an authenticated `api.anthropic.com` call over the same credential-injection path every turn already uses, and a CLI parked at build time holds the build-time CA until respawned, because Node reads `NODE_EXTRA_CA_CERTS` at process start. That affects https telemetry from a parked CLI after a rotation, not turns, which ride the cleartext lane.

## Verification

Falsified rather than assumed. With the tests unchanged and ONLY the `prewarm` trust call removed:

```
FAILED test_process_manager_prewarm_child_inherits_fetched_egress_ca_trust
FAILED test_process_manager_prewarm_marks_ready_after_init
Executed 1 out of 1 test: 1 fails remotely.
```

The inheritance test spawns a real child process and asserts all five trust variables arrive, rather than only checking that the function was called.

Restored: `1 test passes`. The no-sidecar path (dev, which runs no egress-proxy) still completes prewarm with the trust variables absent, and is tested.

Note for reviewers: a bare `ci test` on a fresh worktree reports "affected-targets: no changes, nothing to test" and exits 0 having tested nothing. Run the target explicitly: `ci test -- //projects/embervm/runtimes/claude:shim_test`.

## Expected effect

The image rebuild moves only the claude-runtime digest, so the prod roll rebuilds one base rather than the fleet. Success is `claude-runtime` reaching `BaseBuilt` with a ref off `7c08eb4dbc91`, then 13 of 13 workloads built.
